### PR TITLE
Only send git metadata that's configured as allowed

### DIFF
--- a/core/js/src/git_fields.ts
+++ b/core/js/src/git_fields.ts
@@ -1,0 +1,18 @@
+export interface RepoStatus {
+  commit?: string;
+  branch?: string;
+  tag?: string;
+  dirty?: boolean;
+  author_name?: string;
+  author_email?: string;
+  commit_message?: string;
+  commit_time?: string;
+  git_diff?: string;
+}
+
+export type GitFields = Array<keyof RepoStatus>;
+export type CollectMetadata = "all" | "none" | "some";
+export type GitMetadataSettings = {
+  collect: CollectMetadata;
+  fields: GitFields;
+};

--- a/core/js/src/git_fields.ts
+++ b/core/js/src/git_fields.ts
@@ -16,3 +16,23 @@ export type GitMetadataSettings = {
   collect: CollectMetadata;
   fields: GitFields;
 };
+
+export function mergeGitMetadataSettings(
+  s1: GitMetadataSettings,
+  s2: GitMetadataSettings
+): GitMetadataSettings {
+  if (s1.collect === "all") {
+    return s2;
+  } else if (s2.collect === "all") {
+    return s1;
+  } else if (s1.collect === "none") {
+    return s1;
+  } else if (s2.collect === "none") {
+    return s2;
+  }
+
+  // s1.collect === "some" && s2.collect === "some"
+  const fields = s1.fields.filter((f) => s2.fields.includes(f));
+  const collect = fields.length > 0 ? "some" : "none";
+  return { collect, fields };
+}

--- a/core/js/src/git_fields.ts
+++ b/core/js/src/git_fields.ts
@@ -14,7 +14,7 @@ export type GitFields = Array<keyof RepoStatus>;
 export type CollectMetadata = "all" | "none" | "some";
 export type GitMetadataSettings = {
   collect: CollectMetadata;
-  fields: GitFields;
+  fields?: GitFields;
 };
 
 export function mergeGitMetadataSettings(
@@ -32,7 +32,7 @@ export function mergeGitMetadataSettings(
   }
 
   // s1.collect === "some" && s2.collect === "some"
-  const fields = s1.fields.filter((f) => s2.fields.includes(f));
+  const fields = (s1.fields ?? []).filter((f) => (s2.fields ?? []).includes(f));
   const collect = fields.length > 0 ? "some" : "none";
   return { collect, fields };
 }

--- a/core/js/src/index.ts
+++ b/core/js/src/index.ts
@@ -3,3 +3,4 @@ export * from "./merge_row_batch";
 export * from "./score";
 export * from "./util";
 export * from "./span_types";
+export * from "./git_fields";

--- a/core/py/src/braintrust_core/__init__.py
+++ b/core/py/src/braintrust_core/__init__.py
@@ -1,2 +1,3 @@
+from .git_fields import *
 from .score import *
 from .util import *

--- a/core/py/src/braintrust_core/git_fields.py
+++ b/core/py/src/braintrust_core/git_fields.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass, field
+from typing import List, Literal, Optional
+
+from .util import SerializableDataClass
+
+
+@dataclass
+class RepoStatus(SerializableDataClass):
+    """Information about the current HEAD of the repo."""
+
+    commit: Optional[str]
+    branch: Optional[str]
+    tag: Optional[str]
+    dirty: Optional[bool]
+    author_name: Optional[str]
+    author_email: Optional[str]
+    commit_message: Optional[str]
+    commit_time: Optional[str]
+    git_diff: Optional[str]
+
+
+@dataclass
+class GitMetadataSettings(SerializableDataClass):
+    collect: Literal["all", "some", "none"] = "all"
+    fields: Optional[List[str]] = field(default_factory=list)

--- a/core/py/src/braintrust_core/git_fields.py
+++ b/core/py/src/braintrust_core/git_fields.py
@@ -23,3 +23,23 @@ class RepoStatus(SerializableDataClass):
 class GitMetadataSettings(SerializableDataClass):
     collect: Literal["all", "some", "none"] = "all"
     fields: Optional[List[str]] = field(default_factory=list)
