### PR TITLE
Fix kwargs param

### DIFF
--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -239,6 +239,9 @@ async def call_user_fn(event_loop, fn, **kwargs):
     final_kwargs = {}
 
     for name, param in signature.parameters.items():
+        if param.kind == inspect.Parameter.VAR_KEYWORD:
+            continue
+
         if name in kwargs:
             final_kwargs[name] = kwargs.pop(name)
         else:


### PR DESCRIPTION
We were errantly handling the `VAR_KEYWORD`, i.e. `kwargs` param and the `final_kwargs` argument would just include it as an arg named `kwargs`.