### PR TITLE
remove root-only constraint for span tags

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -2486,14 +2486,6 @@ export class SpanImpl implements Span {
       return ids;
     });
 
-    if (
-      sanitizedAndInternalData.tags &&
-      sanitizedAndInternalData.tags.length > 0 &&
-      this.rowIds.span_id !== this.rowIds.root_span_id
-    ) {
-      throw new Error("Tags can only be logged to the root span");
-    }
-
     const record = new LazyValue(async () => {
       return {
         ...sanitizedAndInternalData,


### PR DESCRIPTION
Couldn't find code on the python side of things:
https://github.com/braintrustdata/braintrust-sdk/blob/235904923f703c3a95f74f55ebfba37385fb7761/py/src/braintrust/logger.py#L1824-L1851