### PR TITLE
Demote "flushing final log events" message from info to debug.

### DIFF
--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -427,7 +427,7 @@ class _BackgroundLogger:
                     self.started = True
 
     def _finalize(self):
-        self.logger.info("Flushing final log events...")
+        self.logger.debug("Flushing final log events...")
         self.flush()
 
     def _publisher(self):


### PR DESCRIPTION
Noticed it's really starting to spam the unit tests. Seems mainly useful for debugging anyways.