### PR TITLE
Remove strictness requirements on API typespecs.

### DIFF
--- a/core/js/typespecs/api_types.ts
+++ b/core/js/typespecs/api_types.ts
@@ -285,7 +285,6 @@ export const fetchEventsRequestSchema = z
     filters: fetchFiltersSchema.nullish(),
     version: versionSchema.nullish(),
   })
-  .strict()
   .openapi("FetchEventsRequest");
 
 function makeFetchEventsResponseSchema<T extends z.AnyZodObject>(
@@ -300,7 +299,6 @@ function makeFetchEventsResponseSchema<T extends z.AnyZodObject>(
     .object({
       events: eventSchema.array().describe("A list of fetched events"),
     })
-    .strict()
     .openapi(`Fetch${eventName}EventsResponse`);
 }
 
@@ -340,7 +338,6 @@ const experimentEventSchema = z
     root_span_id: experimentEventBaseSchema.shape.root_span_id,
     span_attributes: experimentEventBaseSchema.shape.span_attributes,
   })
-  .strict()
   .openapi("ExperimentEvent");
 
 const datasetEventBaseSchema = generateBaseEventOpSchema("dataset");
@@ -362,7 +359,6 @@ const datasetEventSchema = z
     span_id: datasetEventBaseSchema.shape.span_id,
     root_span_id: datasetEventBaseSchema.shape.root_span_id,
   })
-  .strict()
   .openapi("DatasetEvent");
 
 const projectLogsEventBaseSchema = generateBaseEventOpSchema("project");
@@ -398,7 +394,6 @@ const projectLogsEventSchema = z
     root_span_id: projectLogsEventBaseSchema.shape.root_span_id,
     span_attributes: projectLogsEventBaseSchema.shape.span_attributes,
   })
-  .strict()
   .openapi("ProjectLogsEvent");
 
 // Section: inserting data objects.
@@ -452,11 +447,9 @@ function makeInsertEventSchemas<T extends z.AnyZodObject>(
   ).replace("_", "");
   const replaceVariantSchema = insertSchema
     .merge(replacementEventSchema)
-    .strict()
     .openapi(`Insert${eventSchemaName}EventReplace`);
   const mergeVariantSchema = insertSchema
     .merge(mergeEventSchema)
-    .strict()
     .openapi(`Insert${eventSchemaName}EventMerge`);
   const eventSchema = z
     .union([replaceVariantSchema, mergeVariantSchema])
@@ -468,7 +461,6 @@ function makeInsertEventSchemas<T extends z.AnyZodObject>(
         .array()
         .describe(`A list of ${eventDescription} events to insert`),
     })
-    .strict()
     .openapi(`Insert${eventSchemaName}EventRequest`);
   return { eventSchema, requestSchema };
 }
@@ -482,7 +474,6 @@ export const insertEventsResponseSchema = z
         "The ids of all rows that were inserted, aligning one-to-one with the rows provided as input"
       ),
   })
