### PR TITLE
Improve IPython repr for EvalResultWithSummary

### DIFF
--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -213,6 +213,9 @@ class EvalResultWithSummary(SerializableDataClass):
     summary: ExperimentSummary
     results: List[EvalResult]
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(f'EvalResultWithSummary(summary="...", results=[...])')
+
 
 EvalReport = TypeVar("EvalReport")
 


### PR DESCRIPTION
Prior to this change, when you ran `Eval()` in a notebook, it'd spit out a full summary along with all the results. This just cleans up the `_repr_pretty_` implementation to print a tighter object.

Note that we print (to the console) the summary itself, so if we printed the summary itself, it'd show up twice.