### PR TITLE
Fallback to str(o)

### DIFF
--- a/core/py/src/braintrust_core/bt_json.py
+++ b/core/py/src/braintrust_core/bt_json.py
@@ -19,7 +19,8 @@ class BraintrustJSONEncoder(json.JSONEncoder):
         except (AttributeError, TypeError):
             pass
 
-        return super().default(o)
+        # When everything fails, just return the string representation of the object
+        return str(o)
 
 
 def bt_dumps(obj, **kwargs) -> str:


### PR DESCRIPTION
Using `super().default(o)` did not work for us as we have some types that are not serializable out of the box, i.e our pydantic models have other model types as attributes:
```
class KYBProofOfAddressVerificationTool(BaseCheckTool):
    tool_id: ClassVar[str] = "kyb.proof_of_address_verification"
    name: str = "Proof of Address Verification Tool"
    description: str = "A tool to verify a proof of address document provided by applicant and extracting relevant data"
    args_schema: Type[BaseCheckArgsSchema] = ProofOfAddressVerificationArgsSchema
    output_payload_schema: Type[BaseOutputSchema] = ProofOfAddressCheckResult
    input_data_schema: Type[ProofOfAddressCheckInputs] = ProofOfAddressCheckInputs
    verification_data_schema: Type[ProofOfAddressExtractonData] = ProofOfAddressExtractonData
```
The proposed workaround is a rather crude fallback behavior. Another option would be to introduce a `custom_fallback` argument and pass in preferred fall back method.