### PR TITLE
Allow window.ai model params and fix a bug

### DIFF
--- a/core/js/typespecs/prompt.ts
+++ b/core/js/typespecs/prompt.ts
@@ -43,78 +43,81 @@ export type PromptBlockData = z.infer<typeof promptBlockDataSchema>;
 // Note that for prompt options, we relax the strictness requirement because
 // these params may come from external sources.
 
-const braintrustModelParamsSchema = z.object({
-  use_cache: z.boolean().optional(),
-});
+const braintrustModelParamsSchema = z
+  .strictObject({
+    use_cache: z.boolean().optional(),
+  })
+  .strip();
 
 export const BRAINTRUST_PARAMS = Object.keys(braintrustModelParamsSchema.shape);
 
-const openAIModelParamsSchema = z.object({
-  temperature: z.number().optional(),
-  top_p: z.number().optional(),
-  max_tokens: z.number().optional(),
-  frequency_penalty: z.number().optional(),
-  presence_penalty: z.number().optional(),
-  response_format: z.strictObject({ type: z.literal("json_object") }).nullish(),
-  tool_choice: z
-    .union([
-      z.literal("auto"),
-      z.literal("none"),
-      z
-        .strictObject({
-          type: z.literal("function"),
-          function: z.strictObject({ name: z.string() }).strip(),
-        })
-        .strip(),
-    ])
-    .optional(),
-  function_call: z
-    .union([
-      z.literal("auto"),
-      z.literal("none"),
-      z.strictObject({
-        name: z.string(),
-      }),
-    ])
-    .optional(),
-  n: z.number().optional(),
-  stop: z.array(z.string()).optional(),
-});
+const openAIModelParamsSchema = z
+  .strictObject({
+    temperature: z.number().optional(),
+    top_p: z.number().optional(),
+    max_tokens: z.number().optional(),
+    frequency_penalty: z.number().optional(),
+    presence_penalty: z.number().optional(),
+    response_format: z
+      .strictObject({ type: z.literal("json_object") })
+      .nullish(),
+    tool_choice: z
+      .union([
+        z.literal("auto"),
+        z.literal("none"),
+        z
+          .strictObject({
+            type: z.literal("function"),
+            function: z.strictObject({ name: z.string() }).strip(),
+          })
+          .strip(),
+      ])
+      .optional(),
+    function_call: z
+      .union([
+        z.literal("auto"),
+        z.literal("none"),
+        z.strictObject({
+          name: z.string(),
+        }),
+      ])
+      .optional(),
+    n: z.number().optional(),
+    stop: z.array(z.string()).optional(),
+  })
+  .strip();
 
 export type OpenAIModelParams = z.infer<typeof openAIModelParamsSchema>;
 
-const anthropicModelParamsSchema = z.object({
-  max_tokens: z.number(),
-  temperature: z.number(),
-  top_p: z.number().optional(),
-  top_k: z.number().optional(),
-  stop_sequences: z.array(z.string()).optional(),
-  max_tokens_to_sample: z
-    .number()
-    .optional()
-    .describe("This is a legacy parameter that should not be used."),
-});
+const anthropicModelParamsSchema = z
+  .strictObject({
+    max_tokens: z.number(),
+    temperature: z.number(),
+    top_p: z.number().optional(),
+    top_k: z.number().optional(),
+    stop_sequences: z.array(z.string()).optional(),
+    max_tokens_to_sample: z
+      .number()
+      .optional()
+      .describe("This is a legacy parameter that should not be used."),
+  })
+  .strip();
 
-const googleModelParamsSchema = z.object({
-  temperature: z.number().optional(),
-  maxOutputTokens: z.number().optional(),
-  topP: z.number().optional(),
-  topK: z.number().optional(),
-});
+const googleModelParamsSchema = z
+  .strictObject({
+    temperature: z.number(),
+    maxOutputTokens: z.number().optional(),
+    topP: z.number().optional(),
+    topK: z.number().optional(),
+  })
+  .strip();
 
-const windowAIModelParamsSchema = z.object({
-  temperature: z.number().optional(),
-  topK: z.number().optional(),
-});
-
-const jsCompletionParamsSchema = z.object({});
-
+const jsCompletionParamsSchema = z.strictObject({}).strip();
 export const modelParamsSchema = z.union([
-  braintrustModelParamsSchema.merge(openAIModelParamsSchema).passthrough(),
-  braintrustModelParamsSchema.merge(anthropicModelParamsSchema).passthrough(),
-  braintrustModelParamsSchema.merge(googleModelParamsSchema).passthrough(),
-  braintrustModelParamsSchema.merge(windowAIModelParamsSchema).passthrough(),
-  braintrustModelParamsSchema.merge(jsCompletionParamsSchema).passthrough(),
+  braintrustModelParamsSchema.merge(openAIModelParamsSchema),
+  braintrustModelParamsSchema.merge(anthropicModelParamsSchema),
+  braintrustModelParamsSchema.merge(googleModelParamsSchema),
+  braintrustModelParamsSchema.merge(jsCompletionParamsSchema),
 ]);
 
 export type ModelParams = z.infer<typeof modelParamsSchema>;
