### PR TITLE
Try to use env variables in browser environments

### DIFF
--- a/js/src/browser-config.ts
+++ b/js/src/browser-config.ts
@@ -23,6 +23,13 @@ export function configureBrowser() {
     // Ignore
   }
 
+  iso.getEnv = (name: string) => {
+    if (typeof process === "undefined" || typeof process.env === "undefined") {
+      return undefined;
+    }
+    return process.env[name];
+  };
+
   _internalSetInitialState();
   browserConfigured = true;
 }


### PR DESCRIPTION
Our isomorphic code should attempt to use environment variables, even in environments that are "browser-like" (i.e. non-node). Vercel edge functions/cloudflare, for example, set process.env.