### PR TITLE
Small fixes

### DIFF
--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -115,7 +115,7 @@ export async function Eval<Input, Output, Expected>(
 
   const progressReporter = new BarProgressReporter();
   try {
-    const { metadata } = _evals[evalName];
+    const { metadata } = evaluator;
     return await withExperiment(
       name,
       async (experiment) => {

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -13,21 +13,30 @@
  * your Braintrust API key):
  *
  * ```javascript
- * import * as braintrust from "braintrust";
+ * import { Eval } from "braintrust";
  *
- * const experiment = await braintrust.init("NodeTest", {apiKey: "YOUR_API_KEY"});
- * experiment.log({
- *   inputs: {test: 1},
- *   output: "foo",
- *   expected: "bar",
- *   scores: {
- *     n: 0.5,
+ * function isEqual({ output, expected }: { output: string; expected?: string }) {
+ *   return { name: "is_equal", score: output === expected ? 1 : 0 };
+ * }
+ *
+ * Eval("Say Hi Bot", {
+ *   data: () => {
+ *     return [
+ *       {
+ *         input: "Foo",
+ *         expected: "Hi Foo",
+ *       },
+ *       {
+ *         input: "Bar",
+ *         expected: "Hello Bar",
+ *       },
+ *     ]; // Replace with your eval dataset
  *   },
- *   metadata: {
- *     id: 1,
+ *   task: (input: string) => {
+ *     return "Hi " + input; // Replace with your LLM call
  *   },
+ *   scores: [isEqual],
  * });
- * console.log(await experiment.summarize());
  * ```
  *
  * @module braintrust

--- a/py/src/braintrust/__init__.py
+++ b/py/src/braintrust/__init__.py
@@ -14,21 +14,26 @@ Then, run a simple experiment with the following code (replace `YOUR_API_KEY` wi
 your Braintrust API key):
 
 ```python
-import braintrust
+from braintrust import Eval
 
-experiment = braintrust.init(project="PyTest", api_key="YOUR_API_KEY")
-experiment.log(
-    inputs={"test": 1},
-    output="foo",
-    expected="bar",
-    scores={
-        "n": 0.5,
-    },
-    metadata={
-        "id": 1,
-    },
+def is_equal(expected, output):
+    return expected == output
+ 
+Eval(
+  "Say Hi Bot",
+  data=lambda: [
+      {
+          "input": "Foo",
+          "expected": "Hi Foo",
+      },
+      {
+          "input": "Bar",
+          "expected": "Hello Bar",
+      },
+  ],  # Replace with your eval dataset
+  task=lambda input: "Hi " + input,  # Replace with your LLM call
+  scores=[is_equal],
 )
-print(experiment.summarize())
 ```
 
 ### API Reference


### PR DESCRIPTION
* Change built-in examples to use Eval framework
* Use `evaluator` instead of `_evals[evalName]` to access metadata. The latter is not set if you're running Evals directly in a script.