### PR TITLE
Check if AsyncLocalStorage has enterWith function, to make Deno happy

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -169,7 +169,9 @@ class BraintrustState {
     this.currentExperiment = iso.newAsyncLocalStorage();
     this.currentLogger = iso.newAsyncLocalStorage();
     this.currentSpan = iso.newAsyncLocalStorage();
-    this.currentSpan.enterWith(noopSpan);
+    if (this.currentSpan.enterWith) {
+        this.currentSpan.enterWith(noopSpan);
+    }
 
     this.apiUrl = null;
     this.loginToken = null;

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -1136,7 +1136,7 @@ export function currentLogger(): Logger | undefined {
  * See `Span` for full details.
  */
 export function currentSpan(): Span {
-  return _state.currentSpan.getStore()!;
+  return _state.currentSpan.getStore() ?? noopSpan;
 }
 
 /**


### PR DESCRIPTION
Deno doesn't support the `enterWith` function in `AsyncLocalStorage`:

- https://github.com/denoland/deno/issues/18127

The function is still marked experimental.

- https://nodejs.org/api/async_context.html#asynclocalstorageenterwithstore

This PR checks the `enterWith` function exists before calling it. 