### PR TITLE
Pin zod to 3.22.4.

### DIFF
--- a/core/js/package.json
+++ b/core/js/package.json
@@ -63,6 +63,6 @@
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^6.3.1",
     "uuid": "^9.0.1",
-    "zod": "^3.22.4"
+    "zod": "3.22.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         specifier: ^9.0.1
         version: 9.0.1
       zod:
-        specifier: ^3.22.4
+        specifier: 3.22.4
         version: 3.22.4
     devDependencies:
       '@types/node':


### PR DESCRIPTION
Aligns with internal changes. We were ending up with multiple versions of zod floating around across projects which made our builds get confused.