### PR TITLE
Don't log full embedding vector from EmbeddingWrapper

### DIFF
--- a/js/src/oai.ts
+++ b/js/src/oai.ts
@@ -261,9 +261,9 @@ function wrapEmbeddings<
     return traced(
       async (span) => {
         const result = await create(params, options);
-        const output = result.data[0];
         span.log({
-          output,
+          // TODO: Add this back gated behind a flag, possibly w/ JSON compression.
+          // output: result.data[0],
           metrics: {
             tokens: result.usage?.total_tokens,
             prompt_tokens: result.usage?.prompt_tokens,

--- a/js/src/oai.ts
+++ b/js/src/oai.ts
@@ -261,9 +261,11 @@ function wrapEmbeddings<
     return traced(
       async (span) => {
         const result = await create(params, options);
+        const embedding_length = result.data[0].embedding.length;
         span.log({
-          // TODO: Add this back gated behind a flag, possibly w/ JSON compression.
-          // output: result.data[0],
+          // TODO: Add a flag to control whether to log the full embedding vector,
+          // possibly w/ JSON compression.
+          output: { embedding_length },
           metrics: {
             tokens: result.usage?.total_tokens,
             prompt_tokens: result.usage?.prompt_tokens,

--- a/py/src/braintrust/oai.py
+++ b/py/src/braintrust/oai.py
@@ -142,7 +142,8 @@ class EmbeddingWrapper:
                     "tokens": log_response["usage"]["total_tokens"],
                     "prompt_tokens": log_response["usage"]["prompt_tokens"],
                 },
-                output=log_response["data"],
+                # TODO: Add this back gated behind a flag, possibly w/ JSON compression.
+                # output=log_response["data"],
             )
             return raw_response
 
@@ -159,7 +160,8 @@ class EmbeddingWrapper:
                     "tokens": log_response["usage"]["total_tokens"],
                     "prompt_tokens": log_response["usage"]["prompt_tokens"],
                 },
-                output=log_response["data"],
+                # TODO: Add this back gated behind a flag, possibly w/ JSON compression.
+                # output=log_response["data"],
             )
             return raw_response
 

--- a/py/src/braintrust/oai.py
+++ b/py/src/braintrust/oai.py
@@ -142,8 +142,9 @@ class EmbeddingWrapper:
                     "tokens": log_response["usage"]["total_tokens"],
                     "prompt_tokens": log_response["usage"]["prompt_tokens"],
                 },
-                # TODO: Add this back gated behind a flag, possibly w/ JSON compression.
-                # output=log_response["data"],
+                # TODO: Add a flag to control whether to log the full embedding vector,
+                # possibly w/ JSON compression.
+                output={"embedding_length": len(log_response["data"][0]["embedding"])},
             )
             return raw_response
 
@@ -160,8 +161,9 @@ class EmbeddingWrapper:
                     "tokens": log_response["usage"]["total_tokens"],
                     "prompt_tokens": log_response["usage"]["prompt_tokens"],
                 },
-                # TODO: Add this back gated behind a flag, possibly w/ JSON compression.
-                # output=log_response["data"],
+                # TODO: Add a flag to control whether to log the full embedding vector,
+                # possibly w/ JSON compression.
+                output={"embedding_length": len(log_response["data"][0]["embedding"])},
             )
             return raw_response
 


### PR DESCRIPTION
Just remove the vector and replace it with `{"embedding_length": <length>}` for now. We can add a flag for it later if it turns out to be useful.