+
+    @classmethod
+    def merge(cls, s1: "GitMetadataSettings", s2: "GitMetadataSettings") -> "GitMetadataSettings":
+        # If either is all, then return the other
+        # If either is none, then return that one
+        if s1.collect == "all":
+            return s2
+        elif s2.collect == "all":
+            return s1
+        elif s1.collect == "none":
+            return s1
+        elif s2.collect == "none":
+            return s2
+
+        assert s1.collect == "some" and s2.collect == "some"
+        # intersect the fields
+        ret = GitMetadataSettings(collect="some", fields=list(set(s1.fields).intersection(s2.fields)))
+        if not ret.fields:
+            ret.collect = "none"
+        return ret

--- a/core/py/src/braintrust_core/git_fields.py
+++ b/core/py/src/braintrust_core/git_fields.py
@@ -39,7 +39,7 @@ class GitMetadataSettings(SerializableDataClass):
 
         assert s1.collect == "some" and s2.collect == "some"
         # intersect the fields
-        ret = GitMetadataSettings(collect="some", fields=list(set(s1.fields).intersection(s2.fields)))
+        ret = GitMetadataSettings(collect="some", fields=list(set(s1.fields or []).intersection(s2.fields or [])))
         if not ret.fields:
             ret.collect = "none"
         return ret

--- a/js/src/gitutil.ts
+++ b/js/src/gitutil.ts
@@ -1,3 +1,4 @@
+import { GitMetadataSettings, RepoStatus } from "@braintrust/core";
 import { simpleGit } from "simple-git";
 
 const COMMON_BASE_BRANCHES = ["main", "master", "develop"];
@@ -5,25 +6,6 @@ const COMMON_BASE_BRANCHES = ["main", "master", "develop"];
 /**
  * Information about the current HEAD of the repo.
  */
-export interface RepoStatus {
-  commit?: string;
-  branch?: string;
-  tag?: string;
-  dirty?: boolean;
-  author_name?: string;
-  author_email?: string;
-  commit_message?: string;
-  commit_time?: string;
-  git_diff?: string;
-}
-
-type GitFields = Array<keyof RepoStatus>;
-type CollectMetadata = "all" | "none" | "some";
-export type GitMetadataSettings = {
-  collect: CollectMetadata;
-  fields: GitFields;
-};
-
 export async function currentRepo() {
   try {
     const git = simpleGit();
@@ -95,9 +77,8 @@ async function getBaseBranchAncestor(remote: string | undefined = undefined) {
     throw new Error("Not in a git repo");
   }
 
-  const { remote: remoteName, branch: baseBranch } = await getBaseBranch(
-    remote
-  );
+  const { remote: remoteName, branch: baseBranch } =
+    await getBaseBranch(remote);
 
   const isDirty = (await git.diffSummary()).files.length > 0;
   const head = isDirty ? "HEAD" : "HEAD^";
@@ -176,11 +157,10 @@ export async function getRepoStatus(settings?: GitMetadataSettings) {
   let sanitized: RepoStatus = {};
   settings.fields?.forEach((field) => {
     sanitized = { ...sanitized, [field]: repo[field] };
-  })
+  });
 
   return sanitized;
 }
