### PR TITLE
Fix distributed tracing object id checks in JS

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -1738,8 +1738,8 @@ async function computeLoggerMetadata({
   project_name,
   project_id,
 }: {
-  project_name?: string;
-  project_id?: string;
+  project_name?: string | null;
+  project_id?: string | null;
 }) {
   await login();
   const org_id = _state.orgId!;

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -1743,7 +1743,7 @@ async function computeLoggerMetadata({
 }) {
   await login();
   const org_id = _state.orgId!;
-  if (project_id === undefined) {
+  if (isEmpty(project_id)) {
     const response = await _state.apiConn().post_json("api/project/register", {
       project_name: project_name || GLOBAL_PROJECT,
       org_id,
@@ -1756,7 +1756,7 @@ async function computeLoggerMetadata({
         fullInfo: response.project,
       },
     };
-  } else if (project_name === undefined) {
+  } else if (isEmpty(project_name)) {
     const response = await _state.apiConn().get_json("api/project", {
       id: project_id,
     });


### PR DESCRIPTION
If the span components are serialized in, e.g. Python, they may have `null` instead of `undefined` for the object ids.