### PR TITLE
Show --verbose warning at the end of the error list

### DIFF
--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -360,13 +360,14 @@ export function reportEvaluatorResult(
           "error",
           failingResults.length,
           true
-        )}${
-          !verbose ? " (add --verbose to see the full error)" : ""
-        }. This evaluation ("${evaluatorName}") will not be fully logged.`
+        )}. This evaluation ("${evaluatorName}") will not be fully logged.`
       )
     );
     for (const result of failingResults) {
       logError(result.error, verbose);
+    }
+    if (!verbose) {
+      console.warn(warning("Add --verbose to see full stack traces."));
     }
   } else if (summary) {
     console.log(summary);

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -190,6 +190,8 @@ def report_evaluator_result(eval_name, results, summary, verbose):
                 result.exc_info if verbose else traceback.format_exception_only(type(result.error), result.error)
             ).rstrip()
             print(f"{bcolors.FAIL}{info}{bcolors.ENDC}")
+
+        print(f"{bcolors.FAIL}Add --verbose to see full stack traces.{bcolors.ENDC}")
     if summary:
         print(f"{summary}")
     else:


### PR DESCRIPTION
Users were reporting that the `--verbose` flag is lost if it's at the beginning of the list of errors. This change simply prints the clarification at the end (and adds it to python)