### PR TITLE
Better error message for parseNoStrip.

### DIFF
--- a/core/js/src/zod_util.test.ts
+++ b/core/js/src/zod_util.test.ts
@@ -14,6 +14,6 @@ test("parseNoStrip basic", () => {
   });
   expect(parseNoStrip(testSchema, { a: "hello" })).toEqual({ a: "hello" });
   expect(() => parseNoStrip(testSchema, { a: "hello", c: 5 })).toThrowError(
-    /Key.*c.*was stripped from input/,
+    /Extraneous key.*c.*at path.*in input/,
   );
 });

--- a/core/js/src/zod_util.ts
+++ b/core/js/src/zod_util.ts
@@ -30,9 +30,9 @@ export function parseNoStrip<T extends z.ZodType>(schema: T, input: unknown) {
     rhs: input,
     fn: ({ k, path }) => {
       throw new Error(
-        `Key ${JSON.stringify(k)} at path ${JSON.stringify(
+        `Extraneous key ${JSON.stringify(k)} at path ${JSON.stringify(
           path,
-        )} was stripped from input`,
+        )} in input`,
       );
     },
   });


### PR DESCRIPTION
So we can share it with the user.