### PR TITLE
Fix prompt params typespecs.

### DIFF
--- a/core/js/typespecs/prompt.ts
+++ b/core/js/typespecs/prompt.ts
@@ -95,21 +95,19 @@ const googleModelParamsSchema = z.strictObject({
 });
 
 const jsCompletionParamsSchema = z.strictObject({});
-export const modelParamsSchema = braintrustModelParamsSchema.and(
-  z.union([
-    openAIModelParamsSchema,
-    anthropicModelParamsSchema,
-    googleModelParamsSchema,
-    jsCompletionParamsSchema,
-  ])
-);
+export const modelParamsSchema = z.union([
+  braintrustModelParamsSchema.merge(openAIModelParamsSchema),
+  braintrustModelParamsSchema.merge(anthropicModelParamsSchema),
+  braintrustModelParamsSchema.merge(googleModelParamsSchema),
+  braintrustModelParamsSchema.merge(jsCompletionParamsSchema),
+]);
 
 export type ModelParams = z.infer<typeof modelParamsSchema>;
 
 const anyModelParamsSchema = openAIModelParamsSchema
-  .and(anthropicModelParamsSchema)
-  .and(googleModelParamsSchema)
-  .and(braintrustModelParamsSchema);
+  .merge(anthropicModelParamsSchema)
+  .merge(googleModelParamsSchema)
+  .merge(braintrustModelParamsSchema);
 
 export type AnyModelParam = z.infer<typeof anyModelParamsSchema>;
 


### PR DESCRIPTION
After https://github.com/braintrustdata/braintrust-sdk/pull/166, we moved to using strict objects by default. Apparently creating intersections between two strict objects (e.g.
`braintrustModelParamsSchema` and `openAIModelParamsSchema`) doesn't seem to work at all. We have to use `merge` to make everything work.

See https://github.com/colinhacks/zod/issues/390 for an explanation of the issue.