-  .strict()
   .openapi("InsertEventsResponse");
 
 const {
@@ -490,23 +481,20 @@ const {
   requestSchema: insertExperimentEventsRequestSchema,
 } = makeInsertEventSchemas(
   "experiment",
-  z
-    .object({
-      input: experimentEventSchema.shape.input,
-      output: experimentEventSchema.shape.output,
-      expected: experimentEventSchema.shape.expected,
-      scores: experimentEventSchema.shape.scores,
-      metadata: experimentEventSchema.shape.metadata,
-      tags: experimentEventSchema.shape.tags,
-      metrics: experimentEventSchema.shape.metrics,
-      context: experimentEventSchema.shape.context,
-      span_attributes: experimentEventSchema.shape.span_attributes,
-      id: experimentEventSchema.shape.id.nullish(),
-      dataset_record_id: experimentEventSchema.shape.dataset_record_id,
-      [OBJECT_DELETE_FIELD]:
-        experimentEventBaseSchema.shape[OBJECT_DELETE_FIELD],
-    })
-    .strict()
+  z.object({
+    input: experimentEventSchema.shape.input,
+    output: experimentEventSchema.shape.output,
+    expected: experimentEventSchema.shape.expected,
+    scores: experimentEventSchema.shape.scores,
+    metadata: experimentEventSchema.shape.metadata,
+    tags: experimentEventSchema.shape.tags,
+    metrics: experimentEventSchema.shape.metrics,
+    context: experimentEventSchema.shape.context,
+    span_attributes: experimentEventSchema.shape.span_attributes,
+    id: experimentEventSchema.shape.id.nullish(),
+    dataset_record_id: experimentEventSchema.shape.dataset_record_id,
+    [OBJECT_DELETE_FIELD]: experimentEventBaseSchema.shape[OBJECT_DELETE_FIELD],
+  })
 );
 
 const {
@@ -514,16 +502,14 @@ const {
   requestSchema: insertDatasetEventsRequestSchema,
 } = makeInsertEventSchemas(
   "dataset",
-  z
-    .object({
-      input: datasetEventSchema.shape.input,
-      expected: datasetEventSchema.shape.expected,
-      metadata: datasetEventSchema.shape.metadata,
-      tags: datasetEventSchema.shape.tags,
-      id: datasetEventSchema.shape.id.nullish(),
-      [OBJECT_DELETE_FIELD]: datasetEventBaseSchema.shape[OBJECT_DELETE_FIELD],
-    })
-    .strict()
+  z.object({
+    input: datasetEventSchema.shape.input,
+    expected: datasetEventSchema.shape.expected,
+    metadata: datasetEventSchema.shape.metadata,
+    tags: datasetEventSchema.shape.tags,
+    id: datasetEventSchema.shape.id.nullish(),
+    [OBJECT_DELETE_FIELD]: datasetEventBaseSchema.shape[OBJECT_DELETE_FIELD],
+  })
 );
 
 const {
@@ -531,22 +517,20 @@ const {
   requestSchema: insertProjectLogsEventsRequestSchema,
 } = makeInsertEventSchemas(
   "project",
-  z
-    .object({
-      input: projectLogsEventSchema.shape.input,
-      output: projectLogsEventSchema.shape.output,
-      expected: projectLogsEventSchema.shape.expected,
-      scores: projectLogsEventSchema.shape.scores,
-      metadata: projectLogsEventSchema.shape.metadata,
-      tags: projectLogsEventSchema.shape.tags,
-      metrics: projectLogsEventSchema.shape.metrics,
-      context: projectLogsEventSchema.shape.context,
-      span_attributes: projectLogsEventSchema.shape.span_attributes,
-      id: projectLogsEventSchema.shape.id.nullish(),
-      [OBJECT_DELETE_FIELD]:
-        projectLogsEventBaseSchema.shape[OBJECT_DELETE_FIELD],
-    })
-    .strict()
+  z.object({
+    input: projectLogsEventSchema.shape.input,
+    output: projectLogsEventSchema.shape.output,
+    expected: projectLogsEventSchema.shape.expected,
+    scores: projectLogsEventSchema.shape.scores,
+    metadata: projectLogsEventSchema.shape.metadata,
+    tags: projectLogsEventSchema.shape.tags,
+    metrics: projectLogsEventSchema.shape.metrics,
+    context: projectLogsEventSchema.shape.context,
+    span_attributes: projectLogsEventSchema.shape.span_attributes,
+    id: projectLogsEventSchema.shape.id.nullish(),
+    [OBJECT_DELETE_FIELD]:
+      projectLogsEventBaseSchema.shape[OBJECT_DELETE_FIELD],
+  })
 );
 
 // Section: logging feedback.
@@ -566,7 +550,6 @@ function makeFeedbackRequestSchema<T extends z.AnyZodObject>(
         .array()
         .describe(`A list of ${eventDescription} feedback items`),
     })
-    .strict()
     .openapi(`Feedback${eventSchemaName}EventRequest`);
 }
 
@@ -581,7 +564,6 @@ const feedbackExperimentItemSchema = z
     metadata: feedbackExperimentRequestBaseSchema.shape.metadata,
     source: feedbackExperimentRequestBaseSchema.shape.source,
   })
