### PR TITLE
Add created timestamp to insert event schemas.

### DIFF
--- a/core/js/typespecs/api_types.ts
+++ b/core/js/typespecs/api_types.ts
@@ -564,6 +564,7 @@ const {
     id: experimentEventSchema.shape.id.nullish(),
     dataset_record_id: experimentEventSchema.shape.dataset_record_id,
     [OBJECT_DELETE_FIELD]: experimentEventBaseSchema.shape[OBJECT_DELETE_FIELD],
+    created: experimentEventBaseSchema.shape.created.nullish(),
   }),
 );
 
@@ -579,6 +580,7 @@ const {
     tags: datasetEventSchema.shape.tags,
     id: datasetEventSchema.shape.id.nullish(),
     [OBJECT_DELETE_FIELD]: datasetEventBaseSchema.shape[OBJECT_DELETE_FIELD],
+    created: experimentEventBaseSchema.shape.created.nullish(),
   }),
 );
 
@@ -600,6 +602,7 @@ const {
     id: projectLogsEventSchema.shape.id.nullish(),
     [OBJECT_DELETE_FIELD]:
       projectLogsEventBaseSchema.shape[OBJECT_DELETE_FIELD],
+    created: experimentEventBaseSchema.shape.created.nullish(),
   }),
 );
 


### PR DESCRIPTION
This lets us specify a `created` timestamp when using the REST API, which is useful at least for unit testing and doesn't seem too harmful to expose to the public.