### PR TITLE
Make object type consistent across JS and Py for distributed tracing

### DIFF
--- a/core/js/src/span_identifier_v2.ts
+++ b/core/js/src/span_identifier_v2.ts
@@ -25,8 +25,8 @@ const INVALID_ENCODING_ERRMSG = `SpanComponents string is not properly encoded. 
 const INTEGER_ENCODING_NUM_BYTES = 4;
 
 export enum SpanObjectTypeV2 {
-  EXPERIMENT = 0,
-  PROJECT_LOGS = 1,
+  EXPERIMENT = 1,
+  PROJECT_LOGS = 2,
 }
 
 const SpanObjectTypeV2EnumSchema = z.nativeEnum(SpanObjectTypeV2);

--- a/core/py/src/braintrust_core/span_identifier_v2.py
+++ b/core/py/src/braintrust_core/span_identifier_v2.py
@@ -29,8 +29,8 @@ INVALID_ENCODING_ERRMSG = f"SpanComponents string is not properly encoded. This 
 
 
 class SpanObjectTypeV2(Enum):
-    EXPERIMENT = auto()
-    PROJECT_LOGS = auto()
+    EXPERIMENT = 1
+    PROJECT_LOGS = 2
 
     def __str__(self):
         return {SpanObjectTypeV2.EXPERIMENT: "experiment", SpanObjectTypeV2.PROJECT_LOGS: "project_logs"}[self]


### PR DESCRIPTION
`auto()` in python [starts from 1](https://docs.python.org/3/library/enum.html), not `0`. But we incremented the equivalent components from 0 in JS.