### PR TITLE
Log objects eagerly

### DIFF
--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -436,6 +436,7 @@ export async function runEvaluator(
             ])
           );
           metadata["scorer_errors"] = scorerErrors;
+          rootSpan.log({ metadata: { scorer_errors: scorerErrors } });
           const names = Object.keys(scorerErrors).join(", ");
           const errors = failingScorersAndResults.map((item) => item.error);
           throw new AggregateError(

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -582,6 +582,7 @@ async def run_evaluator(experiment, evaluator: Evaluator, position: Optional[int
                         scorer_name: exc_info for scorer_name, _, exc_info in failing_scorers_and_exceptions
                     }
                     metadata["scorer_errors"] = scorer_errors
+                    root_span.log(metadata=metadata)
                     names = ", ".join(scorer_errors.keys())
                     exceptions = [x[1] for x in failing_scorers_and_exceptions]
                     raise exceptiongroup.ExceptionGroup(

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -332,7 +332,7 @@ def construct_logs3_data(items):
 
 def _check_json_serializable(event):
     try:
-        _ = bt_dumps(event)
+        return bt_dumps(event)
     except TypeError as e:
         raise Exception(f"All logged values must be JSON-serializable: {event}") from e
 
@@ -986,22 +986,23 @@ def get_span_parent_object() -> Union["Logger", "Experiment", Span]:
     return NOOP_SPAN
 
 
-def _try_log_input_output(span, f_sig, f_args, f_kwargs, output):
+def _try_log_input(span, f_sig, f_args, f_kwargs):
     bound_args = f_sig.bind(*f_args, **f_kwargs).arguments
-
     input_serializable = bound_args
     try:
         _check_json_serializable(bound_args)
     except Exception as e:
         input_serializable = "<input not json-serializable>: " + str(e)
+    span.log(input=input_serializable)
 
+
+def _try_log_output(span, output):
     output_serializable = output
     try:
         _check_json_serializable(output)
     except Exception as e:
         output_serializable = "<output not json-serializable>: " + str(e)
-
-    span.log(input=input_serializable, output=output_serializable)
+    span.log(output=output_serializable)
 
 
 def traced(*span_args, **span_kwargs):
@@ -1036,17 +1037,21 @@ def traced(*span_args, **span_kwargs):
         @wraps(f)
         def wrapper_sync(*f_args, **f_kwargs):
             with start_span(*span_args, **span_kwargs) as span:
+                if trace_io:
+                    _try_log_input(span, f_sig, f_args, f_kwargs)
                 ret = f(*f_args, **f_kwargs)
                 if trace_io:
-                    _try_log_input_output(span, f_sig, f_args, f_kwargs, ret)
+                    _try_log_output(span, ret)
                 return ret
 
         @wraps(f)
         async def wrapper_async(*f_args, **f_kwargs):
             with start_span(*span_args, **span_kwargs) as span:
+                if trace_io:
+                    _try_log_input(span, f_sig, f_args, f_kwargs)
                 ret = await f(*f_args, **f_kwargs)
                 if trace_io:
-                    _try_log_input_output(span, f_sig, f_args, f_kwargs, ret)
+                    _try_log_output(span, ret)
                 return ret
 
         if inspect.iscoroutinefunction(f):
@@ -1837,10 +1842,17 @@ class SpanImpl(Span):
             **dataclasses.asdict(self.row_ids),
             **{IS_MERGE_FIELD: self._is_merge},
         )
-        _check_json_serializable(partial_record)
 
         if "metrics" in partial_record and "end" in partial_record["metrics"]:
             self._logged_end_time = partial_record["metrics"]["end"]
+
+        # We both check for serializability and round-trip `partial_record`
+        # through JSON in order to create a "deep copy". This has the benefit of
+        # cutting out any reference to user objects when the object is logged
+        # asynchronously, so that in case the objects are modified, the logging
+        # is unaffected.
+        serialized_partial_record = _check_json_serializable(partial_record)
+        partial_record = json.loads(serialized_partial_record)
 
         def compute_record():
             return dict(


### PR DESCRIPTION
It was pointed out that objects logged to braintrust may be mutated after logging, and braintrust would end up logging the mutated version. We fix this by round-tripping the object through the JSON serializer, which doubles as a synchronous check for serializability (that we were already doing in python).

We also adjust the `@traced` decorator in python to log the input before running the function, so that it's immediately visible.