### PR TITLE
Still capture git metadata, even if dirty

### DIFF
--- a/js/src/gitutil.ts
+++ b/js/src/gitutil.ts
@@ -141,26 +141,22 @@ export async function getRepoStatus() {
 
   const dirty = (await git.diffSummary()).files.length > 0;
 
-  if (!dirty) {
-    commit = await attempt(async () => await git.revparse(["HEAD"]));
-    commit_message = await attempt(async () =>
-      (await git.raw(["log", "-1", "--pretty=%B"])).trim()
-    );
-    commit_time = await attempt(async () =>
-      (await git.raw(["log", "-1", "--pretty=%cI"])).trim()
-    );
-    author_name = await attempt(async () =>
-      (await git.raw(["log", "-1", "--pretty=%aN"])).trim()
-    );
-    author_email = await attempt(async () =>
-      (await git.raw(["log", "-1", "--pretty=%aE"])).trim()
-    );
-    tag = await attempt(async () =>
-      (
-        await git.raw(["describe", "--tags", "--exact-match", "--always"])
-      ).trim()
-    );
-  }
+  commit = await attempt(async () => await git.revparse(["HEAD"]));
+  commit_message = await attempt(async () =>
+    (await git.raw(["log", "-1", "--pretty=%B"])).trim()
+  );
+  commit_time = await attempt(async () =>
+    (await git.raw(["log", "-1", "--pretty=%cI"])).trim()
+  );
+  author_name = await attempt(async () =>
+    (await git.raw(["log", "-1", "--pretty=%aN"])).trim()
+  );
+  author_email = await attempt(async () =>
+    (await git.raw(["log", "-1", "--pretty=%aE"])).trim()
+  );
+  tag = await attempt(async () =>
+    (await git.raw(["describe", "--tags", "--exact-match", "--always"])).trim()
+  );
 
   branch = await attempt(async () =>
     (await git.raw(["rev-parse", "--abbrev-ref", "HEAD"])).trim()

--- a/py/src/braintrust/gitutil.py
+++ b/py/src/braintrust/gitutil.py
@@ -135,13 +135,12 @@ def get_repo_status():
 
         dirty = repo.is_dirty()
 
-        if not dirty:
-            commit = attempt(lambda: repo.head.commit.hexsha).strip()
-            commit_message = attempt(lambda: repo.head.commit.message).strip()
-            commit_time = attempt(lambda: repo.head.commit.committed_datetime.isoformat())
-            author_name = attempt(lambda: repo.head.commit.author.name).strip()
-            author_email = attempt(lambda: repo.head.commit.author.email).strip()
-            tag = attempt(lambda: repo.git.describe("--tags", "--exact-match", "--always"))
+        commit = attempt(lambda: repo.head.commit.hexsha).strip()
+        commit_message = attempt(lambda: repo.head.commit.message).strip()
+        commit_time = attempt(lambda: repo.head.commit.committed_datetime.isoformat())
+        author_name = attempt(lambda: repo.head.commit.author.name).strip()
+        author_email = attempt(lambda: repo.head.commit.author.email).strip()
+        tag = attempt(lambda: repo.git.describe("--tags", "--exact-match", "--always"))
 
         branch = attempt(lambda: repo.active_branch.name)
 


### PR DESCRIPTION
I'm working on a few experiment metadata related changes, and want to improve the UX when you're running in a dirty repo to still capture the git metadata.