### PR TITLE
Logger: warn instead of crashing when logging fails. Also attempt retry.

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -244,6 +244,9 @@ function constructJsonArray(items: string[]) {
   return `[${items.join(",")}]`;
 }
 
+const DefaultBatchSize = 100;
+const NumRetries = 3;
+
 class LogThread {
   private items: LogEvent[] = [];
   private active_flush: Promise<string[]> = Promise.resolve([]);
@@ -258,7 +261,7 @@ class LogThread {
     }
   }
 
-  async flush_once(batchSize: number = 100): Promise<string[]> {
+  async flush_once(batchSize: number = DefaultBatchSize): Promise<string[]> {
     this.active_flush_resolved = false;
 
     const initialItems = (this.items || []).reverse();
@@ -281,14 +284,22 @@ class LogThread {
         itemsLen += itemS.length;
       }
 
-      if (items.length > 0) {
-        const resp = await log_conn().post_json(
-          "logs",
-          constructJsonArray(items)
-        );
-        ret = resp.data;
-      } else {
+      if (items.length === 0) {
         break;
+      }
+
+      for (let i = 0; i < NumRetries; i++) {
+        try {
+          ret.push(
+            ...(
+              await log_conn().post_json("logs", constructJsonArray(items))
+            ).map((res: any) => res.id)
+          );
+          break;
+        } catch (e) {
+          const retryingText = i + 1 === NumRetries ? "" : " Retrying";
+          console.warn(`log request failed with error ${e}.${retryingText}`);
+        }
       }
     }
 

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -216,6 +216,7 @@ def construct_json_array(items):
 
 
 DEFAULT_BATCH_SIZE = 100
+NUM_RETRIES = 3
 
 
 class _LogThread:
@@ -284,10 +285,16 @@ class _LogThread:
                     items.append(item_s)
                     items_len += len(item_s)
 
-                if len(items) > 0:
-                    response_raise_for_status(conn.post("/logs", data=construct_json_array(items)))
-                else:
+                if len(items) == 0:
                     break
+                for i in range(NUM_RETRIES):
+                    resp = conn.post("/logs", data=construct_json_array(items))
+                    if resp.ok:
+                        break
+                    retrying_text = "" if i + 1 == NUM_RETRIES else " Retrying"
+                    _logger.warning(
+                        f"log request failed with status code {resp.status_code}: {resp.text}.{retrying_text}"
+                    )
             self.queue_filled_event.clear()
 
 


### PR DESCRIPTION
Tested locally by failing the `logs` endpoint in chalice.

Fixes BRA-515