### PR TITLE
Minor tweaks to SDKs

### DIFF
--- a/js/src/isomorph.ts
+++ b/js/src/isomorph.ts
@@ -39,6 +39,7 @@ export interface Common {
   getEnv: (name: string) => string | undefined;
   getCallerLocation: () => CallerLocation | undefined;
   newAsyncLocalStorage: <T>() => IsoAsyncLocalStorage<T>;
+  processOn: (event: string, handler: (code: any) => void) => void;
 }
 
 const iso: Common = {
@@ -47,5 +48,6 @@ const iso: Common = {
   getEnv: (_name) => undefined,
   getCallerLocation: () => undefined,
   newAsyncLocalStorage: <T>() => new DefaultAsyncLocalStorage<T>(),
+  processOn: (_0, _1) => {},
 };
 export default iso;

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -493,6 +493,15 @@ class LogThread {
   private active_flush: Promise<string[]> = Promise.resolve([]);
   private active_flush_resolved = true;
 
+  constructor() {
+    // Note that this will not run for explicit termination events, such as
+    // calls to `process.exit()` or uncaught exceptions. Thus it is a
+    // "best-effort" flush.
+    iso.processOn("beforeExit", async () => {
+      await this.flush();
+    });
+  }
+
   log(items: LogEvent[]) {
     this.items.push(...items);
 

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -51,7 +51,7 @@ export interface Span {
   /**
    * Create a new span. This is useful if you want to log more detailed trace information beyond the scope of a single log event. Data logged over several calls to `Span.log` will be merged into one logical row.
    *
-   * We recommend running spans within a callback (using `startSpanWithinCallback`) to automatically mark them as current and ensure they are terminated. If you wish to start a span outside a callback, be sure to terminate it with `span.end()`.
+   * We recommend running spans within a callback (using `traced`) to automatically mark them as current and ensure they are terminated. If you wish to start a span outside a callback, be sure to terminate it with `span.end()`.
    *
    * @param name The name of the span.
    * @param args.span_attributes Optional additional attributes to attach to the span, such as a type name.
@@ -913,7 +913,7 @@ export function currentSpan(): Span {
  *
  * Unless a name is explicitly provided, the name of the span will be the name of the calling function, or "root" if no meaningful name can be determined.
  *
- * We recommend running spans within a callback (using `startSpanWithinCallback`) to automatically mark them as current and ensure they are terminated. If you wish to start a span outside a callback, be sure to terminate it with `span.end()`.
+ * We recommend running spans within a callback (using `traced`) to automatically mark them as current and ensure they are terminated. If you wish to start a span outside a callback, be sure to terminate it with `span.end()`.
  *
  * See `Span.startSpan` for full details.
  */

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -219,7 +219,7 @@ class UnterminatedObjectsHandler {
 
   constructor() {
     this.unterminatedObjects = new Map();
-    process.on("exit", () => {
+    iso.processOn("exit", () => {
       this.warnUnterminated();
     });
   }

--- a/js/src/node.ts
+++ b/js/src/node.ts
@@ -10,4 +10,7 @@ export function configureNode() {
   iso.getEnv = (name) => process.env[name];
   iso.getCallerLocation = getCallerLocation;
   iso.newAsyncLocalStorage = <T>() => new AsyncLocalStorage<T>();
+  iso.processOn = (event: string, handler: (code: any) => void) => {
+    process.on(event, handler);
+  };
 }

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -693,7 +693,7 @@ def current_span() -> Span:
     return _state.current_span.get()
 
 
-def start_span(name, span_attributes={}, start_time=None, set_current=None, **event) -> Span:
+def start_span(name=None, span_attributes={}, start_time=None, set_current=None, **event) -> Span:
     """Toplevel function for starting a span. If there is a currently-active span, the new span is created as a subspan. Otherwise, if there is a currently-active experiment, the new span is created as a toplevel span. Otherwise, it returns a no-op span object.
 
     Unless a name is explicitly provided, the name of the span will be the name of the calling function, or "root" if no meaningful name can be determined.
@@ -703,7 +703,7 @@ def start_span(name, span_attributes={}, start_time=None, set_current=None, **ev
     See `Span.startSpan` for full details.
     """
 
-    name = name or get_caller_location().caller_functionname or "root"
+    name = name or get_caller_location()["caller_functionname"] or "root"
     kwargs = dict(name=name, span_attributes=span_attributes, start_time=start_time, set_current=set_current, **event)
     parent_span = current_span()
     if parent_span != NOOP_SPAN:


### PR DESCRIPTION
Python:
    - `braintrust.start_span` should have an optional name, as in the JS
      version.

Javascript:
    - Mirror the atexit flushing in the python SDK in JS.