### PR TITLE
Add a prompt fallback

### DIFF
--- a/core/js/typespecs/openai/messages.ts
+++ b/core/js/typespecs/openai/messages.ts
@@ -1,5 +1,15 @@
 import { z } from "zod";
 
+export const messageRoleSchema = z.enum([
+  "system",
+  "user",
+  "assistant",
+  "function",
+  "tool",
+  "model",
+]);
+export type MessageRole = z.infer<typeof messageRoleSchema>;
+
 const chatCompletionSystemMessageParamSchema = z
   .strictObject({
     content: z.string().default(""),
@@ -99,7 +109,7 @@ const chatCompletionAssistantMessageParamSchema = z
 
 const chatCompletionFallbackMessageParamSchema = z
   .strictObject({
-    role: z.string(),
+    role: messageRoleSchema,
     content: z.string().nullish(),
   })
   .strip();

--- a/core/js/typespecs/openai/messages.ts
+++ b/core/js/typespecs/openai/messages.ts
@@ -97,12 +97,24 @@ const chatCompletionAssistantMessageParamSchema = z
   })
   .strip();
 
-export const chatCompletionMessageParamSchema = z.union([
+const chatCompletionFallbackMessageParamSchema = z
+  .strictObject({
+    role: z.string(),
+    content: z.string().nullish(),
+  })
+  .strip();
+
+export const chatCompletionOpenAIMessageParamSchema = z.union([
   chatCompletionSystemMessageParamSchema,
   chatCompletionUserMessageParamSchema,
   chatCompletionAssistantMessageParamSchema,
   chatCompletionToolMessageParamSchema,
   chatCompletionFunctionMessageParamSchema,
+]);
+
+export const chatCompletionMessageParamSchema = z.union([
+  chatCompletionOpenAIMessageParamSchema,
+  chatCompletionFallbackMessageParamSchema,
 ]);
 
 export type ToolCall = z.infer<typeof chatCompletionMessageToolCallSchema>;

--- a/core/js/typespecs/openai/messages.ts
+++ b/core/js/typespecs/openai/messages.ts
@@ -109,7 +109,13 @@ const chatCompletionAssistantMessageParamSchema = z
 
 const chatCompletionFallbackMessageParamSchema = z
   .strictObject({
-    role: messageRoleSchema,
+    role: messageRoleSchema.exclude([
+      "system",
+      "user",
+      "assistant",
+      "tool",
+      "function",
+    ]),
     content: z.string().nullish(),
   })
   .strip();

--- a/core/js/typespecs/prompt.ts
+++ b/core/js/typespecs/prompt.ts
@@ -6,21 +6,11 @@ import {
   chatCompletionMessageParamSchema,
   chatCompletionOpenAIMessageParamSchema,
 } from "./openai/messages";
-export { ToolCall } from "./openai/messages";
+export { ToolCall, messageRoleSchema, MessageRole } from "./openai/messages";
 export { chatCompletionContentPartImageSchema };
 
 export { toolsSchema } from "./openai/tools";
 export type { Tools } from "./openai/tools";
-
-export const messageRoleSchema = z.enum([
-  "system",
-  "user",
-  "assistant",
-  "function",
-  "tool",
-  "model",
-]);
-export type MessageRole = z.infer<typeof messageRoleSchema>;
 
 export type OpenAIMessage = z.infer<
   typeof chatCompletionOpenAIMessageParamSchema

--- a/core/js/typespecs/prompt.ts
+++ b/core/js/typespecs/prompt.ts
@@ -4,6 +4,7 @@ import {
   chatCompletionContentPartImageSchema,
   chatCompletionContentPartTextSchema,
   chatCompletionMessageParamSchema,
+  chatCompletionOpenAIMessageParamSchema,
 } from "./openai/messages";
 export { ToolCall } from "./openai/messages";
 export { chatCompletionContentPartImageSchema };
@@ -21,7 +22,11 @@ export const messageRoleSchema = z.enum([
 ]);
 export type MessageRole = z.infer<typeof messageRoleSchema>;
 
+export type OpenAIMessage = z.infer<
+  typeof chatCompletionOpenAIMessageParamSchema
+>;
 export type Message = z.infer<typeof chatCompletionMessageParamSchema>;
+
 export type Content = Message["content"];
 export type ContentPartText = z.infer<
   typeof chatCompletionContentPartTextSchema

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -45,7 +45,7 @@ import {
   Prompt as PromptRow,
   toolsSchema,
   PromptSessionEvent,
-  repoInfoSchema,
+  OpenAIMessage,
 } from "@braintrust/core/typespecs";
 
 import iso, { IsoAsyncLocalStorage } from "./isomorph";
@@ -3393,7 +3393,7 @@ export type CompiledPromptParams = Omit<
 > & { model: NonNullable<NonNullable<PromptData["options"]>["model"]> };
 
 export type ChatPrompt = {
-  messages: Message[];
+  messages: OpenAIMessage[];
   tools?: Tools;
 };
 export type CompletionPrompt = {


### PR DESCRIPTION
This is likely not the final solution... but allow the messages array to have a fallback for arbitrary roles (e.g. "model" from google), so that in the playground, we permit non-openai-compatible sessions.

`prompt.build()` still needs to produce something that typechecks with the OpenAI API, so still expose `OpenAIMessages` and cast `prompt.build()` to that. Note that with this approach, you can (incorrectly) cast a Google prompt to OpenAI.