### PR TITLE
JS SDK: Launch logging requests concurrently.

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -2,7 +2,8 @@ import axios, { AxiosInstance } from "axios";
 import { v4 as uuidv4 } from "uuid";
 
 import iso, { IsoAsyncLocalStorage, CallerLocation } from "./isomorph";
-import { runFinally } from "./util";
+import { runFinally, TRANSACTION_ID_FIELD, IS_MERGE_FIELD } from "./util";
+import { mergeRowBatch } from "./merge_row_batch";
 
 export type SetCurrentArg = { setCurrent?: boolean };
 
@@ -248,8 +249,6 @@ class UnterminatedObjectsHandler {
 
 let unterminatedObjects = new UnterminatedObjectsHandler();
 
-const TRANSACTION_ID_FIELD = "_xact_id";
-
 class HTTPConnection {
   base_url: string;
   token: string | null;
@@ -395,7 +394,7 @@ type ExperimentEvent = Partial<InputField> &
     root_span_id: string;
     project_id: string;
     experiment_id: string;
-    _is_merge: boolean;
+    [IS_MERGE_FIELD]: boolean;
   } & Partial<{
     user_id: string;
     created: string;
@@ -450,10 +449,13 @@ class LogThread {
   async flush_once(batchSize: number = DefaultBatchSize): Promise<string[]> {
     this.active_flush_resolved = false;
 
-    const initialItems = (this.items || []).reverse();
+    // Since the merged rows are guaranteed to refer to independent rows,
+    // publish order does not matter and we can flush all item batches
+    // concurrently.
+    const initialItems = mergeRowBatch(this.items || []).reverse();
     this.items = [];
 
-    let ret = [];
+    let postPromises = [];
     while (true) {
       const items = [];
       let itemsLen = 0;
@@ -474,22 +476,30 @@ class LogThread {
         break;
       }
 
-      for (let i = 0; i < NumRetries; i++) {
-        try {
-          ret.push(
-            ...(
+      postPromises.push(
+        (async () => {
+          for (let i = 0; i < NumRetries; i++) {
+            try {
+              return (
                 await _state
-                    .logConn()
-                    .post_json("logs", constructJsonArray(items))
-            ).map((res: any) => res.id)
+                  .logConn()
+                  .post_json("logs", constructJsonArray(items))
+              ).map((res: any) => res.id);
+            } catch (e) {
+              const retryingText = i + 1 === NumRetries ? "" : " Retrying";
+              console.warn(
+                `log request failed with error ${e}.${retryingText}`
+              );
+            }
+          }
+          console.warn(
+            `log request failed after ${NumRetries} retries. Dropping batch`
           );
-          break;
-        } catch (e) {
-          const retryingText = i + 1 === NumRetries ? "" : " Retrying";
-          console.warn(`log request failed with error ${e}.${retryingText}`);
-        }
-      }
+          return [];
+        })()
+      );
     }
+    let ret = await Promise.all(postPromises);
 
     // If more items were added while we were flushing, flush again
     if (this.items.length > 0) {
@@ -1372,7 +1382,7 @@ export class SpanImpl implements Span {
       root_span_id: this.root_span_id,
       project_id: this._project_id,
       experiment_id: this._experiment_id,
-      _is_merge: this.isMerge,
+      [IS_MERGE_FIELD]: this.isMerge,
     };
     this.internalData = {};
     this.experimentLogger.log([record]);

--- a/js/src/merge_row_batch.ts
+++ b/js/src/merge_row_batch.ts
@@ -1,0 +1,50 @@
+// Mirrors the implementation of merge_row_batch in api/chalicelib/util.py.
+//
+// TODO(manu): Share common functionality between SDK and chalicelib.
+
+import { IS_MERGE_FIELD, mergeDicts } from "./util";
+
+function generateUniqueRowKey(row: Record<string, any>) {
+  const coalesceEmpty = (field: string) => row[field] ?? "";
+  return (
+    coalesceEmpty("experiment_id") +
+    ":" +
+    coalesceEmpty("dataset_id") +
+    ":" +
+    coalesceEmpty("prompt_session_id") +
+    ":" +
+    coalesceEmpty("id")
+  );
+}
+
+export function mergeRowBatch(
+  rows: Record<string, any>[]
+): Record<string, any>[] {
+  const out: Record<string, any>[] = [];
+  const remainingRows: Record<string, any>[] = [];
+  // First add any rows with no ID to `out`, since they will always be
+  // independent.
+  for (const row of rows) {
+    if (row["id"] === undefined) {
+      out.push(row);
+    } else {
+      remainingRows.push(row);
+    }
+  }
+  const rowGroups: Record<string, Record<string, any>> = {};
+  for (const row of remainingRows) {
+    const key = generateUniqueRowKey(row);
+    const existingRow = rowGroups[key];
+    if (existingRow !== undefined && row[IS_MERGE_FIELD]) {
+      const preserveNoMerge = !existingRow[IS_MERGE_FIELD];
+      mergeDicts(existingRow, row);
+      if (preserveNoMerge) {
+        delete existingRow[IS_MERGE_FIELD];
+      }
+    } else {
+      rowGroups[key] = row;
+    }
+  }
+  out.push(...Object.values(rowGroups));
+  return out;
+}

--- a/js/src/util.ts
+++ b/js/src/util.ts
@@ -1,3 +1,6 @@
+export const TRANSACTION_ID_FIELD = "_xact_id";
+export const IS_MERGE_FIELD = "_is_merge";
+
 // Given a callback, runs the callback as a "finally" component. If
 // `callback` returns a Promise, `finallyF` is chained to the promise. Otherwise,
 // it is run afterwards synchronously.
@@ -14,6 +17,26 @@ export function runFinally<R>(f: () => R, finallyF: () => void): R {
   } finally {
     if (runSyncCleanup) {
       finallyF();
+    }
+  }
+}
+
+// Mutably updates `mergeInto` with the contents of `mergeFrom`, merging objects deeply.
+export function mergeDicts(
+  mergeInto: Record<any, any>,
+  mergeFrom: Record<any, any>
+) {
+  for (const [k, mergeFromV] of Object.entries(mergeFrom)) {
+    const mergeIntoV = mergeInto[k];
+    if (
+      mergeIntoV instanceof Object &&
+      !Array.isArray(mergeIntoV) &&
+      mergeFrom instanceof Object &&
+      !Array.isArray(mergeFromV)
+    ) {
+      mergeDicts(mergeIntoV, mergeFromV);
+    } else {
+      mergeInto[k] = mergeFromV;
     }
   }
 }

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -392,6 +392,8 @@ class _LogThread:
                     _logger.warning(
                         f"log request failed with status code {resp.status_code}: {resp.text}.{retrying_text}"
                     )
+                if not resp.ok:
+                    _logger.warning(f"log request failed after {NUM_RETRIES} retries. Dropping batch")
             self.queue_filled_event.clear()
 
 

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -384,13 +384,15 @@ class _LogThread:
 
                 if len(items) == 0:
                     break
+                items_s = construct_json_array(items)
                 for i in range(NUM_RETRIES):
-                    resp = conn.post("/logs", data=construct_json_array(items))
+                    start_time = time.time()
+                    resp = conn.post("/logs", data=items_s)
                     if resp.ok:
                         break
                     retrying_text = "" if i + 1 == NUM_RETRIES else " Retrying"
                     _logger.warning(
-                        f"log request failed with status code {resp.status_code}: {resp.text}.{retrying_text}"
+                        f"log request failed. Elapsed time: {time.time() - start_time} seconds. Payload size: {len(item_s)}. Error: {resp.status_code}: {resp.text}.{retrying_text}"
                     )
                 if not resp.ok:
                     _logger.warning(f"log request failed after {NUM_RETRIES} retries. Dropping batch")


### PR DESCRIPTION
As long as the row IDs in a set of rows are independent, we can batch them up and log them concurrently. The only extra step we need then is to merge rows with the same ID before logging, which saves on bandwidth anyways.

Aside from sanity-check testing, verified on prod that the `stress-tests/large_experiment.ts` benchmark, run with 1 experiment of 5000 rows shows improvement. Before, it took about 321.26 seconds. After it takes about 99.77 seconds.