### PR TITLE
A couple testing-related improvements

### DIFF
--- a/js/src/cli.ts
+++ b/js/src/cli.ts
@@ -218,6 +218,7 @@ interface EvaluatorOpts {
   orgName?: string;
   apiUrl?: string;
   noSendLogs: boolean;
+  terminateOnFailure: boolean;
   watch: boolean;
   filters: Filter[];
   progressReporter: ProgressReporter;
@@ -230,7 +231,9 @@ function updateEvaluators(
 ) {
   for (const result of buildResults) {
     if (result.type === "failure") {
-      if (opts.verbose) {
+      if (opts.terminateOnFailure) {
+        throw result.error;
+      } else if (opts.verbose) {
         console.warn(`Failed to compile ${result.sourceFile}`);
         console.warn(result.error);
       } else {
@@ -351,6 +354,7 @@ interface RunArgs {
   tsconfig?: string;
   no_send_logs: boolean;
   no_progress_bars: boolean;
+  terminate_on_failure: boolean;
 }
 
 function checkMatch(
@@ -512,6 +516,7 @@ async function run(args: RunArgs) {
     orgName: args.org_name,
     apiUrl: args.api_url,
     noSendLogs: !!args.no_send_logs,
+    terminateOnFailure: !!args.terminate_on_failure,
     watch: !!args.watch,
     progressReporter: args.no_progress_bars
       ? new SimpleProgressReporter()
@@ -589,6 +594,10 @@ async function main() {
   parser_run.add_argument("--no-progress-bars", {
     action: "store_true",
     help: "Do not show progress bars when processing evaluators.",
+  });
+  parser_run.add_argument("--terminate-on-failure", {
+    action: "store_true",
+    help: "If provided, terminates on a failing eval, instead of the default (moving onto the next one).",
   });
   parser_run.add_argument("files", {
     nargs: "*",

--- a/py/src/braintrust/cli/__main__.py
+++ b/py/src/braintrust/cli/__main__.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import os
 import sys
 import textwrap
 
@@ -8,6 +9,11 @@ from . import eval, install
 
 def main(args=None):
     """The main routine."""
+
+    # Add the current working directory to sys.path, similar to python's
+    # unittesting frameworks.
+    sys.path.insert(0, os.getcwd())
+
     if args is None:
         args = sys.argv[1:]
 


### PR DESCRIPTION
- The `braintrust eval` python command can emulate the `python -m unittest` command by adding the directory python was invoked in to `sys.path`. This lets eval files that are run through the CLI to import other paths in the project.

- Add a `--terminate-on-failure` option to both PY and JS eval commands, which terminates the eval runner upon any eval file that itself crashes. This lets us properly propagate crashes out of the eval runner, which we can pick up in our own unit tests.