### PR TITLE
Add py.typed and fix type signature for @traced

### DIFF
--- a/js/src/wrappers/ai-sdk.ts
+++ b/js/src/wrappers/ai-sdk.ts
@@ -9,7 +9,11 @@ import {
   LanguageModelV1FunctionToolCall,
   LanguageModelV1StreamPart,
 } from "@ai-sdk/provider";
-import { parseCachedHeader, X_CACHED_HEADER } from "./oai";
+import {
+  LEGACY_CACHED_HEADER,
+  parseCachedHeader,
+  X_CACHED_HEADER,
+} from "./oai";
 
 /**
  * Wrap an ai-sdk model (created with `.chat()`, `.completion()`, etc.) to add tracing. If Braintrust is
@@ -84,7 +88,8 @@ class BraintrustLanguageModelWrapper implements LanguageModelV1 {
           prompt_tokens: ret.usage?.promptTokens,
           completion_tokens: ret.usage?.completionTokens,
           cached: parseCachedHeader(
-            ret.rawResponse?.headers?.[X_CACHED_HEADER],
+            ret.rawResponse?.headers?.[X_CACHED_HEADER] ??
+              ret.rawResponse?.headers?.[LEGACY_CACHED_HEADER],
           ),
         },
       });
@@ -201,7 +206,8 @@ class BraintrustLanguageModelWrapper implements LanguageModelV1 {
                   prompt_tokens: usage?.promptTokens,
                   completion_tokens: usage?.completionTokens,
                   cached: parseCachedHeader(
-                    ret.rawResponse?.headers?.[X_CACHED_HEADER],
+                    ret.rawResponse?.headers?.[X_CACHED_HEADER] ??
+                      ret.rawResponse?.headers?.[LEGACY_CACHED_HEADER],
                   ),
                 },
               });

--- a/js/src/wrappers/oai.ts
+++ b/js/src/wrappers/oai.ts
@@ -202,7 +202,7 @@ interface APIPromise<T> extends Promise<T> {
   withResponse(): Promise<EnhancedResponse>;
 }
 
-const LEGACY_CACHED_HEADER = "x-cached";
+export const LEGACY_CACHED_HEADER = "x-cached";
 export const X_CACHED_HEADER = "x-bt-cached";
 export function parseCachedHeader(
   value: string | null | undefined,

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -1303,7 +1303,7 @@ def traced(*span_args, **span_kwargs) -> Callable[[F], F]:
     # We determine if the decorator is invoked bare or with arguments by
     # checking if the first positional argument to the decorator is a callable.
     if len(span_args) == 1 and len(span_kwargs) == 0 and callable(span_args[0]):
-        return decorator(span_args[1:], span_kwargs, cast(span_args[0], F))
+        return decorator(span_args[1:], span_kwargs, cast(F, span_args[0]))
     else:
         return cast(Callable[[F], F], partial(decorator, span_args, span_kwargs))
 

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -19,7 +19,7 @@ import uuid
 from abc import ABC, abstractmethod
 from functools import partial, wraps
 from multiprocessing import cpu_count
-from typing import Any, Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional, TypeVar, Union, cast, overload
 
 import chevron
 import exceptiongroup
@@ -1238,7 +1238,15 @@ def _try_log_output(span, output):
     span.log(output=output_serializable)
 
 
-def traced(*span_args, **span_kwargs):
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+@overload
+def traced(f: F) -> F:
+    ...
+
+
+def traced(*span_args, **span_kwargs) -> Callable[[F], F]:
     """Decorator to trace the wrapped function. Can either be applied bare (`@traced`) or by providing arguments (`@traced(*span_args, **span_kwargs)`), which will be forwarded to the created span. See `Span.start_span` for full details on the span arguments.
 
     It checks the following (in precedence order):
@@ -1255,7 +1263,7 @@ def traced(*span_args, **span_kwargs):
 
     trace_io = not span_kwargs.pop("notrace_io", False)
 
-    def decorator(span_args, span_kwargs, f):
+    def decorator(span_args, span_kwargs, f: F):
         # We assume 'name' is the first positional argument in `start_span`.
         if len(span_args) == 0 and span_kwargs.get("name") is None:
             span_args += (f.__name__,)
@@ -1288,16 +1296,16 @@ def traced(*span_args, **span_kwargs):
                 return ret
 
         if inspect.iscoroutinefunction(f):
-            return wrapper_async
+            return cast(F, wrapper_async)
         else:
-            return wrapper_sync
+            return cast(F, wrapper_sync)
 
     # We determine if the decorator is invoked bare or with arguments by
     # checking if the first positional argument to the decorator is a callable.
     if len(span_args) == 1 and len(span_kwargs) == 0 and callable(span_args[0]):
-        return decorator(span_args[1:], span_kwargs, span_args[0])
+        return decorator(span_args[1:], span_kwargs, cast(span_args[0], F))
     else:
-        return partial(decorator, span_args, span_kwargs)
+        return cast(Callable[[F], F], partial(decorator, span_args, span_kwargs))
 
 
 def start_span(


### PR DESCRIPTION
* `py.typed` instructs mypy that it can use the types in `braintrust` to do type checking
* The overloaded case helps mypy realize that calls to `@traced` without additional arguments can simply propagate the original type of `F`.