### PR TITLE
Generalize span_info args for oai wrappers.

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -2978,6 +2978,8 @@ export type CompletionPrompt = {
 export type CompiledPrompt<Flavor extends "chat" | "completion"> =
   CompiledPromptParams & {
     span_info?: {
+      name?: string;
+      spanAttributes?: Record<any, any>;
       metadata: {
         prompt: {
           variables: Record<string, unknown>;

--- a/js/src/oai.ts
+++ b/js/src/oai.ts
@@ -311,7 +311,7 @@ function wrapEmbeddings<
       },
       mergeDicts(
         {
-          name: "OpenAI Embedding",
+          name: "Embedding",
           spanAttributes: {
             type: SpanTypeAttribute.LLM,
           },

--- a/js/src/oai.ts
+++ b/js/src/oai.ts
@@ -154,7 +154,7 @@ function wrapBetaChatCompletion<
     const span = startSpan(
       mergeDicts(
         {
-          name: "OpenAI Chat Completion",
+          name: "Chat Completion",
           spanAttributes: {
             type: SpanTypeAttribute.LLM,
           },
@@ -205,7 +205,7 @@ function wrapChatCompletion<
     const span = startSpan(
       mergeDicts(
         {
-          name: "OpenAI Chat Completion",
+          name: "Chat Completion",
           spanAttributes: {
             type: SpanTypeAttribute.LLM,
           },

--- a/py/src/braintrust/oai.py
+++ b/py/src/braintrust/oai.py
@@ -187,7 +187,7 @@ class EmbeddingWrapper:
         params = self._parse_params(kwargs)
 
         with start_span(
-            **merge_dicts(dict(name="OpenAI Embedding", span_attributes={"type": SpanTypeAttribute.LLM}), params)
+            **merge_dicts(dict(name="Embedding", span_attributes={"type": SpanTypeAttribute.LLM}), params)
         ) as span:
             raw_response = self.create_fn(*args, **kwargs)
             log_response = raw_response if isinstance(raw_response, dict) else raw_response.dict()
@@ -206,7 +206,7 @@ class EmbeddingWrapper:
         params = self._parse_params(kwargs)
 
         with start_span(
-            **merge_dicts(dict(name="OpenAI Embedding", span_attributes={"type": SpanTypeAttribute.LLM}), params)
+            **merge_dicts(dict(name="Embedding", span_attributes={"type": SpanTypeAttribute.LLM}), params)
         ) as span:
             raw_response = await self.acreate_fn(*args, **kwargs)
             log_response = raw_response if isinstance(raw_response, dict) else raw_response.dict()

--- a/py/src/braintrust/oai.py
+++ b/py/src/braintrust/oai.py
@@ -65,7 +65,7 @@ class ChatCompletionWrapper:
         stream = kwargs.get("stream", False)
 
         span = start_span(
-            **merge_dicts(dict(name="OpenAI Chat Completion", span_attributes={"type": SpanTypeAttribute.LLM}), params)
+            **merge_dicts(dict(name="Chat Completion", span_attributes={"type": SpanTypeAttribute.LLM}), params)
         )
         should_end = True
 
@@ -116,7 +116,7 @@ class ChatCompletionWrapper:
         stream = kwargs.get("stream", False)
 
         span = start_span(
-            **merge_dicts(dict(name="OpenAI Chat Completion", span_attributes={"type": SpanTypeAttribute.LLM}), params)
+            **merge_dicts(dict(name="Chat Completion", span_attributes={"type": SpanTypeAttribute.LLM}), params)
         )
         should_end = True
 

--- a/py/src/braintrust/oai.py
+++ b/py/src/braintrust/oai.py
@@ -64,7 +64,9 @@ class ChatCompletionWrapper:
         params = self._parse_params(kwargs)
         stream = kwargs.get("stream", False)
 
-        span = start_span(name="OpenAI Chat Completion", span_attributes={"type": SpanTypeAttribute.LLM}, **params)
+        span = start_span(
+            **merge_dicts(dict(name="OpenAI Chat Completion", span_attributes={"type": SpanTypeAttribute.LLM}), params)
+        )
         should_end = True
 
         try:
@@ -113,7 +115,9 @@ class ChatCompletionWrapper:
         params = self._parse_params(kwargs)
         stream = kwargs.get("stream", False)
 
-        span = start_span(name="OpenAI Chat Completion", span_attributes={"type": SpanTypeAttribute.LLM}, **params)
+        span = start_span(
+            **merge_dicts(dict(name="OpenAI Chat Completion", span_attributes={"type": SpanTypeAttribute.LLM}), params)
+        )
         should_end = True
 
         try:
@@ -165,15 +169,13 @@ class ChatCompletionWrapper:
         # Then, copy the rest of the params
         params = {**params}
         messages = params.pop("messages", None)
-        merge_dicts(
+        return merge_dicts(
             ret,
             {
                 "input": messages,
                 "metadata": params,
             },
         )
-
-        return ret
 
 
 class EmbeddingWrapper:
@@ -184,7 +186,9 @@ class EmbeddingWrapper:
     def create(self, *args, **kwargs):
         params = self._parse_params(kwargs)
 
-        with start_span(name="OpenAI Embedding", span_attributes={"type": SpanTypeAttribute.LLM}, **params) as span:
+        with start_span(
+            **merge_dicts(dict(name="OpenAI Embedding", span_attributes={"type": SpanTypeAttribute.LLM}), params)
+        ) as span:
             raw_response = self.create_fn(*args, **kwargs)
             log_response = raw_response if isinstance(raw_response, dict) else raw_response.dict()
             span.log(
@@ -201,7 +205,9 @@ class EmbeddingWrapper:
     async def acreate(self, *args, **kwargs):
         params = self._parse_params(kwargs)
 
-        with start_span(name="OpenAI Embedding", span_attributes={"type": SpanTypeAttribute.LLM}, **params) as span:
+        with start_span(
+            **merge_dicts(dict(name="OpenAI Embedding", span_attributes={"type": SpanTypeAttribute.LLM}), params)
+        ) as span:
             raw_response = await self.acreate_fn(*args, **kwargs)
             log_response = raw_response if isinstance(raw_response, dict) else raw_response.dict()
             span.log(
@@ -223,15 +229,13 @@ class EmbeddingWrapper:
         params = {**params}
         input = params.pop("input", None)
 
-        merge_dicts(
+        return merge_dicts(
             ret,
             {
                 "input": input,
                 "metadata": params,
             },
         )
-
-        return ret
 
 
 class ChatCompletionV0Wrapper(NamedWrapper):


### PR DESCRIPTION
In general allow passing any of the params that could be used to create a span. Type-wise, we just include `name` and `span_attributes` in the TS type signatures, but could add anything else in `StartSpanArgs` if needed.