### PR TITLE
Fix OpenAI wrapping in edge environments

### DIFF
--- a/js/src/browser-config.ts
+++ b/js/src/browser-config.ts
@@ -1,0 +1,26 @@
+import iso from "./isomorph";
+import { _internalSetInitialState } from "./logger";
+
+// This is copied from next.js. It seems they define AsyncLocalStorage in the edge
+// environment, even though it's not defined in the browser.
+import type { AsyncLocalStorage as NodeAsyncLocalStorage } from "async_hooks";
+
+declare global {
+  var AsyncLocalStorage: typeof NodeAsyncLocalStorage;
+}
+// End copied code
+
+let browserConfigured = false;
+export function configureBrowser() {
+  if (browserConfigured) {
+    return;
+  }
+  try {
+    iso.newAsyncLocalStorage = <T>() => new AsyncLocalStorage<T>();
+  } catch {
+    // Ignore
+  }
+
+  _internalSetInitialState();
+  browserConfigured = true;
+}

--- a/js/src/browser.ts
+++ b/js/src/browser.ts
@@ -1,5 +1,6 @@
-import { _internalSetInitialState } from "./logger";
+import { configureBrowser } from "./browser-config";
 
-_internalSetInitialState();
+configureBrowser();
 
 export * from "./logger";
+export * from "./oai";

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -1147,6 +1147,13 @@ export function startSpan(args?: StartSpanOptionalNameArgs): Span {
   const name =
     (nameOpt ?? iso.getCallerLocation()?.caller_functionname) || "root";
   const parentSpan = currentSpan();
+
+  if (!parentSpan) {
+    throw new Error(
+      "Cannot call startSpan() from outside a trace. Please wrap this code in a traced() callback."
+    );
+  }
+
   if (!Object.is(parentSpan, noopSpan)) {
     return parentSpan.startSpan(name, argsRest);
   }

--- a/js/src/oai.ts
+++ b/js/src/oai.ts
@@ -1,4 +1,4 @@
-import { currentSpan, Span, startSpan } from "./logger";
+import { Span, startSpan } from "./logger";
 import { getCurrentUnixTimestamp } from "./util";
 
 interface ChatLike {


### PR DESCRIPTION
There were two issues here:

* We weren't exporting `oai.ts` from the `browser.ts` entrypoint, which next.js's edge runtime uses
* Next.js seems to stub / support `AsyncLocalStorage` in edge environments, even though it's not supported in the browser. I copied a small snippet of code that adds it to global scope and attempt to initialize it, which fixes it in edge environments.