### PR TITLE
Add metadata field to eval definition.

### DIFF
--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -44,7 +44,9 @@ export type EvalScorer<Input, Output> =
   | ((args: EvalScorerArgs<Input, Output>) => Score)
   | ((args: EvalScorerArgs<Input, Output>) => Promise<Score>);
 
-// Additional metadata for the eval definition, such as experiment name.
+/**
+ * Additional metadata for the eval definition, such as experiment name.
+ */
 export type EvalMetadata = {
   // Specify a name for the experiment holding the eval results.
   experimentName?: string;

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -50,7 +50,7 @@ export type EvalScorer<Input, Output> =
 export type EvalMetadata = {
   // Specify a name for the experiment holding the eval results.
   experimentName?: string;
-};
+}
 
 export function evalMetadataToInitOptions(
   metadata: EvalMetadata | undefined

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -44,7 +44,9 @@ export type EvalScorer<Input, Output> =
   | ((args: EvalScorerArgs<Input, Output>) => Score)
   | ((args: EvalScorerArgs<Input, Output>) => Promise<Score>);
 
+// Additional metadata for the eval definition, such as experiment name.
 export type EvalMetadata = {
+  // Specify a name for the experiment holding the eval results.
   experimentName?: string;
 };
 
@@ -78,8 +80,8 @@ function makeEvalName(projectName: string, metadata: EvalMetadata | undefined) {
 }
 
 export type EvaluatorDef<Input, Output> = {
-  evalName: string;
   projectName: string;
+  evalName: string;
 } & Evaluator<Input, Output>;
 
 export type EvaluatorFile = {

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -47,7 +47,7 @@ export type EvalScorer<Input, Output> =
 /**
  * Additional metadata for the eval definition, such as experiment name.
  */
-export type EvalMetadata = {
+export interface EvalMetadata {
   // Specify a name for the experiment holding the eval results.
   experimentName?: string;
 }

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -38,4 +38,4 @@ import { configureNode } from "./node";
 configureNode();
 
 export * from "./logger";
-export { Evaluator, EvalTask, Eval, EvalScorerArgs } from "./framework";
+export { Evaluator, EvalTask, Eval, EvalMetadata, EvalScorerArgs } from "./framework";

--- a/py/src/braintrust/cli/eval.py
+++ b/py/src/braintrust/cli/eval.py
@@ -97,7 +97,7 @@ def update_evaluators(evaluators, handles):
 async def run_evaluator_task(evaluator, position, opts: EvaluatorOpts):
     experiment = None
     if not opts.no_send_logs:
-        experiment = init_experiment(evaluator.name)
+        experiment = init_experiment(evaluator.name, evaluator.metadata)
 
     try:
         return await run_evaluator(

--- a/py/src/braintrust/cli/eval.py
+++ b/py/src/braintrust/cli/eval.py
@@ -81,23 +81,23 @@ def update_evaluators(evaluators, handles):
             print(f"Failed to import {handle.in_file}: {e}", file=sys.stderr)
             continue
 
-        for name, evaluator in module_evals.items():
+        for eval_name, evaluator in module_evals.items():
             if not isinstance(evaluator, Evaluator):
                 continue
 
-            if name in evaluators:
+            if eval_name in evaluators:
                 _logger.warning(
-                    f"Evaluator {name} already exists (in {evaluators[name].handle.in_file} and {handle.in_file}). Will skip {name} in {handle.in_file}."
+                    f"Evaluator {eval_name} already exists (in {evaluators[eval_name].handle.in_file} and {handle.in_file}). Will skip {eval_name} in {handle.in_file}."
                 )
                 continue
 
-            evaluators[name] = LoadedEvaluator(evaluator=evaluator, handle=handle)
+            evaluators[eval_name] = LoadedEvaluator(evaluator=evaluator, handle=handle)
 
 
 async def run_evaluator_task(evaluator, position, opts: EvaluatorOpts):
     experiment = None
     if not opts.no_send_logs:
-        experiment = init_experiment(evaluator.name, evaluator.metadata)
+        experiment = init_experiment(evaluator.project_name, evaluator.metadata)
 
     try:
         return await run_evaluator(
@@ -118,8 +118,8 @@ async def run_once(handles, evaluator_opts):
     ]
     eval_results = [await p for p in eval_promises]
 
-    for name, (results, summary) in zip(evaluators.keys(), eval_results):
-        report_evaluator_result(name, results, summary, evaluator_opts.verbose)
+    for eval_name, (results, summary) in zip(evaluators.keys(), eval_results):
+        report_evaluator_result(eval_name, results, summary, evaluator_opts.verbose)
 
 
 def check_match(path_input, include_patterns, exclude_patterns):

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -93,6 +93,9 @@ class EvalMetadata(SerializableDataClass):
     Additional metadata for the eval definition, such as experiment name.
     """
 
+    """
+    Specify a name for the experiment holding the eval results.
+    """
     experiment_name: Optional[str] = None
 
 
@@ -114,14 +117,14 @@ class Evaluator:
     """
 
     """
-    A unique name for the eval.
-    """
-    eval_name: str
-
-    """
     The name of the project the eval falls under.
     """
     project_name: str
+
+    """
+    A name that uniquely defines this type of experiment. You do not need to change it each time the experiment runs, but you should not have other experiments in your code with the same name.
+    """
+    eval_name: str
 
     """
     Returns an iterator over the evaluation dataset. Each element of the iterator should be an `EvalCase` or a dict

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -870,7 +870,7 @@ def _validate_and_sanitize_experiment_log_partial_args(event):
     if input is not None and inputs is not None:
         raise ValueError("Only one of input or inputs (deprecated) can be specified. Prefer input.")
     if inputs is not None:
-        return dict(**{k: v for k, v in event.items() if k != "inputs"}, input=inputs)
+        return dict(**{k: v for k, v in event.items() if k not in ["input", "inputs"]}, input=inputs)
     else:
         return {k: v for k, v in event.items()}
 


### PR DESCRIPTION
Sometimes it's useful to specify additional metadata for the experiment, such as the name of the experiment. We also add support for running multiple evals with the same project and different experiment names.