### PR TITLE
Fix deadlock in python logger.

### DIFF
--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -38,4 +38,10 @@ import { configureNode } from "./node";
 configureNode();
 
 export * from "./logger";
-export { Evaluator, EvalTask, Eval, EvalMetadata, EvalScorerArgs } from "./framework";
+export {
+  Evaluator,
+  EvalTask,
+  Eval,
+  EvalMetadata,
+  EvalScorerArgs,
+} from "./framework";


### PR DESCRIPTION
The condition variable approach was flawed because `condition_variable.wait()` will only respond to notify signals sent after the `wait` runs. So if the logger thread was in the middle of a flush while the producer thread fills up the queue and sends a notify signal, the consumer thread will miss the notify signal on its next `wait` call and we have a deadlock.

The solution is to replace the condition variable with a semaphore. So that the producer can increment the semaphore as a "persistent" way to trigger the consumer thread, which blocks on the semaphore being 0.

One possible concern is that the background thread can spin for a while on a filled-up semaphore after draining the queue (since we call `release` each time we log). I ran a quick benchmark for the cost to drain a semaphore:
```
In [1]: def drain_semaphore(sem):
   ...:     while sem.acquire(blocking=False):
   ...:         pass
   ...:

In [2]: import threading

In [3]: sem = threading.Semaphore(value=0)
...
In [9]: %timeit sem.release(100); drain_semaphore(sem)
43.2 µs ± 1.2 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [10]: %timeit sem.release(1000); drain_semaphore(sem)
420 µs ± 5.51 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [11]: %timeit sem.release(10000); drain_semaphore(sem)
4.19 ms ± 115 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

Seems to be about 400 ns per acquire call, and 420us for a completely filled-up queue, so not too worried.