### PR TITLE
Explicitly check for arrays when logging scores

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -2202,6 +2202,9 @@ function validateAndSanitizeExperimentLogPartialArgs(
   event: ExperimentLogPartialArgs,
 ): SanitizedExperimentLogPartialArgs {
   if (event.scores) {
+    if (Array.isArray(event.scores)) {
+      throw new Error("scores must be an object, not an array");
+    }
     for (let [name, score] of Object.entries(event.scores)) {
       if (typeof name !== "string") {
         throw new Error("score names must be strings");


### PR DESCRIPTION
We saw a Sentry crash where a user somehow got a scores object into the database as an array. My theory is that this happened because the validation is too lose on this function. 

An input like `{scores: [0.5, 0.8, 0.9]}` will not trigger an exception as Object.entries happily turns that into ['0', 0.5], ['1', 0.8], ['2', 0.9], which looks like valid scores data.

Let's explicitly check for arrays and throw if users try to log scores that are arrays.