### PR TITLE
wrap the iterator only in the OAI stream interface

### DIFF
--- a/js/src/oai.ts
+++ b/js/src/oai.ts
@@ -208,7 +208,9 @@ function wrapChatCompletion<
     if (params.stream) {
       const startTime = getCurrentUnixTimestamp();
       const ret = (await completion(params, options)) as StreamingChatResponse;
-      return new WrapperStream(span, startTime, ret);
+      const wrapperStream = new WrapperStream(span, startTime, ret.iterator());
+      ret.iterator = () => wrapperStream[Symbol.asyncIterator]();
+      return ret;
     } else {
       try {
         const ret = (await completion(


### PR DESCRIPTION
The stream object in the openAI api has some other functionality other than just being an `AsyncIterator` (e.g. `toReadableStream`, `tee`, etc.). So just wrap the iterator itself and return the base open ai stream object

Not sure if this is what you were looking for but it seems to work.