### PR TITLE
Logger: don't block span export on resolving id

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -490,6 +490,7 @@ interface OrgProjectMetadata {
 
 export interface LogOptions<IsAsyncFlush> {
   asyncFlush?: IsAsyncFlush;
+  computeMetadataArgs?: Record<string, any>;
 }
 
 export type PromiseUnless<B, R> = B extends true ? R : Promise<Awaited<R>>;
@@ -583,14 +584,42 @@ interface ParentSpanIds {
   rootSpanId: string;
 }
 
+function spanComponentsToObjectIdLambda(
+  components: SpanComponents,
+): () => Promise<string> {
+  if (components.objectId) {
+    const ret = components.objectId;
+    return async () => ret;
+  }
+  if (!components.computeObjectMetadataArgs) {
+    throw new Error(
+      "Impossible: must provide either objectId or computeObjectMetadataArgs",
+    );
+  }
+  switch (components.objectType) {
+    case SpanObjectType.EXPERIMENT:
+      throw new Error(
+        "Impossible: computeObjectMetadataArgs not supported for experiments",
+      );
+    case SpanObjectType.PROJECT_LOGS:
+      const args = components.computeObjectMetadataArgs;
+      return async () => (await computeLoggerMetadata(args)).project.id;
+    default:
+      const x: never = components.objectType;
+      throw new Error(`Unknown object type: ${x}`);
+  }
+}
+
 function startSpanParentArgs(args: {
   parent: string | undefined;
   parentObjectType: SpanObjectType;
   parentObjectId: LazyValue<string>;
+  parentComputeObjectMetadataArgs: Record<string, any> | undefined;
   parentSpanIds: ParentSpanIds | undefined;
 }): {
   parentObjectType: SpanObjectType;
   parentObjectId: LazyValue<string>;
+  parentComputeObjectMetadataArgs: Record<string, any> | undefined;
   parentSpanIds: ParentSpanIds | undefined;
 } {
   let argParentObjectId: LazyValue<string> | undefined = undefined;
@@ -606,12 +635,13 @@ function startSpanParentArgs(args: {
       );
     }
 
+    const parentComponentsObjectIdLambda =
+      spanComponentsToObjectIdLambda(parentComponents);
     const computeParentObjectId = async () => {
-      if ((await args.parentObjectId.get()) !== parentComponents.objectId) {
+      const parentComponentsObjectId = await parentComponentsObjectIdLambda();
+      if ((await args.parentObjectId.get()) !== parentComponentsObjectId) {
         throw new Error(
-          `Mismatch between expected span parent object id ${await args.parentObjectId.get()} and provided id ${
-            parentComponents.objectId
-          }`,
+          `Mismatch between expected span parent object id ${await args.parentObjectId.get()} and provided id ${parentComponentsObjectId}`,
         );
       }
       return await args.parentObjectId.get();
@@ -631,13 +661,15 @@ function startSpanParentArgs(args: {
   return {
     parentObjectType: args.parentObjectType,
     parentObjectId: argParentObjectId,
+    parentComputeObjectMetadataArgs: args.parentComputeObjectMetadataArgs,
     parentSpanIds: argParentSpanIds,
   };
 }
 
 export class Logger<IsAsyncFlush extends boolean> {
   private lazyMetadata: LazyValue<OrgProjectMetadata>;
-  private logOptions: LogOptions<IsAsyncFlush>;
+  private _asyncFlush: IsAsyncFlush | undefined;
+  private computeMetadataArgs: Record<string, any> | undefined;
   private lastStartTime: number;
   private lazyId: LazyValue<string>;
   private calledStartSpan: boolean;
@@ -650,7 +682,8 @@ export class Logger<IsAsyncFlush extends boolean> {
     logOptions: LogOptions<IsAsyncFlush> = {},
   ) {
     this.lazyMetadata = lazyMetadata;
-    this.logOptions = logOptions;
+    this._asyncFlush = logOptions.asyncFlush;
+    this.computeMetadataArgs = logOptions.computeMetadataArgs;
     this.lastStartTime = getCurrentUnixTimestamp();
     this.lazyId = new LazyValue(async () => await this.id);
     this.calledStartSpan = false;
@@ -705,7 +738,7 @@ export class Logger<IsAsyncFlush extends boolean> {
     this.lastStartTime = span.end();
     const ret = span.id;
     type Ret = PromiseUnless<IsAsyncFlush, string>;
-    if (this.logOptions.asyncFlush === true) {
+    if (this.asyncFlush === true) {
       return ret as Ret;
     } else {
       return (async () => {
@@ -738,7 +771,7 @@ export class Logger<IsAsyncFlush extends boolean> {
     );
     type Ret = PromiseUnless<IsAsyncFlush, R>;
 
-    if (this.logOptions.asyncFlush) {
+    if (this.asyncFlush) {
       return ret as Ret;
     } else {
       return (async () => {
@@ -767,6 +800,7 @@ export class Logger<IsAsyncFlush extends boolean> {
         parent: args?.parent,
         parentObjectType: this.parentObjectType(),
         parentObjectId: this.lazyId,
+        parentComputeObjectMetadataArgs: this.computeMetadataArgs,
         parentSpanIds: undefined,
       }),
       ...args,
@@ -793,9 +827,21 @@ export class Logger<IsAsyncFlush extends boolean> {
    * Return a serialized representation of the logger that can be used to start subspans in other places. See `Span.start_span` for more details.
    */
   public async export(): Promise<string> {
+    let objectId: string | undefined = undefined;
+    let computeObjectMetadataArgs: Record<string, any> | undefined = undefined;
+    // Note: it is important that the object id we are checking for
+    // `has_computed` is the same as the one we are passing into the span
+    // logging functions. So that if the spans actually do get logged, then this
+    // `_lazy_id` object specifically will also be marked as computed.
+    if (this.computeMetadataArgs && !this.lazyId.hasComputed) {
+      computeObjectMetadataArgs = this.computeMetadataArgs;
+    } else {
+      objectId = await this.lazyId.get();
+    }
     return new SpanComponents({
       objectType: this.parentObjectType(),
-      objectId: await this.id,
+      objectId,
+      computeObjectMetadataArgs,
     }).toStr();
   }
 
@@ -807,7 +853,7 @@ export class Logger<IsAsyncFlush extends boolean> {
   }
 
   get asyncFlush(): IsAsyncFlush | undefined {
-    return this.logOptions.asyncFlush;
+    return this._asyncFlush;
   }
 }
 
@@ -1685,6 +1731,51 @@ export function withDataset<
   return callback(dataset);
 }
 
+// Note: the argument names *must* serialize the same way as the argument names
+// for the corresponding python function, because this function may be invoked
+// from arguments serialized elsewhere.
+async function computeLoggerMetadata({
+  project_name,
+  project_id,
+}: {
+  project_name?: string;
+  project_id?: string;
+}) {
+  await login();
+  const org_id = _state.orgId!;
+  if (project_id === undefined) {
+    const response = await _state.apiConn().post_json("api/project/register", {
+      project_name: project_name || GLOBAL_PROJECT,
+      org_id,
+    });
+    return {
+      org_id,
+      project: {
+        id: response.project.id,
+        name: response.project.name,
+        fullInfo: response.project,
+      },
+    };
+  } else if (project_name === undefined) {
+    const response = await _state.apiConn().get_json("api/project", {
+      id: project_id,
+    });
+    return {
+      org_id,
+      project: {
+        id: project_id,
+        name: response.name,
+        fullInfo: response.project,
+      },
+    };
+  } else {
+    return {
+      org_id,
+      project: { id: project_id, name: project_name, fullInfo: {} },
+    };
+  }
+}
+
 type AsyncFlushArg<IsAsyncFlush> = {
   asyncFlush?: IsAsyncFlush;
 };
@@ -1727,6 +1818,10 @@ export function initLogger<IsAsyncFlush extends boolean = false>(
     forceLogin,
   } = options || {};
 
+  const computeMetadataArgs = {
+    project_name: projectName,
+    project_id: projectId,
+  };
   const lazyMetadata: LazyValue<OrgProjectMetadata> = new LazyValue(
     async () => {
       await login({
@@ -1735,45 +1830,13 @@ export function initLogger<IsAsyncFlush extends boolean = false>(
         appUrl,
         forceLogin,
       });
-      const org_id = _state.orgId!;
-      if (projectId === undefined) {
-        const response = await _state
-          .apiConn()
-          .post_json("api/project/register", {
-            project_name: projectName || GLOBAL_PROJECT,
-            org_id,
-          });
-        return {
-          org_id,
-          project: {
-            id: response.project.id,
-            name: response.project.name,
-            fullInfo: response.project,
-          },
-        };
-      } else if (projectName === undefined) {
-        const response = await _state.apiConn().get_json("api/project", {
-          id: projectId,
-        });
-        return {
-          org_id,
-          project: {
-            id: projectId,
-            name: response.name,
-            fullInfo: response.project,
-          },
-        };
-      } else {
-        return {
-          org_id,
-          project: { id: projectId, name: projectName, fullInfo: {} },
-        };
-      }
+      return computeLoggerMetadata(computeMetadataArgs);
     },
   );
 
   const ret = new Logger<IsAsyncFlush>(lazyMetadata, {
     asyncFlush,
+    computeMetadataArgs,
   });
   if (options.setCurrent ?? true) {
     _state.currentLogger = ret as Logger<false>;
@@ -2135,7 +2198,8 @@ function startSpanAndIsLogger<IsAsyncFlush extends boolean = false>(
     const span = new SpanImpl({
       ...args,
       parentObjectType: components.objectType,
-      parentObjectId: new LazyValue(async () => components.objectId),
+      parentObjectId: new LazyValue(spanComponentsToObjectIdLambda(components)),
+      parentComputeObjectMetadataArgs: components.computeObjectMetadataArgs,
       parentSpanIds,
     });
     return {
@@ -2520,6 +2584,7 @@ export class Experiment extends ObjectFetcher<ExperimentEvent> {
         parent: args?.parent,
         parentObjectType: this.parentObjectType(),
         parentObjectId: this.lazyId,
+        parentComputeObjectMetadataArgs: undefined,
         parentSpanIds: undefined,
       }),
       ...args,
@@ -2729,6 +2794,7 @@ export class SpanImpl implements Span {
   // For internal use only.
   private parentObjectType: SpanObjectType;
   private parentObjectId: LazyValue<string>;
+  private parentComputeObjectMetadataArgs: Record<string, any> | undefined;
   private _id: string;
   private spanId: string;
   private rootSpanId: string;
@@ -2740,6 +2806,7 @@ export class SpanImpl implements Span {
     args: {
       parentObjectType: SpanObjectType;
       parentObjectId: LazyValue<string>;
+      parentComputeObjectMetadataArgs: Record<string, any> | undefined;
       parentSpanIds: ParentSpanIds | undefined;
       defaultRootType?: SpanType;
     } & Omit<StartSpanArgs, "parent">,
@@ -2752,6 +2819,7 @@ export class SpanImpl implements Span {
     this.loggedEndTime = undefined;
     this.parentObjectType = args.parentObjectType;
     this.parentObjectId = args.parentObjectId;
+    this.parentComputeObjectMetadataArgs = args.parentComputeObjectMetadataArgs;
 
     const callerLocation = iso.getCallerLocation();
     const name = (() => {
@@ -2882,6 +2950,7 @@ export class SpanImpl implements Span {
         parent: args?.parent,
         parentObjectType: this.parentObjectType,
         parentObjectId: this.parentObjectId,
+        parentComputeObjectMetadataArgs: this.parentComputeObjectMetadataArgs,
         parentSpanIds,
       }),
     });
@@ -2900,9 +2969,20 @@ export class SpanImpl implements Span {
   }
 
   public async export(): Promise<string> {
+    let objectId: string | undefined = undefined;
+    let computeObjectMetadataArgs: Record<string, any> | undefined = undefined;
+    if (
+      this.parentComputeObjectMetadataArgs &&
+      !this.parentObjectId.hasComputed
+    ) {
+      computeObjectMetadataArgs = this.parentComputeObjectMetadataArgs;
+    } else {
+      objectId = await this.parentObjectId.get();
+    }
     return new SpanComponents({
       objectType: this.parentObjectType,
-      objectId: await this.parentObjectId.get(),
+      objectId,
+      computeObjectMetadataArgs,
       rowIds: new SpanRowIds({
         rowId: this.id,
         spanId: this.spanId,

--- a/js/src/util.ts
+++ b/js/src/util.ts
@@ -57,4 +57,8 @@ export class LazyValue<T> {
     this.value = { hasComputed: true, val: this.callable() };
     return this.value.val;
   }
+
+  public get hasComputed(): boolean {
+    return this.value.hasComputed;
+  }
 }

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -916,6 +916,33 @@ def init_dataset(
     return Dataset(lazy_metadata=LazyValue(compute_metadata, use_mutex=True), version=version, legacy=use_output)
 
 
+def _compute_logger_metadata(project_name: Optional[str] = None, project_id: Optional[str] = None):
+    login()
+    org_id = _state.org_id
+    if project_id is None:
+        response = _state.app_conn().post_json(
+            "api/project/register",
+            {
+                "project_name": project_name or GLOBAL_PROJECT,
+                "org_id": _state.org_id,
+            },
+        )
+        resp_project = response["project"]
+        return OrgProjectMetadata(
+            org_id=org_id,
+            project=ObjectMetadata(id=resp_project["id"], name=resp_project["name"], full_info=resp_project),
+        )
+    elif project_name is None:
+        response = _state.app_conn().get_json("api/project", {"id": project_id})
+        return OrgProjectMetadata(
+            org_id=org_id, project=ObjectMetadata(id=project_id, name=response["name"], full_info=response)
+        )
+    else:
+        return OrgProjectMetadata(
+            org_id=org_id, project=ObjectMetadata(id=project_id, name=project_name, full_info=dict())
+        )
+
+
 def init_logger(
     project: Optional[str] = None,
     project_id: Optional[str] = None,
@@ -941,35 +968,16 @@ def init_logger(
     :returns: The newly created Logger.
     """
 
+    compute_metadata_args = dict(project_name=project, project_id=project_id)
+
     def compute_metadata():
         login(org_name=org_name, api_key=api_key, app_url=app_url, force_login=force_login)
-        org_id = _state.org_id
-        if project_id is None:
-            response = _state.app_conn().post_json(
-                "api/project/register",
-                {
-                    "project_name": project or GLOBAL_PROJECT,
-                    "org_id": _state.org_id,
-                },
-            )
-            resp_project = response["project"]
-            return OrgProjectMetadata(
-                org_id=org_id,
-                project=ObjectMetadata(id=resp_project["id"], name=resp_project["name"], full_info=resp_project),
-            )
-        elif project is None:
-            response = _state.app_conn().get_json("api/project", {"id": project_id})
-            return OrgProjectMetadata(
-                org_id=org_id, project=ObjectMetadata(id=project_id, name=response["name"], full_info=response)
-            )
-        else:
-            return OrgProjectMetadata(
-                org_id=org_id, project=ObjectMetadata(id=project_id, name=project, full_info=dict())
-            )
+        return _compute_logger_metadata(**compute_metadata_args)
 
     ret = Logger(
         lazy_metadata=LazyValue(compute_metadata, use_mutex=True),
         async_flush=async_flush,
+        compute_metadata_args=compute_metadata_args,
     )
     if set_current:
         _state.current_logger = ret
@@ -1303,7 +1311,8 @@ def start_span(
             parent_span_ids = None
         return SpanImpl(
             parent_object_type=components.object_type,
-            parent_object_id=LazyValue(lambda: components.object_id, use_mutex=False),
+            parent_object_id=LazyValue(_span_components_to_object_id_lambda(components), use_mutex=False),
+            parent_compute_object_metadata_args=components.compute_object_metadata_args,
             parent_span_ids=parent_span_ids,
             name=name,
             type=type,
@@ -1642,10 +1651,23 @@ class ParentSpanIds:
     root_span_id: str
 
 
+def _span_components_to_object_id_lambda(components: SpanComponents):
+    if components.object_id:
+        return lambda: components.object_id
+    assert components.compute_object_metadata_args
+    if components.object_type == SpanObjectType.EXPERIMENT:
+        raise Exception("Impossible: compute_object_metadata_args not supported for experiments")
+    elif components.object_type == SpanObjectType.PROJECT_LOGS:
+        return lambda: _compute_logger_metadata(**components.compute_object_metadata_args).project.id
+    else:
+        raise Exception(f"Unknown object type: {object_type}")
+
+
 def _start_span_parent_args(
     parent: Optional[str],
     parent_object_type: SpanObjectType,
     parent_object_id: LazyValue[str],
+    parent_compute_object_metadata_args: Optional[Dict],
     parent_span_ids: Optional[ParentSpanIds],
 ):
     if parent:
@@ -1655,10 +1677,13 @@ def _start_span_parent_args(
             parent_object_type == parent_components.object_type
         ), f"Mismatch between expected span parent object type {parent_object_type} and provided type {parent_components.object_type}"
 
+        parent_components_object_id_lambda = _span_components_to_object_id_lambda(parent_components)
+
         def compute_parent_object_id():
+            parent_components_object_id = parent_components_object_id_lambda()
             assert (
-                parent_object_id.get() == parent_components.object_id
-            ), f"Mismatch between expected span parent object id {parent_object_id.get()} and provided id {parent_components.object_id}"
+                parent_object_id.get() == parent_components_object_id
+            ), f"Mismatch between expected span parent object id {parent_object_id.get()} and provided id {parent_components_object_id}"
             return parent_object_id.get()
 
         arg_parent_object_id = LazyValue(compute_parent_object_id, use_mutex=False)
@@ -1675,6 +1700,7 @@ def _start_span_parent_args(
     return dict(
         parent_object_type=parent_object_type,
         parent_object_id=arg_parent_object_id,
+        parent_compute_object_metadata_args=parent_compute_object_metadata_args,
         parent_span_ids=arg_parent_span_ids,
     )
 
@@ -1982,6 +2008,7 @@ class Experiment(ObjectFetcher):
                 parent=parent,
                 parent_object_type=self._parent_object_type(),
                 parent_object_id=self._lazy_id,
+                parent_compute_object_metadata_args=None,
                 parent_span_ids=None,
             ),
             name=name,
@@ -2040,6 +2067,7 @@ class SpanImpl(Span):
         self,
         parent_object_type: SpanObjectType,
         parent_object_id: LazyValue[str],
+        parent_compute_object_metadata_args: Optional[Dict],
         parent_span_ids: Optional[ParentSpanIds],
         name=None,
         type=None,
@@ -2061,6 +2089,7 @@ class SpanImpl(Span):
 
         self.parent_object_type = parent_object_type
         self.parent_object_id = parent_object_id
+        self.parent_compute_object_metadata_args = parent_compute_object_metadata_args
 
         caller_location = get_caller_location()
         if name is None:
@@ -2183,6 +2212,7 @@ class SpanImpl(Span):
                 parent=parent,
                 parent_object_type=self.parent_object_type,
                 parent_object_id=self.parent_object_id,
+                parent_compute_object_metadata_args=self.parent_compute_object_metadata_args,
                 parent_span_ids=parent_span_ids,
             ),
             name=name,
@@ -2203,9 +2233,17 @@ class SpanImpl(Span):
         return end_time
 
     def export(self) -> str:
+        if self.parent_compute_object_metadata_args and not self.parent_object_id.has_computed:
+            object_id = None
+            compute_object_metadata_args = self.parent_compute_object_metadata_args
+        else:
+            object_id = self.parent_object_id.get()
+            compute_object_metadata_args = None
+
         return SpanComponents(
             object_type=self.parent_object_type,
-            object_id=self.parent_object_id.get(),
+            object_id=object_id,
+            compute_object_metadata_args=compute_object_metadata_args,
             row_ids=SpanRowIds(row_id=self.id, span_id=self.span_id, root_span_id=self.root_span_id),
         ).to_str()
 
@@ -2579,9 +2617,15 @@ class Project:
 
 
 class Logger:
-    def __init__(self, lazy_metadata: LazyValue[OrgProjectMetadata], async_flush: bool = True):
+    def __init__(
+        self,
+        lazy_metadata: LazyValue[OrgProjectMetadata],
+        async_flush: bool = True,
+        compute_metadata_args: Optional[Dict] = None,
+    ):
         self._lazy_metadata = lazy_metadata
         self.async_flush = async_flush
+        self._compute_metadata_args = compute_metadata_args
         self.last_start_time = time.time()
         self._lazy_id = LazyValue(lambda: self.id, use_mutex=False)
         self._called_start_span = False
@@ -2728,6 +2772,7 @@ class Logger:
                 parent=parent,
                 parent_object_type=self._parent_object_type(),
                 parent_object_id=self._lazy_id,
+                parent_compute_object_metadata_args=self._compute_metadata_args,
                 parent_span_ids=None,
             ),
             name=name,
@@ -2741,7 +2786,22 @@ class Logger:
 
     def export(self) -> str:
         """Return a serialized representation of the logger that can be used to start subspans in other places. See `Span.start_span` for more details."""
-        return SpanComponents(object_type=self._parent_object_type(), object_id=self.id).to_str()
+        # Note: it is important that the object id we are checking for
+        # `has_computed` is the same as the one we are passing into the span
+        # logging functions. So that if the spans actually do get logged, then
+        # this `_lazy_id` object specifically will also be marked as computed.
+        if self._compute_metadata_args and not self._lazy_id.has_computed:
+            object_id = None
+            compute_object_metadata_args = self._compute_metadata_args
+        else:
+            object_id = self._lazy_id.get()
+            compute_object_metadata_args = None
+
+        return SpanComponents(
+            object_type=self._parent_object_type(),
+            object_id=object_id,
+            compute_object_metadata_args=compute_object_metadata_args,
+        ).to_str()
 
     def __enter__(self):
         return self


### PR DESCRIPTION
Currently, logging is fully non-blocking (in that it doesn't need to hit the network on the critical path), except for the `[Logger/Span].export` function, which needs to resolve the object ID to serialize for the distributed tracer.

In order to work around this and make the export function non-blocking, we pass the arguments to the logger's `computeMetadata` registration function into the `Logger` and include them in the serialized span identifier if the object ID has not yet been resolved. Then when deserializing the parent span slug, we can obtain the object ID either from the serialized ID or by reconstructing the `computeMetadata` lambda from the serialized args.