### PR TITLE
Fix bug in `computeLoggerMetadata`

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -2024,6 +2024,7 @@ async function computeLoggerMetadata(
     project_id?: string;
   },
 ) {
+  await state.login({});
   const org_id = state.orgId!;
   if (isEmpty(project_id)) {
     const response = await state.appConn().post_json("api/project/register", {


### PR DESCRIPTION
This function is invoked when lazily initializing the logger object's metadata, either when initializing a logger or when logging to a parent span that originates from a logger. In the former case, we were already logging in with the user's provided params, but in the second case, we still need to log in.

This matches the implementation in the python `logger.py`, so it was just an accidental omission.