### PR TITLE
Replace all usages of `strictObject` with `object`.

### DIFF
--- a/core/js/src/index.ts
+++ b/core/js/src/index.ts
@@ -9,3 +9,4 @@ export * from "./span_identifier_v2";
 export * from "./span_types";
 export * from "./git_fields";
 export * from "./xact-ids";
+export * from "./zod_util";

--- a/core/js/src/util.test.ts
+++ b/core/js/src/util.test.ts
@@ -10,3 +10,36 @@ test("mapAt basic", () => {
   expect(util.mapAt(m, 5)).toBe("goodbye");
   expect(() => util.mapAt(m, 6)).toThrowError("Map does not contain key 6");
 });
+
+function makeAccumulateMissingKeysF() {
+  const missingKeys: Record<string, string[]> = {};
+  function fn({ k, path }: { k: string; path: string[] }) {
+    missingKeys[k] = path;
+  }
+  return { missingKeys, fn };
+}
+
+test("forEachMissingKey basic", () => {
+  let lhs = { a: 4, b: "hello", c: { d: "what" }, x: [1, 2, 3] };
+  let rhs = { b: lhs.b, q: "hi", c: { e: "yes" }, x: [6, 7, 8, 9] };
+
+  let keysAndFn = makeAccumulateMissingKeysF();
+  util.forEachMissingKey({ lhs, rhs, fn: keysAndFn.fn });
+  expect(keysAndFn.missingKeys).toEqual({ q: [], e: ["c"], 3: ["x"] });
+});
+
+test("forEachMissingKey structural mismatch", () => {
+  let lhs = { a: 4, c: { d: "what" }, x: [1, 2, 3] };
+  let rhs: Record<string, any> = { q: "hi", c: "dog", x: { dog: "cat" } };
+
+  let keysAndFn = makeAccumulateMissingKeysF();
+  expect(() =>
+    util.forEachMissingKey({ lhs, rhs, fn: keysAndFn.fn }),
+  ).toThrowError(`Type mismatch between lhs and rhs object at path ["c"]`);
+
+  // Should work if we take away element `c`.
+  delete rhs["c"];
+  keysAndFn = makeAccumulateMissingKeysF();
+  util.forEachMissingKey({ lhs, rhs, fn: keysAndFn.fn });
+  expect(keysAndFn.missingKeys).toEqual({ q: [], dog: ["x"] });
+});

--- a/core/js/src/util.ts
+++ b/core/js/src/util.ts
@@ -22,6 +22,45 @@ export function mergeDicts(
   return mergeInto;
 }
 
