### PR TITLE
Add trace wrapper

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -3227,7 +3227,7 @@ export class SpanImpl implements Span {
     };
     const serializedPartialRecord = JSON.stringify(partialRecord, (k, v) => {
       if (v instanceof SpanImpl) {
-        return `<span id=${v.id}>`;
+        return `<span>`;
       } else if (v instanceof Experiment) {
         return `<experiment>`;
       } else if (v instanceof Dataset) {

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -2348,7 +2348,29 @@ export function traced<IsAsyncFlush extends boolean = false, R = void>(
   }
 }
 
-export function trace<
+/**
+ * Wrap a function with `traced`, using the arguments as `input` and return value as `output`.
+ * Any functions wrapped this way will automatically be traced, similar to the `@traced` decorator
+ * in Python. If you want to correctly propagate the function's name and define it in one go, then
+ * you can do so like this:
+ *
+ * ```ts
+ * const myFunc = wrapTraced(async function myFunc(input) {
+ *  const result = await client.chat.completions.create({
+ *    model: "gpt-3.5-turbo",
+ *    messages: [{ role: "user", content: input }],
+ *  });
+ *  return result.choices[0].message.content ?? "unknown";
+ * });
+ * ```
+ * Now, any calls to `myFunc` will be traced, and the input and output will be logged automatically.
+ * If tracing is inactive, i.e. there is no active logger or experiment, it's just a no-op.
+ *
+ * @param fn The function to wrap.
+ * @param args Span-level arguments (e.g. a custom name or type) to pass to `traced`.
+ * @returns The wrapped function.
+ */
+export function wrapTraced<
   F extends (...args: any[]) => any,
   IsAsyncFlush extends boolean = false,
 >(

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -2435,6 +2435,12 @@ export function wrapTraced<
 }
 
 /**
+ * A synonym for `wrapTraced`. If you're porting from systems that use `traceable`, you can use this to
+ * make your codebase more consistent.
+ */
+export const traceable = wrapTraced;
+
+/**
  * Lower-level alternative to `traced`. This allows you to start a span yourself, and can be useful in situations
  * where you cannot use callbacks. However, spans started with `startSpan` will not be marked as the "current span",
  * so `currentSpan()` and `traced()` will be no-ops. If you want to mark a span as current, use `traced` instead.

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -2403,7 +2403,11 @@ export function wrapTraced<
 
         if (!hasExplicitOutput) {
           if (output instanceof Promise) {
-            output.then((result) => span.log({ output: result }));
+            return (async () => {
+              const result = await output;
+              span.log({ output: result });
+              return result;
+            })();
           } else {
             span.log({ output: output });
           }
@@ -2420,8 +2424,7 @@ export function wrapTraced<
 
         const outputResult = fn(...fnArgs);
 
-        const output =
-          outputResult instanceof Promise ? await outputResult : outputResult;
+        const output = await outputResult;
 
         if (!hasExplicitOutput) {
           span.log({ output });

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -2348,8 +2348,6 @@ export function traced<IsAsyncFlush extends boolean = false, R = void>(
   }
 }
 
-type PromiseIfNotPromise<T> = T extends Promise<any> ? T : Promise<T>;
-
 export function trace<
   F extends (...args: any[]) => any,
   IsAsyncFlush extends boolean = false,
@@ -2357,7 +2355,7 @@ export function trace<
   fn: F,
   args?: StartSpanArgs & SetCurrentArg & AsyncFlushArg<IsAsyncFlush>,
 ): IsAsyncFlush extends false
-  ? (...args: Parameters<F>) => PromiseIfNotPromise<ReturnType<F>>
+  ? (...args: Parameters<F>) => Promise<Awaited<ReturnType<F>>>
   : F {
   const spanArgs: typeof args = {
     name: fn.name,
@@ -2386,7 +2384,7 @@ export function trace<
         span.log({ output });
         return output;
       }, spanArgs)) as IsAsyncFlush extends false
-      ? (...args: Parameters<F>) => PromiseIfNotPromise<ReturnType<F>>
+      ? (...args: Parameters<F>) => Promise<Awaited<ReturnType<F>>>
       : never;
   }
 }


### PR DESCRIPTION
This wrapper resembles the `@braintrust.traced` decorator in Python.