### PR TITLE
Issue a warning, not an error, if an invalid base experiment is specified

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -1398,9 +1398,25 @@ async function _initExperiment(
     args["public"] = isPublic;
   }
 
-  const response = await _state
-    .apiConn()
-    .post_json("api/experiment/register", args);
+  let response = null;
+  while (true) {
+    try {
+      response = await _state
+        .apiConn()
+        .post_json("api/experiment/register", args);
+      break;
+    } catch (e: any) {
+      if (
+        args["base_experiment"] &&
+        `${"data" in e && e.data}`.includes("base experiment")
+      ) {
+        console.warn(`Base experiment ${args["base_experiment"]} not found.`);
+        delete args["base_experiment"];
+      } else {
+        throw e;
+      }
+    }
+  }
 
   const project = response.project;
   const experiment = response.experiment;


### PR DESCRIPTION
It's useful to be able to specify base experiments (by name) before they exist, e.g. in a CI system where you know what they'll be called but they may run out of order. This changes the SDK to mark them as a warning (and retry registration) if the base experiment does not exist.