### PR TITLE
Support metric summaries

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -1529,6 +1529,7 @@ export class Experiment {
     const experimentUrl = `${projectUrl}/${encodeURIComponent(this.name)}`;
 
     let scores: Record<string, ScoreSummary> | undefined = undefined;
+    let metrics: Record<string, MetricSummary> | undefined = undefined;
     let comparisonExperimentName = undefined;
     if (summarizeScores) {
       if (comparisonExperimentId === undefined) {
@@ -1544,14 +1545,17 @@ export class Experiment {
       }
 
       if (comparisonExperimentId !== undefined) {
-        scores = await _state.logConn().get_json(
-          "/experiment-comparison",
+        const results = await _state.logConn().get_json(
+          "/experiment-comparison2",
           {
             experiment_id: this.id,
             base_experiment_id: comparisonExperimentId,
           },
           3
         );
+
+        scores = results["scores"];
+        metrics = results["metrics"];
       }
     }
 
@@ -1562,6 +1566,7 @@ export class Experiment {
       experimentUrl: experimentUrl,
       comparisonExperimentName: comparisonExperimentName,
       scores,
+      metrics,
     };
   }
 
@@ -2056,6 +2061,24 @@ export interface ScoreSummary {
 }
 
 /**
+ * Summary of a metric's performance.
+ * @property name Name of the metric.
+ * @property metric Average metric across all examples.
+ * @property unit Unit label for the metric.
+ * @property diff Difference in metric between the current and reference experiment.
+ * @property improvements Number of improvements in the metric.
+ * @property regressions Number of regressions in the metric.
+ */
+export interface MetricSummary {
+  name: string;
+  metric: number;
+  unit: string;
+  diff: number;
+  improvements: number;
+  regressions: number;
+}
+
+/**
  * Summary of an experiment's scores and metadata.
  * @property projectName Name of the project that the experiment belongs to.
  * @property experimentName Name of the experiment.
@@ -2071,6 +2094,7 @@ export interface ExperimentSummary {
   experimentUrl: string;
   comparisonExperimentName: string | undefined;
   scores: Record<string, ScoreSummary> | undefined;
+  metrics: Record<string, MetricSummary> | undefined;
 }
 
 /**

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -1704,17 +1704,17 @@ class ScoreSummary(SerializableDataClass):
 class MetricSummary(SerializableDataClass):
     """Summary of a metric's performance."""
 
-    """Name of the score."""
+    """Name of the metric."""
     name: str
-    """Average score across all examples."""
+    """Average metric across all examples."""
     metric: float
     """Unit label for the metric."""
     unit: str
-    """Difference in score between the current and reference experiment."""
+    """Difference in metric between the current and reference experiment."""
     diff: float
-    """Number of improvements in the score."""
+    """Number of improvements in the metric."""
     improvements: int
-    """Number of regressions in the score."""
+    """Number of regressions in the metric."""
     regressions: int
 
     # Used to help with formatting


### PR DESCRIPTION
Enable metric summaries (like duration) from the new `experiment-comparison2` endpoint.