### PR TITLE
Only mark braintrust/autoevals as external

### DIFF
--- a/js/src/cli.ts
+++ b/js/src/cli.ts
@@ -665,7 +665,7 @@ async function collectFiles(inputPath: string): Promise<string[]> {
 let markOurPackagesExternalPlugin = {
   name: "make-all-packages-external",
   setup(build: esbuild.PluginBuild) {
-    const filter = /^(\w)/;
+    const filter = /^(braintrust|autoevals|@braintrust\/)/;
     build.onResolve({ filter }, (args) => ({
       path: args.path,
       external: true,


### PR DESCRIPTION
I don't know why (and git doesn't seem to tell more) why we did a catch-all filter here, but it breaks some complex bundling scenarios (exposed in a test app we're working on). The intent was to exclude braintrust-flavored packages, so I made the regex more specific and manually confirmed.