### PR TITLE
fix(sdk-py): add timeout parameter to Eval

### DIFF
--- a/py/src/braintrust/cli/__main__.py
+++ b/py/src/braintrust/cli/__main__.py
@@ -42,8 +42,15 @@ def main(args=None):
     level = logging.DEBUG if args.verbose else logging.INFO
     logging.basicConfig(format="%(asctime)s %(levelname)s [%(name)s]: %(message)s", level=level)
 
-    return args.func(args)
+    try:
+        ret = args.func(args)
+        if ret:
+            os._exit(1)
+        else:
+            os._exit(0)
+    except:
+        os._exit(1)
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -207,6 +207,12 @@ class Evaluator:
     Whether to update an existing experiment with `experiment_name` if one exists. Defaults to false.
     """
 
+    timeout: Optional[float] = None
+    """
+    The duration, in seconds, after which to time out the evaluation.
+    Defaults to None, in which case there is no timeout.
+    """
+
 
 @dataclasses.dataclass
 class EvalResultWithSummary(SerializableDataClass):
@@ -400,6 +406,7 @@ def Eval(
     is_public: bool = False,
     update: bool = False,
     reporter: Optional[Union[ReporterDef, str]] = None,
+    timeout: Optional[float] = None,
 ):
     """
     A function you can use to define an evaluator. This is a convenience wrapper around the `Evaluator` class.
@@ -436,6 +443,8 @@ def Eval(
     can be any JSON-serializable type, but its keys must be strings.
     :param is_public: (Optional) Whether the experiment should be public. Defaults to false.
     :param reporter: (Optional) A reporter that takes an evaluator and its result and returns a report.
+    :param timeout: (Optional) The duration, in seconds, after which to time out the evaluation.
+    Defaults to None, in which case there is no timeout.
     :return: An `EvalResultWithSummary` object, which contains all results and a summary.
     """
     eval_name = _make_eval_name(name, experiment_name)
@@ -455,6 +464,7 @@ def Eval(
         metadata=metadata,
         is_public=is_public,
         update=update,
+        timeout=timeout,
     )
 
     if _lazy_load:
@@ -648,6 +658,19 @@ def _scorer_name(scorer, scorer_idx):
 
 
 async def run_evaluator(experiment, evaluator: Evaluator, position: Optional[int], filters: List[Filter]):
+    """Wrapper on _run_evaluator_internal that times out execution after evaluator.timeout."""
+    async with asyncio.timeout(evaluator.timeout):
+        results = await _run_evaluator_internal(experiment, evaluator, position, filters)
+
+    if experiment:
+        summary = experiment.summarize()
+    else:
+        summary = build_local_summary(evaluator, results)
+
+    return EvalResultWithSummary(results=results, summary=summary)
+
+
+async def _run_evaluator_internal(experiment, evaluator: Evaluator, position: Optional[int], filters: List[Filter]):
     event_loop = asyncio.get_event_loop()
 
     async def await_or_run_scorer(root_span, scorer, name, **kwargs):
@@ -817,13 +840,7 @@ async def run_evaluator(experiment, evaluator: Evaluator, position: Optional[int
     results = []
     for task in std_tqdm(tasks, desc=f"{evaluator.eval_name} (tasks)", position=position, disable=position is None):
         results.append(await task)
-
-    if experiment:
-        summary = experiment.summarize()
-    else:
-        summary = build_local_summary(evaluator, results)
-
-    return EvalResultWithSummary(results=results, summary=summary)
+    return results
 
 
 def build_local_summary(evaluator, results):


### PR DESCRIPTION
Currently, must be specified by the Eval function.
We could set a global timeout from the cmd line in the future.
