### PR TITLE
Update links for npm package

### DIFF
--- a/js/CHANGELOG.md
+++ b/js/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+Release notes can be found [here](https://www.braintrust.dev/docs/reference/release-notes).

--- a/js/package.json
+++ b/js/package.json
@@ -2,6 +2,12 @@
   "name": "braintrust",
   "version": "0.0.141",
   "description": "SDK for integrating Braintrust",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/braintrustdata/braintrust-sdk.git",
+    "directory": "blob/main/js"
+  },
+  "homepage": "https://www.braintrust.dev/docs",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
The update to the package.json file allow the npm package to link to the repository and the homepage from the main npm page https://www.npmjs.com/package/braintrust