### PR TITLE
Move `eprint` to core.

### DIFF
--- a/core/py/src/braintrust_core/util.py
+++ b/core/py/src/braintrust_core/util.py
@@ -1,6 +1,13 @@
 import dataclasses
 import json
+import sys
 from typing import Dict, Set, Tuple
+
+
+# Taken from
+# https://stackoverflow.com/questions/5574702/how-do-i-print-to-stderr-in-python.
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
 
 
 class SerializableDataClass:

--- a/py/src/braintrust/cli/eval.py
+++ b/py/src/braintrust/cli/eval.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from threading import Lock
 from typing import List
 
-from braintrust.util import eprint
+from braintrust_core.util import eprint
 
 from .. import login
 from ..framework import (

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -15,11 +15,12 @@ from typing import Any, AsyncIterator, Awaitable, Callable, Dict, Iterator, List
 
 from braintrust_core.score import Score, Scorer
 from braintrust_core.span_types import SpanTypeAttribute
-from braintrust_core.util import SerializableDataClass
+from braintrust_core.util import (
+    SerializableDataClass,
+    eprint,
+)
 from tqdm.asyncio import tqdm as async_tqdm
 from tqdm.auto import tqdm as std_tqdm
-
-from braintrust.util import eprint
 
 from .logger import NOOP_SPAN, Metadata, Span
 from .logger import init as _init_experiment

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -32,6 +32,7 @@ from braintrust_core.span_types import SpanTypeAttribute
 from braintrust_core.util import (
     SerializableDataClass,
     coalesce,
+    eprint,
     merge_dicts,
 )
 from requests.adapters import HTTPAdapter
@@ -44,7 +45,6 @@ from .util import (
     AugmentedHTTPError,
     LazyValue,
     encode_uri_component,
-    eprint,
     get_caller_location,
     response_raise_for_status,
 )

--- a/py/src/braintrust/util.py
+++ b/py/src/braintrust/util.py
@@ -48,12 +48,6 @@ def get_caller_location():
     return None
 
 
-# Taken from
-# https://stackoverflow.com/questions/5574702/how-do-i-print-to-stderr-in-python.
-def eprint(*args, **kwargs):
-    print(*args, file=sys.stderr, **kwargs)
-
-
 T = TypeVar("T")
 
 


### PR DESCRIPTION
It's useful in other places too (e.g. chalicelib).