### PR TITLE
Allow span_id and root_span_id to be non-UUID.

### DIFF
--- a/core/js/typespecs/api_types.ts
+++ b/core/js/typespecs/api_types.ts
@@ -138,7 +138,6 @@ function generateBaseEventOpSchema(objectType: ObjectTypeWithEvent) {
       ),
     span_id: z
       .string()
-      .uuid()
       .describe(
         `A unique identifier used to link different ${eventDescription} events together as part of a full trace. See the [tracing guide](https://www.braintrust.dev/docs/guides/tracing) for full details on tracing`,
       ),
@@ -151,7 +150,6 @@ function generateBaseEventOpSchema(objectType: ObjectTypeWithEvent) {
       ),
     root_span_id: z
       .string()
-      .uuid()
       .describe(
         `The \`span_id\` of the root of the trace this ${eventDescription} event belongs to`,
       ),


### PR DESCRIPTION
This can arise in general when various parts of the application fill in `span_id = root_span_id = id`, and the user is using a manually-provided id. Since these coercions should only occur for non-trace rows, a strong uniqueness constraint is not required anyways.