### PR TITLE
Do not loudly fail if git is missing

### DIFF
--- a/py/src/braintrust/gitutil.py
+++ b/py/src/braintrust/gitutil.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 import subprocess
 import threading
@@ -6,9 +7,11 @@ from dataclasses import dataclass
 from functools import cache as _cache
 from typing import Optional
 
-import git
-
 from .util import SerializableDataClass
+
+# https://stackoverflow.com/questions/48399498/git-executable-not-found-in-python
+os.environ["GIT_PYTHON_REFRESH"] = "quiet"
+import git
 
 _logger = logging.getLogger("braintrust.gitutil")
 _gitlock = threading.RLock()

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import queue
+import sys
 import textwrap
 import threading
 import time
@@ -490,7 +491,7 @@ def login(api_url=None, api_key=None, org_name=None, disable_cache=False, force_
 
             ping_ok = conn.ping()
 
-        if not ping_ok or ORG_ID is None or ORG_NAME is None or LOG_URL is None:
+        if (not ping_ok or ORG_ID is None or ORG_NAME is None or LOG_URL is None) and sys.stdout.isatty():
             print(
                 textwrap.dedent(
                     f"""\
@@ -525,7 +526,10 @@ def login(api_url=None, api_key=None, org_name=None, disable_cache=False, force_
 
             ping_ok = conn.ping()
 
-        assert conn, "Conn should be set at this point (a bug)"
+        if not conn:
+            raise ValueError(
+                "Could not login to Braintrust. You may need to set BRAINTRUST_API_KEY in your environment."
+            )
 
         # Do not use the "ping" method here, because we'd like to `raise_for_status()` in case
         # of any remaining errors.


### PR DESCRIPTION
After this change, if `git` is missing, we still import the `git` package but (as expected) do not use git metadata.

Also fixed the token logic to only run if we're in a terminal.