-  .strict()
   .openapi("FeedbackExperimentItem");
 const feedbackExperimentRequestSchema = makeFeedbackRequestSchema(
   "experiment",
@@ -597,7 +579,6 @@ const feedbackDatasetItemSchema = z
     metadata: feedbackDatasetRequestBaseSchema.shape.metadata,
     source: feedbackDatasetRequestBaseSchema.shape.source,
   })
-  .strict()
   .openapi("FeedbackDatasetItem");
 const feedbackDatasetRequestSchema = makeFeedbackRequestSchema(
   "dataset",
@@ -615,7 +596,6 @@ const feedbackProjectLogsItemSchema = z
     metadata: feedbackProjectLogsRequestBaseSchema.shape.metadata,
     source: feedbackProjectLogsRequestBaseSchema.shape.source,
   })
-  .strict()
   .openapi("FeedbackProjectLogsItem");
 const feedbackProjectLogsRequestSchema = makeFeedbackRequestSchema(
   "project",
@@ -631,7 +611,6 @@ const feedbackPromptItemSchema = z
     metadata: feedbackPromptRequestBaseSchema.shape.metadata,
     source: feedbackPromptRequestBaseSchema.shape.source,
   })
-  .strict()
   .openapi("FeedbackPromptItem");
 const feedbackPromptRequestSchema = makeFeedbackRequestSchema(
   "prompt",
@@ -683,22 +662,20 @@ function makeCrossObjectIndividualRequestSchema(objectType: ObjectType) {
   const eventObjectType = getEventObjectType(objectType);
   const eventDescription = getEventObjectDescription(objectType);
   const eventObjectSchema = eventObjectSchemas[eventObjectType];
-  const insertObject = z
-    .object({
-      ...(eventObjectSchema.insertEvent
-        ? {
-            events: eventObjectSchema.insertEvent
-              .array()
-              .nullish()
-              .describe(`A list of ${eventDescription} events to insert`),
-          }
-        : {}),
-      feedback: eventObjectSchema.feedbackItem
-        .array()
-        .nullish()
-        .describe(`A list of ${eventDescription} feedback items`),
-    })
-    .strict();
+  const insertObject = z.object({
+    ...(eventObjectSchema.insertEvent
+      ? {
+          events: eventObjectSchema.insertEvent
+            .array()
+            .nullish()
+            .describe(`A list of ${eventDescription} events to insert`),
+        }
+      : {}),
+    feedback: eventObjectSchema.feedbackItem
+      .array()
+      .nullish()
+      .describe(`A list of ${eventDescription} feedback items`),
+  });
   return z
     .record(z.string().uuid(), insertObject)
     .nullish()
@@ -723,7 +700,6 @@ export const crossObjectInsertRequestSchema = z
     project_logs: makeCrossObjectIndividualRequestSchema("project"),
     prompt: makeCrossObjectIndividualRequestSchema("prompt"),
   })
-  .strict()
   .openapi("CrossObjectInsertRequest");
 
 export const crossObjectInsertResponseSchema = z
@@ -733,7 +709,6 @@ export const crossObjectInsertResponseSchema = z
     project_logs: makeCrossObjectIndividualResponseSchema("project"),
     prompt: makeCrossObjectIndividualResponseSchema("prompt"),
   })
-  .strict()
   .openapi("CrossObjectInsertResponse");
 
 // Section: Summarization operations.
@@ -837,7 +812,6 @@ const summarizeExperimentResponseSchema = z
       .nullish()
       .describe("Summary of the experiment's metrics"),
   })
-  .strict()
   .describe("Summary of an experiment")
   .openapi("SummarizeExperimentResponse");
 
@@ -867,7 +841,6 @@ const summarizeDatasetResponseSchema = z
       .describe("Summary of a dataset's data")
       .openapi("DataSummary"),
   })
-  .strict()
   .describe("Summary of a dataset")
   .openapi("SummarizeDatasetResponse");
 

--- a/core/js/typespecs/app_types.ts
+++ b/core/js/typespecs/app_types.ts
@@ -67,7 +67,6 @@ export const userSchema = z
     avatar_url: z.string().nullish().describe("URL of the user's Avatar image"),
     created: userBaseSchema.shape.created,
   })
