### PR TITLE
Modify `update` in experiment init to just open the experiment.

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -987,15 +987,17 @@ export function init<IsOpen extends boolean = false>(
     gitMetadataSettings,
   } = options || {};
 
-  if (open) {
+  if (open && update) {
+    throw new Error("Cannot open and update an experiment at the same time");
+  }
+
+  if (open || update) {
     if (isEmpty(experiment)) {
-      throw new Error("Cannot open an experiment without specifying its name");
-    }
-    if (update) {
-      throw new Error("Cannot open and update an experiment at the same time");
+      const action = open ? "open" : "update";
+      throw new Error(`Cannot ${action} an experiment without specifying its name`);
     }
 
-    const lazyMetadata: LazyValue<ObjectMetadata> = new LazyValue(async () => {
+    const lazyMetadata: LazyValue<ProjectExperimentMetadata> = new LazyValue(async () => {
       await login({
         orgName: orgName,
         apiKey,
@@ -1019,15 +1021,30 @@ export function init<IsOpen extends boolean = false>(
 
       const info = response[0];
       return {
-        id: info.id,
-        name: info.name,
-        fullInfo: info,
+        project: {
+            id: info.project_id,
+            name: "",
+            fullInfo: {},
+        },
+        experiment: {
+            id: info.id,
+            name: info.name,
+            fullInfo: info,
+        },
       };
     });
 
-    return new ReadonlyExperiment(
-      lazyMetadata
-    ) as InitializedExperiment<IsOpen>;
+    if (open) {
+      return new ReadonlyExperiment(
+        lazyMetadata
+      ) as InitializedExperiment<IsOpen>;
+    } else {
+        const ret = new Experiment(lazyMetadata, dataset);
+        if (options.setCurrent ?? true) {
+          _state.currentExperiment = ret;
+        }
+        return ret as InitializedExperiment<IsOpen>;
+    }
   }
 
   const lazyMetadata: LazyValue<ProjectExperimentMetadata> = new LazyValue(
@@ -1048,10 +1065,6 @@ export function init<IsOpen extends boolean = false>(
 
       if (description) {
         args["description"] = description;
-      }
-
-      if (update) {
-        args["update"] = update;
       }
 
       let mergedGitMetadataSettings = {
@@ -2028,19 +2041,19 @@ export class Experiment extends ObjectFetcher<ExperimentEvent> {
  * A read-only view of an experiment, initialized by passing `open: true` to `init()`.
  */
 export class ReadonlyExperiment extends ObjectFetcher<ExperimentEvent> {
-  constructor(private readonly lazyMetadata: LazyValue<ObjectMetadata>) {
+  constructor(private readonly lazyMetadata: LazyValue<ProjectExperimentMetadata>) {
     super("experiment", undefined);
   }
 
   public get id(): Promise<string> {
     return (async () => {
-      return (await this.lazyMetadata.get()).id;
+      return (await this.lazyMetadata.get()).experiment.id;
     })();
   }
 
   public get name(): Promise<string> {
     return (async () => {
-      return (await this.lazyMetadata.get()).name;
+      return (await this.lazyMetadata.get()).experiment.name;
     })();
   }
 

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -555,11 +555,13 @@ def init(
     :returns: The experiment object.
     """
 
-    if open:
+    if open and update:
+        raise ValueError("Cannot open and update an experiment at the same time")
+
+    if open or update:
         if experiment is None:
-            raise ValueError("Cannot open an experiment without specifying its name")
-        if update:
-            raise ValueError("Cannot open and update an experiment at the same time")
+            action = 'open' if open else 'update'
+            raise ValueError(f"Cannot {action} an experiment without specifying its name")
 
         def compute_metadata():
             login(org_name=org_name, api_key=api_key, app_url=app_url)
@@ -570,13 +572,23 @@ def init(
                 raise ValueError(f"Experiment {experiment} not found in project {project}.")
 
             info = response[0]
-            return ObjectMetadata(
-                id=info["id"],
-                name=info["name"],
-                full_info=info,
+            return ProjectExperimentMetadata(
+                project=ObjectMetadata(id=info["project_id"], name='', full_info=dict()),
+                experiment=ObjectMetadata(
+                    id=info["id"],
+                    name=info["name"],
+                    full_info=info,
+                )
             )
 
-        return ReadonlyExperiment(lazy_metadata=LazyValue(compute_metadata, use_mutex=True))
+        lazy_metadata = LazyValue(compute_metadata, use_mutex=True)
+        if open:
+            return ReadonlyExperiment(lazy_metadata=lazy_metadata)
+        else:
+            ret = Experiment(lazy_metadata=lazy_metadata, dataset=dataset)
+            if set_current:
+                _state.current_experiment = ret
+            return ret
 
     def compute_metadata():
         login(org_name=org_name, api_key=api_key, app_url=app_url)
@@ -587,9 +599,6 @@ def init(
 
         if description is not None:
             args["description"] = description
-
-        if update:
-            args["update"] = update
 
         merged_git_metadata_settings = _state.git_metadata_settings
         if git_metadata_settings is not None:
@@ -1555,7 +1564,7 @@ class ReadonlyExperiment(ObjectFetcher):
 
     def __init__(
         self,
-        lazy_metadata: LazyValue[ObjectMetadata],
+        lazy_metadata: LazyValue[ProjectExperimentMetadata],
     ):
         self._lazy_metadata = lazy_metadata
 
@@ -1563,7 +1572,7 @@ class ReadonlyExperiment(ObjectFetcher):
 
     @property
     def id(self):
-        return self._lazy_metadata.get().id
+        return self._lazy_metadata.get().experiment.id
 
     def as_dataset(self):
         return ExperimentDatasetIterator(self.fetch())


### PR DESCRIPTION
Before it would "replace" the existing experiment, which means overwriting any specified metadata on the existing experiment, or creating a new one. But we think the more useful purpose is to re-open an existing experiment in read-write mode.