### PR TITLE
Fix bug in castLogger.

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -1000,7 +1000,7 @@ function castLogger<ToB extends boolean, FromB extends boolean>(
   asyncFlush?: ToB,
 ): Logger<ToB> | undefined {
   if (logger === undefined) return undefined;
-  if (asyncFlush && !!asyncFlush !== !!logger.asyncFlush) {
+  if (asyncFlush !== undefined && !!asyncFlush !== !!logger.asyncFlush) {
     throw new Error(
       `Asserted asyncFlush setting ${asyncFlush} does not match stored logger's setting ${logger.asyncFlush}`,
     );


### PR DESCRIPTION
It should also throw if you attempt to cast a logger with `asyncFlush: false` when `logger.asyncFlush === true`.