### PR TITLE
Log errors in `Eval()` at the top level

### DIFF
--- a/core/js/typespecs/openai/messages.ts
+++ b/core/js/typespecs/openai/messages.ts
@@ -78,7 +78,7 @@ const chatCompletionAssistantMessageParamSchema = z.object({
   role: z.literal("assistant"),
   content: z.string().nullish(),
   function_call: functionCallSchema.nullish(),
-  name: z.string().optional(),
+  name: z.string().nullish(),
   tool_calls: z.array(chatCompletionMessageToolCallSchema).nullish(),
 });
 const chatCompletionFallbackMessageParamSchema = z.object({

--- a/core/js/typespecs/openai/messages.ts
+++ b/core/js/typespecs/openai/messages.ts
@@ -77,9 +77,9 @@ export const chatCompletionMessageToolCallSchema = z.object({
 const chatCompletionAssistantMessageParamSchema = z.object({
   role: z.literal("assistant"),
   content: z.string().nullish(),
-  function_call: functionCallSchema.optional(),
+  function_call: functionCallSchema.nullish(),
   name: z.string().optional(),
-  tool_calls: z.array(chatCompletionMessageToolCallSchema).optional(),
+  tool_calls: z.array(chatCompletionMessageToolCallSchema).nullish(),
 });
 const chatCompletionFallbackMessageParamSchema = z.object({
   role: messageRoleSchema.exclude([

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -13,6 +13,7 @@ import {
   currentSpan,
   FullInitOptions,
   BraintrustState,
+  logError as logSpanError,
 } from "./logger";
 import { Score, SpanTypeAttribute, mergeDicts } from "@braintrust/core";
 import { BarProgressReporter, ProgressReporter } from "./progress";
@@ -757,6 +758,7 @@ async function runEvaluatorInternal(
             );
           }
         } catch (e) {
+          logSpanError(rootSpan, e);
           error = e;
         } finally {
           progressReporter.increment(evaluator.evalName);

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -2460,7 +2460,7 @@ export function getSpanParentObject<IsAsyncFlush extends boolean>(
   return NOOP_SPAN;
 }
 
-function logError(span: Span, error: unknown) {
+export function logError(span: Span, error: unknown) {
   let errorMessage = "<error>";
   let stackTrace = "";
   if (error instanceof Error) {

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -5,6 +5,7 @@ import dataclasses
 import inspect
 import json
 import re
+import sys
 import traceback
 from collections import defaultdict
 from collections.abc import Iterable
@@ -24,7 +25,7 @@ from braintrust_core.util import (
 from tqdm.asyncio import tqdm as async_tqdm
 from tqdm.auto import tqdm as std_tqdm
 
-from .logger import NOOP_SPAN, ExperimentSummary, Metadata, ScoreSummary, Span
+from .logger import NOOP_SPAN, ExperimentSummary, Metadata, ScoreSummary, Span, stringify_exception
 from .logger import init as _init_experiment
 from .resource_manager import ResourceManager
 
@@ -814,6 +815,9 @@ async def _run_evaluator_internal(experiment, evaluator: Evaluator, position: Op
                         f"Found exceptions for the following scorers: {names}", exceptions
                     )
             except Exception as e:
+                exc_type, exc_value, tb = sys.exc_info()
+                root_span.log(error=stringify_exception(exc_type, exc_value, tb))
+
                 error = e
                 # Python3.10 has a different set of arguments to format_exception than earlier versions,
                 # so just capture the stack trace here.


### PR DESCRIPTION
Mark the entire eval row as failed if the task fails. This makes it easier to filter down to failing rows.