### PR TITLE
Remove key_hash from api keys schema.

### DIFF
--- a/core/js/typespecs/app_types.ts
+++ b/core/js/typespecs/app_types.ts
@@ -130,7 +130,6 @@ export const apiKeySchema = z
   .strictObject({
     id: apiKeyBaseSchema.shape.id,
     created: apiKeyBaseSchema.shape.created,
-    key_hash: z.string(),
     name: apiKeyBaseSchema.shape.name,
     preview_name: z.string(),
     user_id: userSchema.shape.id.nullish(),


### PR DESCRIPTION
We are using it now and it doesn't seem necessary (and maybe a bit risky) to return the binary key hash.