### PR TITLE
Fix currentSpan() in no-op case

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -1111,7 +1111,7 @@ export function currentLogger(): Logger | undefined {
  * See `Span` for full details.
  */
 export function currentSpan(): Span {
-  return _state.currentSpan.getStore()!;
+  return _state.currentSpan.getStore() || noopSpan;
 }
 
 /**


### PR DESCRIPTION
If there's no span set, then return the no-op span.