### PR TITLE
Track execution counter

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -359,8 +359,8 @@ class HTTPConnection {
           typeof params === "string"
             ? params
             : params
-            ? JSON.stringify(params)
-            : undefined,
+              ? JSON.stringify(params)
+              : undefined,
         keepalive: true,
         ...rest,
       })
@@ -1888,6 +1888,8 @@ interface ParentProjectLogIds {
   log_id: "g";
 }
 
+let executionCounter = 0;
+
 /**
  * Primary implementation of the `Span` interface. See the `Span` interface for full details on each method.
  *
@@ -1951,7 +1953,11 @@ export class SpanImpl implements Span {
         start: args.startTime ?? getCurrentUnixTimestamp(),
       },
       context: { ...callerLocation },
-      span_attributes: { ...args.spanAttributes, name },
+      span_attributes: {
+        ...args.spanAttributes,
+        name,
+        exec_counter: executionCounter++,
+      },
       created: new Date().toISOString(),
     };
 

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -1400,6 +1400,11 @@ class Experiment:
         del type, value, callback
 
 
+# Make this an atomic counter
+_EXEC_COUNTER_LOCK = threading.Lock()
+_EXEC_COUNTER = 0
+
+
 class SpanImpl(Span):
     """Primary implementation of the `Span` interface. See the `Span` interface for full details on each method.
 
@@ -1440,11 +1445,16 @@ class SpanImpl(Span):
         # `internal_data` contains fields that are not part of the
         # "user-sanitized" set of fields which we want to log in just one of the
         # span rows.
+        global _EXEC_COUNTER
+        with _EXEC_COUNTER_LOCK:
+            _EXEC_COUNTER += 1
+            exec_counter = _EXEC_COUNTER
+
         self.internal_data = dict(
             metrics=dict(
                 start=start_time or time.time(),
             ),
-            span_attributes=dict(**span_attributes, name=name),
+            span_attributes=dict(**span_attributes, name=name, exec_counter=exec_counter),
             created=datetime.datetime.now(datetime.timezone.utc).isoformat(),
         )
         if caller_location:


### PR DESCRIPTION
This change introduces a global counter that we track, in addition to start time, to help tie breaks spans. This is useful if two spans start in a logical order, within the same millisecond, so that they'll appear in the same order in the UI across traces.