### PR TITLE
Add support in wrapOpenAI for the beta.chat.completions.stream API

### DIFF
--- a/js/src/oai.ts
+++ b/js/src/oai.ts
@@ -1,11 +1,19 @@
 import { Span, startSpan } from "./logger";
 import { getCurrentUnixTimestamp } from "./util";
 
+interface BetaLike {
+  chat: {
+    completions: {
+      stream: any;
+    };
+  };
+}
 interface ChatLike {
   completions: any;
 }
 interface OpenAILike {
   chat: ChatLike;
+  beta?: BetaLike;
 }
 
 /**
@@ -44,10 +52,42 @@ export function wrapOpenAIv4<T extends OpenAILike>(openai: T): T {
       return Reflect.get(target, name, receiver);
     },
   });
+
+  let betaProxy: OpenAILike;
+  if (openai.beta?.chat?.completions?.stream) {
+    let betaChatCompletionProxy = new Proxy(openai?.beta?.chat.completions, {
+      get(target, name, receiver) {
+        const baseVal = Reflect.get(target, name, receiver);
+        if (name === "stream") {
+          return wrapBetaChatCompletion(baseVal.bind(target));
+        }
+        return baseVal;
+      },
+    });
+    let betaChatProxy = new Proxy(openai.beta.chat, {
+      get(target, name, receiver) {
+        if (name === "completions") {
+          return betaChatCompletionProxy;
+        }
+        return Reflect.get(target, name, receiver);
+      },
+    });
+    betaProxy = new Proxy(openai.beta, {
+      get(target, name, receiver) {
+        if (name === "chat") {
+          return betaChatProxy;
+        }
+        return Reflect.get(target, name, receiver);
+      },
+    });
+  }
   let proxy = new Proxy(openai, {
     get(target, name, receiver) {
       if (name === "chat") {
         return chatProxy;
+      }
+      if (name === "beta" && betaProxy) {
+        return betaProxy;
       }
       return Reflect.get(target, name, receiver);
     },
@@ -70,6 +110,50 @@ interface NonStreamingChatResponse {
         completion_tokens: number;
       }
     | undefined;
+}
+
+function wrapBetaChatCompletion<
+  P extends ChatParams,
+  C extends StreamingChatResponse
+>(completion: (params: P) => Promise<C>): (params: P) => Promise<any> {
+  return async (params: P) => {
+    const { messages, ...rest } = params;
+    const span = startSpan({
+      name: "OpenAI Chat Completion",
+      event: {
+        input: messages,
+        metadata: {
+          ...rest,
+        },
+      },
+    });
+    const startTime = getCurrentUnixTimestamp();
+
+    const ret = (await completion(params)) as StreamingChatResponse;
+
+    let first = true;
+    ret.on("chunk", (_chunk: any) => {
+      if (first) {
+        const now = getCurrentUnixTimestamp();
+        span.log({
+          metrics: {
+            time_to_first_token: now - startTime,
+          },
+        });
+        first = false;
+      }
+    });
+    ret.on("chatCompletion", (completion: any) => {
+      span.log({
+        output: completion.choices[0],
+      });
+    });
+    ret.on("end", () => {
+      span.end();
+    });
+
+    return ret;
+  };
 }
 
 // TODO: Mock this up better


### PR DESCRIPTION
This seems to work, but probably needs more testing.

This change adds support for `wrapOpenAI` to also trace `openai.beta.chat.completions.stream` calls:
https://github.com/openai/openai-node?tab=readme-ov-file#streaming-responses-1