### PR TITLE
Typespecs: more strictness

### DIFF
--- a/core/js/typespecs/api_types.ts
+++ b/core/js/typespecs/api_types.ts
@@ -698,7 +698,6 @@ export const crossObjectInsertRequestSchema = z
     experiment: makeCrossObjectIndividualRequestSchema("experiment"),
     dataset: makeCrossObjectIndividualRequestSchema("dataset"),
     project_logs: makeCrossObjectIndividualRequestSchema("project"),
-    prompt: makeCrossObjectIndividualRequestSchema("prompt"),
   })
   .openapi("CrossObjectInsertRequest");
 
@@ -707,7 +706,6 @@ export const crossObjectInsertResponseSchema = z
     experiment: makeCrossObjectIndividualResponseSchema("experiment"),
     dataset: makeCrossObjectIndividualResponseSchema("dataset"),
     project_logs: makeCrossObjectIndividualResponseSchema("project"),
-    prompt: makeCrossObjectIndividualResponseSchema("prompt"),
   })
   .openapi("CrossObjectInsertResponse");
 

--- a/core/js/typespecs/app_types.ts
+++ b/core/js/typespecs/app_types.ts
@@ -19,7 +19,7 @@ function generateBaseTableSchema(
     nameDescription += `. Within a project, ${objectName} names are unique`;
   }
 
