### PR TITLE
Add some more tuning params to the loggers.

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -1084,6 +1084,7 @@ class BackgroundLogger {
           payloadDir: this.failedPublishPayloadsDir,
           payload: dataStr,
         });
+        this.logFailedPayloadsDir();
       }
 
       if (!isRetrying && this.syncFlush) {
@@ -1115,6 +1116,9 @@ class BackgroundLogger {
       console.warn(
         `Dropped ${this.queueDropLoggingState.numDropped} elements due to full queue`,
       );
+      if (this.failedPublishPayloadsDir) {
+        this.logFailedPayloadsDir();
+      }
       this.queueDropLoggingState.numDropped = 0;
       this.queueDropLoggingState.lastLoggedTimestamp = timeNow;
     }
@@ -1188,6 +1192,10 @@ class BackgroundLogger {
         }
       })();
     }
+  }
+
+  private logFailedPayloadsDir() {
+    console.warn(`Logging failed payloads to ${this.failedPublishPayloadsDir}`);
   }
 
   // Should only be called by BraintrustState.

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -1115,6 +1115,7 @@ class BackgroundLogger {
       console.warn(
         `Dropped ${this.queueDropLoggingState.numDropped} elements due to full queue`,
       );
+      this.queueDropLoggingState.numDropped = 0;
       this.queueDropLoggingState.lastLoggedTimestamp = timeNow;
     }
   }

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -649,6 +649,7 @@ class _BackgroundLogger:
                     f"Dropped {self._queue_drop_logging_state['num_dropped']} elements due to full queue",
                     file=self.outfile,
                 )
+                self._queue_drop_logging_state["num_dropped"] = 0
                 self._queue_drop_logging_state["last_logged_timestamp"] = time_now
 
     @staticmethod


### PR DESCRIPTION
`BRAINTRUST_ALL_PUBLISH_PAYLOADS_DIR`: Set this to log all payloads we publish (regardless of success or failure) to the specified directory.

`BRAINTRUST_QUEUE_DROP_WHEN_FULL` (in python): configures the logger to drop additional elements instead of doing a blocking insert.

`BRAINTRUST_QUEUE_DROP_EXCEEDING_MAXSIZE` (in javascript): configures the logger to drop elements after exceeding the given size. This is basically a combination of `BRAINTRUST_QUEUE_SIZE` and `BRAINTRUST_QUEUE_DROP_WHEN_FULL`. The reason we can't use the same params in JS is that JS doesn't have a blocking queue functionality.

Fixes BRA-1332, BRA-1215