### PR TITLE
Typespecs: Add summarization and cross-object insertion endpoints

### DIFF
--- a/core/js/src/typespecs/common_types.ts
+++ b/core/js/src/typespecs/common_types.ts
@@ -26,3 +26,7 @@ export type EventObjectType = ReturnType<typeof getEventObjectType>;
 export function getEventObjectDescription(objectType: ObjectType) {
   return getEventObjectType(objectType).replace("_", " ");
 }
+
+export function getEventObjectArticle(objectType: ObjectType) {
+  return objectType === "experiment" ? "an" : "a";
+}

--- a/core/py/src/braintrust_core/util.py
+++ b/core/py/src/braintrust_core/util.py
@@ -1,6 +1,7 @@
 import dataclasses
 import json
 import sys
+import urllib.parse
 from typing import Dict, Set, Tuple
 
 
@@ -63,3 +64,12 @@ def merge_dicts(merge_into: Dict, merge_from: Dict):
     """Merges merge_from into merge_into, destructively updating merge_into."""
 
     return merge_dicts_with_paths(merge_into, merge_from, (), set())
+
+
+def encode_uri_component(name):
+    """Encode a single component of a URI. Slashes are encoded as well, so this
+    should not be used for multiple slash-separated URI components."""
+
+    return urllib.parse.quote(name, safe="")
+
+

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -35,6 +35,7 @@ from braintrust_core.span_types import SpanTypeAttribute
 from braintrust_core.util import (
     SerializableDataClass,
     coalesce,
+    encode_uri_component,
     eprint,
     merge_dicts,
 )
@@ -47,7 +48,6 @@ from .util import (
     GLOBAL_PROJECT,
     AugmentedHTTPError,
     LazyValue,
-    encode_uri_component,
     get_caller_location,
     response_raise_for_status,
 )

--- a/py/src/braintrust/util.py
+++ b/py/src/braintrust/util.py
@@ -10,13 +10,6 @@ from requests import HTTPError
 GLOBAL_PROJECT = "Global"
 
 
-def encode_uri_component(name):
-    """Encode a single component of a URI. Slashes are encoded as well, so this
-    should not be used for multiple slash-separated URI components."""
-
-    return urllib.parse.quote(name, safe="")
-
-
 class AugmentedHTTPError(Exception):
     pass
 


### PR DESCRIPTION
This should give us parity with the endpoints used by the SDKs, which means we can start replacing the SDK endpoints with these once users have upgraded their backend.