### PR TITLE
Use single global BackgroundLogger instance everywhere.

### DIFF
--- a/py/src/braintrust/__init__.py
+++ b/py/src/braintrust/__init__.py
@@ -47,5 +47,5 @@ BRAINTRUST_API_KEY=<YOUR_BRAINTRUST_API_KEY> braintrust eval eval_hello.py
 
 from .framework import *
 from .logger import *
-from .logger import _internal_reset_global_state
+from .logger import _internal_reset_global_state, _internal_with_custom_background_logger
 from .oai import wrap_openai


### PR DESCRIPTION
Originally we would spawn a separate BackgroundLogger for each object we created. This is not particularly useful anymore, because the background logger already batches and parallelizes requests. It also leads to problems with flushing, because you have to call flush on every logger that you have logged to (including the global logger if you are doing distributed tracing).

We change everything to use just the single global logger and add a global flush function for good measure. Fix a few bugs along the way.