### PR TITLE
Add explicit "disabled" state for async scoring.

### DIFF
--- a/core/js/typespecs/api_types.ts
+++ b/core/js/typespecs/api_types.ts
@@ -944,6 +944,11 @@ export const asyncScoringStateSchema = z.union([
     token: z.string(),
     function_ids: z.array(functionIdSchema).nonempty(),
   }),
+  // Explicitly disabled.
+  z.object({
+    status: z.literal("disabled"),
+  }),
+  // Inactive but may be selected later.
   z.null(),
 ]);
 


### PR DESCRIPTION
Sometimes we want to log a row (or a trace) where we explicitly exclude it from async scoring. This is not easy to do right now, because you'd have to pass `SKIP_ASYNC_SCORING: true` every time you do any incremental logging. But now we can override the state to disabled once at the beginning and leave it.