+// Recursively walks down `lhs` and `rhs`, invoking `fn` for each key in any
+// `rhs` subobject which is not in the corresponding `lhs` subobject.
+export function forEachMissingKey({
+  lhs,
+  rhs,
+  fn,
+}: {
+  lhs: unknown;
+  rhs: unknown;
+  fn: (args: {
+    lhs: Record<string, unknown>;
+    k: string;
+    v: unknown;
+    path: string[];
+  }) => void;
+}) {
+  function helper(lhs: unknown, rhs: unknown, path: string[]) {
+    if (lhs instanceof Object) {
+      if (!(rhs instanceof Object)) {
+        throw new Error(
+          `Type mismatch between lhs and rhs object at path ${JSON.stringify(
+            path,
+          )}`,
+        );
+      }
+      const lhsRec = lhs as Record<string, unknown>;
+      const rhsRec = rhs as Record<string, unknown>;
+      for (const [k, v] of Object.entries(rhsRec)) {
+        if (!(k in lhsRec)) {
+          fn({ lhs: lhsRec, k, v, path });
+        } else {
+          helper(lhsRec[k], rhsRec[k], [...path, k]);
+        }
+      }
+    }
+  }
+  helper(lhs, rhs, []);
+}
+
 export function capitalize(s: string, sep?: string) {
   const items = sep ? s.split(sep) : [s];
   return items

--- a/core/js/src/zod_util.test.ts
+++ b/core/js/src/zod_util.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "vitest";
+import { parseNoStrip } from "./zod_util";
+import { z } from "zod";
+
+const testSchema = z.object({
+  a: z.string(),
+  b: z.number().optional(),
+});
+
+test("parseNoStrip basic", () => {
+  expect(parseNoStrip(testSchema, { a: "hello", b: 5 })).toEqual({
+    a: "hello",
+    b: 5,
+  });
+  expect(parseNoStrip(testSchema, { a: "hello" })).toEqual({ a: "hello" });
+  expect(() => parseNoStrip(testSchema, { a: "hello", c: 5 })).toThrowError(
+    /Key.*c.*was stripped from input/,
+  );
+});

--- a/core/js/src/zod_util.ts
+++ b/core/js/src/zod_util.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import { forEachMissingKey } from "./util";
+
+// Parses a zod schema, checking afterwards that no fields were stripped during
+// parsing.
+//
+// Note: this check is not exactly equivalent to a deep version of `z.strict()`.
+// For instance, schemas which intentionally strip keys from objects using
+// something like `z.transform` can fail this check.
+export function parseNoStrip<T extends z.ZodType>(schema: T, input: unknown) {
+  const output = schema.parse(input) as z.infer<T>;
+  forEachMissingKey({
+    lhs: output,
+    rhs: input,
+    fn: ({ k, path }) => {
+      throw new Error(
+        `Key ${JSON.stringify(k)} at path ${JSON.stringify(
+          path,
+        )} was stripped from input`,
+      );
+    },
+  });
+  return output;
+}

--- a/core/js/src/zod_util.ts
+++ b/core/js/src/zod_util.ts
@@ -2,7 +2,23 @@ import { z } from "zod";
 import { forEachMissingKey } from "./util";
 
 // Parses a zod schema, checking afterwards that no fields were stripped during
-// parsing.
+// parsing. There are several reasons we have this function:
+//
+// - Marking a schema `strict` before parsing is not sufficient:
+//
+//   - `strict` only works at the top level of an object, not for nested
+//   objects. It doesn't seem like support for deep strict
+//   (https://github.com/colinhacks/zod/issues/2062) is on the roadmap.
+//
+//   - `strict` would not work for non-toplevel-object types like unions.
+//
+//  - Enforcing `strict` for all objects in our typespecs is not feasible:
+//
+//    - In some contexts, we may want to use the schema in a "less-strict" mode,
+//    which just validates the fields it knows about. E.g. openAPI spec
+//    validation, or we may just want to pull out a subset of fields we care
+//    about. In these cases, if our schemas are deeply-strict, it is very hard
+//    to un-strictify them.
 //
 // Note: this check is not exactly equivalent to a deep version of `z.strict()`.
 // For instance, schemas which intentionally strip keys from objects using

--- a/core/js/typespecs/api_types.ts
+++ b/core/js/typespecs/api_types.ts
@@ -37,7 +37,7 @@ export const auditSourcesSchema = z.enum(VALID_SOURCES);
 
 function generateBaseEventOpSchema(objectType: ObjectTypeWithEvent) {
   const eventDescription = getEventObjectDescription(objectType);
-  return z.strictObject({
+  return z.object({
     id: z
       .string()
       .describe(
@@ -63,7 +63,7 @@ function generateBaseEventOpSchema(objectType: ObjectTypeWithEvent) {
         "A dictionary with additional data about the test example, model outputs, or just about anything else that's relevant, that you can use to help find and analyze examples later. For example, you could log the `prompt`, example's `id`, or anything else that would be useful to slice/dice later. The values in `metadata` can be any JSON-serializable type, but its keys must be strings",
       ),
     metrics: z
-      .strictObject({
+      .object({
         start: z
           .number()
           .nullish()
@@ -109,7 +109,7 @@ function generateBaseEventOpSchema(objectType: ObjectTypeWithEvent) {
         `Metrics are numerical measurements tracking the execution of the code that produced the ${eventDescription} event. Use "start" and "end" to track the time span over which the ${eventDescription} event was produced`,
       ),
     context: z
-      .strictObject({
+      .object({
         caller_functionname: z
           .string()
           .nullish()
@@ -155,7 +155,7 @@ function generateBaseEventOpSchema(objectType: ObjectTypeWithEvent) {
         `The \`span_id\` of the root of the trace this ${eventDescription} event belongs to`,
       ),
     span_attributes: z
-      .strictObject({
+      .object({
         name: z
           .string()
           .nullish()
@@ -182,7 +182,7 @@ function generateBaseEventOpSchema(objectType: ObjectTypeWithEvent) {
 function generateBaseEventFeedbackSchema(objectType: ObjectTypeWithEvent) {
   const eventObjectType = getEventObjectType(objectType);
   const eventDescription = getEventObjectDescription(objectType);
-  return z.strictObject({
+  return z.object({
     id: z
       .string()
       .describe(
@@ -267,7 +267,7 @@ export const versionSchema = z
   );
 
 const pathTypeFilterSchema = z
-  .strictObject({
+  .object({
     type: z
       .literal("path_lookup")
       .describe("Denotes the type of filter as a path-lookup filter"),
@@ -287,7 +287,7 @@ const pathTypeFilterSchema = z
   .openapi("PathLookupFilter");
 
 const sqlTypeFilterSchema = z
-  .strictObject({
+  .object({
     type: z
       .literal("sql_filter")
       .describe("Denotes the type of filter as a sql-type filter"),
@@ -318,7 +318,7 @@ export const fetchFiltersSchema = pathTypeFilterSchema
   .openapi("FetchEventsFilters");
 
 export const fetchEventsRequestSchema = z
-  .strictObject({
+  .object({
     limit: fetchLimitSchema.nullish(),
     cursor: fetchPaginationCursorSchema.nullish(),
     max_xact_id: maxXactIdSchema.nullish(),
@@ -337,7 +337,7 @@ function makeFetchEventsResponseSchema<T extends z.AnyZodObject>(
     "",
   );
   return z
-    .strictObject({
+    .object({
       events: eventSchema.array().describe("A list of fetched events"),
       cursor: z
         .string()
@@ -354,7 +354,7 @@ function makeFetchEventsResponseSchema<T extends z.AnyZodObject>(
 
 const experimentEventBaseSchema = generateBaseEventOpSchema("experiment");
 export const experimentEventSchema = z
-  .strictObject({
+  .object({
     id: experimentEventBaseSchema.shape.id,
     dataset_record_id: z
       .string()
@@ -393,7 +393,7 @@ export type ExperimentEvent = z.infer<typeof experimentEventSchema>;
 
 const datasetEventBaseSchema = generateBaseEventOpSchema("dataset");
 export const datasetEventSchema = z
-  .strictObject({
+  .object({
     id: datasetEventBaseSchema.shape.id,
     [TRANSACTION_ID_FIELD]: datasetEventBaseSchema.shape[TRANSACTION_ID_FIELD],
     created: datasetEventBaseSchema.shape.created,
@@ -416,7 +416,7 @@ export type DatasetEvent = z.infer<typeof datasetEventSchema>;
 const promptSessionEventBaseSchema =
   generateBaseEventOpSchema("prompt_session");
 export const promptSessionEventSchema = z
-  .strictObject({
+  .object({
     id: promptSessionEventBaseSchema.shape.id,
     [TRANSACTION_ID_FIELD]:
       promptSessionEventBaseSchema.shape[TRANSACTION_ID_FIELD],
@@ -436,7 +436,7 @@ export type PromptSessionEvent = z.infer<typeof promptSessionEventSchema>;
 
 const projectLogsEventBaseSchema = generateBaseEventOpSchema("project");
 export const projectLogsEventSchema = z
-  .strictObject({
+  .object({
     id: projectLogsEventBaseSchema.shape.id,
     [TRANSACTION_ID_FIELD]:
       projectLogsEventBaseSchema.shape[TRANSACTION_ID_FIELD],
@@ -479,7 +479,7 @@ const isMergeDescription = [
   'For example, say there is an existing row in the DB `{"id": "foo", "input": {"a": 5, "b": 10}}`. If we merge a new row as `{"_is_merge": true, "id": "foo", "input": {"b": 11, "c": 20}}`, the new row will be `{"id": "foo", "input": {"a": 5, "b": 11, "c": 20}}`. If we replace the new row as `{"id": "foo", "input": {"b": 11, "c": 20}}`, the new row will be `{"id": "foo", "input": {"b": 11, "c": 20}}`',
 ].join("\n\n");
 
-const mergeEventSchema = z.strictObject({
+const mergeEventSchema = z.object({
   [IS_MERGE_FIELD]: customTypes.literalTrue.describe(isMergeDescription),
   [MERGE_PATHS_FIELD]: z
     .string()
@@ -494,7 +494,7 @@ const mergeEventSchema = z.strictObject({
     ),
 });
 
-const replacementEventSchema = z.strictObject({
+const replacementEventSchema = z.object({
   [IS_MERGE_FIELD]: customTypes.literalFalse
     .nullish()
     .describe(isMergeDescription),
@@ -530,7 +530,7 @@ function makeInsertEventSchemas<T extends z.AnyZodObject>(
     .describe(`${capitalize(article)} ${eventDescription} event`)
     .openapi(`Insert${eventSchemaName}Event`);
   const requestSchema = z
-    .strictObject({
+    .object({
       events: eventSchema
         .array()
         .describe(`A list of ${eventDescription} events to insert`),
@@ -540,7 +540,7 @@ function makeInsertEventSchemas<T extends z.AnyZodObject>(
 }
 
 export const insertEventsResponseSchema = z
-  .strictObject({
+  .object({
     row_ids: z
       .string()
       .array()
@@ -555,7 +555,7 @@ const {
   requestSchema: insertExperimentEventsRequestSchema,
 } = makeInsertEventSchemas(
   "experiment",
-  z.strictObject({
+  z.object({
     input: experimentEventSchema.shape.input,
     output: experimentEventSchema.shape.output,
     expected: experimentEventSchema.shape.expected,
@@ -577,7 +577,7 @@ const {
   requestSchema: insertDatasetEventsRequestSchema,
 } = makeInsertEventSchemas(
   "dataset",
-  z.strictObject({
+  z.object({
     input: datasetEventSchema.shape.input,
     expected: datasetEventSchema.shape.expected,
     metadata: datasetEventSchema.shape.metadata,
@@ -593,7 +593,7 @@ const {
   requestSchema: insertProjectLogsEventsRequestSchema,
 } = makeInsertEventSchemas(
   "project",
-  z.strictObject({
+  z.object({
     input: projectLogsEventSchema.shape.input,
     output: projectLogsEventSchema.shape.output,
     expected: projectLogsEventSchema.shape.expected,
@@ -622,7 +622,7 @@ function makeFeedbackRequestSchema<T extends z.AnyZodObject>(
     "_",
   ).replace("_", "");
   return z
-    .strictObject({
+    .object({
       feedback: feedbackSchema
         .array()
         .describe(`A list of ${eventDescription} feedback items`),
@@ -633,7 +633,7 @@ function makeFeedbackRequestSchema<T extends z.AnyZodObject>(
 const feedbackExperimentRequestBaseSchema =
   generateBaseEventFeedbackSchema("experiment");
 const feedbackExperimentItemSchema = z
-  .strictObject({
+  .object({
     id: feedbackExperimentRequestBaseSchema.shape.id,
     scores: feedbackExperimentRequestBaseSchema.shape.scores,
     expected: feedbackExperimentRequestBaseSchema.shape.expected,
@@ -650,7 +650,7 @@ const feedbackExperimentRequestSchema = makeFeedbackRequestSchema(
 const feedbackDatasetRequestBaseSchema =
   generateBaseEventFeedbackSchema("dataset");
 const feedbackDatasetItemSchema = z
-  .strictObject({
+  .object({
     id: feedbackDatasetRequestBaseSchema.shape.id,
     comment: feedbackDatasetRequestBaseSchema.shape.comment,
     metadata: feedbackDatasetRequestBaseSchema.shape.metadata,
@@ -665,7 +665,7 @@ const feedbackDatasetRequestSchema = makeFeedbackRequestSchema(
 const feedbackProjectLogsRequestBaseSchema =
   generateBaseEventFeedbackSchema("project");
 const feedbackProjectLogsItemSchema = z
-  .strictObject({
+  .object({
     id: feedbackProjectLogsRequestBaseSchema.shape.id,
     scores: feedbackProjectLogsRequestBaseSchema.shape.scores,
     expected: feedbackProjectLogsRequestBaseSchema.shape.expected,
@@ -682,7 +682,7 @@ const feedbackProjectLogsRequestSchema = makeFeedbackRequestSchema(
 const feedbackPromptRequestBaseSchema =
   generateBaseEventFeedbackSchema("prompt");
 const feedbackPromptItemSchema = z
-  .strictObject({
+  .object({
     id: feedbackPromptRequestBaseSchema.shape.id,
     comment: feedbackPromptRequestBaseSchema.shape.comment,
     metadata: feedbackPromptRequestBaseSchema.shape.metadata,
@@ -697,7 +697,7 @@ const feedbackPromptRequestSchema = makeFeedbackRequestSchema(
 const feedbackFunctionRequestBaseSchema =
   generateBaseEventFeedbackSchema("function");
 const feedbackFunctionItemSchema = z
-  .strictObject({
+  .object({
     id: feedbackFunctionRequestBaseSchema.shape.id,
     comment: feedbackFunctionRequestBaseSchema.shape.comment,
     metadata: feedbackFunctionRequestBaseSchema.shape.metadata,
@@ -777,7 +777,7 @@ function makeCrossObjectIndividualRequestSchema(
   const eventObjectType = getEventObjectType(objectType);
   const eventDescription = getEventObjectDescription(objectType);
   const eventObjectSchema = apiSpecEventObjectSchemas[eventObjectType];
-  const insertObject = z.strictObject({
+  const insertObject = z.object({
     ...(eventObjectSchema.insertEvent
       ? {
           events: eventObjectSchema.insertEvent
@@ -813,7 +813,7 @@ function makeCrossObjectIndividualResponseSchema(objectType: ObjectType) {
 }
 
 export const crossObjectInsertRequestSchema = z
-  .strictObject({
+  .object({
     experiment: makeCrossObjectIndividualRequestSchema("experiment"),
     dataset: makeCrossObjectIndividualRequestSchema("dataset"),
     project_logs: makeCrossObjectIndividualRequestSchema("project"),
@@ -821,7 +821,7 @@ export const crossObjectInsertRequestSchema = z
   .openapi("CrossObjectInsertRequest");
 
 export const crossObjectInsertResponseSchema = z
-  .strictObject({
+  .object({
     experiment: makeCrossObjectIndividualResponseSchema("experiment"),
     dataset: makeCrossObjectIndividualResponseSchema("dataset"),
     project_logs: makeCrossObjectIndividualResponseSchema("project"),
@@ -850,7 +850,7 @@ export const summarizeDataParamSchema = z
   );
 
 const summarizeExperimentResponseSchema = z
-  .strictObject({
+  .object({
     project_name: z
       .string()
       .describe("Name of the project that the experiment belongs to"),
@@ -870,7 +870,7 @@ const summarizeExperimentResponseSchema = z
     scores: z
       .record(
         z
-          .strictObject({
+          .object({
             name: z.string().describe("Name of the score"),
             score: z
               .number()
@@ -904,7 +904,7 @@ const summarizeExperimentResponseSchema = z
     metrics: z
       .record(
         z
-          .strictObject({
+          .object({
             name: z.string().describe("Name of the metric"),
             metric: z.number().describe("Average metric across all examples"),
             unit: z.string().describe("Unit label for the metric"),
@@ -935,7 +935,7 @@ const summarizeExperimentResponseSchema = z
   .openapi("SummarizeExperimentResponse");
 
 const summarizeDatasetResponseSchema = z
-  .strictObject({
+  .object({
     project_name: z
       .string()
       .describe("Name of the project that the dataset belongs to"),
@@ -949,7 +949,7 @@ const summarizeDatasetResponseSchema = z
       .url()
       .describe("URL to the dataset's page in the Braintrust app"),
     data_summary: z
-      .strictObject({
+      .object({
         total_records: z
           .number()
           .int()

--- a/core/js/typespecs/app_types.ts
+++ b/core/js/typespecs/app_types.ts
@@ -20,7 +20,7 @@ function generateBaseTableSchema(
     nameDescription += `. Within a project, ${objectName} names are unique`;
   }
 
-  return z.strictObject({
+  return z.object({
     id: z.string().uuid().describe(`Unique identifier for the ${objectName}`),
     project_id: z
       .string()
@@ -55,7 +55,7 @@ function generateBaseTableSchema(
 
 const userBaseSchema = generateBaseTableSchema("user");
 export const userSchema = z
-  .strictObject({
+  .object({
     id: userBaseSchema.shape.id,
     given_name: z.string().nullish().describe("Given name of the user"),
     family_name: z.string().nullish().describe("Family name of the user"),
@@ -68,7 +68,7 @@ export type User = z.infer<typeof userSchema>;
 
 const organizationBaseSchema = generateBaseTableSchema("organization");
 export const organizationSchema = z
-  .strictObject({
+  .object({
     id: organizationBaseSchema.shape.id,
     name: organizationBaseSchema.shape.name,
     api_url: z.string().nullish(),
@@ -80,7 +80,7 @@ export const organizationSchema = z
 export type Organization = z.infer<typeof organizationSchema>;
 
 export const maxOverWindowSchema = z
-  .strictObject({
+  .object({
     window_size_days: z.number().int().positive(),
     max_value: z.number().nonnegative(),
   })
@@ -89,7 +89,7 @@ export const maxOverWindowSchema = z
 export type MaxOverWindow = z.infer<typeof maxOverWindowSchema>;
 
 export const resourcesSchema = z
-  .strictObject({
+  .object({
     org_id: organizationSchema.shape.id,
     forbid_toggle_experiment_public_to_private: z.boolean().nullish(),
     num_private_experiment_row_actions: maxOverWindowSchema.nullish(),
@@ -104,7 +104,7 @@ export const resourcesSchema = z
 export type Resources = z.infer<typeof resourcesSchema>;
 
 export const memberSchema = z
-  .strictObject({
+  .object({
     org_id: organizationSchema.shape.id,
     user_id: userSchema.shape.id,
   })
@@ -113,7 +113,7 @@ export type Member = z.infer<typeof memberSchema>;
 
 const orgSecretsBaseSchema = generateBaseTableSchema("org secrets");
 export const orgSecretsSchema = z
-  .strictObject({
+  .object({
     id: orgSecretsBaseSchema.shape.id,
     created: orgSecretsBaseSchema.shape.created,
     key_id: z.string().uuid(),
@@ -128,7 +128,7 @@ export type OrgSecrets = z.infer<typeof orgSecretsSchema>;
 
 const apiKeyBaseSchema = generateBaseTableSchema("api key");
 export const apiKeySchema = z
-  .strictObject({
+  .object({
     id: apiKeyBaseSchema.shape.id,
     created: apiKeyBaseSchema.shape.created,
     name: apiKeyBaseSchema.shape.name,
@@ -139,19 +139,17 @@ export const apiKeySchema = z
   .openapi("ApiKey");
 export type ApiKey = z.infer<typeof apiKeySchema>;
 
-export const projectSettingsSchema = z
-  .strictObject({
-    comparison_key: z
-      .string()
-      .nullish()
-      .describe("The key used to join two experiments (defaults to `input`)."),
-  })
-  .strip();
+export const projectSettingsSchema = z.object({
+  comparison_key: z
+    .string()
+    .nullish()
+    .describe("The key used to join two experiments (defaults to `input`)."),
+});
 export type ProjectSettings = z.infer<typeof projectSettingsSchema>;
 
 const projectBaseSchema = generateBaseTableSchema("project");
 export const projectSchema = z
-  .strictObject({
+  .object({
     id: projectBaseSchema.shape.id,
     org_id: z
       .string()
@@ -172,7 +170,7 @@ const datasetBaseSchema = generateBaseTableSchema("dataset", {
   uniqueName: true,
 });
 export const datasetSchema = z
-  .strictObject({
+  .object({
     id: datasetBaseSchema.shape.id,
     project_id: datasetBaseSchema.shape.project_id.nullish(),
     name: datasetBaseSchema.shape.name,
@@ -188,14 +186,14 @@ export type Dataset = z.infer<typeof datasetSchema>;
 export const validRuntimesEnum = z.enum(["node"]);
 export type Runtime = z.infer<typeof validRuntimesEnum>;
 
-export const runtimeContextSchema = z.strictObject({
+export const runtimeContextSchema = z.object({
   runtime: validRuntimesEnum,
   version: z.string(),
 });
 export type RuntimeContext = z.infer<typeof runtimeContextSchema>;
 
-const promptBaseSchema = generateBaseTableSchema("prompt");
-const promptSchemaObject = z.strictObject({
+export const promptBaseSchema = generateBaseTableSchema("prompt");
+const promptSchemaObject = z.object({
   id: promptBaseSchema.shape.id,
   // This has to be copy/pasted because zod blows up when there are circular dependencies
   _xact_id: z
@@ -222,37 +220,34 @@ const promptSchemaObject = z.strictObject({
 export const promptSchema = promptSchemaObject.openapi("Prompt");
 export type Prompt = z.infer<typeof promptSchema>;
 
-export const codeBundleSchema = z.strictObject({
-  runtime_context: z.strictObject({
+export const codeBundleSchema = z.object({
+  runtime_context: z.object({
     runtime: validRuntimesEnum,
     version: z.string(),
   }),
   // This should be a union, once we support code living in different places
   // Other options should be:
   //  - a "handler" function that has some signature [does AWS lambda assume it's always called "handler"?]
-  location: z.strictObject({
+  location: z.object({
     type: z.literal("experiment"),
     eval_name: z.string(),
-    position: z.union([
-      z.literal("task"),
-      z.strictObject({ score: z.number() }),
-    ]),
+    position: z.union([z.literal("task"), z.object({ score: z.number() })]),
   }),
   bundle_id: z.string(),
 });
 export type CodeBundle = z.infer<typeof codeBundleSchema>;
 
 export const functionDataSchema = z.union([
-  z.strictObject({
+  z.object({
     type: z.literal("prompt"),
     // For backwards compatibility reasons, this is hoisted out and stored
     // in the outer object
   }),
-  z.strictObject({
+  z.object({
     type: z.literal("code"),
     data: codeBundleSchema,
   }),
-  z.strictObject({
+  z.object({
     type: z.literal("global"),
     name: z.string(),
   }),
@@ -260,7 +255,7 @@ export const functionDataSchema = z.union([
 
 export const functionSchema = promptSchemaObject
   .merge(
-    z.strictObject({
+    z.object({
       function_data: functionDataSchema,
     }),
   )
@@ -270,7 +265,7 @@ export const functionSchema = promptSchemaObject
 export type FunctionObject = z.infer<typeof functionSchema>;
 
 export const repoInfoSchema = z
-  .strictObject({
+  .object({
     commit: z.string().nullish().describe("SHA of most recent commit"),
     branch: z
       .string()
@@ -315,7 +310,7 @@ const experimentBaseSchema = generateBaseTableSchema("experiment", {
   uniqueName: true,
 });
 export const experimentSchema = z
-  .strictObject({
+  .object({
     id: experimentBaseSchema.shape.id,
     project_id: experimentBaseSchema.shape.project_id,
     name: experimentBaseSchema.shape.name,
@@ -362,7 +357,7 @@ const promptSessionBaseSchema = generateBaseTableSchema("promptSession", {
   uniqueName: true,
 });
 export const promptSessionSchema = z
-  .strictObject({
+  .object({
     id: promptSessionBaseSchema.shape.id,
     name: promptSessionBaseSchema.shape.name,
     description: promptSessionBaseSchema.shape.description,
@@ -417,7 +412,7 @@ export type AclObjectType = z.infer<typeof aclObjectTypeEnum>;
 
 const roleBaseSchema = generateBaseTableSchema("role");
 export const roleSchema = z
-  .strictObject({
+  .object({
     id: roleBaseSchema.shape.id,
     org_id: z
       .string()
@@ -437,7 +432,7 @@ export const roleSchema = z
     deleted_at: roleBaseSchema.shape.deleted_at,
     member_permissions: z
       .array(
-        z.strictObject({
+        z.object({
           permission: permissionEnum,
           restrict_object_type: aclObjectTypeEnum.nullish(),
         }),
@@ -467,7 +462,7 @@ export type Role = z.infer<typeof roleSchema>;
 
 const groupBaseSchema = generateBaseTableSchema("group");
 export const groupSchema = z
-  .strictObject({
+  .object({
     id: groupBaseSchema.shape.id,
     org_id: z
       .string()
@@ -526,7 +521,7 @@ export type ProjectScoreCategory = z.infer<typeof projectScoreCategory>;
 
 const projectScoreBaseSchema = generateBaseTableSchema("project score");
 export const projectScoreSchema = z
-  .strictObject({
+  .object({
     id: projectScoreBaseSchema.shape.id,
     project_id: projectScoreBaseSchema.shape.project_id,
     user_id: projectScoreBaseSchema.shape.user_id.unwrap().unwrap(),
@@ -554,7 +549,7 @@ export const projectScoreSchema = z
       ])
       .nullish(),
     config: z
-      .strictObject({
+      .object({
         multi_select: z.boolean().nullish(),
         destination: z.literal("expected").nullish(),
       })
@@ -568,7 +563,7 @@ export type ProjectScore = z.infer<typeof projectScoreSchema>;
 
 const projectTagBaseSchema = generateBaseTableSchema("project tag");
 export const projectTagSchema = z
-  .strictObject({
+  .object({
     id: projectTagBaseSchema.shape.id,
     project_id: projectTagBaseSchema.shape.project_id,
     user_id: projectTagBaseSchema.shape.user_id.unwrap().unwrap(),
@@ -585,7 +580,7 @@ export type ProjectTag = z.infer<typeof projectTagSchema>;
 
 const viewBaseSchema = generateBaseTableSchema("view");
 export const viewSchema = z
-  .strictObject({
+  .object({
     id: viewBaseSchema.shape.id,
     object_type: aclObjectTypeEnum,
     object_id: z
@@ -607,7 +602,7 @@ export type View = z.infer<typeof viewSchema>;
 
 const aclBaseSchema = generateBaseTableSchema("acl");
 export const aclSchema = z
-  .strictObject({
+  .object({
     id: aclBaseSchema.shape.id,
     object_type: aclObjectTypeEnum,
     object_id: z
@@ -670,7 +665,7 @@ export const appLimitSchema = z
   .describe("Limit the number of objects to return");
 
 function generateBaseTableOpSchema(objectName: string) {
-  return z.strictObject({
+  return z.object({
     org_name: z
       .string()
       .nullish()
@@ -717,14 +712,14 @@ export function makeObjectIdsFilterSchema(objectName: string) {
 
 const createProjectBaseSchema = generateBaseTableOpSchema("project");
 const createProjectSchema = z
-  .strictObject({
+  .object({
     name: projectSchema.shape.name,
     org_name: createProjectBaseSchema.shape.org_name,
   })
   .openapi("CreateProject");
 
-const patchProjectSchema = z
-  .strictObject({
+export const patchProjectSchema = z
+  .object({
     name: projectSchema.shape.name.nullish(),
     settings: projectSchema.shape.settings
       .describe(
@@ -735,7 +730,7 @@ const patchProjectSchema = z
   .openapi("PatchProject");
 
 const createExperimentSchema = z
-  .strictObject({
+  .object({
     project_id: experimentSchema.shape.project_id,
     name: experimentSchema.shape.name.nullish(),
     description: experimentSchema.shape.description,
@@ -754,20 +749,20 @@ const createExperimentSchema = z
   })
   .openapi("CreateExperiment");
 
-const patchExperimentSchema = createExperimentSchema
+export const patchExperimentSchema = createExperimentSchema
   .omit({ project_id: true, ensure_new: true })
   .openapi("PatchExperiment");
 
 const createDatasetSchema = z
-  .strictObject({
+  .object({
     project_id: datasetSchema.shape.project_id,
     name: datasetSchema.shape.name,
     description: datasetSchema.shape.description,
   })
   .openapi("CreateDataset");
 
-const patchDatasetSchema = z
-  .strictObject({
+export const patchDatasetSchema = z
+  .object({
     name: datasetSchema.shape.name.nullish(),
     description: datasetSchema.shape.description,
   })
@@ -796,7 +791,7 @@ const createFunctionSchema = functionSchema
   .openapi("CreateFunction");
 
 const patchPromptSchema = z
-  .strictObject({
+  .object({
     name: promptSchema.shape.name.nullish(),
     description: promptSchema.shape.description.nullish(),
     prompt_data: promptSchema.shape.prompt_data.nullish(),
@@ -805,7 +800,7 @@ const patchPromptSchema = z
   .openapi("PatchPrompt");
 
 const patchFunctionSchema = z
-  .strictObject({
+  .object({
     name: functionSchema.shape.name.nullish(),
     description: functionSchema.shape.description.nullish(),
     prompt_data: functionSchema.shape.prompt_data.nullish(),
@@ -816,7 +811,7 @@ const patchFunctionSchema = z
 
 const createRoleBaseSchema = generateBaseTableOpSchema("role");
 const createRoleSchema = z
-  .strictObject({
+  .object({
     name: roleSchema.shape.name,
     description: roleSchema.shape.description,
     member_permissions: roleSchema.shape.member_permissions,
@@ -825,7 +820,7 @@ const createRoleSchema = z
   })
   .openapi("CreateRole");
 
-const patchRoleSchema = createRoleSchema
+export const patchRoleSchema = createRoleSchema
   .omit({
     name: true,
     org_name: true,
@@ -833,7 +828,7 @@ const patchRoleSchema = createRoleSchema
     member_roles: true,
   })
   .merge(
-    z.strictObject({
+    z.object({
       name: createRoleSchema.shape.name.nullish(),
       add_member_permissions: roleSchema.shape.member_permissions
         .nullish()
@@ -857,7 +852,7 @@ const patchRoleSchema = createRoleSchema
 
 const createGroupBaseSchema = generateBaseTableOpSchema("group");
 const createGroupSchema = z
-  .strictObject({
+  .object({
     name: groupSchema.shape.name,
     description: groupSchema.shape.description,
     member_users: groupSchema.shape.member_users,
@@ -866,10 +861,10 @@ const createGroupSchema = z
   })
   .openapi("CreateGroup");
 
-const patchGroupSchema = createGroupSchema
+export const patchGroupSchema = createGroupSchema
   .omit({ name: true, org_name: true, member_users: true, member_groups: true })
   .merge(
-    z.strictObject({
+    z.object({
       name: createGroupSchema.shape.name.nullish(),
       add_member_users: groupSchema.shape.member_users
         .nullish()
@@ -900,7 +895,7 @@ export const createAclSchema = aclSchema
   .openapi("CreateAcl");
 
 const createProjectScoreSchema = z
-  .strictObject({
+  .object({
     project_id: projectScoreSchema.shape.project_id,
     name: projectScoreSchema.shape.name,
     description: projectScoreSchema.shape.description,
@@ -909,8 +904,8 @@ const createProjectScoreSchema = z
   })
   .openapi("CreateProjectScore");
 
-const patchProjectScoreSchema = z
-  .strictObject({
+export const patchProjectScoreSchema = z
+  .object({
     name: projectScoreSchema.shape.name.nullish(),
     description: projectScoreSchema.shape.description,
     score_type: projectScoreSchema.shape.score_type.nullish(),
@@ -919,7 +914,7 @@ const patchProjectScoreSchema = z
   .openapi("PatchProjectScore");
 
 const createProjectTagSchema = z
-  .strictObject({
+  .object({
     project_id: projectTagSchema.shape.project_id,
     name: projectTagSchema.shape.name,
     description: projectTagSchema.shape.description,
@@ -927,8 +922,8 @@ const createProjectTagSchema = z
   })
   .openapi("CreateProjectTag");
 
-const patchProjectTagSchema = z
-  .strictObject({
+export const patchProjectTagSchema = z
+  .object({
     name: projectTagSchema.shape.name.nullish(),
     description: projectTagSchema.shape.description,
     color: projectTagSchema.shape.color,
@@ -943,7 +938,7 @@ export const createViewSchema = viewSchema
   .openapi("CreateView");
 
 export const patchViewSchema = z
-  .strictObject({
+  .object({
     object_type: viewSchema.shape.object_type,
     object_id: viewSchema.shape.object_id,
     view_type: viewSchema.shape.view_type.nullish(),
@@ -955,14 +950,14 @@ export const patchViewSchema = z
   .openapi("PatchView");
 
 const deleteViewSchema = z
-  .strictObject({
+  .object({
     object_type: viewSchema.shape.object_type,
     object_id: viewSchema.shape.object_id,
   })
   .openapi("DeleteView");
 
-const patchOrganizationSchema = z
-  .strictObject({
+export const patchOrganizationSchema = z
+  .object({
     name: organizationSchema.shape.name.nullish(),
     api_url: organizationSchema.shape.api_url.nullish(),
     proxy_url: organizationSchema.shape.proxy_url.nullish(),

--- a/core/js/typespecs/common_types.ts
+++ b/core/js/typespecs/common_types.ts
@@ -15,6 +15,15 @@ export const jsonSchema: z.ZodType<Json> = z.lazy(() =>
   z.union([literalSchema, z.array(jsonSchema), z.record(jsonSchema)]),
 );
 
+// It is often hard for us to control every piece of code that serializes
+// datetimes to strings to ensure they are always strictly ISO8601-compliant.
+// Thus asserting `z.string().datetime()` will not often work. While
+// `z.string().datetime({ offset: true })` could work, it has the downside of
+// not actually sanitizing the string to a consistent format, which is a
+// nice-to-have.
+//
+// Thus we implement this more-lenient parsing and sanitization as a transform
+// and explicitly add the "date-time" format specifier for openAPI.
 export const datetimeStringSchema = z
   .string()
   .transform((x, ctx) => {

--- a/core/js/typespecs/common_types.ts
+++ b/core/js/typespecs/common_types.ts
@@ -1,4 +1,6 @@
 import { z } from "zod";
+import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
+extendZodWithOpenApi(z);
 
 export const literalSchema = z.union([
   z.string(),
@@ -13,7 +15,21 @@ export const jsonSchema: z.ZodType<Json> = z.lazy(() =>
   z.union([literalSchema, z.array(jsonSchema), z.record(jsonSchema)]),
 );
 
-export const datetimeStringSchema = z.string().datetime({ offset: true });
+export const datetimeStringSchema = z
+  .string()
+  .transform((x, ctx) => {
+    const d = new Date(x);
+    if (isNaN(d.getTime())) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.invalid_string,
+        validation: "datetime",
+        message: "Invalid datetime",
+      });
+      return z.NEVER;
+    }
+    return d.toISOString();
+  })
+  .openapi({ format: "date-time" });
 
 export const objectTypes = z.enum([
   "project",

--- a/core/js/typespecs/openai/messages.ts
+++ b/core/js/typespecs/openai/messages.ts
@@ -10,36 +10,26 @@ export const messageRoleSchema = z.enum([
 ]);
 export type MessageRole = z.infer<typeof messageRoleSchema>;
 
-const chatCompletionSystemMessageParamSchema = z
-  .strictObject({
-    content: z.string().default(""),
-    role: z.literal("system"),
-    name: z.string().optional(),
-  })
-  .strip();
+const chatCompletionSystemMessageParamSchema = z.object({
+  content: z.string().default(""),
+  role: z.literal("system"),
+  name: z.string().optional(),
+});
+export const chatCompletionContentPartTextSchema = z.object({
+  text: z.string().default(""),
+  type: z.literal("text"),
+});
 
-export const chatCompletionContentPartTextSchema = z
-  .strictObject({
-    text: z.string().default(""),
-    type: z.literal("text"),
-  })
-  .strip();
-
-const imageURLSchema = z
-  .strictObject({
-    url: z.string(),
-    detail: z
-      .union([z.literal("auto"), z.literal("low"), z.literal("high")])
-      .optional(),
-  })
-  .strip();
-
-export const chatCompletionContentPartImageSchema = z
-  .strictObject({
-    image_url: imageURLSchema,
-    type: z.literal("image_url"),
-  })
-  .strip();
+const imageURLSchema = z.object({
+  url: z.string(),
+  detail: z
+    .union([z.literal("auto"), z.literal("low"), z.literal("high")])
+    .optional(),
+});
+export const chatCompletionContentPartImageSchema = z.object({
+  image_url: imageURLSchema,
+  type: z.literal("image_url"),
+});
 
 export const chatCompletionContentPartSchema = z.union([
   chatCompletionContentPartTextSchema,
@@ -51,75 +41,52 @@ export const chatCompletionContentSchema = z.union([
   z.array(chatCompletionContentPartSchema),
 ]);
 
-const chatCompletionUserMessageParamSchema = z
-  .strictObject({
-    content: chatCompletionContentSchema,
-    role: z.literal("user"),
-    name: z.string().optional(),
-  })
-  .strip();
+const chatCompletionUserMessageParamSchema = z.object({
+  content: chatCompletionContentSchema,
+  role: z.literal("user"),
+  name: z.string().optional(),
+});
+const functionCallSchema = z.object({
+  arguments: z.string(),
+  name: z.string(),
+});
+const functionSchema = z.object({
+  arguments: z.string(),
+  name: z.string(),
+});
+const chatCompletionToolMessageParamSchema = z.object({
+  content: z.string().default(""),
+  role: z.literal("tool"),
+  tool_call_id: z.string().default(""),
+});
+const chatCompletionFunctionMessageParamSchema = z.object({
+  content: z.string().default(""),
+  name: z.string(),
+  role: z.literal("function"),
+});
+export const chatCompletionMessageToolCallSchema = z.object({
+  id: z.string(),
+  function: functionSchema,
+  type: z.literal("function"),
+});
 
-const functionCallSchema = z
-  .strictObject({
-    arguments: z.string(),
-    name: z.string(),
-  })
-  .strip();
-
-const functionSchema = z
-  .strictObject({
-    arguments: z.string(),
-    name: z.string(),
-  })
-  .strip();
-
-const chatCompletionToolMessageParamSchema = z
-  .strictObject({
-    content: z.string().default(""),
-    role: z.literal("tool"),
-    tool_call_id: z.string().default(""),
-  })
-  .strip();
-
-const chatCompletionFunctionMessageParamSchema = z
-  .strictObject({
-    content: z.string().default(""),
-    name: z.string(),
-    role: z.literal("function"),
-  })
-  .strip();
-
-export const chatCompletionMessageToolCallSchema = z
-  .strictObject({
-    id: z.string(),
-    function: functionSchema,
-    type: z.literal("function"),
-  })
-  .strip();
-
-const chatCompletionAssistantMessageParamSchema = z
-  .strictObject({
-    role: z.literal("assistant"),
-    content: z.string().nullish(),
-    function_call: functionCallSchema.optional(),
-    name: z.string().optional(),
-    tool_calls: z.array(chatCompletionMessageToolCallSchema).optional(),
-  })
-  .strip();
-
-const chatCompletionFallbackMessageParamSchema = z
-  .strictObject({
-    role: messageRoleSchema.exclude([
-      "system",
-      "user",
-      "assistant",
-      "tool",
-      "function",
-    ]),
-    content: z.string().nullish(),
-  })
-  .strip();
-
+const chatCompletionAssistantMessageParamSchema = z.object({
+  role: z.literal("assistant"),
+  content: z.string().nullish(),
+  function_call: functionCallSchema.optional(),
+  name: z.string().optional(),
+  tool_calls: z.array(chatCompletionMessageToolCallSchema).optional(),
+});
+const chatCompletionFallbackMessageParamSchema = z.object({
+  role: messageRoleSchema.exclude([
+    "system",
+    "user",
+    "assistant",
+    "tool",
+    "function",
+  ]),
+  content: z.string().nullish(),
+});
 export const chatCompletionOpenAIMessageParamSchema = z.union([
   chatCompletionSystemMessageParamSchema,
   chatCompletionUserMessageParamSchema,

--- a/core/js/typespecs/openai/tools.ts
+++ b/core/js/typespecs/openai/tools.ts
@@ -2,20 +2,16 @@ import { z } from "zod";
 
 export const functionParametersSchema = z.record(z.unknown());
 
-export const functionDefinitionSchema = z
-  .strictObject({
-    name: z.string(),
-    description: z.string().optional(),
-    parameters: functionParametersSchema.optional(),
-  })
-  .strip();
+export const functionDefinitionSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  parameters: functionParametersSchema.optional(),
+});
 
-export const chatCompletionToolSchema = z
-  .strictObject({
-    function: functionDefinitionSchema,
-    type: z.literal("function"),
-  })
-  .strip();
+export const chatCompletionToolSchema = z.object({
+  function: functionDefinitionSchema,
+  type: z.literal("function"),
+});
 
 export const toolsSchema = z.array(chatCompletionToolSchema);
 export type Tools = z.infer<typeof toolsSchema>;

--- a/core/js/typespecs/prompt.ts
+++ b/core/js/typespecs/prompt.ts
@@ -32,11 +32,11 @@ export type ContentPartImage = z.infer<
 export type ContentPart = z.infer<typeof chatCompletionContentPartSchema>;
 
 export const promptBlockDataSchema = z.union([
-  z.strictObject({
+  z.object({
     type: z.literal("completion"),
     content: z.string(),
   }),
-  z.strictObject({
+  z.object({
     type: z.literal("chat"),
     messages: z.array(chatCompletionMessageParamSchema),
     tools: z.string().optional(),
@@ -48,83 +48,64 @@ export type PromptBlockData = z.infer<typeof promptBlockDataSchema>;
 // Note that for prompt options, we relax the strictness requirement because
 // these params may come from external sources.
 
-const braintrustModelParamsSchema = z
-  .strictObject({
-    use_cache: z.boolean().optional(),
-  })
-  .strip();
-
+const braintrustModelParamsSchema = z.object({
+  use_cache: z.boolean().optional(),
+});
 export const BRAINTRUST_PARAMS = Object.keys(braintrustModelParamsSchema.shape);
 
-const openAIModelParamsSchema = z
-  .strictObject({
-    temperature: z.number().optional(),
-    top_p: z.number().optional(),
-    max_tokens: z.number().optional(),
-    frequency_penalty: z.number().optional(),
-    presence_penalty: z.number().optional(),
-    response_format: z
-      .strictObject({ type: z.literal("json_object") })
-      .nullish(),
-    tool_choice: z
-      .union([
-        z.literal("auto"),
-        z.literal("none"),
-        z
-          .strictObject({
-            type: z.literal("function"),
-            function: z.strictObject({ name: z.string() }).strip(),
-          })
-          .strip(),
-      ])
-      .optional(),
-    function_call: z
-      .union([
-        z.literal("auto"),
-        z.literal("none"),
-        z.strictObject({
-          name: z.string(),
-        }),
-      ])
-      .optional(),
-    n: z.number().optional(),
-    stop: z.array(z.string()).optional(),
-  })
-  .strip();
-
+const openAIModelParamsSchema = z.object({
+  temperature: z.number().optional(),
+  top_p: z.number().optional(),
+  max_tokens: z.number().optional(),
+  frequency_penalty: z.number().optional(),
+  presence_penalty: z.number().optional(),
+  response_format: z.object({ type: z.literal("json_object") }).nullish(),
+  tool_choice: z
+    .union([
+      z.literal("auto"),
+      z.literal("none"),
+      z.object({
+        type: z.literal("function"),
+        function: z.object({ name: z.string() }),
+      }),
+    ])
+    .optional(),
+  function_call: z
+    .union([
+      z.literal("auto"),
+      z.literal("none"),
+      z.object({
+        name: z.string(),
+      }),
+    ])
+    .optional(),
+  n: z.number().optional(),
+  stop: z.array(z.string()).optional(),
+});
 export type OpenAIModelParams = z.infer<typeof openAIModelParamsSchema>;
 
-const anthropicModelParamsSchema = z
-  .strictObject({
-    max_tokens: z.number(),
-    temperature: z.number(),
-    top_p: z.number().optional(),
-    top_k: z.number().optional(),
-    stop_sequences: z.array(z.string()).optional(),
-    max_tokens_to_sample: z
-      .number()
-      .optional()
-      .describe("This is a legacy parameter that should not be used."),
-  })
-  .strip();
-
-const googleModelParamsSchema = z
-  .strictObject({
-    temperature: z.number().optional(),
-    maxOutputTokens: z.number().optional(),
-    topP: z.number().optional(),
-    topK: z.number().optional(),
-  })
-  .strip();
-
-const windowAIModelParamsSchema = z
-  .strictObject({
-    temperature: z.number().optional(),
-    topK: z.number().optional(),
-  })
-  .strip();
-
-const jsCompletionParamsSchema = z.strictObject({}).strip();
+const anthropicModelParamsSchema = z.object({
+  max_tokens: z.number(),
+  temperature: z.number(),
+  top_p: z.number().optional(),
+  top_k: z.number().optional(),
+  stop_sequences: z.array(z.string()).optional(),
+  max_tokens_to_sample: z
+    .number()
+    .optional()
+    .describe("This is a legacy parameter that should not be used."),
+});
+const googleModelParamsSchema = z.object({
+  temperature: z.number().optional(),
+  maxOutputTokens: z.number().optional(),
+  topP: z.number().optional(),
+  topK: z.number().optional(),
+});
+const windowAIModelParamsSchema = z.object({
+  temperature: z.number().optional(),
+  topK: z.number().optional(),
+});
+const jsCompletionParamsSchema = z.object({});
 export const modelParamsSchema = z.union([
   braintrustModelParamsSchema.merge(openAIModelParamsSchema).passthrough(),
   braintrustModelParamsSchema.merge(anthropicModelParamsSchema).passthrough(),
@@ -142,22 +123,20 @@ const anyModelParamsSchema = openAIModelParamsSchema
 
 export type AnyModelParam = z.infer<typeof anyModelParamsSchema>;
 
-export const promptOptionsSchema = z
-  .strictObject({
-    model: z.string().optional(),
-    params: modelParamsSchema.optional(),
-    position: z.string().optional(),
-  })
-  .strip();
+export const promptOptionsSchema = z.object({
+  model: z.string().optional(),
+  params: modelParamsSchema.optional(),
+  position: z.string().optional(),
+});
 
 export type PromptOptions = z.infer<typeof promptOptionsSchema>;
 
 export const promptDataSchema = z
-  .strictObject({
+  .object({
     prompt: promptBlockDataSchema.nullish(),
     options: promptOptionsSchema.nullish(),
     origin: z
-      .strictObject({
+      .object({
         prompt_id: z.string().optional(),
         project_id: z.string().optional(),
         prompt_version: z.string().optional(),

--- a/core/js/typespecs/view.ts
+++ b/core/js/typespecs/view.ts
@@ -16,7 +16,7 @@ export const viewTypeEnum = z
 export type ViewType = z.infer<typeof viewTypeEnum>;
 
 export const viewDataSearchSchema = z
-  .strictObject({
+  .object({
     filter: z.array(customTypes.any).nullish(),
     tag: z.array(customTypes.any).nullish(),
     match: z.array(customTypes.any).nullish(),
@@ -25,7 +25,7 @@ export const viewDataSearchSchema = z
   .strip()
   .openapi("ViewDataSearch");
 export const viewDataSchema = z
-  .strictObject({
+  .object({
     search: viewDataSearchSchema.nullish(),
   })
   .strip()
@@ -33,7 +33,7 @@ export const viewDataSchema = z
 export type ViewData = z.infer<typeof viewDataSchema>;
 
 export const viewOptionsSchema = z
-  .strictObject({
+  .object({
     columnVisibility: z.record(z.boolean()).nullish(),
     columnOrder: z.array(z.string()).nullish(),
     columnSizing: z.record(z.number()).nullish(),


### PR DESCRIPTION
We've decided that by default, our zod object schemas should be in `strip` mode rather than `strict` mode, because there are many usage sites which only want to use the schema for validation, which may not be always up-to-date with the latest schema definition (e.g. the API server, sdk libraries). So `strip` is safer for validation.

For users who do want to check no extra fields, we introduce a `parseNoStrip` utility function which parses the object and checks that no fields were removed from the final object.