### PR TITLE
Use .strip() for views fields

### DIFF
--- a/core/js/typespecs/view.ts
+++ b/core/js/typespecs/view.ts
@@ -28,6 +28,7 @@ export const viewDataSchema = z
   .strictObject({
     search: viewDataSearchSchema.nullish(),
   })
+  .strip()
   .openapi("ViewData");
 export type ViewData = z.infer<typeof viewDataSchema>;
 

--- a/core/js/typespecs/view.ts
+++ b/core/js/typespecs/view.ts
@@ -22,6 +22,7 @@ export const viewDataSearchSchema = z
     match: z.array(customTypes.any).nullish(),
     sort: z.array(customTypes.any).nullish(),
   })
+  .strip()
   .openapi("ViewDataSearch");
 export const viewDataSchema = z
   .strictObject({
@@ -36,5 +37,6 @@ export const viewOptionsSchema = z
     columnOrder: z.array(z.string()).nullish(),
     columnSizing: z.record(z.number()).nullish(),
   })
+  .strip()
   .openapi("ViewOptions");
 export type ViewOptions = z.infer<typeof viewOptionsSchema>;


### PR DESCRIPTION
This will make it easier to add new fields to the view schema without breaking compatibility.