### PR TITLE
Use REST API endpoints for fetching data.

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -2206,7 +2206,7 @@ class ObjectFetcher<RecordType>
         {
           version: this.pinnedVersion,
         },
-        { headers: { ["Accept-Encoding"]: "gzip" } }
+        { headers: { "Accept-Encoding": "identity" } }
       );
       const data = (await resp.json()).events;
       this._fetchedData = this.mutateRecord

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -380,8 +380,10 @@ class HTTPConnection {
 
   async get(
     path: string,
-    params: Record<string, string | undefined> | undefined = undefined
+    params: Record<string, string | undefined> | undefined = undefined,
+    config?: RequestInit
   ) {
+    const { headers, ...rest } = config || {};
     const url = new URL(_urljoin(this.base_url, path));
     url.search = new URLSearchParams(
       params
@@ -393,8 +395,12 @@ class HTTPConnection {
     return await checkResponse(
       // Using toString() here makes it work with isomorphic fetch
       await fetch(url.toString(), {
-        headers: this.headers,
+        headers: {
+          ...this.headers,
+          ...headers,
+        },
         keepalive: true,
+        ...rest,
       })
     );
   }
@@ -2195,26 +2201,14 @@ class ObjectFetcher<RecordType>
   async fetchedData() {
     if (this._fetchedData === undefined) {
       const state = await this.getState();
-      let data = undefined;
-      try {
-        const resp = await state.logConn().get(`object3/${this.objectType}`, {
-          id: await this.id,
-          fmt: "json2",
+      const resp = await state.logConn().get(
+        `v1/${this.objectType}/${await this.id}/fetch`,
+        {
           version: this.pinnedVersion,
-          api_version: "2",
-        });
-        data = await resp.json();
-      } catch (e) {
-        // DEPRECATION_NOTICE: When hitting old versions of the API where the "object3/" endpoint isn't available, we fall back to
-        // the "object/" endpoint, which may require patching the incoming records. Remove this code once
-        // all APIs are updated.
-        const resp = await state.logConn().get(`object/${this.objectType}`, {
-          id: await this.id,
-          fmt: "json2",
-          version: this.pinnedVersion,
-        });
-        data = await resp.json();
-      }
+        },
+        { headers: { ["Accept-Encoding"]: "gzip" } }
+      );
+      const data = (await resp.json()).events;
       this._fetchedData = this.mutateRecord
         ? data?.map(this.mutateRecord)
         : data;


### PR DESCRIPTION
Also removed the fallback requests, because after
https://github.com/braintrustdata/braintrust-sdk/pull/159, we require API version 0.0.35, which includes the REST API.

Tested on prod by fetching a very large dataset successfully in the SDK. Verified that things fail without gzip compression by changing the header from `Accept-Encoding: gzip` to `Accept-Encoding: identity`.