### PR TITLE
Add a .close() method as an alias for .end() for spans

### DIFF
--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -1098,6 +1098,10 @@ class ExperimentSpan:
         _unterminated_objects.remove_unterminated(self)
         return end_time
 
+    def close(self, *args, **kwargs):
+        """Alias for `end`."""
+        return self.end(*args, **kwargs)
+
     def _set_as_current_span(self):
         # Set this span as the currently-active span if not already set.
         if not self._context_token:


### PR DESCRIPTION
This allows the catch-all warning we send to still send a single instruction (call `.close()`)