-
 
 async function repoStatus() {
   const git = await currentRepo();

--- a/js/src/isomorph.ts
+++ b/js/src/isomorph.ts
@@ -1,20 +1,4 @@
-export interface RepoStatus {
-  commit?: string;
-  branch?: string;
-  tag?: string;
-  dirty?: boolean;
-  author_name?: string;
-  author_email?: string;
-  commit_message?: string;
-  commit_time?: string;
-}
-
-type GitFields = Array<keyof RepoStatus>;
-type CollectMetadata = "all" | "none" | "some";
-export type GitMetadataSettings = {
-  collect: CollectMetadata;
-  fields: GitFields;
-};
+import { GitMetadataSettings, RepoStatus } from "@braintrust/core";
 
 export interface CallerLocation {
   caller_functionname: string;
@@ -41,7 +25,9 @@ class DefaultAsyncLocalStorage<T> implements IsoAsyncLocalStorage<T> {
 }
 
 export interface Common {
-  getRepoStatus: (settings?: GitMetadataSettings) => Promise<RepoStatus | undefined>;
+  getRepoStatus: (
+    settings?: GitMetadataSettings
+  ) => Promise<RepoStatus | undefined>;
   getPastNAncestors: () => Promise<string[]>;
   getEnv: (name: string) => string | undefined;
   getCallerLocation: () => CallerLocation | undefined;

--- a/js/src/isomorph.ts
+++ b/js/src/isomorph.ts
@@ -2,12 +2,19 @@ export interface RepoStatus {
   commit?: string;
   branch?: string;
   tag?: string;
-  dirty: boolean;
+  dirty?: boolean;
   author_name?: string;
   author_email?: string;
   commit_message?: string;
   commit_time?: string;
 }
+
+type GitFields = Array<keyof RepoStatus>;
+type CollectMetadata = "all" | "none" | "some";
+export type GitMetadataSettings = {
+  collect: CollectMetadata;
+  fields: GitFields;
+};
 
 export interface CallerLocation {
   caller_functionname: string;
@@ -34,7 +41,7 @@ class DefaultAsyncLocalStorage<T> implements IsoAsyncLocalStorage<T> {
 }
 
 export interface Common {
-  getRepoStatus: () => Promise<RepoStatus | undefined>;
+  getRepoStatus: (settings?: GitMetadataSettings) => Promise<RepoStatus | undefined>;
   getPastNAncestors: () => Promise<string[]>;
   getEnv: (name: string) => string | undefined;
   getCallerLocation: () => CallerLocation | undefined;
@@ -43,7 +50,7 @@ export interface Common {
 }
 
 const iso: Common = {
-  getRepoStatus: async () => undefined,
+  getRepoStatus: async (_settings) => undefined,
   getPastNAncestors: async () => [],
   getEnv: (_name) => undefined,
   getCallerLocation: () => undefined,

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -982,7 +982,6 @@ export function init(
     let mergedGitMetadataSettings = {
       ...(_state.gitMetadataSettings || {
         collect: "all",
-        fields: [],
       }),
     };
     if (gitMetadataSettings) {

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -14,7 +14,7 @@ import {
   AUDIT_METADATA_FIELD,
 } from "@braintrust/core";
 
-import iso, { IsoAsyncLocalStorage } from "./isomorph";
+import iso, { GitMetadataSettings, IsoAsyncLocalStorage } from "./isomorph";
 import {
   runFinally,
   GLOBAL_PROJECT,
@@ -186,6 +186,7 @@ class BraintrustState {
   public orgName: string | null = null;
   public logUrl: string | null = null;
   public loggedIn: boolean = false;
+  public gitMetadataSettings?: GitMetadataSettings;
 
   private _apiConn: HTTPConnection | null = null;
   private _logConn: HTTPConnection | null = null;
@@ -207,6 +208,7 @@ class BraintrustState {
     this.orgName = null;
     this.logUrl = null;
     this.loggedIn = false;
+    this.gitMetadataSettings = undefined;
 
     this._apiConn = null;
     this._logConn = null;
@@ -972,7 +974,7 @@ export function init(
       args["update"] = update;
     }
 
-    const repoStatus = await iso.getRepoStatus();
+    const repoStatus = await iso.getRepoStatus(_state.gitMetadataSettings);
     if (repoStatus) {
       args["repo_info"] = repoStatus;
     }
@@ -1477,6 +1479,7 @@ function _check_org_info(org_info: any, org_name: string | undefined) {
       _state.orgId = org.id;
       _state.orgName = org.name;
       _state.logUrl = iso.getEnv("BRAINTRUST_LOG_URL") ?? org.api_url;
+      _state.gitMetadataSettings = org.git_metadata || undefined;
       break;
     }
   }

--- a/py/src/braintrust/gitutil.py
+++ b/py/src/braintrust/gitutil.py
@@ -3,11 +3,9 @@ import os
 import re
 import subprocess
 import threading
-from dataclasses import dataclass, field
 from functools import lru_cache as _cache
-from typing import List, Literal, Optional
-
-from braintrust_core.util import SerializableDataClass
+from typing import List, Optional
+from braintrust_core.git_fields import GitMetadataSettings, RepoStatus
 
 # https://stackoverflow.com/questions/48399498/git-executable-not-found-in-python
 os.environ["GIT_PYTHON_REFRESH"] = "quiet"
@@ -15,27 +13,6 @@ import git
 
 _logger = logging.getLogger("braintrust.gitutil")
 _gitlock = threading.RLock()
-
-
-@dataclass
-class GitMetadataSettings(SerializableDataClass):
-    collect: Literal["all", "some", "none"] = "all"
-    fields: Optional[List[str]] = field(default_factory=list)
-
-
-@dataclass
-class RepoStatus(SerializableDataClass):
-    """Information about the current HEAD of the repo."""
-
-    commit: Optional[str]
-    branch: Optional[str]
-    tag: Optional[str]
-    dirty: Optional[bool]
-    author_name: Optional[str]
-    author_email: Optional[str]
-    commit_message: Optional[str]
-    commit_time: Optional[str]
-    git_diff: Optional[str]
 
 
 @_cache(1)

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -37,7 +37,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from .cache import CACHE_PATH, EXPERIMENTS_PATH, LOGIN_INFO_PATH
-from .gitutil import get_past_n_ancestors, get_repo_status
+from .gitutil import GitMetadataSettings, get_past_n_ancestors, get_repo_status
 from .resource_manager import ResourceManager
 from .util import (
     GLOBAL_PROJECT,
@@ -185,6 +185,7 @@ class BraintrustState:
         self.org_name = None
         self.log_url = None
         self.logged_in = False
+        self.git_metadata_settings = None
 
         self._api_conn = None
         self._log_conn = None
@@ -558,7 +559,7 @@ def init(
         if update:
             args["update"] = update
 
-        repo_status = get_repo_status()
+        repo_status = get_repo_status(_state.git_metadata_settings)
         if repo_status:
             args["repo_info"] = repo_status.as_dict()
 
@@ -955,6 +956,7 @@ def _check_org_info(org_info, org_name):
             _state.org_id = orgs["id"]
             _state.org_name = orgs["name"]
             _state.log_url = os.environ.get("BRAINTRUST_LOG_URL", orgs["api_url"])
+            _state.git_metadata_settings = GitMetadataSettings(**(orgs.get("git_metadata") or {}))
             break
 
     if _state.org_id is None:

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -26,6 +26,7 @@ from braintrust_core.db_fields import (
     TRANSACTION_ID_FIELD,
     VALID_SOURCES,
 )
+from braintrust_core.git_fields import GitMetadataSettings
 from braintrust_core.merge_row_batch import merge_row_batch
 from braintrust_core.span_types import SpanTypeAttribute
 from braintrust_core.util import (
@@ -37,8 +38,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from .cache import CACHE_PATH, EXPERIMENTS_PATH, LOGIN_INFO_PATH
-from .gitutil import GitMetadataSettings, get_past_n_ancestors, get_repo_status
-from .resource_manager import ResourceManager
+from .gitutil import get_past_n_ancestors, get_repo_status
 from .util import (
     GLOBAL_PROJECT,
     AugmentedHTTPError,

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -523,6 +523,7 @@ def init(
     api_key: Optional[str] = None,
     org_name: Optional[str] = None,
     metadata: Optional[Metadata] = None,
+    git_metadata_settings: Optional[GitMetadataSettings] = None,
     set_current: bool = True,
 ):
     """
@@ -542,6 +543,7 @@ def init(
     key is specified, will prompt the user to login.
     :param org_name: (Optional) The name of a specific organization to connect to. This is useful if you belong to multiple.
     :param metadata: (Optional) a dictionary with additional data about the test example, model outputs, or just about anything else that's relevant, that you can use to help find and analyze examples later. For example, you could log the `prompt`, example's `id`, or anything else that would be useful to slice/dice later. The values in `metadata` can be any JSON-serializable type, but its keys must be strings.
+    :param git_metadata_settings: (Optional) Settings for collecting git metadata. By default, will collect all git metadata fields allowed in org-level settings.
     :param set_current: If true (the default), set the global current-experiment to the newly-created one.
     :returns: The experiment object.
     """
@@ -559,7 +561,13 @@ def init(
         if update:
             args["update"] = update
 
-        repo_status = get_repo_status(_state.git_metadata_settings)
+        merged_git_metadata_settings = _state.git_metadata_settings
+        if git_metadata_settings is not None:
+            merged_git_metadata_settings = GitMetadataSettings.merge(
+                merged_git_metadata_settings, git_metadata_settings
+            )
+
+        repo_status = get_repo_status(merged_git_metadata_settings)
         if repo_status:
             args["repo_info"] = repo_status.as_dict()
 


### PR DESCRIPTION
Now that we support configuring which git metadata you can collect at an org-wide level, this change updates the SDK to respect that configuration, and further allows users to optionally override it (merging the two settings into the _least_ permissive setting). 