### PR TITLE
Adjust sdk logging limit.

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -422,8 +422,8 @@ export interface DatasetRecord {
   metadata: any;
 }
 
-// 10 MB (https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html)
-const MaxRequestSize = 10 * 1024 * 1024;
+// 6 MB (from our own testing).
+const MaxRequestSize = 6 * 1024 * 1024;
 
 function constructJsonArray(items: string[]) {
   return `[${items.join(",")}]`;

--- a/py/src/braintrust/cli/install/logs.py
+++ b/py/src/braintrust/cli/install/logs.py
@@ -1,6 +1,6 @@
 import logging
-from concurrent.futures import ThreadPoolExecutor
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 from ...aws import cloudformation, logs
 

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -304,8 +304,8 @@ class ModelWrapper:
         return self.data[name]
 
 
-# 10 MB (https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html)
-MAX_REQUEST_SIZE = 10 * 1024 * 1024
+# 6 MB (from our own testing).
+MAX_REQUEST_SIZE = 6 * 1024 * 1024
 
 
 def construct_json_array(items):


### PR DESCRIPTION
Our empirical testing shows the limit is around 6MB. This aligns with the internal server errors customers were seeing