-  return z.object({
+  return z.strictObject({
     id: z.string().uuid().describe(`Unique identifier for the ${objectName}`),
     project_id: z
       .string()
@@ -54,7 +54,7 @@ function generateBaseTableSchema(
 
 const userBaseSchema = generateBaseTableSchema("user");
 export const userSchema = z
-  .object({
+  .strictObject({
     id: userBaseSchema.shape.id,
     auth_id: z
       .string()
@@ -67,50 +67,46 @@ export const userSchema = z
     avatar_url: z.string().nullish().describe("URL of the user's Avatar image"),
     created: userBaseSchema.shape.created,
   })
-  .strict()
   .openapi("User");
 export type User = z.infer<typeof userSchema>;
 
 const organizationBaseSchema = generateBaseTableSchema("organization");
 export const organizationSchema = z
-  .object({
+  .strictObject({
     id: organizationBaseSchema.shape.id,
     name: organizationBaseSchema.shape.name.nullish(),
     api_url: z.string().nullish(),
     created: organizationBaseSchema.shape.created,
   })
-  .strict()
   .openapi("Organization");
 export type Organization = z.infer<typeof organizationSchema>;
 
 export const memberSchema = z
-  .object({
+  .strictObject({
     org_id: organizationSchema.shape.id,
     user_id: userSchema.shape.id,
   })
-  .strict()
   .openapi("Member");
 export type Member = z.infer<typeof memberSchema>;
 
 export const meSchema = z
-  .object({
+  .strictObject({
     id: userSchema.shape.id,
     // By filtering by auth_id equality, we will ensure this is not-null.
     auth_id: userSchema.shape.auth_id.unwrap().unwrap(),
     organizations: z
-      .object({
+      .strictObject({
         id: memberSchema.shape.org_id,
         name: organizationSchema.shape.name,
       })
       .array(),
   })
-  .strict()
   .openapi("Me");
 export type Me = z.infer<typeof meSchema>;
 
 const apiKeyBaseSchema = generateBaseTableSchema("api key");
 export const apiKeySchema = z
-  .object({
+  .strictObject({
     id: apiKeyBaseSchema.shape.id,
     created: apiKeyBaseSchema.shape.created,
     key_hash: z.string(),
@@ -119,13 +115,12 @@ export const apiKeySchema = z
     user_id: userSchema.shape.id.nullish(),
     org_id: organizationSchema.shape.id.nullish(),
   })
-  .strict()
   .openapi("ApiKey");
 export type ApiKey = z.infer<typeof apiKeySchema>;
 
 const projectBaseSchema = generateBaseTableSchema("project");
 export const projectSchema = z
-  .object({
+  .strictObject({
     id: projectBaseSchema.shape.id,
     org_id: z
       .string()
@@ -138,7 +133,6 @@ export const projectSchema = z
     deleted_at: projectBaseSchema.shape.deleted_at,
     user_id: projectBaseSchema.shape.user_id,
   })
-  .strict()
   .openapi("Project");
 export type Project = z.infer<typeof projectSchema>;
 
@@ -146,7 +140,7 @@ const datasetBaseSchema = generateBaseTableSchema("dataset", {
   uniqueName: true,
 });
 export const datasetSchema = z
-  .object({
+  .strictObject({
     id: datasetBaseSchema.shape.id,
     project_id: datasetBaseSchema.shape.project_id.nullish(),
     name: datasetBaseSchema.shape.name,
@@ -155,12 +149,11 @@ export const datasetSchema = z
     deleted_at: datasetBaseSchema.shape.deleted_at,
     user_id: datasetBaseSchema.shape.user_id,
   })
-  .strict()
   .openapi("Dataset");
 export type Dataset = z.infer<typeof datasetSchema>;
 
 const promptBaseSchema = generateBaseTableSchema("prompt");
-export const promptSchema = z.object({
+export const promptSchema = z.strictObject({
   id: promptBaseSchema.shape.id,
   // This has to be copy/pasted because zod blows up when there are circular dependencies
   _xact_id: z
@@ -180,7 +173,7 @@ export const promptSchema = z.object({
 export type Prompt = z.infer<typeof promptSchema>;
 
 const repoInfoSchema = z
-  .object({
+  .strictObject({
     commit: z.string().nullish().describe("SHA of most recent commit"),
     branch: z
       .string()
@@ -225,7 +218,7 @@ const experimentBaseSchema = generateBaseTableSchema("experiment", {
   uniqueName: true,
 });
 export const experimentSchema = z
-  .object({
+  .strictObject({
     id: experimentBaseSchema.shape.id,
     project_id: experimentBaseSchema.shape.project_id,
     name: experimentBaseSchema.shape.name,
@@ -265,7 +258,6 @@ export const experimentSchema = z
     user_id: experimentBaseSchema.shape.user_id,
     metadata: experimentBaseSchema.shape.metadata,
   })
-  .strict()
   .openapi("Experiment");
 export type Experiment = z.infer<typeof experimentSchema>;
 
@@ -278,7 +270,7 @@ export const appLimitSchema = z
   .describe("Limit the number of objects to return");
 
 function generateBaseTableOpSchema(objectName: string) {
-  return z.object({
+  return z.strictObject({
     org_name: z
       .string()
       .nullish()
@@ -314,22 +306,20 @@ export const endingBeforeSchema = z
 
 const createProjectBaseSchema = generateBaseTableOpSchema("project");
 const createProjectSchema = z
-  .object({
+  .strictObject({
     name: projectSchema.shape.name,
     org_name: createProjectBaseSchema.shape.org_name,
   })
-  .strict()
   .openapi("CreateProject");
 
 const patchProjectSchema = z
-  .object({
+  .strictObject({
     name: projectSchema.shape.name.nullish(),
   })
-  .strict()
   .openapi("PatchProject");
 
 const createExperimentSchema = z
-  .object({
+  .strictObject({
     project_id: experimentSchema.shape.project_id,
     name: experimentSchema.shape.name.nullish(),
     description: experimentSchema.shape.description,
@@ -340,41 +330,35 @@ const createExperimentSchema = z
     public: experimentSchema.shape.public.nullish(),
     metadata: experimentSchema.shape.metadata,
   })
-  .strict()
   .openapi("CreateExperiment");
 
 const patchExperimentSchema = createExperimentSchema
   .omit({ project_id: true })
-  .strict()
   .openapi("PatchExperiment");
 
 const createDatasetSchema = z
-  .object({
+  .strictObject({
     project_id: datasetSchema.shape.project_id,
     name: datasetSchema.shape.name,
     description: datasetSchema.shape.description,
   })
-  .strict()
   .openapi("CreateDataset");
 
 const patchDatasetSchema = createDatasetSchema
   .omit({ project_id: true })
-  .strict()
   .openapi("PatchDataset");
 
 const createPromptSchema = promptSchema
   .omit({ id: true, _xact_id: true })
-  .strict()
   .openapi("CreatePrompt");
 
 const patchPromptSchema = z
-  .object({
+  .strictObject({
     name: promptSchema.shape.name.nullish(),
     description: promptSchema.shape.description.nullish(),
     prompt_data: promptSchema.shape.prompt_data.nullish(),
     tags: promptSchema.shape.tags.nullish(),
   })
-  .strict()
   .openapi("PatchPrompt");
 
 // Section: exported schemas, grouped by object type.

--- a/core/js/typespecs/app_types.ts
+++ b/core/js/typespecs/app_types.ts
@@ -162,13 +162,19 @@ export const promptSchema = z.strictObject({
       `The transaction id of an event is unique to the network operation that processed the event insertion. Transaction ids are monotonically increasing over time and can be used to retrieve a versioned snapshot of the prompt (see the \`version\` parameter)`
     ),
   project_id: promptBaseSchema.shape.project_id,
+  log_id: z
+    .literal("p")
+    .describe("A literal 'p' which identifies the object as a project prompt"),
+  org_id: organizationSchema.shape.id,
   name: promptBaseSchema.shape.name,
   slug: z.string().describe("Unique identifier for the prompt"),
   description: promptBaseSchema.shape.description,
+  created: promptBaseSchema.shape.created,
   prompt_data: promptDataSchema
     .nullish()
     .describe("The prompt, model, and its parameters"),
   tags: z.array(z.string()).nullish().describe("A list of tags for the prompt"),
+  metadata: promptBaseSchema.shape.metadata,
 });
 export type Prompt = z.infer<typeof promptSchema>;
 

--- a/core/js/typespecs/app_types.ts
+++ b/core/js/typespecs/app_types.ts
@@ -355,7 +355,14 @@ const patchDatasetSchema = createDatasetSchema
   .openapi("PatchDataset");
 
 const createPromptSchema = promptSchema
-  .omit({ id: true, _xact_id: true })
+  .omit({
+    id: true,
+    _xact_id: true,
+    org_id: true,
+    log_id: true,
+    created: true,
+    metadata: true,
+  })
   .openapi("CreatePrompt");
 
 const patchPromptSchema = z

--- a/core/js/typespecs/openai/messages.ts
+++ b/core/js/typespecs/openai/messages.ts
@@ -1,24 +1,24 @@
 import { z } from "zod";
 
-const chatCompletionSystemMessageParamSchema = z.object({
+const chatCompletionSystemMessageParamSchema = z.strictObject({
   content: z.string().default(""),
   role: z.literal("system"),
   name: z.string().optional(),
 });
 
-export const chatCompletionContentPartTextSchema = z.object({
+export const chatCompletionContentPartTextSchema = z.strictObject({
   text: z.string().default(""),
   type: z.literal("text"),
 });
 
-const imageURLSchema = z.object({
+const imageURLSchema = z.strictObject({
   url: z.string(),
   detail: z
     .union([z.literal("auto"), z.literal("low"), z.literal("high")])
     .optional(),
 });
 
-export const chatCompletionContentPartImageSchema = z.object({
+export const chatCompletionContentPartImageSchema = z.strictObject({
   image_url: imageURLSchema,
   type: z.literal("image_url"),
 });
@@ -33,41 +33,41 @@ export const chatCompletionContentSchema = z.union([
   z.array(chatCompletionContentPartSchema),
 ]);
 
-const chatCompletionUserMessageParamSchema = z.object({
+const chatCompletionUserMessageParamSchema = z.strictObject({
   content: chatCompletionContentSchema,
   role: z.literal("user"),
   name: z.string().optional(),
 });
 
-const functionCallSchema = z.object({
+const functionCallSchema = z.strictObject({
   arguments: z.string(),
   name: z.string(),
 });
 
-const functionSchema = z.object({
+const functionSchema = z.strictObject({
   arguments: z.string(),
   name: z.string(),
 });
 
-const chatCompletionToolMessageParamSchema = z.object({
+const chatCompletionToolMessageParamSchema = z.strictObject({
   content: z.string().default(""),
   role: z.literal("tool"),
   tool_call_id: z.string(),
 });
 
-const chatCompletionFunctionMessageParamSchema = z.object({
+const chatCompletionFunctionMessageParamSchema = z.strictObject({
   content: z.string().default(""),
   name: z.string(),
   role: z.literal("function"),
 });
 
-const chatCompletionMessageToolCallSchema = z.object({
+const chatCompletionMessageToolCallSchema = z.strictObject({
   id: z.string(),
   function: functionSchema,
   type: z.literal("function"),
 });
 
-const chatCompletionAssistantMessageParamSchema = z.object({
+const chatCompletionAssistantMessageParamSchema = z.strictObject({
   role: z.literal("assistant"),
   content: z.string().nullish(),
   function_call: functionCallSchema.optional(),

--- a/core/js/typespecs/openai/tools.ts
+++ b/core/js/typespecs/openai/tools.ts
@@ -2,13 +2,13 @@ import { z } from "zod";
 
 export const functionParametersSchema = z.record(z.unknown());
 
-export const functionDefinitionSchema = z.object({
+export const functionDefinitionSchema = z.strictObject({
   name: z.string(),
   description: z.string().optional(),
   parameters: functionParametersSchema.optional(),
 });
 
-export const chatCompletionToolSchema = z.object({
+export const chatCompletionToolSchema = z.strictObject({
   function: functionDefinitionSchema,
   type: z.literal("function"),
 });

--- a/core/js/typespecs/prompt.ts
+++ b/core/js/typespecs/prompt.ts
@@ -31,11 +31,11 @@ export type ContentPartImage = z.infer<
 export type ContentPart = z.infer<typeof chatCompletionContentPartSchema>;
 
 export const promptBlockDataSchema = z.union([
-  z.object({
+  z.strictObject({
     type: z.literal("completion"),
     content: z.string(),
   }),
-  z.object({
+  z.strictObject({
     type: z.literal("chat"),
     messages: z.array(chatCompletionMessageParamSchema),
     tools: z.string().optional(),
@@ -44,28 +44,31 @@ export const promptBlockDataSchema = z.union([
 
 export type PromptBlockData = z.infer<typeof promptBlockDataSchema>;
 
-const braintrustModelParamsSchema = z.object({
+const braintrustModelParamsSchema = z.strictObject({
   use_cache: z.boolean().optional(),
 });
 
 export const BRAINTRUST_PARAMS = Object.keys(braintrustModelParamsSchema.shape);
 
-const openAIModelParamsSchema = z.object({
+const openAIModelParamsSchema = z.strictObject({
   temperature: z.number(),
   top_p: z.number().optional(),
   max_tokens: z.number().optional(),
   frequency_penalty: z.number().optional(),
   presence_penalty: z.number().optional(),
   response_format: z
-    .union([z.literal(null), z.object({ type: z.literal("json_object") })])
+    .union([
+      z.literal(null),
+      z.strictObject({ type: z.literal("json_object") }),
+    ])
     .optional(),
   tool_choice: z
     .union([
       z.literal("auto"),
       z.literal("none"),
-      z.object({
+      z.strictObject({
         type: z.literal("function"),
-        function: z.object({ name: z.string() }),
+        function: z.strictObject({ name: z.string() }),
       }),
     ])
     .optional(),
@@ -73,7 +76,7 @@ const openAIModelParamsSchema = z.object({
 
 export type OpenAIModelParams = z.infer<typeof openAIModelParamsSchema>;
 
-const anthropicModelParamsSchema = z.object({
+const anthropicModelParamsSchema = z.strictObject({
   max_tokens: z.number(),
   temperature: z.number(),
   top_p: z.number().optional(),
@@ -84,14 +87,14 @@ const anthropicModelParamsSchema = z.object({
     .describe("This is a legacy parameter that should not be used."),
 });
 
-const googleModelParamsSchema = z.object({
+const googleModelParamsSchema = z.strictObject({
   temperature: z.number(),
   maxOutputTokens: z.number().optional(),
   topP: z.number().optional(),
   topK: z.number().optional(),
 });
 
-const jsCompletionParamsSchema = z.object({});
+const jsCompletionParamsSchema = z.strictObject({});
 export const modelParamsSchema = braintrustModelParamsSchema.and(
   z.union([
     openAIModelParamsSchema,
@@ -110,7 +113,7 @@ const anyModelParamsSchema = openAIModelParamsSchema
 
 export type AnyModelParam = z.infer<typeof anyModelParamsSchema>;
 
-export const promptOptionsSchema = z.object({
+export const promptOptionsSchema = z.strictObject({
   model: z.string().optional(),
   params: modelParamsSchema.optional(),
   position: z.string().optional(),
@@ -119,11 +122,11 @@ export const promptOptionsSchema = z.object({
 export type PromptOptions = z.infer<typeof promptOptionsSchema>;
 
 export const promptDataSchema = z
-  .object({
+  .strictObject({
     prompt: promptBlockDataSchema.nullish(),
     options: promptOptionsSchema.nullish(),
     origin: z
-      .object({
+      .strictObject({
         prompt_id: z.string().optional(),
         prompt_version: z.string().optional(),
       })


### PR DESCRIPTION
Replaced all instances of `z.object` with `z.strictObject`, which seems like a less error-prone way to ensure strictness everywhere by default.