### PR TITLE
Accept json content type explicitly

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -395,6 +395,7 @@ class HTTPConnection {
       // Using toString() here makes it work with isomorphic fetch
       await fetch(url.toString(), {
         headers: {
+          Accept: "application/json",
           ...this.headers,
           ...headers,
         },
@@ -414,6 +415,7 @@ class HTTPConnection {
       await fetch(_urljoin(this.base_url, path), {
         method: "POST",
         headers: {
+          Accept: "application/json",
           "Content-Type": "application/json",
           ...this.headers,
           ...headers,


### PR DESCRIPTION
We noticed that Vercel edge functions appear to do the equivalent of `Accept: ""` which breaks our API handler code. This change explicitly sets the accept header, in the hopes that it will fix that issue.