### PR TITLE
Fix gitutil crash when repo is partially downloaded.

### DIFF
--- a/py/src/braintrust/gitutil.py
+++ b/py/src/braintrust/gitutil.py
@@ -98,9 +98,15 @@ def get_past_n_ancestors(n=10, remote=None):
         ancestor = repo.commit(ancestor_output)
         for _ in range(n):
             yield ancestor.hexsha
-            if ancestor.parents:
-                ancestor = ancestor.parents[0]
-            else:
+            try:
+                if ancestor.parents:
+                    ancestor = ancestor.parents[0]
+                else:
+                    break
+            except ValueError:
+                # Since parents are fetched on-demand, this can happen if the
+                # downloaded repo does not have information for this commit's
+                # parent.
                 break
 
 


### PR DESCRIPTION
Was seeing errors like the following in CI tests.

```
  File "/home/runner/work/braintrust/braintrust/sdk/py/src/braintrust/gitutil.py", line 101, in get_past_n_ancestors
    if ancestor.parents:
       ^^^^^^^^^^^^^^^^
  File "/home/runner/work/braintrust/braintrust/venv/lib/python3.11/site-packages/gitdb/util.py", line 253, in __getattr__
    self._set_cache_(attr)
  File "/home/runner/work/braintrust/braintrust/venv/lib/python3.11/site-packages/git/objects/commit.py", line 215, in _set_cache_
    _binsha, _typename, self.size, stream = self.repo.odb.stream(self.binsha)
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/braintrust/braintrust/venv/lib/python3.11/site-packages/git/db.py", line 45, in stream
    hexsha, typename, size, stream = self._git.stream_object_data(bin_to_hex(binsha))
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/braintrust/braintrust/venv/lib/python3.11/site-packages/git/cmd.py", line 1402, in stream_object_data
    hexsha, typename, size = self.__get_object_header(cmd, ref)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/braintrust/braintrust/venv/lib/python3.11/site-packages/git/cmd.py", line 1371, in __get_object_header
    return self._parse_object_header(cmd.stdout.readline())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/braintrust/braintrust/venv/lib/python3.11/site-packages/git/cmd.py", line 1332, in _parse_object_header
    raise ValueError("SHA %s could not be resolved, git returned: %r" % (tokens[0], header_line.strip()))
ValueError: SHA b'009de0f8dca79db60d8f9c166b317e40297a6ac1' could not be resolved, git returned: b'009de0f8dca79db60d8f9c166b317e40297a6ac1 missing'
```