### PR TITLE
Incorporate .env files in CLI

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@ai-sdk/provider": "^0.0.0",
     "@braintrust/core": "workspace:*",
+    "@next/env": "^14.2.3",
     "argparse": "^2.0.1",
     "chalk": "^4.1.2",
     "cli-progress": "^3.12.0",

--- a/js/package.json
+++ b/js/package.json
@@ -50,6 +50,7 @@
     "argparse": "^2.0.1",
     "chalk": "^4.1.2",
     "cli-progress": "^3.12.0",
+    "dotenv": "^16.4.5",
     "esbuild": "^0.18.20",
     "graceful-fs": "^4.2.11",
     "minimatch": "^9.0.3",

--- a/js/src/cli.ts
+++ b/js/src/cli.ts
@@ -37,6 +37,7 @@ import {
 } from "./framework";
 import { configureNode } from "./node";
 import { isEmpty } from "./util";
+import { loadEnvConfig } from "@next/env";
 
 // This requires require
 // https://stackoverflow.com/questions/50822310/how-to-import-package-json-in-typescript
@@ -799,6 +800,9 @@ async function main() {
   parser_run.set_defaults({ func: run });
 
   const parsed = parser.parse_args();
+
+  // Load the environment variables from the .env files using the same rules as Next.js
+  console.log(loadEnvConfig(process.cwd(), true));
 
   try {
     await parsed.func(parsed);

--- a/js/src/cli.ts
+++ b/js/src/cli.ts
@@ -802,7 +802,7 @@ async function main() {
   const parsed = parser.parse_args();
 
   // Load the environment variables from the .env files using the same rules as Next.js
-  console.log(loadEnvConfig(process.cwd(), true));
+  loadEnvConfig(process.cwd(), true);
 
   try {
     await parsed.func(parsed);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@braintrust/core':
         specifier: workspace:*
         version: link:../core/js
+      '@next/env':
+        specifier: ^14.2.3
+        version: 14.2.3
       argparse:
         specifier: ^2.0.1
         version: 2.0.1
@@ -557,6 +560,10 @@ packages:
 
   /@kwsites/promise-deferred@1.1.1:
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
+    dev: false
+
+  /@next/env@14.2.3:
+    resolution: {integrity: sha512-W7fd7IbkfmeeY2gXrzJYDx8D2lWKbVoTIj1o1ScPHNzvp30s1AuoEFSdr39bC5sjxJaxTtq3OTCZboNp0lNWHA==}
     dev: false
 
   /@nodelib/fs.scandir@2.1.5:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       cli-progress:
         specifier: ^3.12.0
         version: 3.12.0
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.4.5
       esbuild:
         specifier: ^0.18.20
         version: 0.18.20
@@ -972,6 +975,11 @@ packages:
     dependencies:
       path-type: 4.0.0
     dev: true
+
+  /dotenv@16.4.5:
+    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
+    engines: {node: '>=12'}
+    dev: false
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}

--- a/py/setup.py
+++ b/py/setup.py
@@ -11,7 +11,7 @@ with open(os.path.join(dir_name, "src", "braintrust", "version.py"), encoding="u
 with open(os.path.join(dir_name, "README.md"), "r", encoding="utf-8") as f:
     long_description = f.read()
 
-install_requires = ["GitPython", "requests", "chevron", "braintrust_core", "tqdm", "exceptiongroup==1.2.0"]
+install_requires = ["GitPython", "requests", "chevron", "braintrust_core", "tqdm", "exceptiongroup==1.2.0", "dotenv"]
 
 extras_require = {
     "cli": ["boto3", "psycopg2-binary"],

--- a/py/setup.py
+++ b/py/setup.py
@@ -11,7 +11,15 @@ with open(os.path.join(dir_name, "src", "braintrust", "version.py"), encoding="u
 with open(os.path.join(dir_name, "README.md"), "r", encoding="utf-8") as f:
     long_description = f.read()
 
-install_requires = ["GitPython", "requests", "chevron", "braintrust_core", "tqdm", "exceptiongroup==1.2.0", "dotenv"]
+install_requires = [
+    "GitPython",
+    "requests",
+    "chevron",
+    "braintrust_core",
+    "tqdm",
+    "exceptiongroup==1.2.0",
+    "python-dotenv",
+]
 
 extras_require = {
     "cli": ["boto3", "psycopg2-binary"],

--- a/py/src/braintrust/cli/eval.py
+++ b/py/src/braintrust/cli/eval.py
@@ -249,6 +249,11 @@ def run(args):
     if args.num_workers:
         set_thread_pool_max_workers(args.num_workers)
 
+    if args.env_file:
+        from dotenv import load_dotenv
+
+        load_dotenv(args.env_file)
+
     evaluator_opts = EvaluatorOpts(
         verbose=args.verbose,
         no_send_logs=args.no_send_logs,
@@ -329,6 +334,10 @@ def build_parser(subparsers, parent_parser):
         "--terminate-on-failure",
         action="store_true",
         help="If provided, terminates on a failing eval, instead of the default (moving onto the next one).",
+    )
+    parser.add_argument(
+        "--env-file",
+        help="A path to a .env file containing environment variables to load (via dotenv).",
     )
     parser.add_argument(
         "--num-workers",


### PR DESCRIPTION
Follows the `.env.*` conventions laid out (and implemented) by Next.js.

For both TS and Py, add a `--env-file` flag to specify an env file