### PR TITLE
Org membership endpoint accept multiple groups.

### DIFF
--- a/core/js/typespecs/app_types.ts
+++ b/core/js/typespecs/app_types.ts
@@ -1066,15 +1066,17 @@ export const patchOrganizationMembersSchema = z
           .describe(
             "If true, send invite emails to the users who wore actually added",
           ),
-        group_id: groupSchema.shape.id
+        group_ids: groupSchema.shape.id
+          .array()
           .nullish()
           .describe(
-            "Optional id of a group to add newly-invited users to. Cannot specify both a group id and a group name.",
+            "Optional list of group ids to add newly-invited users to.",
           ),
-        group_name: groupSchema.shape.name
+        group_names: groupSchema.shape.name
+          .array()
           .nullish()
           .describe(
-            "Optional name of a group to add newly-invited users to. Cannot specify both a group id and a group name.",
+            "Optional list of group names to add newly-invited users to.",
           ),
       })
       .nullish()

--- a/core/js/typespecs/app_types.ts
+++ b/core/js/typespecs/app_types.ts
@@ -1078,6 +1078,12 @@ export const patchOrganizationMembersSchema = z
           .describe(
             "Optional list of group names to add newly-invited users to.",
           ),
+        group_id: groupSchema.shape.id
+          .nullish()
+          .describe("Singular form of group_ids"),
+        group_name: groupSchema.shape.name
+          .nullish()
+          .describe("Singular form of group_names"),
       })
       .nullish()
       .describe("Users to invite to the organization"),


### PR DESCRIPTION
This lets people invite somebody to multiple groups. They can be IDs or names.