### PR TITLE
Fix unhandled promise rejections in typescript SDK.

### DIFF
--- a/js/src/gitutil.ts
+++ b/js/src/gitutil.ts
@@ -77,8 +77,9 @@ async function getBaseBranchAncestor(remote: string | undefined = undefined) {
     throw new Error("Not in a git repo");
   }
 
-  const { remote: remoteName, branch: baseBranch } =
-    await getBaseBranch(remote);
+  const { remote: remoteName, branch: baseBranch } = await getBaseBranch(
+    remote
+  );
 
   const isDirty = (await git.diffSummary()).files.length > 0;
   const head = isDirty ? "HEAD" : "HEAD^";

--- a/js/src/util.ts
+++ b/js/src/util.ts
@@ -27,3 +27,27 @@ export function getCurrentUnixTimestamp(): number {
 export function isEmpty(a: unknown): a is null | undefined {
   return a === undefined || a === null;
 }
+
+// A simple wrapper around a callable async function which computes the value
+// on-demand and saves it for future retrievals. The difference between this and
+// a bare Promise is that the async callable is run only when asked for. There
+// should be no un-awaited promises floating around (as long as the user
+// immediately consumes what is returned by `LazyValue.value()`).
+export class LazyValue<T> {
+  private callable: () => Promise<T>;
+  private value: { hasComputed: true; val: T } | { hasComputed: false } = {
+    hasComputed: false,
+  };
+
+  constructor(callable: () => Promise<T>) {
+    this.callable = callable;
+  }
+
+  async get(): Promise<T> {
+    if (this.value.hasComputed) {
+      return this.value.val;
+    }
+    this.value = { hasComputed: true, val: await this.callable() };
+    return this.value.val;
+  }
+}

--- a/py/src/braintrust/gitutil.py
+++ b/py/src/braintrust/gitutil.py
@@ -5,6 +5,7 @@ import subprocess
 import threading
 from functools import lru_cache as _cache
 from typing import List, Optional
+
 from braintrust_core.git_fields import GitMetadataSettings, RepoStatus
 
 # https://stackoverflow.com/questions/48399498/git-executable-not-found-in-python


### PR DESCRIPTION
To accomplish lazy initialization, we were wrapping everything in promises. The problem with this is that if the promise is not awaited (more specifically, a rejection handler is not explicitly attached), the promise's exceptions will get reported as "unhandled" at the end of the program, as it's clearing out its event loop. This seems to happen even if the promise is awaited somewhere else and the exception handled (i.e. in the background logger). I think as long as there is still some context in which the promise may run without a rejection handler, it will bubble up at the end.

To work around this, we add one more step of indirection, now similar to what we do in the python SDK. The LazyValue wrapper creates the promise only when asked for, and the user is expected to await it immediately. Any delayed computations that are passed around as arguments or used in other lazy computations should be wrapped in LazyValue rather than as a bare promise.

Fixes BRA-890