### PR TITLE
GitUtil: Add try-catch block when resolving Git repo

### DIFF
--- a/js/src/gitutil.ts
+++ b/js/src/gitutil.ts
@@ -18,10 +18,16 @@ export interface RepoStatus {
 }
 
 export async function currentRepo() {
-  const git = simpleGit();
-  if (await git.checkIsRepo()) {
-    return git;
-  } else {
+  try {
+    const git = simpleGit();
+    if (await git.checkIsRepo()) {
+      return git;
+    } else {
+      return null;
+    }
+  }
+  catch  (e) {
+    console.warn('Error occurred while checking if current directory is a git repo.', e);
     return null;
   }
 }

--- a/js/src/gitutil.ts
+++ b/js/src/gitutil.ts
@@ -27,7 +27,6 @@ export async function currentRepo() {
     }
   }
   catch  (e) {
-    console.warn('Error occurred while checking if current directory is a git repo.', e);
     return null;
   }
 }


### PR DESCRIPTION
**GitUtil: Add try-catch block when resolving Git repo**
* Added simple try-catch around `simpleGit()` initialization - If anything error'ed out, `null` will be returned.