@@ -122,21 +125,22 @@ export type ModelParams = z.infer<typeof modelParamsSchema>;
 const anyModelParamsSchema = openAIModelParamsSchema
   .merge(anthropicModelParamsSchema)
   .merge(googleModelParamsSchema)
-  .merge(braintrustModelParamsSchema)
-  .merge(windowAIModelParamsSchema);
+  .merge(braintrustModelParamsSchema);
 
 export type AnyModelParam = z.infer<typeof anyModelParamsSchema>;
 
-export const promptOptionsSchema = z.object({
-  model: z.string().optional(),
-  params: modelParamsSchema.optional(),
-  position: z.string().optional(),
-});
+export const promptOptionsSchema = z
+  .strictObject({
+    model: z.string().optional(),
+    params: modelParamsSchema.optional(),
+    position: z.string().optional(),
+  })
+  .strip();
 
 export type PromptOptions = z.infer<typeof promptOptionsSchema>;
 
 export const promptDataSchema = z
-  .object({
+  .strictObject({
     prompt: promptBlockDataSchema.nullish(),
     options: promptOptionsSchema.nullish(),
     origin: z

--- a/core/js/typespecs/prompt.ts
+++ b/core/js/typespecs/prompt.ts
@@ -105,19 +105,27 @@ const anthropicModelParamsSchema = z
 
 const googleModelParamsSchema = z
   .strictObject({
-    temperature: z.number(),
+    temperature: z.number().optional(),
     maxOutputTokens: z.number().optional(),
     topP: z.number().optional(),
     topK: z.number().optional(),
   })
   .strip();
 
+const windowAIModelParamsSchema = z
+  .strictObject({
+    temperature: z.number().optional(),
+    topK: z.number().optional(),
+  })
+  .strip();
+
 const jsCompletionParamsSchema = z.strictObject({}).strip();
 export const modelParamsSchema = z.union([
-  braintrustModelParamsSchema.merge(openAIModelParamsSchema),
-  braintrustModelParamsSchema.merge(anthropicModelParamsSchema),
-  braintrustModelParamsSchema.merge(googleModelParamsSchema),
-  braintrustModelParamsSchema.merge(jsCompletionParamsSchema),
+  braintrustModelParamsSchema.merge(openAIModelParamsSchema).passthrough(),
+  braintrustModelParamsSchema.merge(anthropicModelParamsSchema).passthrough(),
+  braintrustModelParamsSchema.merge(googleModelParamsSchema).passthrough(),
+  braintrustModelParamsSchema.merge(windowAIModelParamsSchema).passthrough(),
+  braintrustModelParamsSchema.merge(jsCompletionParamsSchema).passthrough(),
 ]);
 
 export type ModelParams = z.infer<typeof modelParamsSchema>;

--- a/core/js/typespecs/prompt.ts
+++ b/core/js/typespecs/prompt.ts
@@ -43,81 +43,78 @@ export type PromptBlockData = z.infer<typeof promptBlockDataSchema>;
 // Note that for prompt options, we relax the strictness requirement because
 // these params may come from external sources.
 
-const braintrustModelParamsSchema = z
-  .strictObject({
-    use_cache: z.boolean().optional(),
-  })
-  .strip();
+const braintrustModelParamsSchema = z.object({
+  use_cache: z.boolean().optional(),
+});
 
 export const BRAINTRUST_PARAMS = Object.keys(braintrustModelParamsSchema.shape);
 
-const openAIModelParamsSchema = z
-  .strictObject({
-    temperature: z.number().optional(),
-    top_p: z.number().optional(),
-    max_tokens: z.number().optional(),
-    frequency_penalty: z.number().optional(),
-    presence_penalty: z.number().optional(),
-    response_format: z
-      .strictObject({ type: z.literal("json_object") })
-      .nullish(),
-    tool_choice: z
-      .union([
-        z.literal("auto"),
-        z.literal("none"),
-        z
-          .strictObject({
-            type: z.literal("function"),
-            function: z.strictObject({ name: z.string() }).strip(),
-          })
-          .strip(),
-      ])
-      .optional(),
-    function_call: z
-      .union([
-        z.literal("auto"),
-        z.literal("none"),
-        z.strictObject({
-          name: z.string(),
-        }),
-      ])
-      .optional(),
-    n: z.number().optional(),
-    stop: z.array(z.string()).optional(),
-  })
-  .strip();
+const openAIModelParamsSchema = z.object({
+  temperature: z.number().optional(),
+  top_p: z.number().optional(),
+  max_tokens: z.number().optional(),
+  frequency_penalty: z.number().optional(),
+  presence_penalty: z.number().optional(),
+  response_format: z.strictObject({ type: z.literal("json_object") }).nullish(),
+  tool_choice: z
+    .union([
+      z.literal("auto"),
+      z.literal("none"),
+      z
+        .strictObject({
+          type: z.literal("function"),
+          function: z.strictObject({ name: z.string() }).strip(),
+        })
+        .strip(),
+    ])
+    .optional(),
+  function_call: z
+    .union([
+      z.literal("auto"),
+      z.literal("none"),
+      z.strictObject({
+        name: z.string(),
+      }),
+    ])
+    .optional(),
+  n: z.number().optional(),
+  stop: z.array(z.string()).optional(),
+});
 
 export type OpenAIModelParams = z.infer<typeof openAIModelParamsSchema>;
 
-const anthropicModelParamsSchema = z
-  .strictObject({
-    max_tokens: z.number(),
-    temperature: z.number(),
-    top_p: z.number().optional(),
-    top_k: z.number().optional(),
-    stop_sequences: z.array(z.string()).optional(),
-    max_tokens_to_sample: z
-      .number()
-      .optional()
-      .describe("This is a legacy parameter that should not be used."),
-  })
-  .strip();
+const anthropicModelParamsSchema = z.object({
+  max_tokens: z.number(),
+  temperature: z.number(),
+  top_p: z.number().optional(),
+  top_k: z.number().optional(),
+  stop_sequences: z.array(z.string()).optional(),
+  max_tokens_to_sample: z
+    .number()
+    .optional()
+    .describe("This is a legacy parameter that should not be used."),
+});
 
-const googleModelParamsSchema = z
-  .strictObject({
-    temperature: z.number(),
-    maxOutputTokens: z.number().optional(),
-    topP: z.number().optional(),
-    topK: z.number().optional(),
-  })
-  .strip();
+const googleModelParamsSchema = z.object({
+  temperature: z.number().optional(),
+  maxOutputTokens: z.number().optional(),
+  topP: z.number().optional(),
+  topK: z.number().optional(),
+});
 
-const jsCompletionParamsSchema = z.strictObject({}).strip();
+const windowAIModelParamsSchema = z.object({
+  temperature: z.number().optional(),
+  topK: z.number().optional(),
+});
+
+const jsCompletionParamsSchema = z.object({});
+
 export const modelParamsSchema = z.union([
-  braintrustModelParamsSchema.merge(openAIModelParamsSchema),
-  braintrustModelParamsSchema.merge(anthropicModelParamsSchema),
-  braintrustModelParamsSchema.merge(googleModelParamsSchema),
-  braintrustModelParamsSchema.merge(jsCompletionParamsSchema),
+  braintrustModelParamsSchema.merge(openAIModelParamsSchema).passthrough(),
+  braintrustModelParamsSchema.merge(anthropicModelParamsSchema).passthrough(),
+  braintrustModelParamsSchema.merge(googleModelParamsSchema).passthrough(),
+  braintrustModelParamsSchema.merge(windowAIModelParamsSchema).passthrough(),
+  braintrustModelParamsSchema.merge(jsCompletionParamsSchema).passthrough(),
 ]);
 
 export type ModelParams = z.infer<typeof modelParamsSchema>;
@@ -125,22 +122,21 @@ export type ModelParams = z.infer<typeof modelParamsSchema>;
 const anyModelParamsSchema = openAIModelParamsSchema
   .merge(anthropicModelParamsSchema)
   .merge(googleModelParamsSchema)
-  .merge(braintrustModelParamsSchema);
+  .merge(braintrustModelParamsSchema)
+  .merge(windowAIModelParamsSchema);
 
 export type AnyModelParam = z.infer<typeof anyModelParamsSchema>;
 
-export const promptOptionsSchema = z
-  .strictObject({
-    model: z.string().optional(),
-    params: modelParamsSchema.optional(),
-    position: z.string().optional(),
-  })
-  .strip();
+export const promptOptionsSchema = z.object({
+  model: z.string().optional(),
+  params: modelParamsSchema.optional(),
+  position: z.string().optional(),
+});
 
 export type PromptOptions = z.infer<typeof promptOptionsSchema>;
 
 export const promptDataSchema = z
-  .strictObject({
+  .object({
     prompt: promptBlockDataSchema.nullish(),
     options: promptOptionsSchema.nullish(),
     origin: z


### PR DESCRIPTION
* Add `window.ai` model params
* Use `passthrough` parsing in the union, so that if a set of model params gets accidentally identified in the wrong branch of a union, it does not strip the parameters. We were, for example, stripping the top k parameter.