### PR TITLE
Fixes to enable usage from Swift via PythonKit.

### DIFF
--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -249,11 +249,8 @@ def is_inspectable(obj):
     True when obj is inspectable via `inspect`.
     False when it is, e.g., a native function or builtin.
     """
-    if obj.__name__ == 'pythonkit_swift_function' or obj.__name__ == "pythonkit_swift_function_with_keywords":
-        return False
-
     t = type(obj)
-    if t.__module__ == 'builtins' and t.__name__ == 'PyCapsule':
+    if t.__module__ == 'builtins' and t.__name__ == 'builtin_function_or_method':
         return False
 
     return True

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -749,9 +749,7 @@ async def _run_evaluator_internal(experiment, evaluator: Evaluator, position: Op
 
                 # Check if the task takes a hooks argument
                 task_args = [datum.input]
-                if not is_inspectable(evaluator.task):
-                    task_args.append(hooks)
-                elif len(inspect.signature(evaluator.task).parameters) == 2:
+                if not is_inspectable(evaluator.task) or len(inspect.signature(evaluator.task).parameters) == 2:
                     task_args.append(hooks)
 
                 with root_span.start_span("task", span_attributes={"type": SpanTypeAttribute.TASK}) as span:
@@ -829,7 +827,7 @@ async def _run_evaluator_internal(experiment, evaluator: Evaluator, position: Op
             project=evaluator.project_name, experiment=base_experiment.name, open=True, set_current=False
         ).as_dataset()
 
-    if inspect.isfunction(data_iterator) or not is_inspectable(data_iterator):
+    if not is_inspectable(data_iterator) or inspect.isfunction(data_iterator):
         data_iterator = data_iterator()
 
     if not inspect.isasyncgen(data_iterator):


### PR DESCRIPTION
To test our swift code, we've been building a prototype that uses the Braintrust Python SDK via [PythonKit](https://github.com/pvieito/PythonKit).

When we past Swift lambda's to `Eval()` (as `PythonFunction`s), places where the SDK uses `inspect.*` need to be tweaked, as the our lambdas show up as builtin `PyCapsule` objects.