### PR TITLE
Use header for api key login

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -2176,10 +2176,8 @@ export async function loginToState(options: LoginOptions = {}) {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
         },
-        body: JSON.stringify({
-          token: apiKey,
-        }),
       }),
     );
     const info = await resp.json();


### PR DESCRIPTION
This allows systems that intercept the header to do so for the api key login as well.