### PR TITLE
Python SDK: print exceptions instead of aborting logger

### DIFF
--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -415,8 +415,13 @@ class _BackgroundLogger:
             except queue.Empty:
                 pass
             # Unwrap all the lazily-computed values.
-            all_items = [item.get() for item in all_items]
-            all_items = list(reversed(merge_row_batch(all_items)))
+            try:
+                all_items = [item.get() for item in all_items]
+                all_items = list(reversed(merge_row_batch(all_items)))
+            except Exception as e:
+                print("Encountered error when constructing records to flush:")
+                traceback.print_exc()
+                all_items = []
 
             if len(all_items) == 0:
                 return


### PR DESCRIPTION
Similar to what we do in javascript. This way any issues encountered during logging will not crash the application.

Fixes BRA-550