### PR TITLE
Only require cli extra for the `install` functionality

### DIFF
--- a/py/src/braintrust/cli/__main__.py
+++ b/py/src/braintrust/cli/__main__.py
@@ -3,24 +3,7 @@ import logging
 import sys
 import textwrap
 
-_module_not_found_error = None
-try:
-    from . import eval, install
-except ModuleNotFoundError as e:
-    _module_not_found_error = e
-
-if _module_not_found_error is not None:
-    raise ModuleNotFoundError(
-        textwrap.dedent(
-            f"""\
-            At least one dependency not found: {str(_module_not_found_error)!r}
-            It is possible that braintrust was installed without the CLI dependencies. Run:
-
-              pip install 'braintrust[cli]'
-
-            to install braintrust with the CLI dependencies (make sure to quote 'braintrust[cli]')."""
-        )
-    )
+from . import eval, install
 
 
 def main(args=None):

--- a/py/src/braintrust/cli/install/__init__.py
+++ b/py/src/braintrust/cli/install/__init__.py
@@ -1,4 +1,25 @@
-from . import api, redshift
+import argparse
+import textwrap
+
+_module_not_found_error = None
+try:
+    from . import api, redshift
+except ModuleNotFoundError as e:
+    _module_not_found_error = e
+
+
+def fail_with_module_not_found_error(*args, **kwargs):
+    raise ModuleNotFoundError(
+        textwrap.dedent(
+            f"""\
+            At least one dependency not found: {str(_module_not_found_error)!r}
+            It is possible that braintrust was installed without the CLI dependencies. Run:
+
+              pip install 'braintrust[cli]'
+
+            to install braintrust with the CLI dependencies (make sure to quote 'braintrust[cli]')."""
+        )
+    )
 
 
 def build_parser(subparsers, parent_parser):
@@ -7,7 +28,11 @@ def build_parser(subparsers, parent_parser):
         help="Tools to setup and verify Braintrust's installation in your environment.",
         parents=[parent_parser],
     )
-    install_subparsers = install_parser.add_subparsers(dest="install_subcommand", required=True)
+    if _module_not_found_error:
+        install_parser.add_argument("args", nargs=argparse.REMAINDER)
+        install_parser.set_defaults(func=fail_with_module_not_found_error)
+    else:
+        install_subparsers = install_parser.add_subparsers(dest="install_subcommand", required=True)
 
-    for module in [api, redshift]:
-        module.build_parser(install_subparsers, parents=[parent_parser])
+        for module in [api, redshift]:
+            module.build_parser(install_subparsers, parents=[parent_parser])


### PR DESCRIPTION
After this change, `braintrust eval` won't require `pip install braintrust[cli]`