### PR TITLE
Fix SDK to point to braintrust.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Braintrust SDK
 
-[Braintrust](https://www.braintrustdata.com/) is a platform for evaluating and shipping AI products. To learn more about Braintrust or sign up for free,
-visit our [website](https://www.braintrustdata.com/) or check out the [docs](https://www.braintrustdata.com/docs).
+[Braintrust](https://www.braintrust.dev/) is a platform for evaluating and shipping AI products. To learn more about Braintrust or sign up for free,
+visit our [website](https://www.braintrust.dev/) or check out the [docs](https://www.braintrust.dev/docs).
 
 This repository contains the Python and Javascript SDKs for Braintrust. The SDKs include utilities to:
 
@@ -98,7 +98,7 @@ BRAINTRUST_API_KEY=<YOUR_API_KEY> \
 
 ## Documentation
 
-For more information, check out the [docs](https://www.braintrustdata.com/docs):
+For more information, check out the [docs](https://www.braintrust.dev/docs):
 
-- [Typescript](https://www.braintrustdata.com/docs/libs/nodejs)
-- [Python](https://www.braintrustdata.com/docs/libs/python)
+- [Typescript](https://www.braintrust.dev/docs/libs/nodejs)
+- [Python](https://www.braintrust.dev/docs/libs/python)

--- a/core/js/package.json
+++ b/core/js/package.json
@@ -42,7 +42,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "https://www.braintrustdata.com",
+  "homepage": "https://www.braintrust.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/braintrustdata/braintrust-sdk.git"

--- a/core/js/src/merge_row_batch.ts
+++ b/core/js/src/merge_row_batch.ts
@@ -35,7 +35,7 @@ export function mergeRowBatch<
   for (const row of rows) {
     if (row.id === undefined) {
       throw new Error(
-        "Logged row is missing an id. This is an internal braintrust error. Please contact us at info@braintrustdata.com for help",
+        "Logged row is missing an id. This is an internal braintrust error. Please contact us at info@braintrust.dev for help",
       );
     }
   }

--- a/core/js/typespecs/api_types.ts
+++ b/core/js/typespecs/api_types.ts
@@ -136,7 +136,7 @@ function generateBaseEventOpSchema(objectType: ObjectTypeWithEvent) {
     span_id: z
       .string()
       .describe(
-        `A unique identifier used to link different ${eventDescription} events together as part of a full trace. See the [tracing guide](https://www.braintrustdata.com/docs/guides/tracing) for full details on tracing`,
+        `A unique identifier used to link different ${eventDescription} events together as part of a full trace. See the [tracing guide](https://www.braintrust.dev/docs/guides/tracing) for full details on tracing`,
       ),
     span_parents: z
       .string()
@@ -495,7 +495,7 @@ const replacementEventSchema = z.strictObject({
     .nullish()
     .describe(
       [
-        "Use the `_parent_id` field to create this row as a subspan of an existing row. It cannot be specified alongside `_is_merge=true`. Tracking hierarchical relationships are important for tracing (see the [guide](https://www.braintrustdata.com/docs/guides/tracing) for full details).",
+        "Use the `_parent_id` field to create this row as a subspan of an existing row. It cannot be specified alongside `_is_merge=true`. Tracking hierarchical relationships are important for tracing (see the [guide](https://www.braintrust.dev/docs/guides/tracing) for full details).",
         'For example, say we have logged a row `{"id": "abc", "input": "foo", "output": "bar", "expected": "boo", "scores": {"correctness": 0.33}}`. We can create a sub-span of the parent row by logging `{"_parent_id": "abc", "id": "llm_call", "input": {"prompt": "What comes after foo?"}, "output": "bar", "metrics": {"tokens": 1}}`. In the webapp, only the root span row `"abc"` will show up in the summary view. You can view the full trace hierarchy (in this case, the `"llm_call"` row) by clicking on the "abc" row.',
       ].join("\n\n"),
     ),

--- a/core/py/setup.py
+++ b/core/py/setup.py
@@ -20,11 +20,11 @@ setuptools.setup(
     name="braintrust_core",
     version=version_contents["VERSION"],
     author="Braintrust",
-    author_email="info@braintrustdata.com",
+    author_email="info@braintrust.dev",
     description="Shared core dependencies for Braintrust packages",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://www.braintrustdata.com",
+    url="https://www.braintrust.dev",
     classifiers=[
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",

--- a/core/py/src/braintrust_core/merge_row_batch.py
+++ b/core/py/src/braintrust_core/merge_row_batch.py
@@ -67,7 +67,7 @@ def merge_row_batch(rows: List[Dict]) -> List[List[Dict]]:
     for row in rows:
         if row.get("id") is None:
             raise Exception(
-                "Logged row is missing an id. This is an internal braintrust error. Please contact us at info@braintrustdata.com for help"
+                "Logged row is missing an id. This is an internal braintrust error. Please contact us at info@braintrust.dev for help"
             )
 
     row_groups = {}

--- a/js/src/cli.ts
+++ b/js/src/cli.ts
@@ -774,7 +774,7 @@ async function main() {
     help: "The name of a specific organization to connect to. This is useful if you belong to multiple.",
   });
   parser_run.add_argument("--app-url", {
-    help: "Specify a custom braintrust app url. Defaults to https://www.braintrustdata.com. This is only necessary if you are using an experimental version of Braintrust",
+    help: "Specify a custom braintrust app url. Defaults to https://www.braintrust.dev. This is only necessary if you are using an experimental version of Braintrust",
   });
   parser_run.add_argument("--watch", {
     action: "store_true",

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -1244,7 +1244,7 @@ type InitializedExperiment<IsOpen extends boolean | undefined> =
  * @param options.update If the experiment already exists, continue logging to it. If it does not exist, creates the experiment with the specified arguments.
  * @param options.baseExperiment An optional experiment name to use as a base. If specified, the new experiment will be summarized and compared to this experiment. Otherwise, it will pick an experiment by finding the closest ancestor on the default (e.g. main) branch.
  * @param options.isPublic An optional parameter to control whether the experiment is publicly visible to anybody with the link or privately visible to only members of the organization. Defaults to private.
- * @param options.appUrl The URL of the Braintrust App. Defaults to https://www.braintrustdata.com.
+ * @param options.appUrl The URL of the Braintrust App. Defaults to https://www.braintrust.dev.
  * @param options.apiKey The API key to use. If the parameter is not specified, will try to use the `BRAINTRUST_API_KEY` environment variable. If no API key is specified, will prompt the user to login.
  * @param options.orgName (Optional) The name of a specific organization to connect to. This is useful if you belong to multiple.
  * @param options.metadata (Optional) A dictionary with additional data about the test example, model outputs, or just about anything else that's relevant, that you can use to help find and analyze examples later. For example, you could log the `prompt`, example's `id`, or anything else that would be useful to slice/dice later. The values in `metadata` can be any JSON-serializable type, but its keys must be strings.
@@ -1567,7 +1567,7 @@ type FullInitDatasetOptions<IsLegacyDataset extends boolean> = {
  * @param options.project The name of the project to create the dataset in. Must specify at least one of `project` or `projectId`.
  * @param options.dataset The name of the dataset to create. If not specified, a name will be generated automatically.
  * @param options.description An optional description of the dataset.
- * @param options.appUrl The URL of the Braintrust App. Defaults to https://www.braintrustdata.com.
+ * @param options.appUrl The URL of the Braintrust App. Defaults to https://www.braintrust.dev.
  * @param options.apiKey The API key to use. If the parameter is not specified, will try to use the `BRAINTRUST_API_KEY` environment variable. If no API key is specified, will prompt the user to login.
  * @param options.orgName (Optional) The name of a specific organization to connect to. This is useful if you belong to multiple.
  * @param options.projectId The id of the project to create the dataset in. This takes precedence over `project` if specified.
@@ -1704,7 +1704,7 @@ type InitLoggerOptions<IsAsyncFlush> = {
  * @param options.projectName The name of the project to log into. If unspecified, will default to the Global project.
  * @param options.projectId The id of the project to log into. This takes precedence over projectName if specified.
  * @param options.asyncFlush If true, will log asynchronously in the background. Otherwise, will log synchronously. (false by default, to support serverless environments)
- * @param options.appUrl The URL of the Braintrust App. Defaults to https://www.braintrustdata.com.
+ * @param options.appUrl The URL of the Braintrust App. Defaults to https://www.braintrust.dev.
  * @param options.apiKey The API key to use. If the parameter is not specified, will try to use the `BRAINTRUST_API_KEY` environment variable. If no API
  * key is specified, will prompt the user to login.
  * @param options.orgName (Optional) The name of a specific organization to connect to. This is useful if you belong to multiple.
@@ -1801,7 +1801,7 @@ interface LoadPromptOptions {
  * @param options.version An optional version of the prompt (to read). If not specified, the latest version will be used.
  * @param options.defaults (Optional) A dictionary of default values to use when rendering the prompt. Prompt values will override these defaults.
  * @param options.noTrace If true, do not include logging metadata for this prompt when build() is called.
- * @param options.appUrl The URL of the Braintrust App. Defaults to https://www.braintrustdata.com.
+ * @param options.appUrl The URL of the Braintrust App. Defaults to https://www.braintrust.dev.
  * @param options.apiKey The API key to use. If the parameter is not specified, will try to use the `BRAINTRUST_API_KEY` environment variable. If no API
  * key is specified, will prompt the user to login.
  * @param options.orgName (Optional) The name of a specific organization to connect to. This is useful if you belong to multiple.
@@ -1870,10 +1870,10 @@ export async function loadPrompt({
 
 /**
  * Log into Braintrust. This will prompt you for your API token, which you can find at
- * https://www.braintrustdata.com/app/token. This method is called automatically by `init()`.
+ * https://www.braintrust.dev/app/token. This method is called automatically by `init()`.
  *
  * @param options Options for configuring login().
- * @param options.appUrl The URL of the Braintrust App. Defaults to https://www.braintrustdata.com.
+ * @param options.appUrl The URL of the Braintrust App. Defaults to https://www.braintrust.dev.
  * @param options.apiKey The API key to use. If the parameter is not specified, will try to use the `BRAINTRUST_API_KEY` environment variable. If no API
  * key is specified, will prompt the user to login.
  * @param options.orgName (Optional) The name of a specific organization to connect to. This is useful if you belong to multiple.
@@ -1917,8 +1917,7 @@ export async function login(
   }
 
   const {
-    appUrl = iso.getEnv("BRAINTRUST_APP_URL") ||
-      "https://www.braintrustdata.com",
+    appUrl = iso.getEnv("BRAINTRUST_APP_URL") || "https://www.braintrust.dev",
     apiKey = iso.getEnv("BRAINTRUST_API_KEY"),
     orgName = iso.getEnv("BRAINTRUST_ORG_NAME"),
   } = options || {};

--- a/py/setup.py
+++ b/py/setup.py
@@ -43,11 +43,11 @@ setuptools.setup(
     name="braintrust",
     version=version_contents["VERSION"],
     author="Braintrust",
-    author_email="info@braintrustdata.com",
+    author_email="info@braintrust.dev",
     description="SDK for integrating Braintrust",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://www.braintrustdata.com",
+    url="https://www.braintrust.dev",
     # project_urls={
     #    "Bug Tracker": "https://github.com/TODO/issues",
     # },

--- a/py/src/braintrust/cli/eval.py
+++ b/py/src/braintrust/cli/eval.py
@@ -302,7 +302,7 @@ def build_parser(subparsers, parent_parser):
     )
     parser.add_argument(
         "--app-url",
-        help="Specify a custom braintrust app url. Defaults to https://www.braintrustdata.com. This is only necessary if you are using an experimental version of Braintrust",
+        help="Specify a custom braintrust app url. Defaults to https://www.braintrust.dev. This is only necessary if you are using an experimental version of Braintrust",
     )
     parser.add_argument(
         "--watch",

--- a/py/src/braintrust/cli/install/api.py
+++ b/py/src/braintrust/cli/install/api.py
@@ -261,7 +261,7 @@ def main(args):
             textwrap.dedent(
                 f"""\
             Stack with name {args.name} does not exist. Either create it manually by following
-            https://www.braintrustdata.com/docs/getting-started/install or use the --create flag."""
+            https://www.braintrust.dev/docs/guides/self-hosting/aws or use the --create flag."""
             )
         )
         exit(1)

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -747,7 +747,7 @@ def init(
     :param update: If the experiment already exists, continue logging to it. If it does not exist, creates the experiment with the specified arguments.
     :param base_experiment: An optional experiment name to use as a base. If specified, the new experiment will be summarized and compared to this experiment. Otherwise, it will pick an experiment by finding the closest ancestor on the default (e.g. main) branch.
     :param is_public: An optional parameter to control whether the experiment is publicly visible to anybody with the link or privately visible to only members of the organization. Defaults to private.
-    :param app_url: The URL of the Braintrust App. Defaults to https://www.braintrustdata.com.
+    :param app_url: The URL of the Braintrust App. Defaults to https://www.braintrust.dev.
     :param api_key: The API key to use. If the parameter is not specified, will try to use the `BRAINTRUST_API_KEY` environment variable. If no API
     key is specified, will prompt the user to login.
     :param org_name: (Optional) The name of a specific organization to connect to. This is useful if you belong to multiple.
@@ -889,7 +889,7 @@ def init_dataset(
     :param name: The name of the dataset to create. If not specified, a name will be generated automatically.
     :param description: An optional description of the dataset.
     :param version: An optional version of the dataset (to read). If not specified, the latest version will be used.
-    :param app_url: The URL of the Braintrust App. Defaults to https://www.braintrustdata.com.
+    :param app_url: The URL of the Braintrust App. Defaults to https://www.braintrust.dev.
     :param api_key: The API key to use. If the parameter is not specified, will try to use the `BRAINTRUST_API_KEY` environment variable. If no API
     key is specified, will prompt the user to login.
     :param org_name: (Optional) The name of a specific organization to connect to. This is useful if you belong to multiple.
@@ -932,7 +932,7 @@ def init_logger(
     :param project: The name of the project to log into. If unspecified, will default to the Global project.
     :param project_id: The id of the project to log into. This takes precedence over project if specified.
     :param async_flush: If true (the default), log events will be batched and sent asynchronously in a background thread. If false, log events will be sent synchronously. Set to false in serverless environments.
-    :param app_url: The URL of the Braintrust API. Defaults to https://www.braintrustdata.com.
+    :param app_url: The URL of the Braintrust API. Defaults to https://www.braintrust.dev.
     :param api_key: The API key to use. If the parameter is not specified, will try to use the `BRAINTRUST_API_KEY` environment variable. If no API
     key is specified, will prompt the user to login.
     :param org_name: (Optional) The name of a specific organization to connect to. This is useful if you belong to multiple.
@@ -996,7 +996,7 @@ def load_prompt(
     :param project_id: The id of the project to load the prompt from. This takes precedence over `project` if specified.
     :param defaults: (Optional) A dictionary of default values to use when rendering the prompt. Prompt values will override these defaults.
     :param no_trace: If true, do not include logging metadata for this prompt when build() is called.
-    :param app_url: The URL of the Braintrust App. Defaults to https://www.braintrustdata.com.
+    :param app_url: The URL of the Braintrust App. Defaults to https://www.braintrust.dev.
     :param api_key: The API key to use. If the parameter is not specified, will try to use the `BRAINTRUST_API_KEY` environment variable. If no API
     key is specified, will prompt the user to login.
     :param org_name: (Optional) The name of a specific organization to connect to. This is useful if you belong to multiple.
@@ -1040,9 +1040,9 @@ login_lock = threading.RLock()
 def login(app_url=None, api_key=None, org_name=None, force_login=False):
     """
     Log into Braintrust. This will prompt you for your API token, which you can find at
-    https://www.braintrustdata.com/app/token. This method is called automatically by `init()`.
+    https://www.braintrust.dev/app/token. This method is called automatically by `init()`.
 
-    :param app_url: The URL of the Braintrust App. Defaults to https://www.braintrustdata.com.
+    :param app_url: The URL of the Braintrust App. Defaults to https://www.braintrust.dev.
     :param api_key: The API key to use. If the parameter is not specified, will try to use the `BRAINTRUST_API_KEY` environment variable. If no API
     key is specified, will prompt the user to login.
     :param org_name: (Optional) The name of a specific organization to connect to. This is useful if you belong to multiple.
@@ -1071,7 +1071,7 @@ def login(app_url=None, api_key=None, org_name=None, force_login=False):
             return
 
         if app_url is None:
-            app_url = os.environ.get("BRAINTRUST_APP_URL", "https://www.braintrustdata.com")
+            app_url = os.environ.get("BRAINTRUST_APP_URL", "https://www.braintrust.dev")
 
         app_public_url = os.environ.get("BRAINTRUST_APP_PUBLIC_URL", app_url)
 


### PR DESCRIPTION
Currently, our redirects are a bit of a mess, because we redirect braintrustdata.com->www.braintrust.dev, but cannot redirect www.braintrustdata.com because there are SDKs that reference that API (and were failing to point to braintrust.dev).

This change reworks everything to braintrust.dev.