### PR TITLE
Revise span components slug again

### DIFF
--- a/core/js/src/index.ts
+++ b/core/js/src/index.ts
@@ -9,6 +9,7 @@ export * from "./string_util";
 export * from "./type_util";
 export * from "./span_identifier_v1";
 export * from "./span_identifier_v2";
+export * from "./span_identifier_v3";
 export * from "./span_types";
 export * from "./git_fields";
 export * from "./xact-ids";

--- a/core/js/src/span_identifier_v3.ts
+++ b/core/js/src/span_identifier_v3.ts
@@ -148,7 +148,6 @@ export class SpanComponentsV3 {
       const jsonObj: Record<string, unknown> = {};
       if (rawBytes[0] < ENCODING_VERSION_NUMBER) {
         const spanComponentsOld = SpanComponentsV2.fromStr(s);
-        const jsonObj: Record<string, unknown> = {};
         jsonObj["object_type"] = spanComponentsOld.objectType;
         jsonObj["object_id"] = spanComponentsOld.objectId;
         jsonObj["compute_object_metadata_args"] =

--- a/core/js/src/span_identifier_v3.ts
+++ b/core/js/src/span_identifier_v3.ts
@@ -1,0 +1,206 @@
+// Mirror of core/py/src/braintrust_core/span_identifier_v3.py.
+
+import * as uuid from "uuid";
+import { ParentExperimentIds, ParentProjectLogIds } from "./object";
+import { SpanComponentsV2 } from "./span_identifier_v2";
+import { z } from "zod";
+
+function tryMakeUuid(
+  s: string,
+): { bytes: Buffer; isUUID: true } | { bytes: undefined; isUUID: false } {
+  try {
+    const ret = uuid.parse(s);
+    if (ret.length !== 16) {
+      throw new Error();
+    }
+    return { bytes: Buffer.from(ret), isUUID: true };
+  } catch (e) {
+    return { bytes: undefined, isUUID: false };
+  }
+}
+
+const ENCODING_VERSION_NUMBER = 3;
+
+const INVALID_ENCODING_ERRMSG = `SpanComponents string is not properly encoded. This library only supports encoding versions up to ${ENCODING_VERSION_NUMBER}. Please make sure the SDK library used to decode the SpanComponents is at least as new as any library used to encode it.`;
+
+export enum SpanObjectTypeV3 {
+  EXPERIMENT = 1,
+  PROJECT_LOGS = 2,
+}
+
+export const spanObjectTypeV3EnumSchema = z.nativeEnum(SpanObjectTypeV3);
+
+enum InternalSpanComponentUUIDFields {
+  OBJECT_ID = 1,
+  ROW_ID = 2,
+  SPAN_ID = 3,
+  ROOT_SPAN_ID = 4,
+}
+
+const internalSpanComponentUUIDFieldsEnumSchema = z.nativeEnum(
+  InternalSpanComponentUUIDFields,
+);
+
+const _INTERNAL_SPAN_COMPONENT_UUID_FIELDS_ID_TO_NAME: Record<
+  InternalSpanComponentUUIDFields,
+  string
+> = {
+  [InternalSpanComponentUUIDFields.OBJECT_ID]: "object_id",
+  [InternalSpanComponentUUIDFields.ROW_ID]: "row_id",
+  [InternalSpanComponentUUIDFields.SPAN_ID]: "span_id",
+  [InternalSpanComponentUUIDFields.ROOT_SPAN_ID]: "root_span_id",
+};
+
+export const spanComponentsV3Schema = z
+  .object({
+    object_type: spanObjectTypeV3EnumSchema,
+  })
+  .and(
+    z.union([
+      // Must provide one or the other.
+      z.object({
+        object_id: z.string().nullish(),
+        compute_object_metadata_args: z.optional(z.null()),
+      }),
+      z.object({
+        object_id: z.optional(z.null()),
+        compute_object_metadata_args: z.record(z.unknown()),
+      }),
+    ]),
+  )
+  .and(
+    z.union([
+      // Either all of these must be provided or none.
+      z.object({
+        row_id: z.string(),
+        span_id: z.string(),
+        root_span_id: z.string(),
+      }),
+      z.object({
+        row_id: z.optional(z.null()),
+        span_id: z.optional(z.null()),
+        root_span_id: z.optional(z.null()),
+      }),
+    ]),
+  );
+
+export type SpanComponentsV3Data = z.infer<typeof spanComponentsV3Schema>;
+
+export class SpanComponentsV3 {
+  constructor(public data: SpanComponentsV3Data) {}
+
+  public toStr(): string {
+    const jsonObj: Record<string, unknown> = {
+      compute_object_metadata_args:
+        this.data.compute_object_metadata_args || undefined,
+    };
+    const allBuffers: Array<Buffer> = [];
+    allBuffers.push(
+      Buffer.from([ENCODING_VERSION_NUMBER, this.data.object_type]),
+    );
+
+    const uuidEntries: Array<Buffer> = [];
+    function addUuidField(
+      origVal: string,
+      fieldId: InternalSpanComponentUUIDFields,
+    ) {
+      const ret = tryMakeUuid(origVal);
+      if (ret.isUUID) {
+        uuidEntries.push(Buffer.concat([Buffer.from([fieldId]), ret.bytes]));
+      } else {
+        jsonObj[_INTERNAL_SPAN_COMPONENT_UUID_FIELDS_ID_TO_NAME[fieldId]] =
+          origVal;
+      }
+    }
+    if (this.data.object_id) {
+      addUuidField(
+        this.data.object_id,
+        InternalSpanComponentUUIDFields.OBJECT_ID,
+      );
+    }
+    if (this.data.row_id) {
+      addUuidField(this.data.row_id, InternalSpanComponentUUIDFields.ROW_ID);
+    }
+    if (this.data.span_id) {
+      addUuidField(this.data.span_id, InternalSpanComponentUUIDFields.SPAN_ID);
+    }
+    if (this.data.root_span_id) {
+      addUuidField(
+        this.data.root_span_id,
+        InternalSpanComponentUUIDFields.ROOT_SPAN_ID,
+      );
+    }
+
+    if (uuidEntries.length > 255) {
+      throw new Error("Impossible: too many UUID entries to encode");
+    }
+    allBuffers.push(Buffer.from([uuidEntries.length]));
+    allBuffers.push(...uuidEntries);
+    if (Object.keys(jsonObj).length > 0) {
+      allBuffers.push(Buffer.from(JSON.stringify(jsonObj), "utf-8"));
+    }
+    return Buffer.concat(allBuffers).toString("base64");
+  }
+
+  public static fromStr(s: string): SpanComponentsV3 {
+    try {
+      const rawBytes = Buffer.from(s, "base64");
+      const jsonObj: Record<string, unknown> = {};
+      if (rawBytes[0] < ENCODING_VERSION_NUMBER) {
+        const spanComponentsOld = SpanComponentsV2.fromStr(s);
+        const jsonObj: Record<string, unknown> = {};
+        jsonObj["object_type"] = spanComponentsOld.objectType;
+        jsonObj["object_id"] = spanComponentsOld.objectId;
+        jsonObj["compute_object_metadata_args"] =
+          spanComponentsOld.computeObjectMetadataArgs;
+        if (spanComponentsOld.rowIds) {
+          jsonObj["row_id"] = spanComponentsOld.rowIds.rowId;
+          jsonObj["span_id"] = spanComponentsOld.rowIds.spanId;
+          jsonObj["root_span_id"] = spanComponentsOld.rowIds.rootSpanId;
+        }
+      } else {
+        jsonObj["object_type"] = rawBytes[1];
+        const numUuidEntries = rawBytes[2];
+        let byteOffset = 3;
+        for (let i = 0; i < numUuidEntries; ++i) {
+          const fieldId = internalSpanComponentUUIDFieldsEnumSchema.parse(
+            rawBytes[byteOffset],
+          );
+          const fieldBytes = rawBytes.subarray(byteOffset + 1, byteOffset + 17);
+          byteOffset += 17;
+          jsonObj[_INTERNAL_SPAN_COMPONENT_UUID_FIELDS_ID_TO_NAME[fieldId]] =
+            uuid.stringify(fieldBytes);
+        }
+        if (byteOffset < rawBytes.length) {
+          const remainingJsonObj = JSON.parse(
+            rawBytes.subarray(byteOffset).toString("utf-8"),
+          );
+          Object.assign(jsonObj, remainingJsonObj);
+        }
+      }
+      return SpanComponentsV3.fromJsonObj(jsonObj);
+    } catch (e) {
+      throw new Error(INVALID_ENCODING_ERRMSG);
+    }
+  }
+
+  public objectIdFields(): ParentExperimentIds | ParentProjectLogIds {
+    if (!this.data.object_id) {
+      throw new Error(
+        "Impossible: cannot invoke `objectIdFields` unless SpanComponentsV3 is initialized with an `object_id`",
+      );
+    }
+    switch (this.data.object_type) {
+      case SpanObjectTypeV3.EXPERIMENT:
+        return { experiment_id: this.data.object_id };
+      case SpanObjectTypeV3.PROJECT_LOGS:
+        return { project_id: this.data.object_id, log_id: "g" };
+      default:
+        throw new Error("Impossible");
+    }
+  }
+
+  private static fromJsonObj(jsonObj: unknown): SpanComponentsV3 {
+    return new SpanComponentsV3(spanComponentsV3Schema.parse(jsonObj));
+  }
+}

--- a/py/src/braintrust/span_identifier_v3.py
+++ b/py/src/braintrust/span_identifier_v3.py
@@ -1,0 +1,187 @@
+# Serialization format for capturing all relevant information about a span
+# necessary for distributed logging / tracing. Meant to be passed around as an
+# opaque string.
+
+import base64
+import dataclasses
+import json
+from enum import Enum
+from typing import Dict, Optional
+from uuid import UUID
+
+from .span_identifier_v2 import SpanComponentsV2
+from .util import coalesce
+
+
+def _try_make_uuid(s):
+    try:
+        ret = UUID(s).bytes
+        assert len(ret) == 16
+        return ret, True
+    except Exception:
+        return None, False
+
+
+ENCODING_VERSION_NUMBER = 3
+
+INVALID_ENCODING_ERRMSG = f"SpanComponents string is not properly encoded. This library only supports encoding versions up to {ENCODING_VERSION_NUMBER}. Please make sure the SDK library used to decode the SpanComponents is at least as new as any library used to encode it."
+
+
+class SpanObjectTypeV3(Enum):
+    EXPERIMENT = 1
+    PROJECT_LOGS = 2
+
+    def __str__(self):
+        return {SpanObjectTypeV3.EXPERIMENT: "experiment", SpanObjectTypeV3.PROJECT_LOGS: "project_logs"}[self]
+
+
+class InternalSpanComponentUUIDFields(Enum):
+    OBJECT_ID = 1
+    ROW_ID = 2
+    SPAN_ID = 3
+    ROOT_SPAN_ID = 4
+
+
+_INTERNAL_SPAN_COMPONENT_UUID_FIELDS_ID_TO_NAME = {
+    InternalSpanComponentUUIDFields.OBJECT_ID: "object_id",
+    InternalSpanComponentUUIDFields.ROW_ID: "row_id",
+    InternalSpanComponentUUIDFields.SPAN_ID: "span_id",
+    InternalSpanComponentUUIDFields.ROOT_SPAN_ID: "root_span_id",
+}
+
+
+@dataclasses.dataclass
+class SpanComponentsV3:
+    object_type: SpanObjectTypeV3
+
+    # Must provide one or the other.
+    object_id: Optional[str] = None
+    compute_object_metadata_args: Optional[Dict] = None
+
+    # Either all of these must be provided or none.
+    row_id: Optional[str] = None
+    span_id: Optional[str] = None
+    root_span_id: Optional[str] = None
+
+    def __post_init__(self):
+        assert isinstance(self.object_type, SpanObjectTypeV3)
+
+        assert not (self.object_id and self.compute_object_metadata_args)
+        assert self.object_id or self.compute_object_metadata_args
+        if self.object_id is not None:
+            assert isinstance(self.object_id, str)
+        elif self.compute_object_metadata_args:
+            assert isinstance(self.compute_object_metadata_args, dict)
+
+        if self.row_id:
+            assert isinstance(self.row_id, str)
+            assert self.span_id
+            assert isinstance(self.span_id, str)
+            assert self.root_span_id
+            assert isinstance(self.root_span_id, str)
+        else:
+            assert not self.span_id
+            assert not self.root_span_id
+
+    def to_str(self) -> str:
+        # Our binary object format is as follows:
+        #   - Byte 0 encodes the version number of the encoded string. This is
+        #   used to check for incompatibilities with previous iterations.
+        #   - Byte 1 encodes the SpanObjectTypeV3.
+        #   - Byte 2 encodes the number of UUID fields we have serialized in a
+        #   compressed form.
+        #   - For each of the specially-serialized UUID fields, we encode one
+        #   byte for InternalSpanComponentUUIDFields, denoting which field it
+        #   is, followed by the 16 bytes of the UUID.
+        #   - The remaining bytes encode the remaining object properties in JSON
+        #   format, or nothing if the JSON object is empty.
+        json_obj = dict(
+            compute_object_metadata_args=self.compute_object_metadata_args,
+        )
+        json_obj = {k: v for k, v in json_obj.items() if v is not None}
+        raw_bytes = bytes(
+            [
+                ENCODING_VERSION_NUMBER,
+                self.object_type.value,
+            ]
+        )
+
+        uuid_entries = []
+
+        def add_uuid_field(orig_val, field_id):
+            nonlocal uuid_entries
+
+            uuid_bytes, is_uuid = _try_make_uuid(orig_val)
+            if is_uuid:
+                uuid_entries.append(bytes([field_id.value]) + uuid_bytes)
+            else:
+                json_obj[_INTERNAL_SPAN_COMPONENT_UUID_FIELDS_ID_TO_NAME[field_id]] = orig_val
+
+        if self.object_id:
+            add_uuid_field(self.object_id, InternalSpanComponentUUIDFields.OBJECT_ID)
+        if self.row_id:
+            add_uuid_field(self.row_id, InternalSpanComponentUUIDFields.ROW_ID)
+        if self.span_id:
+            add_uuid_field(self.span_id, InternalSpanComponentUUIDFields.SPAN_ID)
+        if self.root_span_id:
+            add_uuid_field(self.root_span_id, InternalSpanComponentUUIDFields.ROOT_SPAN_ID)
+
+        if len(uuid_entries) > 255:
+            raise Exception("Impossible: too many UUID entries to encode")
+        raw_bytes += bytes([len(uuid_entries)])
+        for entry in uuid_entries:
+            raw_bytes += entry
+        if json_obj:
+            raw_bytes += bytes(json.dumps(json_obj, separators=(",", ":")).encode())
+        return base64.b64encode(raw_bytes).decode()
+
+    @staticmethod
+    def from_str(s: str) -> "SpanComponentsV3":
+        try:
+            raw_bytes = base64.b64decode(s.encode())
+            json_obj = {}
+            if raw_bytes[0] < ENCODING_VERSION_NUMBER:
+                span_components_old = SpanComponentsV2.from_str(s)
+                json_obj["object_type"] = span_components_old.object_type.value
+                json_obj["object_id"] = span_components_old.object_id
+                json_obj["compute_object_metadata_args"] = span_components_old.compute_object_metadata_args
+                if span_components_old.row_ids:
+                    json_obj["row_id"] = span_components_old.row_ids.row_id
+                    json_obj["span_id"] = span_components_old.row_ids.span_id
+                    json_obj["root_span_id"] = span_components_old.row_ids.root_span_id
+            else:
+                json_obj["object_type"] = SpanObjectTypeV3(raw_bytes[1])
+                num_uuid_entries = raw_bytes[2]
+                byte_offset = 3
+                for i in range(num_uuid_entries):
+                    field_id = InternalSpanComponentUUIDFields(raw_bytes[byte_offset])
+                    uuid_bytes = raw_bytes[byte_offset + 1 : byte_offset + 17]
+                    byte_offset += 17
+                    json_obj[_INTERNAL_SPAN_COMPONENT_UUID_FIELDS_ID_TO_NAME[field_id]] = str(UUID(bytes=uuid_bytes))
+                if byte_offset < len(raw_bytes):
+                    remaining_json_obj = json.loads(raw_bytes[byte_offset:].decode())
+                    json_obj.update(remaining_json_obj)
+            return SpanComponentsV3._from_json_obj(json_obj)
+        except Exception:
+            raise Exception(INVALID_ENCODING_ERRMSG)
+
+    def object_id_fields(self) -> Dict[str, str]:
+        if not self.object_id:
+            raise Exception(
+                "Impossible: cannot invoke `object_id_fields` unless SpanComponentsV3 is initialized with an `object_id`"
+            )
+        if self.object_type == SpanObjectTypeV3.EXPERIMENT:
+            return dict(experiment_id=self.object_id)
+        elif self.object_type == SpanObjectTypeV3.PROJECT_LOGS:
+            return dict(project_id=self.object_id, log_id="g")
+
+    @staticmethod
+    def _from_json_obj(json_obj: Dict) -> "SpanComponentsV3":
+        return SpanComponentsV3(
+            object_type=SpanObjectTypeV3(json_obj["object_type"]),
+            object_id=json_obj.get("object_id"),
+            compute_object_metadata_args=json_obj.get("compute_object_metadata_args"),
+            row_id=json_obj.get("row_id"),
+            span_id=json_obj.get("span_id"),
+            root_span_id=json_obj.get("root_span_id"),
+        )


### PR DESCRIPTION
We need to support adding arbitrary properties. So basically now the serialized object representation consists of (1) a few required fields (2) a set of fields we can serialize as compressed UUIDs (3) a JSON object for any remaining fields. Hopefully this is extensible enough to avoid further revisions.

Tested out that the slug size is roughly the same as before.