### PR TITLE
Constrain score lists to be objects

### DIFF
--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -489,7 +489,9 @@ export async function runEvaluator(
                     for (const s of scoreValue) {
                       if (!(typeof s === "object" && !isEmpty(s))) {
                         throw new Error(
-                          `When returning an array of scores, each score must be a non-empty object. Got: ${s}`
+                          `When returning an array of scores, each score must be a non-empty object. Got: ${JSON.stringify(
+                            s
+                          )}`
                         );
                       }
                     }

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -642,9 +642,6 @@ async def run_evaluator(experiment, evaluator: Evaluator, position: Optional[int
             scorer_args = kwargs
 
             result = await call_user_fn(event_loop, score, **scorer_args)
-            if result is None:
-                return None
-
             if isinstance(result, Iterable):
                 for s in result:
                     if not isinstance(s, Score):

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -106,8 +106,7 @@ class EvalScorerArgs(SerializableDataClass):
     metadata: Optional[Metadata] = None
 
 
-ScoreValue = Union[float, int, bool, None, Score]
-OneOrMoreScores = Optional[Union[ScoreValue, List[ScoreValue]]]
+OneOrMoreScores = Union[float, int, bool, None, Score, List[Score]]
 
 EvalScorer = Union[
     Scorer,
@@ -643,13 +642,20 @@ async def run_evaluator(experiment, evaluator: Evaluator, position: Optional[int
             scorer_args = kwargs
 
             result = await call_user_fn(event_loop, score, **scorer_args)
-            if not isinstance(result, Iterable):
-                result = [result]
+            if result is None:
+                return None
 
-            result = [
-                Score(name=f"{name}_{idx}" if len(result) > 1 else name, score=r) if not isinstance(r, Score) else r
-                for (idx, r) in enumerate(result)
-            ]
+            if isinstance(result, Iterable):
+                for s in result:
+                    if not isinstance(s, Score):
+                        raise ValueError(
+                            f"When returning an array of scores, each score must be a non-empty object. Got: {s}"
+                        )
+                result = list(result)
+            elif isinstance(result, Score):
+                result = [result]
+            else:
+                result = [Score(name=name, score=result)]
 
             def get_other_fields(s):
                 return {k: v for k, v in s.as_dict().items() if k not in ["metadata", "name"]}


### PR DESCRIPTION
Non-objects (nulls and numbers) are not particularly usable, since we don't know what name to attach to each score. This change forces each returned value to be an object, and returns a runtime error if not (along w/ a type error if you're using typescript).