### PR TITLE
De-verbosify schema definitions.

### DIFF
--- a/core/js/typespecs/app_types.ts
+++ b/core/js/typespecs/app_types.ts
@@ -891,7 +891,7 @@ const patchGroupSchema = createGroupSchema
   )
   .openapi("PatchGroup");
 
-const createAclSchema = aclSchema
+export const createAclSchema = aclSchema
   .omit({
     id: true,
     created: true,
@@ -935,14 +935,14 @@ const patchProjectTagSchema = z
   })
   .openapi("PatchProjectTag");
 
-const createViewSchema = viewSchema
+export const createViewSchema = viewSchema
   .omit({
     id: true,
     created: true,
   })
   .openapi("CreateView");
 
-const patchViewSchema = z
+export const patchViewSchema = z
   .strictObject({
     object_type: viewSchema.shape.object_type,
     object_id: viewSchema.shape.object_id,

--- a/core/js/typespecs/app_types.ts
+++ b/core/js/typespecs/app_types.ts
@@ -4,7 +4,7 @@ import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
 extendZodWithOpenApi(z);
 
-import { datetimeStringSchema } from "./common_types";
+import { ObjectType, datetimeStringSchema } from "./common_types";
 import { customTypes } from "./custom_types";
 import { promptDataSchema } from "./prompt";
 import { viewDataSchema, viewOptionsSchema, viewTypeEnum } from "./view";
@@ -970,91 +970,79 @@ const patchOrganizationSchema = z
   })
   .openapi("PatchOrganization");
 
-// Section: exported schemas, grouped by object type.
+// Section: exported schemas, grouped by object type. The schemas are used for
+// API spec generation, so their types are not fully-specified. If you wish to
+// use individual schema types, import them directly.
 
-export const objectSchemas = {
+export type ObjectSchemasEntry = {
+  object?: z.ZodTypeAny;
+  create?: z.ZodTypeAny;
+  patch?: z.ZodTypeAny;
+  delete?: z.ZodTypeAny;
+};
+
+export const apiSpecObjectSchemas: Record<ObjectType, ObjectSchemasEntry> = {
   experiment: {
+    object: experimentSchema,
     create: createExperimentSchema,
     patch: patchExperimentSchema,
-    object: experimentSchema,
-    delete: undefined,
   },
   dataset: {
+    object: datasetSchema,
     create: createDatasetSchema,
     patch: patchDatasetSchema,
-    object: datasetSchema,
-    delete: undefined,
   },
   project: {
+    object: projectSchema,
     create: createProjectSchema,
     patch: patchProjectSchema,
-    object: projectSchema,
-    delete: undefined,
   },
   prompt: {
+    object: promptSchema,
     create: createPromptSchema,
     patch: patchPromptSchema,
-    object: promptSchema,
-    delete: undefined,
   },
   function: {
+    object: functionSchema,
     create: createFunctionSchema,
     patch: patchFunctionSchema,
-    object: functionSchema,
-    delete: undefined,
   },
   role: {
+    object: roleSchema,
     create: createRoleSchema,
     patch: patchRoleSchema,
-    object: roleSchema,
-    delete: undefined,
   },
   group: {
+    object: groupSchema,
     create: createGroupSchema,
     patch: patchGroupSchema,
-    object: groupSchema,
-    delete: undefined,
   },
   acl: {
-    create: createAclSchema,
-    patch: undefined,
     object: aclSchema,
-    delete: undefined,
+    create: createAclSchema,
   },
   user: {
-    create: undefined,
-    patch: undefined,
     object: userSchema,
-    delete: undefined,
   },
-  prompt_session: {
-    create: undefined,
-    patch: undefined,
-    object: undefined,
-    delete: undefined,
-  },
+  prompt_session: {},
   project_score: {
+    object: projectScoreSchema,
     create: createProjectScoreSchema,
     patch: patchProjectScoreSchema,
-    object: projectScoreSchema,
-    delete: undefined,
   },
   project_tag: {
+    object: projectTagSchema,
     create: createProjectTagSchema,
     patch: patchProjectTagSchema,
-    object: projectTagSchema,
-    delete: undefined,
   },
   view: {
-    create: createViewSchema,
-    patch: patchViewSchema,
     object: viewSchema,
     delete: deleteViewSchema,
+    create: createViewSchema,
+    patch: patchViewSchema,
   },
   organization: {
-    create: undefined,
-    patch: patchOrganizationSchema,
     object: organizationSchema,
-    delete: undefined,
+    patch: patchOrganizationSchema,
   },
 };


### PR DESCRIPTION
The schema exports used for API spec generation omit a lot of members that we don't actually want to define methods for (e.g. `organization.delete`, or anything related to `prompt_session`, or object summarization). Instead of explicitly writing in `undefined` for each method of each object type, we allow specifying undefined for each method, but require some entry for each object type. This way, you don't forget to add a new object type to the exports object.

Making fields optional requires erasing some type information for individual schemas. This is fine for the API spec generator, which doesn't care about exact types. But it does impact some internal code which is grabbing typedefs from `objectSchemas` or `eventObjectSchemas` directly. Instead, that code will import the typespecs they need directly, which seems better anyways.