### PR TITLE
Fix bug in setting repo info when creating experiment.

### DIFF
--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -635,7 +635,7 @@ def init(
                 )
             repo_info_arg = get_repo_info(merged_git_metadata_settings)
 
-        if repo_info:
+        if repo_info_arg:
             args["repo_info"] = repo_info_arg.as_dict()
 
         if base_experiment_id is not None:


### PR DESCRIPTION
This was only introduce in
https://github.com/braintrustdata/braintrust-sdk/pull/113, so I don't think it's made it to any users.