### PR TITLE
Update pydoc-markdown requirement

### DIFF
--- a/py/setup.py
+++ b/py/setup.py
@@ -26,7 +26,7 @@ extras_require = {
         "pytest",
         "twine",
     ],
-    "doc": ["pydoc-markdown[novella]"],
+    "doc": ["pydoc-markdown"],
 }
 
 extras_require["all"] = sorted({package for packages in extras_require.values() for package in packages})


### PR DESCRIPTION
To fix the pip warning

```
WARNING: pydoc-markdown 4.8.2 does not provide the extra 'novella'
```

It doesn't look like we use novella anyways.