### PR TITLE
Add normalizeScorers/normalize_scorers helpers

### DIFF
--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -63,6 +63,7 @@ export {
   Reporter,
   buildLocalSummary,
   reportFailures,
+  normalizeScorers,
 } from "./framework";
 export * from "./oai";
 export {


### PR DESCRIPTION
This adds a "higher order" scorer that makes it easier to build other higher order scorers. It takes a list of scorers and returns a single (async) scorer that calls the other scorers and returns a list of Score objects. This way, when you're building a higher order scorer, you don't need to worry about the dependent scorers returning numbers or nulls or whatever. Just call the returned scorer, and you'll get back a list of Score objects.

Here's an example usage:

```ts
// Given a list of scorers, returns a new scorer that includes the assertion
// scorers.
export function withAssertionScorers<
  Input,
  Output,
  Expected,
  Metadata extends BaseMetadata = DefaultMetadataType,
>(scorers: EvalScorer<Input, Output, Expected, Metadata>[]) {
  // Wrap the scorers in a scorer that "normalizes" the scores.
  const NormalizedScorer = normalizeScorers(scorers);
  return async function AssertionScorer(
    args: EvalScorerArgs<Input, Output, Expected, Metadata>,
  ) {
    // We are guaranteed to get back a list of score objects.
    const scores = await NormalizedScorer(args);
    // Now we can add in dependent scores.
    return [...scores, AboveZeroScorer(scores), AcceptableScorer(scores)];
  };
}
```