### PR TITLE
Fix type signatures for scorers in eval framework.

### DIFF
--- a/core/js/src/score.ts
+++ b/core/js/src/score.ts
@@ -10,6 +10,6 @@ export type ScorerArgs<Output, Extra> = {
   expected?: Output;
 } & Extra;
 
-export type Scorer<Output, Extra> =
-  | ((args: ScorerArgs<Output, Extra>) => Promise<Score>)
-  | ((args: ScorerArgs<Output, Extra>) => Score);
+export type Scorer<Output, Extra> = (
+  args: ScorerArgs<Output, Extra>
+) => Score | Promise<Score>;

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -43,9 +43,9 @@ export type EvalScorerArgs<Input, Output, Expected> = EvalCase<
   output: Output;
 };
 
-export type EvalScorer<Input, Output, Expected> =
-  | ((args: EvalScorerArgs<Input, Output, Expected>) => Score)
-  | ((args: EvalScorerArgs<Input, Output, Expected>) => Promise<Score>);
+export type EvalScorer<Input, Output, Expected> = (
+  args: EvalScorerArgs<Input, Output, Expected>
+) => Score | Promise<Score>;
 
 /**
  * Additional metadata for the eval definition, such as experiment name.


### PR DESCRIPTION
Fixes BRA-692.

Tested locally by verifying that the compiler doesn't complain when I try to create an invocation of the scorer with additional arguments, e.g. `(args) => Factuality({...args, model: "gpt-4"})`.