### PR TITLE
Explicitly disallow NaN while serializing

### DIFF
--- a/core/py/src/braintrust_core/bt_json.py
+++ b/core/py/src/braintrust_core/bt_json.py
@@ -24,4 +24,4 @@ class BraintrustJSONEncoder(json.JSONEncoder):
 
 
 def bt_dumps(obj, **kwargs) -> str:
-    return json.dumps(obj, cls=BraintrustJSONEncoder, **kwargs)
+    return json.dumps(obj, cls=BraintrustJSONEncoder, allow_nan=False, **kwargs)


### PR DESCRIPTION
This fails on the server-side, so catch it early in Python.