### PR TITLE
Eval framework allow duplicate names

### DIFF
--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -180,9 +180,9 @@ export async function Eval<
   name: string,
   evaluator: Evaluator<Input, Output, Expected, Metadata>
 ): Promise<ExperimentSummary> {
-  const evalName = makeEvalName(name, evaluator.experimentName);
+  let evalName = makeEvalName(name, evaluator.experimentName);
   if (_evals[evalName]) {
-    throw new Error(`Evaluator ${evalName} already exists`);
+    evalName = `${evalName}_${Object.keys(_evals).length}`;
   }
   if (globalThis._lazy_load) {
     _evals[evalName] = { evalName, projectName: name, ...evaluator };

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -126,7 +126,7 @@ class Evaluator:
     project_name: str
 
     """
-    A name that uniquely defines this type of experiment. You do not need to change it each time the experiment runs, but you should not have other experiments in your code with the same name.
+    A name that describes the experiment. You do not need to change it each time the experiment runs.
     """
     eval_name: str
 
@@ -302,7 +302,7 @@ def Eval(
 
     global _evals
     if eval_name in _evals:
-        raise ValueError(f"Evaluator {eval_name} already exists")
+        eval_name = f"{eval_name}_{len(_evals)}"
 
     evaluator = Evaluator(
         eval_name=eval_name,


### PR DESCRIPTION
We automatically de-duplicate the experiment name when creating it, so enforcing uniqueness is unnecessary.