### PR TITLE
Truncate large git diffs to max 64 KB

### DIFF
--- a/js/src/gitutil.ts
+++ b/js/src/gitutil.ts
@@ -146,6 +146,17 @@ async function attempt<T>(fn: () => Promise<T>): Promise<T | undefined> {
   }
 }
 
+function truncateToByteLimit(s: string, byteLimit: number = 65536): string {
+    const encoded = (new TextEncoder()).encode(s);
+    if (encoded.length <= byteLimit) {
+        return s;
+    }
+
+    const truncated = encoded.subarray(0, byteLimit);
+    // Decode back to string, automatically ignoring any incomplete character at the end
+    return (new TextDecoder()).decode(truncated);
+}
+
 export async function getRepoStatus() {
   const git = await currentRepo();
   if (git === null) {
@@ -185,7 +196,7 @@ export async function getRepoStatus() {
   );
 
   if (dirty) {
-    git_diff = await attempt(async () => await git.raw(["diff", "HEAD"]));
+    git_diff = await attempt(async () => truncateToByteLimit(await git.raw(["diff", "HEAD"])));
   }
 
   return {

--- a/py/src/braintrust/gitutil.py
+++ b/py/src/braintrust/gitutil.py
@@ -118,6 +118,13 @@ def attempt(op):
         return None
 
 
+def truncate_to_byte_limit(input_string, byte_limit=65536):
+    encoded = input_string.encode("utf-8")
+    if len(encoded) <= byte_limit:
+        return input_string
+    return encoded[:byte_limit].decode("utf-8", errors="ignore")
+
+
 def get_repo_status():
     with _gitlock:
         repo = _current_repo()
@@ -145,7 +152,7 @@ def get_repo_status():
         branch = attempt(lambda: repo.active_branch.name)
 
         if dirty:
-            git_diff = attempt(lambda: repo.git.diff("HEAD"))
+            git_diff = attempt(lambda: truncate_to_byte_limit(repo.git.diff("HEAD")))
 
         return RepoStatus(
             commit=commit,


### PR DESCRIPTION
We can revisit truncating big diffs for individual files in a smarter way later.

Fixes BRA-767