### PR TITLE
Undo infer `force_login`.

### DIFF
--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -546,6 +546,7 @@ def init_logger(
     api_url: str = None,
     api_key: str = None,
     org_name: str = None,
+    force_login: bool = False,
     set_current: bool = True,
 ):
     """
@@ -558,12 +559,13 @@ def init_logger(
     :param api_key: The API key to use. If the parameter is not specified, will try to use the `BRAINTRUST_API_KEY` environment variable. If no API
     key is specified, will prompt the user to login.
     :param org_name: (Optional) The name of a specific organization to connect to. This is useful if you belong to multiple.
+    :param force_login: Login again, even if you have already logged in (by default, the logger will not login if you are already logged in)
     :param set_current: If true (the default), set the global current-experiment to the newly-created one.
     :returns: The newly created Logger.
     """
 
     def lazy_login():
-        login(org_name=org_name, api_key=api_key, api_url=api_url)
+        login(org_name=org_name, api_key=api_key, api_url=api_url, force_login=force_login)
 
     ret = Logger(
         lazy_login=lazy_login,
@@ -602,15 +604,6 @@ def login(api_url=None, api_key=None, org_name=None, force_login=False):
 
         if org_name is None:
             org_name = os.environ.get("BRAINTRUST_ORG_NAME")
-
-        # If any provided login inputs disagree with our existing settings,
-        # force login.
-        if (
-            api_url != _state.api_url
-            or (api_key is not None and HTTPConnection.sanitize_token(api_key) != _state.login_token)
-            or (org_name is not None and org_name != _state.org_name)
-        ):
-            force_login = True
 
         if not force_login and _state.logged_in:
             # We have already logged in


### PR DESCRIPTION
We introduced logic in
https://github.com/braintrustdata/braintrust-sdk/pull/4 to infer `force_login=True` if the login params you provide are different from what we have currently logged in as.

But this logic ended up creating a bug in the eval framework, where if you login initially with custom params here
(https://github.com/braintrustdata/braintrust-sdk/blob/844d83b7df2de4b09dd03176391964fa25cae046/py/src/braintrust/cli/eval.py#L202), then we would try to login again whenever creating an experiment here (https://github.com/braintrustdata/braintrust-sdk/blob/844d83b7df2de4b09dd03176391964fa25cae046/py/src/braintrust/framework.py#L396), and the second login could trigger a `force_login` because it uses whatever is in the environment variables.

While there are other ways to work around this, we felt like just asking users to pass `force_login=True` explicitly to login if their params changed should suffice and is simple.