### PR TITLE
Simplify python tracing API

### DIFF
--- a/py/src/braintrust/cli/eval.py
+++ b/py/src/braintrust/cli/eval.py
@@ -110,7 +110,7 @@ async def run_evaluator_task(evaluator, position, opts: EvaluatorOpts):
         )
     finally:
         if experiment:
-            experiment.close()
+            experiment.flush()
 
 
 async def run_once(handles, evaluator_opts):

--- a/py/src/braintrust/cli/install/redshift.py
+++ b/py/src/braintrust/cli/install/redshift.py
@@ -180,7 +180,7 @@ def main(args):
     #    else:
     #        raise NotImplementedError("Only Serverless Redshift is currently supported")
 
-    login_kwargs = {"org_name": args.org_name, "disable_cache": True} if args.org_name else {}
+    login_kwargs = {"org_name": args.org_name} if args.org_name else {}
     login(**login_kwargs)
 
     resp = log_conn().get(

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -17,7 +17,7 @@ from braintrust_core.util import SerializableDataClass
 from tqdm.asyncio import tqdm as async_tqdm
 from tqdm.auto import tqdm as std_tqdm
 
-from .logger import NOOP_SPAN, Metadata, Span, current_span, start_span
+from .logger import NOOP_SPAN, Metadata, Span
 from .logger import init as _init_experiment
 from .resource_manager import ResourceManager
 
@@ -280,9 +280,12 @@ def Eval(
             loop = None
 
         async def run_to_completion():
-            with init_experiment(evaluator.project_name, evaluator.experiment_name, evaluator.metadata) as experiment:
+            experiment = init_experiment(evaluator.project_name, evaluator.experiment_name, evaluator.metadata)
+            try:
                 results, summary = await run_evaluator(experiment, evaluator, 0, [])
                 report_evaluator_result(evaluator.eval_name, results, summary, True)
+            finally:
+                experiment.flush()
 
         if loop:
             return loop.create_task(run_to_completion())
@@ -426,11 +429,11 @@ async def run_evaluator(experiment, evaluator: Evaluator, position: Optional[int
                     thread_pool.thread_pool(), run_f, args, kwargs, contextvars.copy_context()
                 )
 
-    async def await_or_run_scorer(scorer, scorer_idx, **kwargs):
+    async def await_or_run_scorer(root_span, scorer, scorer_idx, **kwargs):
         name = scorer._name() if hasattr(scorer, "_name") else scorer.__name__
         if name == "<lambda>":
             name = f"scorer_{scorer_idx}"
-        with start_span(name=name, input=dict(**kwargs)):
+        with root_span.start_span(name=name, input=dict(**kwargs)) as span:
             score = scorer.eval_async if isinstance(scorer, Scorer) else scorer
 
             scorer_args = kwargs
@@ -444,9 +447,9 @@ async def run_evaluator(experiment, evaluator: Evaluator, position: Optional[int
             if isinstance(result, Score):
                 result_rest = result.as_dict()
                 result_metadata = result_rest.pop("metadata", {})
-                current_span().log(output=result_rest, metadata=result_metadata)
+                span.log(output=result_rest, metadata=result_metadata)
             else:
-                current_span().log(output=result)
+                span.log(output=result)
             return result
 
     async def run_evaluator_task(datum):
@@ -472,11 +475,11 @@ async def run_evaluator(experiment, evaluator: Evaluator, position: Optional[int
                 if len(inspect.signature(evaluator.task).parameters) == 2:
                     task_args.append(hooks)
 
-                with current_span().start_span("task") as task_span:
-                    hooks.set_span(task_span)
+                with root_span.start_span("task") as span:
+                    hooks.set_span(span)
                     output = await await_or_run(evaluator.task, *task_args)
-                    task_span.log(input=task_args[0], output=output)
-                current_span().log(output=output)
+                    span.log(input=task_args[0], output=output)
+                root_span.log(output=output)
 
                 # First, resolve the scorers if they are classes
                 scorers = [
@@ -484,7 +487,7 @@ async def run_evaluator(experiment, evaluator: Evaluator, position: Optional[int
                     for scorer in evaluator.scores
                 ]
                 score_promises = [
-                    asyncio.create_task(await_or_run_scorer(score, idx, **datum.as_dict(), output=output))
+                    asyncio.create_task(await_or_run_scorer(root_span, score, idx, **datum.as_dict(), output=output))
                     for idx, score in enumerate(scorers)
                 ]
                 score_results = [await p for p in score_promises]
@@ -503,7 +506,7 @@ async def run_evaluator(experiment, evaluator: Evaluator, position: Optional[int
                     hooks.meta(scores=score_metadata)
 
                 # XXX: We could probably log these as they are being produced
-                current_span().log(metadata=metadata, scores=scores)
+                root_span.log(metadata=metadata, scores=scores)
             except Exception as e:
                 error = e
                 # Python3.10 has a different set of arguments to format_exception than earlier versions,

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -764,7 +764,7 @@ def traced(*span_args, **span_kwargs):
 
         @wraps(f)
         async def wrapper_async(*f_args, **f_kwargs):
-            with start_span(*span_args, **span_kwargs):
+            with start_span(*span_args, **span_kwargs) as span:
                 ret = await f(*f_args, **f_kwargs)
                 if trace_io:
                     _try_log_input_output(span, f_sig, f_args, f_kwargs, ret)

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -28,6 +28,7 @@ from braintrust_core.db_fields import (
 from braintrust_core.merge_row_batch import merge_row_batch
 from braintrust_core.util import (
     SerializableDataClass,
+    coalesce,
     merge_dicts,
 )
 from requests.adapters import HTTPAdapter
@@ -40,6 +41,7 @@ from .util import (
     GLOBAL_PROJECT,
     AugmentedHTTPError,
     encode_uri_component,
+    eprint,
     get_caller_location,
     response_raise_for_status,
 )
@@ -51,7 +53,7 @@ class Span(ABC):
     """
     A Span encapsulates logged data and metrics for a unit of work. This interface is shared by all span implementations.
 
-    We suggest using one of the various `startSpan` methods, instead of creating Spans directly. See `Span.startSpan` for full details.
+    We suggest using one of the various `start_span` methods, instead of creating Spans directly. See `Span.start_span` for full details.
     """
 
     @property
@@ -77,22 +79,22 @@ class Span(ABC):
         """
 
     @abstractmethod
-    def start_span(self, name, span_attributes={}, start_time=None, set_current=None, **event):
+    def start_span(self, name=None, span_attributes={}, start_time=None, set_current=None, **event):
         """Create a new span. This is useful if you want to log more detailed trace information beyond the scope of a single log event. Data logged over several calls to `Span.log` will be merged into one logical row.
 
-        We recommend running spans within context managers (`with start_span(...) as span`) to automatically mark them as current and ensure they are terminated. If you wish to start a span outside a callback, be sure to terminate it with `span.end()`.
+        We recommend running spans within context managers (`with start_span(...) as span`) to automatically mark them as current and ensure they are ended. Only spans run within a context manager will be marked current, so they can be accessed using `braintrust.current_span()`. If you wish to start a span outside a context manager, be sure to end it with `span.end()`.
 
-        :param name: The name of the span.
+        :param name: Optional name of the span. If not provided, a name will be inferred from the call stack.
         :param span_attributes: Optional additional attributes to attach to the span, such as a type name.
         :param start_time: Optional start time of the span, as a timestamp in seconds.
-        :param set_current: If true (the default), the span will be marked as the currently-active span for the duration of the context manager. Unless the span is bound to a context manager, it will not be marked as current. Equivalent to calling `with braintrust.with_current(span)`.
+        :param set_current: If true (the default), the span will be marked as the currently-active span for the duration of the context manager.
         :param **event: Data to be logged. See `Experiment.log` for full details.
         :returns: The newly-created `Span`
         """
 
     @abstractmethod
     def end(self, end_time=None) -> float:
-        """Terminate the span. Returns the end time logged to the row's metrics. After calling end, you may not invoke any further methods on the span object, except for the property accessors.
+        """Log an end time to the span (defaults to the current time). Returns the logged time.
 
         Will be invoked automatically if the span is bound to a context manager.
 
@@ -134,7 +136,7 @@ class _NoopSpan(Span):
     def log(self, **event):
         pass
 
-    def start_span(self, name, span_attributes={}, start_time=None, set_current=None, **event):
+    def start_span(self, name=None, span_attributes={}, start_time=None, set_current=None, **event):
         return self
 
     def end(self, end_time=None):
@@ -156,8 +158,8 @@ NOOP_SPAN = _NoopSpan()
 class BraintrustState:
     def __init__(self):
         self.id = str(uuid.uuid4())
-        self.current_experiment = contextvars.ContextVar("braintrust_current_experiment", default=None)
-        self.current_logger = contextvars.ContextVar("braintrust_current_logger", default=None)
+        self.current_experiment = None
+        self.current_logger = None
         self.current_span = contextvars.ContextVar("braintrust_current_span", default=NOOP_SPAN)
 
         self.api_url = None
@@ -197,37 +199,6 @@ class BraintrustState:
 
 _state = BraintrustState()
 _logger = logging.getLogger("braintrust")
-
-
-class _UnterminatedObjectsHandler:
-    """A utility to keep track of objects that should be cleaned up before program exit. At the end of the program, the _UnterminatedObjectsHandler will print out all un-terminated objects as a warning."""
-
-    def __init__(self):
-        self._unterminated_objects = ResourceManager({})
-        atexit.register(self._warn_unterminated)
-
-    def add_unterminated(self, obj, created_location=None):
-        with self._unterminated_objects.get() as unterminated_objects:
-            unterminated_objects[obj] = created_location
-
-    def remove_unterminated(self, obj):
-        with self._unterminated_objects.get() as unterminated_objects:
-            del unterminated_objects[obj]
-
-    def _warn_unterminated(self):
-        with self._unterminated_objects.get() as unterminated_objects:
-            if not unterminated_objects:
-                return
-            warning_message = "WARNING: Did not close the following braintrust objects. We recommend running `.close` on the listed objects, or binding them to a context manager so they are closed automatically:"
-            for obj, created_location in unterminated_objects.items():
-                msg = f"\n\tObject of type {type(obj)}"
-                if created_location:
-                    msg += f" created at {created_location}"
-                warning_message += msg
-            print(warning_message, file=sys.stderr)
-
-
-_unterminated_objects = _UnterminatedObjectsHandler()
 
 
 class HTTPConnection:
@@ -340,7 +311,7 @@ DEFAULT_BATCH_SIZE = 100
 NUM_RETRIES = 3
 
 
-class _LogThread:
+class _BackgroundLogger:
     def __init__(self, name=None):
         self.flush_lock = threading.RLock()
         self.start_thread_lock = threading.RLock()
@@ -440,11 +411,13 @@ class _LogThread:
                     break
 
                 try:
-                    post_promises.append(HTTP_REQUEST_THREAD_POOL.submit(_LogThread._submit_logs_request, items, conn))
+                    post_promises.append(
+                        HTTP_REQUEST_THREAD_POOL.submit(_BackgroundLogger._submit_logs_request, items, conn)
+                    )
                 except RuntimeError:
                     # If the thread pool has shut down, e.g. because the process is terminating, run the request the
                     # old fashioned way.
-                    _LogThread._submit_logs_request(items, conn)
+                    _BackgroundLogger._submit_logs_request(items, conn)
 
             concurrent.futures.wait(post_promises)
 
@@ -495,14 +468,10 @@ def init(
     api_url: Optional[str] = None,
     api_key: Optional[str] = None,
     org_name: Optional[str] = None,
-    disable_cache: bool = False,
-    set_current: Optional[bool] = None,
     metadata: Optional[Metadata] = None,
 ):
     """
     Log in, and then initialize a new experiment in a specified project. If the project does not exist, it will be created.
-
-    Remember to close your experiment when it is finished by calling `Experiment.close`. We recommend binding the experiment to a context manager (`with braintrust.init(...) as experiment`) to automatically mark it as current and ensure it is terminated.
 
     :param project: The name of the project to create the experiment in.
     :param experiment: The name of the experiment to create. If not specified, a name will be generated automatically.
@@ -517,13 +486,11 @@ def init(
     :param api_key: The API key to use. If the parameter is not specified, will try to use the `BRAINTRUST_API_KEY` environment variable. If no API
     key is specified, will prompt the user to login.
     :param org_name: (Optional) The name of a specific organization to connect to. This is useful if you belong to multiple.
-    :param disable_cache: Do not use cached login information.
-    :param set_current: If true (default), set the currently-active experiment to the newly-created one. Unless the experiment is bound to a context manager, it will not be marked as current. Equivalent to calling `with braintrust.with_current(experiment)`.
     :param metadata: (Optional) a dictionary with additional data about the test example, model outputs, or just about anything else that's relevant, that you can use to help find and analyze examples later. For example, you could log the `prompt`, example's `id`, or anything else that would be useful to slice/dice later. The values in `metadata` can be any JSON-serializable type, but its keys must be strings.
     :returns: The experiment object.
     """
-    login(org_name=org_name, disable_cache=disable_cache, api_key=api_key, api_url=api_url)
-    return Experiment(
+    login(org_name=org_name, api_key=api_key, api_url=api_url)
+    ret = Experiment(
         project_name=project,
         experiment_name=experiment,
         description=description,
@@ -531,9 +498,10 @@ def init(
         update=update,
         base_experiment=base_experiment,
         is_public=is_public,
-        set_current=set_current,
         metadata=metadata,
     )
+    _state.current_experiment = ret
+    return ret
 
 
 def init_dataset(
@@ -544,12 +512,9 @@ def init_dataset(
     api_url: str = None,
     api_key: str = None,
     org_name: str = None,
-    disable_cache: bool = False,
 ):
     """
     Create a new dataset in a specified project. If the project does not exist, it will be created.
-
-    Remember to close your dataset when it is finished by calling `Dataset.close`. We recommend wrapping the dataset within a context manager (`with braintrust.init_dataset(...) as dataset`) to ensure it is terminated.
 
     :param project: The name of the project to create the dataset in.
     :param name: The name of the dataset to create. If not specified, a name will be generated automatically.
@@ -559,10 +524,9 @@ def init_dataset(
     :param api_key: The API key to use. If the parameter is not specified, will try to use the `BRAINTRUST_API_KEY` environment variable. If no API
     key is specified, will prompt the user to login.
     :param org_name: (Optional) The name of a specific organization to connect to. This is useful if you belong to multiple.
-    :param disable_cache: Do not use cached login information.
     :returns: The dataset object.
     """
-    login(org_name=org_name, disable_cache=disable_cache, api_key=api_key, api_url=api_url)
+    login(org_name=org_name, api_key=api_key, api_url=api_url)
 
     return Dataset(
         project_name=project,
@@ -576,11 +540,9 @@ def init_logger(
     project: str = None,
     project_id: str = None,
     async_flush: bool = True,
-    set_current: bool = True,
     api_url: str = None,
     api_key: str = None,
     org_name: str = None,
-    disable_cache: bool = False,
 ):
     """
     Create a new logger in a specified project. If the project does not exist, it will be created.
@@ -588,30 +550,29 @@ def init_logger(
     :param project: The name of the project to log into. If unspecified, will default to the Global project.
     :param project_id: The id of the project to log into. This takes precedence over project if specified.
     :param async_flush: If true (the default), log events will be batched and sent asynchronously in a background thread. If false, log events will be sent synchronously. Set to false in serverless environments.
-    :param set_current: If true (default), set the currently-active logger to the newly-created one. Unless the logger is bound to a context manager, it will not be marked as current. Equivalent to calling `with braintrust.with_current(logger)`.
     :param api_url: The URL of the Braintrust API. Defaults to https://www.braintrustdata.com.
     :param api_key: The API key to use. If the parameter is not specified, will try to use the `BRAINTRUST_API_KEY` environment variable. If no API
     key is specified, will prompt the user to login.
     :param org_name: (Optional) The name of a specific organization to connect to. This is useful if you belong to multiple.
-    :param disable_cache: Do not use cached login information.
     :returns: The newly created Logger.
     """
 
     def lazy_login():
-        login(org_name=org_name, disable_cache=disable_cache, api_key=api_key, api_url=api_url)
+        login(org_name=org_name, api_key=api_key, api_url=api_url)
 
-    return Logger(
+    ret = Logger(
         lazy_login=lazy_login,
         project=Project(name=project, id=project_id),
         async_flush=async_flush,
-        set_current=set_current,
     )
+    _state.current_logger = ret
+    return ret
 
 
 login_lock = threading.RLock()
 
 
-def login(api_url=None, api_key=None, org_name=None, disable_cache=False, force_login=False):
+def login(api_url=None, api_key=None, org_name=None, force_login=False):
     """
     Log into Braintrust. This will prompt you for your API token, which you can find at
     https://www.braintrustdata.com/app/token. This method is called automatically by `init()`.
@@ -620,7 +581,6 @@ def login(api_url=None, api_key=None, org_name=None, disable_cache=False, force_
     :param api_key: The API key to use. If the parameter is not specified, will try to use the `BRAINTRUST_API_KEY` environment variable. If no API
     key is specified, will prompt the user to login.
     :param org_name: (Optional) The name of a specific organization to connect to. This is useful if you belong to multiple.
-    :param disable_cache: Do not use cached login information.
     :param force_login: Login again, even if you have already logged in (by default, this function will exit quickly if you have already logged in)
     """
 
@@ -693,13 +653,13 @@ def log(**event):
     :param **event: Data to be logged. See `Experiment.log` for full details.
     :returns: The `id` of the logged event.
     """
-
-    current_experiment = _state.current_experiment.get()
-
-    if not current_experiment:
+    eprint(
+        "braintrust.log is deprecated and will be removed in a future version of braintrust. Use `experiment.log` instead."
+    )
+    e = current_experiment()
+    if not e:
         raise Exception("Not initialized. Please call init() first")
-
-    return current_experiment.log(**event)
+    return e.log(**event)
 
 
 def summarize(summarize_scores=True, comparison_experiment_id=None):
@@ -710,31 +670,32 @@ def summarize(summarize_scores=True, comparison_experiment_id=None):
     :param comparison_experiment_id: The experiment to compare against. If None, the most recent experiment on the comparison_commit will be used.
     :returns: `ExperimentSummary`
     """
-    current_experiment = _state.current_experiment.get()
-
-    if not current_experiment:
+    eprint(
+        "braintrust.summarize is deprecated and will be removed in a future version of braintrust. Use `experiment.summarize` instead."
+    )
+    e = _state.current_experiment.get()
+    if not e:
         raise Exception("Not initialized. Please call init() first")
-
-    return current_experiment.summarize(
+    return e.summarize(
         summarize_scores=summarize_scores,
         comparison_experiment_id=comparison_experiment_id,
     )
 
 
 def current_experiment() -> Optional["Experiment"]:
-    """Returns the currently-active experiment (set by `with braintrust.init(...)` or `with braintrust.with_current(experiment)`). Returns undefined if no current experiment has been set."""
+    """Returns the currently-active experiment (set by `braintrust.init(...)`). Returns None if no current experiment has been set."""
 
-    return _state.current_experiment.get()
+    return _state.current_experiment
 
 
 def current_logger() -> Optional["Logger"]:
-    """Returns the currently-active logger (set by `with braintrust.init_logger(...)` or `with braintrust.with_current(logger)`). Returns undefined if no current experiment has been set."""
+    """Returns the currently-active logger (set by `braintrust.init_logger(...)`). Returns None if no current logger has been set."""
 
-    return _state.current_logger.get()
+    return _state.current_logger
 
 
 def current_span() -> Span:
-    """Return the currently-active span for logging (set by `with *.start_span` or `braintrust.with_current`). If there is no active span, returns a no-op span object, which supports the same interface as spans but does no logging.
+    """Return the currently-active span for logging (set by running a span under a context manager). If there is no active span, returns a no-op span object, which supports the same interface as spans but does no logging.
 
     See `Span` for full details.
     """
@@ -742,89 +703,72 @@ def current_span() -> Span:
     return _state.current_span.get()
 
 
-def start_span(name=None, span_attributes={}, start_time=None, set_current=None, **event) -> Span:
-    """Toplevel function for starting a span. It checks the following (in precedence order):
-    * Currently-active span
-    * Currently-active experiment
-    * Currently-active logger
+def get_span_parent_object() -> Union["Logger", "Experiment", Span]:
+    """Mainly for internal use. Return the parent object for starting a span in a global context."""
 
-    and creates a span in the first one that is active. If none of these are active, it returns a no-op span object.
-
-    Unless a name is explicitly provided, the name of the span will be the name of the calling function, or "root" if no meaningful name can be determined.
-
-    We recommend running spans bound to a context manager (`with start_span`) to automatically mark them as current and ensure they are terminated. If you wish to start a span outside a callback, be sure to terminate it with `span.end()`.
-
-    See `Span.startSpan` for full details.
-    """
-
-    name = name or get_caller_location()["caller_functionname"] or "root"
-    kwargs = dict(name=name, span_attributes=span_attributes, start_time=start_time, set_current=set_current, **event)
     parent_span = current_span()
     if parent_span != NOOP_SPAN:
-        return parent_span.start_span(**kwargs)
+        return parent_span
 
     experiment = current_experiment()
     if experiment:
-        return experiment.start_span(**kwargs)
+        return experiment
 
     logger = current_logger()
     if logger:
-        return logger.start_span(**kwargs)
+        return logger
 
     return NOOP_SPAN
 
 
-class _CurrentObjectWrapper:
-    """Context manager wrapper for marking an experiment as current."""
-
-    def __init__(self, object_cvar, object):
-        self.object_cvar = object_cvar
-        self.object = object
-
-    def __enter__(self):
-        self.context_token = self.object_cvar.set(self.object)
-
-    def __exit__(self, type, value, callback):
-        del type, value, callback
-
-        self.object_cvar.reset(self.context_token)
-
-
-def with_current(object: Union["Experiment", "Logger", "SpanImpl", _NoopSpan]):
-    """Set the given experiment or span as current within the bound context manager (`with braintrust.with_current(object)`) and any asynchronous operations created within the block. The current experiment can be accessed with `braintrust.current_experiment`, and the current span with `braintrust.current_span`.
-
-    :param object: The experiment or span to be marked as current.
-    """
-    if type(object) == Experiment:
-        return _CurrentObjectWrapper(_state.current_experiment, object)
-    elif type(object) == Logger:
-        return _CurrentObjectWrapper(_state.current_logger, object)
-    elif type(object) == SpanImpl or type(object) == _NoopSpan:
-        return _CurrentObjectWrapper(_state.current_span, object)
-    else:
-        raise RuntimeError(f"Invalid object of type {type(object)}")
+def _try_log_input_output(span, f_sig, f_args, f_kwargs, output):
+    bound_args = f_sig.bind(*f_args, **f_kwargs).arguments
+    try:
+        span.log(input=bound_args, output=output)
+    except Exception:
+        # Don't complain if the contents are not JSON-serializable.
+        pass
 
 
 def traced(*span_args, **span_kwargs):
-    """Decorator to trace the wrapped function as a span. Can either be applied bare (`@traced`) or by providing arguments (`@traced(*span_args, **span_kwargs)`), which will be forwarded to the created span. See `braintrust.start_span` for details on how the span is created, and `Span.start_span` for full details on the span arguments.
+    """Decorator to trace the wrapped function. Can either be applied bare (`@traced`) or by providing arguments (`@traced(*span_args, **span_kwargs)`), which will be forwarded to the created span. See `Span.start_span` for full details on the span arguments.
+
+    It checks the following (in precedence order):
+        * Currently-active span
+        * Currently-active experiment
+        * Currently-active logger
+
+    and creates a span in the first one that is active. If none of these are active, it returns a no-op span object.
+
+    The decorator will automatically log the input and output of the wrapped function to the corresponding fields of the created span. Pass the kwarg `notrace_io=True` to the decorator to prevent this.
 
     Unless a name is explicitly provided in `span_args` or `span_kwargs`, the name of the span will be the name of the decorated function.
     """
+
+    trace_io = not span_kwargs.pop("notrace_io", False)
 
     def decorator(span_args, span_kwargs, f):
         # We assume 'name' is the first positional argument in `start_span`.
         if len(span_args) == 0 and span_kwargs.get("name") is None:
             span_args += (f.__name__,)
 
+        f_sig = inspect.signature(f)
+
         @wraps(f)
         def wrapper_sync(*f_args, **f_kwargs):
-            with start_span(*span_args, **span_kwargs):
-                return f(*f_args, **f_kwargs)
+            with start_span(*span_args, **span_kwargs) as span:
+                ret = f(*f_args, **f_kwargs)
+                if trace_io:
+                    _try_log_input_output(span, f_sig, f_args, f_kwargs, ret)
+                return ret
 
         @wraps(f)
         async def wrapper_async(*f_args, **f_kwargs):
             with start_span(*span_args, **span_kwargs):
-                return await f(*f_args, **f_kwargs)
+                ret = await f(*f_args, **f_kwargs)
+                if trace_io:
+                    _try_log_input_output(span, f_sig, f_args, f_kwargs, ret)
+                return ret
 
         if inspect.iscoroutinefunction(f):
             return wrapper_async
@@ -837,6 +781,22 @@ def traced(*span_args, **span_kwargs):
         return decorator(span_args[1:], span_kwargs, span_args[0])
     else:
         return partial(decorator, span_args, span_kwargs)
+
+
+def start_span(name=None, span_attributes={}, start_time=None, set_current=None, **event) -> Span:
+    """Lower-level alternative to `@traced` for starting a span at the toplevel. It creates a span under the first active object (using the same precedence order as `@traced`) or returns a no-op span object.
+
+    We recommend running spans bound to a context manager (`with start_span`) to automatically mark them as current and ensure they are terminated. If you wish to start a span outside a context manager, be sure to terminate it with `span.end()`.
+
+    See `Span.start_span` for full details.
+    """
+
+    parent_object = get_span_parent_object()
+    if not isinstance(parent_object, Span):
+        name = coalesce(name, "root")
+    return parent_object.start_span(
+        name=name, span_attributes=span_attributes, start_time=start_time, set_current=set_current, **event
+    )
 
 
 def _check_org_info(org_info, org_name):
@@ -981,12 +941,8 @@ class Experiment(ModelWrapper):
         update: bool = False,
         base_experiment: str = None,
         is_public: bool = False,
-        set_current: bool = None,
         metadata: Optional[Metadata] = None,
     ):
-        self.finished = False
-        self.set_current = True if set_current is None else set_current
-
         args = {"project_name": project_name, "org_id": _state.org_id}
 
         if experiment_name is not None:
@@ -1031,10 +987,8 @@ class Experiment(ModelWrapper):
         self.project = ModelWrapper(response["project"])
         super().__init__(response["experiment"])
         self.dataset = dataset
-        self.logger = _LogThread(name=experiment_name)
+        self.bg_logger = _BackgroundLogger(name=experiment_name)
         self.last_start_time = time.time()
-
-        _unterminated_objects.add_unterminated(self, get_caller_location())
 
     def log(
         self,
@@ -1062,8 +1016,6 @@ class Experiment(ModelWrapper):
         :param inputs: (Deprecated) the same as `input` (will be removed in a future version).
         :returns: The `id` of the logged event.
         """
-        self._check_not_finished()
-
         event = _validate_and_sanitize_experiment_log_full_args(
             dict(
                 input=input,
@@ -1083,14 +1035,12 @@ class Experiment(ModelWrapper):
         return span.id
 
     def start_span(self, name="root", span_attributes={}, start_time=None, set_current=None, **event):
-        """Create a new toplevel span. The name parameter is optional and defaults to "root".
+        """Create a new toplevel span underneath the experiment. The name defaults to "root".
 
         See `Span.start_span` for full details
         """
-        self._check_not_finished()
-
         return SpanImpl(
-            bg_logger=self.logger,
+            bg_logger=self.bg_logger,
             name=name,
             span_attributes=span_attributes,
             start_time=start_time,
@@ -1107,11 +1057,9 @@ class Experiment(ModelWrapper):
         :param comparison_experiment_id: The experiment to compare against. If None, the most recent experiment on the origin's main branch will be used.
         :returns: `ExperimentSummary`
         """
-        self._check_not_finished()
-
         # Flush our events to the API, and to the data warehouse, to ensure that the link we print
         # includes the new experiment.
-        self.logger.flush()
+        self.bg_logger.flush()
 
         project_url = (
             f"{_state.api_url}/app/{encode_uri_component(_state.org_name)}/p/{encode_uri_component(self.project.name)}"
@@ -1165,36 +1113,23 @@ class Experiment(ModelWrapper):
         )
 
     def close(self):
-        """Finish the experiment and return its id. After calling close, you may not invoke any further methods on the experiment object.
+        """This function is deprecated. You can simply remove it from your code."""
 
-        Will be invoked automatically if the experiment is bound to a context manager.
-
-        :returns: The experiment id.
-        """
-        self._check_not_finished()
-
-        self.logger.flush()
-
-        self.finished = True
-        _unterminated_objects.remove_unterminated(self)
+        eprint(
+            "close is deprecated and will be removed in a future version of braintrust. It is now a no-op and can be removed"
+        )
         return self.id
 
-    def _check_not_finished(self):
-        if self.finished:
-            raise RuntimeError("Cannot invoke method on finished experiment")
+    def flush(self):
+        """Flush any pending rows to the server."""
+
+        self.bg_logger.flush()
 
     def __enter__(self):
-        if self.set_current:
-            self._context_token = _state.current_experiment.set(self)
         return self
 
     def __exit__(self, type, value, callback):
         del type, value, callback
-
-        if self.set_current:
-            _state.current_experiment.reset(self._context_token)
-
-        self.close()
 
 
 class SpanImpl(Span):
@@ -1203,12 +1138,10 @@ class SpanImpl(Span):
     We suggest using one of the various `start_span` methods, instead of creating Spans directly. See `Span.start_span` for full details.
     """
 
-    # root_experiment should only be specified for a root span. parent_span
-    # should only be specified for non-root spans.
     def __init__(
         self,
         bg_logger,
-        name,
+        name=None,
         span_attributes={},
         start_time=None,
         set_current=None,
@@ -1220,11 +1153,21 @@ class SpanImpl(Span):
         if sum(x is not None for x in [root_experiment, root_project, parent_span]) != 1:
             raise ValueError("Must specify exactly one of `root_experiment`, `root_project`, and `parent_span`")
 
-        self.finished = False
-        self.set_current = True if set_current is None else set_current
+        self.set_current = coalesce(set_current, True)
         self._logged_end_time = None
 
         self.bg_logger = bg_logger
+
+        caller_location = get_caller_location()
+        if name is None:
+            if caller_location:
+                filename = os.path.basename(caller_location.caller_filename)
+                name = ":".join(
+                    [caller_location.caller_functionname]
+                    + ([f"{filename}:{caller_location.caller_lineno}"] if filename else [])
+                )
+            else:
+                name = "subspan"
 
         # `internal_data` contains fields that are not part of the
         # "user-sanitized" set of fields which we want to log in just one of the
@@ -1266,15 +1209,13 @@ class SpanImpl(Span):
             self._object_info.update(id=id, span_id=span_id)
             self.internal_data.update(span_parents=[parent_span.span_id])
         else:
-            raise RuntimeError("Must provide either 'root_experiment', 'root_project', or 'parent_span'")
+            raise RuntimeError("Must provide parent info")
 
         # The first log is a replacement, but subsequent logs to the same span
         # object will be merges.
         self._is_merge = False
         self.log(**{k: v for k, v in event.items() if k != "id"})
         self._is_merge = True
-
-        _unterminated_objects.add_unterminated(self, caller_location)
 
     @property
     def id(self):
@@ -1289,8 +1230,6 @@ class SpanImpl(Span):
         return self._object_info["root_span_id"]
 
     def log(self, **event):
-        self._check_not_finished()
-
         sanitized = {
             k: v for k, v in _validate_and_sanitize_experiment_log_partial_args(event).items() if v is not None
         }
@@ -1309,9 +1248,7 @@ class SpanImpl(Span):
         self.internal_data = {}
         self.bg_logger.log(record)
 
-    def start_span(self, name, span_attributes={}, start_time=None, set_current=None, **event):
-        self._check_not_finished()
-
+    def start_span(self, name=None, span_attributes={}, start_time=None, set_current=None, **event):
         return SpanImpl(
             bg_logger=self.bg_logger,
             name=name,
@@ -1323,25 +1260,16 @@ class SpanImpl(Span):
         )
 
     def end(self, end_time=None):
-        self._check_not_finished()
-
         if not self._logged_end_time:
             end_time = end_time or time.time()
             self.internal_data = dict(metrics=dict(end=end_time))
         else:
             end_time = self._logged_end_time
         self.log()
-
-        self.finished = True
-        _unterminated_objects.remove_unterminated(self)
         return end_time
 
     def close(self, end_time=None):
         return self.end(end_time)
-
-    def _check_not_finished(self):
-        if self.finished:
-            raise RuntimeError("Cannot invoke method on finished span")
 
     def __enter__(self):
         if self.set_current:
@@ -1367,8 +1295,6 @@ class Dataset(ModelWrapper):
     """
 
     def __init__(self, project_name: str, name: str = None, description: str = None, version: "str | int" = None):
-        self.finished = False
-
         args = _populate_args(
             {"project_name": project_name, "org_id": _state.org_id},
             dataset_name=name,
@@ -1390,9 +1316,7 @@ class Dataset(ModelWrapper):
                 raise ValueError(f"version ({version}) must be a positive integer")
 
         super().__init__(response["dataset"])
-        self.logger = _LogThread(name=self.name)
-
-        _unterminated_objects.add_unterminated(self, get_caller_location())
+        self.bg_logger = _BackgroundLogger(name=self.name)
 
     def insert(self, input, output, metadata=None, id=None):
         """
@@ -1408,8 +1332,6 @@ class Dataset(ModelWrapper):
         :param id: (Optional) a unique identifier for the event. If you don't provide one, Braintrust will generate one for you.
         :returns: The `id` of the logged record.
         """
-        self._check_not_finished()
-
         if metadata:
             if not isinstance(metadata, dict):
                 raise ValueError("metadata must be a dictionary")
@@ -1431,7 +1353,7 @@ class Dataset(ModelWrapper):
 
         self._clear_cache()  # We may be able to optimize this
         self.new_records += 1
-        self.logger.log(args)
+        self.bg_logger.log(args)
         return args["id"]
 
     def delete(self, id):
@@ -1440,8 +1362,6 @@ class Dataset(ModelWrapper):
 
         :param id: The `id` of the record to delete.
         """
-        self._check_not_finished()
-
         args = _populate_args(
             {
                 "id": id,
@@ -1452,7 +1372,7 @@ class Dataset(ModelWrapper):
             },
         )
 
-        self.logger.log(args)
+        self.bg_logger.log(args)
         return args["id"]
 
     def summarize(self, summarize_data=True):
@@ -1462,11 +1382,9 @@ class Dataset(ModelWrapper):
         :param summarize_data: Whether to summarize the data. If False, only the metadata will be returned.
         :returns: `DatasetSummary`
         """
-        self._check_not_finished()
-
         # Flush our events to the API, and to the data warehouse, to ensure that the link we print
         # includes the new experiment.
-        self.logger.flush()
+        self.bg_logger.flush()
 
         project_url = (
             f"{_state.api_url}/app/{encode_uri_component(_state.org_name)}/p/{encode_uri_component(self.project.name)}"
@@ -1507,8 +1425,6 @@ class Dataset(ModelWrapper):
 
         :returns: An iterator over the records in the dataset.
         """
-        self._check_not_finished()
-
         for record in self.fetched_data:
             yield {
                 "id": record.get("id"),
@@ -1520,12 +1436,10 @@ class Dataset(ModelWrapper):
         self._clear_cache()
 
     def __iter__(self):
-        self._check_not_finished()
         return self.fetch()
 
     @property
     def fetched_data(self):
-        self._check_not_finished()
         if not self._fetched_data:
             resp = _state.log_conn().get(
                 "object/dataset", params={"id": self.id, "fmt": "json", "version": self._pinned_version}
@@ -1536,42 +1450,33 @@ class Dataset(ModelWrapper):
         return self._fetched_data
 
     def _clear_cache(self):
-        self._check_not_finished()
         self._fetched_data = None
 
     @property
     def version(self):
-        self._check_not_finished()
         if self._pinned_version is not None:
             return self._pinned_version
         else:
             return max([int(record.get(TRANSACTION_ID_FIELD, 0)) for record in self.fetched_data] or [0])
 
     def close(self):
-        """Terminate connection to the dataset and return its id. After calling close, you may not invoke any further methods on the dataset object.
+        """This function is deprecated. You can simply remove it from your code."""
 
-        Will be invoked automatically if the dataset is bound as a context manager.
-
-        :returns: The dataset id.
-        """
-        self._check_not_finished()
-
-        self.logger.flush()
-
-        self.finished = True
-        _unterminated_objects.remove_unterminated(self)
+        eprint(
+            "close is deprecated and will be removed in a future version of braintrust. It is now a no-op and can be removed"
+        )
         return self.id
 
-    def _check_not_finished(self):
-        if self.finished:
-            raise RuntimeError("Cannot invoke method on finished dataset")
+    def flush(self):
+        """Flush any pending rows to the server."""
+
+        self.bg_logger.flush()
 
     def __enter__(self):
         return self
 
     def __exit__(self, type, value, callback):
         del type, value, callback
-        self.close()
 
 
 class Project:
@@ -1611,15 +1516,14 @@ class Project:
 
 
 class Logger:
-    def __init__(self, lazy_login: Callable, project: Project, async_flush: bool = True, set_current: bool = None):
+    def __init__(self, lazy_login: Callable, project: Project, async_flush: bool = True):
         self._lazy_login = lazy_login
         self._logged_in = False
 
         self.project = project
         self.async_flush = async_flush
-        self.set_current = True if set_current is None else set_current
 
-        self.logger = _LogThread()
+        self.bg_logger = _BackgroundLogger()
         self.last_start_time = time.time()
 
     def log(
@@ -1658,7 +1562,7 @@ class Logger:
         self.last_start_time = span.end()
 
         if not self.async_flush:
-            self.logger.flush()
+            self.bg_logger.flush()
 
         return span.id
 
@@ -1669,13 +1573,13 @@ class Logger:
             self._logged_in = True
 
     def start_span(self, name="root", span_attributes={}, start_time=None, set_current=None, **event):
-        """Create a new toplevel span. The name parameter is optional and defaults to "root".
+        """Create a new toplevel span underneath the logger. The name parameter defaults to "root".
 
         See `Span.start_span` for full details
         """
         self._perform_lazy_login()
         return SpanImpl(
-            bg_logger=self.logger,
+            bg_logger=self.bg_logger,
             name=name,
             span_attributes=span_attributes,
             start_time=start_time,
@@ -1685,25 +1589,17 @@ class Logger:
         )
 
     def __enter__(self):
-        self._perform_lazy_login()
-        if self.set_current:
-            self._context_token = _state.current_logger.set(self)
         return self
 
     def __exit__(self, type, value, callback):
         del type, value, callback
-
-        if self.set_current:
-            _state.current_logger.reset(self._context_token)
-
-        self.logger.flush()
 
     def flush(self):
         """
         Flush any pending logs to the server.
         """
         self._perform_lazy_login()
-        self.logger.flush()
+        self.bg_logger.flush()
 
 
 @dataclasses.dataclass

--- a/py/src/braintrust/util.py
+++ b/py/src/braintrust/util.py
@@ -1,5 +1,6 @@
 import inspect
 import os.path
+import sys
 import urllib.parse
 
 from requests import HTTPError
@@ -43,3 +44,9 @@ def get_caller_location():
                 caller_lineno=caller.lineno,
             )
     return None
+
+
+# Taken from
+# https://stackoverflow.com/questions/5574702/how-do-i-print-to-stderr-in-python.
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)


### PR DESCRIPTION
Subset of https://github.com/braintrustdata/braintrust-sdk/pull/67 which addresses only the python part. This will let us work on the JS changes independently.

It is basically the python-changes up to https://github.com/braintrustdata/braintrust-sdk/pull/67/commits/8840d35937752f36150e5673827bffb2be70d930, with the comments addressed.