-  .strict()
   .openapi("User");
 export type User = z.infer<typeof userSchema>;
 
@@ -79,7 +78,6 @@ export const organizationSchema = z
     api_url: z.string().nullish(),
     created: organizationBaseSchema.shape.created,
   })
-  .strict()
   .openapi("Organization");
 export type Organization = z.infer<typeof organizationSchema>;
 
@@ -88,7 +86,6 @@ export const memberSchema = z
     org_id: organizationSchema.shape.id,
     user_id: userSchema.shape.id,
   })
-  .strict()
   .openapi("Member");
 export type Member = z.infer<typeof memberSchema>;
 
@@ -104,7 +101,6 @@ export const meSchema = z
       })
       .array(),
   })
-  .strict()
   .openapi("Me");
 export type Me = z.infer<typeof meSchema>;
 
@@ -119,7 +115,6 @@ export const apiKeySchema = z
     user_id: userSchema.shape.id.nullish(),
     org_id: organizationSchema.shape.id.nullish(),
   })
-  .strict()
   .openapi("ApiKey");
 export type ApiKey = z.infer<typeof apiKeySchema>;
 
@@ -138,7 +133,6 @@ export const projectSchema = z
     deleted_at: projectBaseSchema.shape.deleted_at,
     user_id: projectBaseSchema.shape.user_id,
   })
-  .strict()
   .openapi("Project");
 export type Project = z.infer<typeof projectSchema>;
 
@@ -155,7 +149,6 @@ export const datasetSchema = z
     deleted_at: datasetBaseSchema.shape.deleted_at,
     user_id: datasetBaseSchema.shape.user_id,
   })
-  .strict()
   .openapi("Dataset");
 export type Dataset = z.infer<typeof datasetSchema>;
 
@@ -265,7 +258,6 @@ export const experimentSchema = z
     user_id: experimentBaseSchema.shape.user_id,
     metadata: experimentBaseSchema.shape.metadata,
   })
-  .strict()
   .openapi("Experiment");
 export type Experiment = z.infer<typeof experimentSchema>;
 
@@ -318,14 +310,12 @@ const createProjectSchema = z
     name: projectSchema.shape.name,
     org_name: createProjectBaseSchema.shape.org_name,
   })
-  .strict()
   .openapi("CreateProject");
 
 const patchProjectSchema = z
   .object({
     name: projectSchema.shape.name.nullish(),
   })
-  .strict()
   .openapi("PatchProject");
 
 const createExperimentSchema = z
@@ -340,12 +330,10 @@ const createExperimentSchema = z
     public: experimentSchema.shape.public.nullish(),
     metadata: experimentSchema.shape.metadata,
   })
-  .strict()
   .openapi("CreateExperiment");
 
 const patchExperimentSchema = createExperimentSchema
   .omit({ project_id: true })
-  .strict()
   .openapi("PatchExperiment");
 
 const createDatasetSchema = z
@@ -354,17 +342,14 @@ const createDatasetSchema = z
     name: datasetSchema.shape.name,
     description: datasetSchema.shape.description,
   })
-  .strict()
   .openapi("CreateDataset");
 
 const patchDatasetSchema = createDatasetSchema
   .omit({ project_id: true })
-  .strict()
   .openapi("PatchDataset");
 
 const createPromptSchema = promptSchema
   .omit({ id: true, _xact_id: true })
-  .strict()
   .openapi("CreatePrompt");
 
 const patchPromptSchema = z
@@ -374,7 +359,6 @@ const patchPromptSchema = z
     prompt_data: promptSchema.shape.prompt_data.nullish(),
     tags: promptSchema.shape.tags.nullish(),
   })
-  .strict()
   .openapi("PatchPrompt");
 
 // Section: exported schemas, grouped by object type.


### PR DESCRIPTION
These typespecs are part of the OpenAPI spec that we publish, and while it's nice to have automated checks in the backend API server to ensure the user doesn't specify unnecessary properties, this strictness makes it hard to add properties to various operations without forcing folks to upgrade their backend.

So we remove the strictness requirements now. We can consider adding the checks back later, perhaps in a more ad-hoc way, if they help users.