### PR TITLE
Support propagated event data in the logging SDK.

### DIFF
--- a/core/js/src/span_identifier_v3.ts
+++ b/core/js/src/span_identifier_v3.ts
@@ -54,6 +54,10 @@ const _INTERNAL_SPAN_COMPONENT_UUID_FIELDS_ID_TO_NAME: Record<
 export const spanComponentsV3Schema = z
   .object({
     object_type: spanObjectTypeV3EnumSchema,
+    // TODO(manu): We should have a more elaborate zod schema for
+    // `propagated_event`. This will required zod-ifying the contents of
+    // sdk/core/js/src/object.ts.
+    propagated_event: z.record(z.unknown()).nullish(),
   })
   .and(
     z.union([
@@ -93,6 +97,7 @@ export class SpanComponentsV3 {
     const jsonObj: Record<string, unknown> = {
       compute_object_metadata_args:
         this.data.compute_object_metadata_args || undefined,
+      propagated_event: this.data.propagated_event || undefined,
     };
     const allBuffers: Array<Buffer> = [];
     allBuffers.push(

--- a/core/js/typespecs/functions.ts
+++ b/core/js/typespecs/functions.ts
@@ -80,8 +80,14 @@ export const invokeFunctionNonIdArgsSchema = z.object({
             })
             .nullish()
             .describe("Identifiers for the row to to log a subspan under"),
+          propagated_event: z
+            .record(z.unknown())
+            .nullish()
+            .describe(
+              "Include these properties in every span created under this parent",
+            ),
         })
-        .describe("Object type, object id, and optional row IDs"),
+        .describe("Span parent properties"),
       z
         .string()
         .optional()

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -75,6 +75,7 @@ export type StartSpanArgs = {
   startTime?: number;
   parent?: string;
   event?: StartSpanEventArgs;
+  propagatedEvent?: StartSpanEventArgs;
 };
 
 export type EndSpanArgs = {
@@ -849,6 +850,10 @@ function spanComponentsToObjectIdLambda(
   }
 }
 
+// IMPORTANT NOTE: This function may pass arguments which override those in the
+// main argument set, so if using this in a spread, like `SpanImpl({ ...args,
+// ...startSpanParentArgs(...)})`, make sure to put startSpanParentArgs after
+// the original argument set.
 function startSpanParentArgs(args: {
   state: BraintrustState;
   parent: string | undefined;
@@ -856,14 +861,17 @@ function startSpanParentArgs(args: {
   parentObjectId: LazyValue<string>;
   parentComputeObjectMetadataArgs: Record<string, any> | undefined;
   parentSpanIds: ParentSpanIds | undefined;
+  propagatedEvent: StartSpanEventArgs | undefined;
 }): {
   parentObjectType: SpanObjectTypeV3;
   parentObjectId: LazyValue<string>;
   parentComputeObjectMetadataArgs: Record<string, any> | undefined;
   parentSpanIds: ParentSpanIds | undefined;
+  propagatedEvent: StartSpanEventArgs | undefined;
 } {
   let argParentObjectId: LazyValue<string> | undefined = undefined;
   let argParentSpanIds: ParentSpanIds | undefined = undefined;
+  let argPropagatedEvent: StartSpanEventArgs | undefined = undefined;
   if (args.parent) {
     if (args.parentSpanIds) {
       throw new Error("Cannot specify both parent and parentSpanIds");
@@ -895,9 +903,15 @@ function startSpanParentArgs(args: {
         rootSpanId: parentComponents.data.root_span_id,
       };
     }
+    argPropagatedEvent =
+      args.propagatedEvent ??
+      ((parentComponents.data.propagated_event ?? undefined) as
+        | StartSpanEventArgs
+        | undefined);
   } else {
     argParentObjectId = args.parentObjectId;
     argParentSpanIds = args.parentSpanIds;
+    argPropagatedEvent = args.propagatedEvent;
   }
 
   return {
@@ -905,6 +919,7 @@ function startSpanParentArgs(args: {
     parentObjectId: argParentObjectId,
     parentComputeObjectMetadataArgs: args.parentComputeObjectMetadataArgs,
     parentSpanIds: argParentSpanIds,
+    propagatedEvent: argPropagatedEvent,
   };
 }
 
@@ -1048,6 +1063,7 @@ export class Logger<IsAsyncFlush extends boolean> implements Exportable {
   private startSpanImpl(args?: StartSpanArgs): Span {
     return new SpanImpl({
       state: this.state,
+      ...args,
       ...startSpanParentArgs({
         state: this.state,
         parent: args?.parent,
@@ -1055,8 +1071,8 @@ export class Logger<IsAsyncFlush extends boolean> implements Exportable {
         parentObjectId: this.lazyId,
         parentComputeObjectMetadataArgs: this.computeMetadataArgs,
         parentSpanIds: undefined,
+        propagatedEvent: args?.propagatedEvent,
       }),
-      ...args,
       defaultRootType: SpanTypeAttribute.TASK,
     });
   }
@@ -2671,6 +2687,11 @@ function startSpanAndIsLogger<IsAsyncFlush extends boolean = false>(
       parentComputeObjectMetadataArgs:
         components.data.compute_object_metadata_args ?? undefined,
       parentSpanIds,
+      propagatedEvent:
+        args?.propagatedEvent ??
+        ((components.data.propagated_event ?? undefined) as
+          | StartSpanEventArgs
+          | undefined),
     });
     return {
       span,
@@ -3079,6 +3100,7 @@ export class Experiment
   private startSpanImpl(args?: StartSpanArgs): Span {
     return new SpanImpl({
       state: this.state,
+      ...args,
       ...startSpanParentArgs({
         state: this.state,
         parent: args?.parent,
@@ -3086,8 +3108,8 @@ export class Experiment
         parentObjectId: this.lazyId,
         parentComputeObjectMetadataArgs: undefined,
         parentSpanIds: undefined,
+        propagatedEvent: args?.propagatedEvent,
       }),
-      ...args,
       defaultRootType: SpanTypeAttribute.EVAL,
     });
   }
@@ -3317,10 +3339,9 @@ export function newId() {
 export class SpanImpl implements Span {
   private state: BraintrustState;
 
-  // `internalData` contains fields that are not part of the "user-sanitized"
-  // set of fields which we want to log in just one of the span rows.
   private isMerge: boolean;
   private loggedEndTime: number | undefined;
+  private propagatedEvent: StartSpanEventArgs | undefined;
 
   // For internal use only.
   private parentObjectType: SpanObjectTypeV3;
@@ -3346,7 +3367,7 @@ export class SpanImpl implements Span {
     this.state = args.state;
 
     const spanAttributes = args.spanAttributes ?? {};
-    const event = args.event ?? {};
+    const rawEvent = args.event ?? {};
     const type =
       args.type ?? (args.parentSpanIds ? undefined : args.defaultRootType);
 
@@ -3354,6 +3375,14 @@ export class SpanImpl implements Span {
     this.parentObjectType = args.parentObjectType;
     this.parentObjectId = args.parentObjectId;
     this.parentComputeObjectMetadataArgs = args.parentComputeObjectMetadataArgs;
+
+    // Merge propagatedEvent into event. The propagatedEvent data will get
+    // propagated-and-merged into every subspan.
+    this.propagatedEvent = args.propagatedEvent;
+    if (this.propagatedEvent) {
+      mergeDicts(rawEvent, this.propagatedEvent);
+    }
+    const { id: eventId, ...event } = rawEvent;
 
     const callerLocation = iso.getCallerLocation();
     const name = (() => {
@@ -3385,7 +3414,7 @@ export class SpanImpl implements Span {
       created: new Date().toISOString(),
     };
 
-    this._id = event.id ?? uuidv4();
+    this._id = eventId ?? uuidv4();
     this.spanId = uuidv4();
     if (args.parentSpanIds) {
       this.rootSpanId = args.parentSpanIds.rootSpanId;
@@ -3398,8 +3427,7 @@ export class SpanImpl implements Span {
     // The first log is a replacement, but subsequent logs to the same span
     // object will be merges.
     this.isMerge = false;
-    const { id: _id, ...eventRest } = event;
-    this.logInternal({ event: eventRest, internalData });
+    this.logInternal({ event, internalData });
     this.isMerge = true;
   }
 
@@ -3524,6 +3552,7 @@ export class SpanImpl implements Span {
         parentObjectId: this.parentObjectId,
         parentComputeObjectMetadataArgs: this.parentComputeObjectMetadataArgs,
         parentSpanIds,
+        propagatedEvent: args?.propagatedEvent ?? this.propagatedEvent,
       }),
     });
   }
@@ -3551,6 +3580,7 @@ export class SpanImpl implements Span {
       row_id: this.id,
       span_id: this.spanId,
       root_span_id: this.rootSpanId,
+      propagated_event: this.propagatedEvent,
     }).toStr();
   }
 

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -1337,6 +1337,7 @@ def start_span(
     start_time=None,
     set_current=None,
     parent=None,
+    propagated_event=None,
     **event,
 ) -> Span:
     """Lower-level alternative to `@traced` for starting a span at the toplevel. It creates a span under the first active object (using the same precedence order as `@traced`), or if `parent` is specified, under the specified parent row, or returns a no-op span object.
@@ -1362,6 +1363,7 @@ def start_span(
             span_attributes=span_attributes,
             start_time=start_time,
             set_current=set_current,
+            propagated_event=coalesce(propagated_event, components.propagated_event),
             event=event,
         )
     else:
@@ -1372,6 +1374,7 @@ def start_span(
             start_time=start_time,
             set_current=set_current,
             parent=parent,
+            propagated_event=propagated_event,
             **event,
         )
 
@@ -1766,6 +1769,7 @@ def _start_span_parent_args(
     parent_object_id: LazyValue[str],
     parent_compute_object_metadata_args: Optional[Dict],
     parent_span_ids: Optional[ParentSpanIds],
+    propagated_event: Optional[Dict],
 ):
     if parent:
         assert parent_span_ids is None, "Cannot specify both parent and parent_span_ids"
@@ -1790,15 +1794,18 @@ def _start_span_parent_args(
             )
         else:
             arg_parent_span_ids = None
+        arg_propagated_event = coalesce(propagated_event, parent_components.propagated_event)
     else:
         arg_parent_object_id = parent_object_id
         arg_parent_span_ids = parent_span_ids
+        arg_propagated_event = propagated_event
 
     return dict(
         parent_object_type=parent_object_type,
         parent_object_id=arg_parent_object_id,
         parent_compute_object_metadata_args=parent_compute_object_metadata_args,
         parent_span_ids=arg_parent_span_ids,
+        propagated_event=arg_propagated_event,
     )
 
 
@@ -1985,6 +1992,7 @@ class Experiment(ObjectFetcher, Exportable):
         start_time=None,
         set_current=None,
         parent=None,
+        propagated_event=None,
         **event,
     ):
         """Create a new toplevel span underneath the experiment. The name defaults to "root" and the span type to "eval".
@@ -1999,6 +2007,7 @@ class Experiment(ObjectFetcher, Exportable):
             start_time=start_time,
             set_current=set_current,
             parent=parent,
+            propagated_event=propagated_event,
             **event,
         )
 
@@ -2122,6 +2131,7 @@ class Experiment(ObjectFetcher, Exportable):
         start_time=None,
         set_current=None,
         parent=None,
+        propagated_event=None,
         **event,
     ):
         return SpanImpl(
@@ -2131,6 +2141,7 @@ class Experiment(ObjectFetcher, Exportable):
                 parent_object_id=self._lazy_id,
                 parent_compute_object_metadata_args=None,
                 parent_span_ids=None,
+                propagated_event=propagated_event,
             ),
             name=name,
             type=type,
@@ -2197,6 +2208,7 @@ class SpanImpl(Span):
         start_time=None,
         set_current=None,
         event=None,
+        propagated_event=None,
     ):
         if span_attributes is None:
             span_attributes = {}
@@ -2211,6 +2223,12 @@ class SpanImpl(Span):
         self.parent_object_type = parent_object_type
         self.parent_object_id = parent_object_id
         self.parent_compute_object_metadata_args = parent_compute_object_metadata_args
+
+        # Merge propagated_event into event. The propagated_event data will get
+        # propagated-and-merged into every subspan.
+        self.propagated_event = propagated_event
+        if self.propagated_event:
+            merge_dicts(event, self.propagated_event)
 
         caller_location = get_caller_location()
         if name is None:
@@ -2244,7 +2262,7 @@ class SpanImpl(Span):
         if caller_location:
             internal_data["context"] = caller_location
 
-        self._id = event.get("id")
+        self._id = event.pop("id", None)
         if self._id is None:
             self._id = str(uuid.uuid4())
         self.span_id = str(uuid.uuid4())
@@ -2258,7 +2276,7 @@ class SpanImpl(Span):
         # The first log is a replacement, but subsequent logs to the same span
         # object will be merges.
         self._is_merge = False
-        self.log_internal(event={k: v for k, v in event.items() if k != "id"}, internal_data=internal_data)
+        self.log_internal(event=event, internal_data=internal_data)
         self._is_merge = True
 
     @property
@@ -2335,6 +2353,7 @@ class SpanImpl(Span):
         start_time=None,
         set_current=None,
         parent=None,
+        propagated_event=None,
         **event,
     ):
         if parent:
@@ -2348,6 +2367,7 @@ class SpanImpl(Span):
                 parent_object_id=self.parent_object_id,
                 parent_compute_object_metadata_args=self.parent_compute_object_metadata_args,
                 parent_span_ids=parent_span_ids,
+                propagated_event=coalesce(propagated_event, self.propagated_event),
             ),
             name=name,
             type=type,
@@ -2382,6 +2402,7 @@ class SpanImpl(Span):
             row_id=self.id,
             span_id=self.span_id,
             root_span_id=self.root_span_id,
+            propagated_event=self.propagated_event,
         ).to_str()
 
     def close(self, end_time=None):
@@ -2914,6 +2935,7 @@ class Logger(Exportable):
         start_time=None,
         set_current=None,
         parent=None,
+        propagated_event=None,
         **event,
     ):
         """Create a new toplevel span underneath the logger. The name defaults to "root" and the span type to "task".
@@ -2928,6 +2950,7 @@ class Logger(Exportable):
             start_time=start_time,
             set_current=set_current,
             parent=parent,
+            propagated_event=propagated_event,
             **event,
         )
 
@@ -2954,6 +2977,7 @@ class Logger(Exportable):
         start_time=None,
         set_current=None,
         parent=None,
+        propagated_event=None,
         **event,
     ):
         return SpanImpl(
@@ -2963,6 +2987,7 @@ class Logger(Exportable):
                 parent_object_id=self._lazy_id,
                 parent_compute_object_metadata_args=self._compute_metadata_args,
                 parent_span_ids=None,
+                propagated_event=propagated_event,
             ),
             name=name,
             type=type,

--- a/py/src/braintrust/span_identifier_v3.py
+++ b/py/src/braintrust/span_identifier_v3.py
@@ -63,6 +63,9 @@ class SpanComponentsV3:
     span_id: Optional[str] = None
     root_span_id: Optional[str] = None
 
+    # Additional span properties.
+    propagated_event: Optional[Dict] = None
+
     def __post_init__(self):
         assert isinstance(self.object_type, SpanObjectTypeV3)
 
@@ -96,7 +99,8 @@ class SpanComponentsV3:
         #   - The remaining bytes encode the remaining object properties in JSON
         #   format, or nothing if the JSON object is empty.
         json_obj = dict(
-            compute_object_metadata_args=self.compute_object_metadata_args,
+            compute_object_metadata_args=self.compute_object_metadata_args or None,
+            propagated_event=self.propagated_event or None,
         )
         json_obj = {k: v for k, v in json_obj.items() if v is not None}
         raw_bytes = bytes(
@@ -177,11 +181,8 @@ class SpanComponentsV3:
 
     @staticmethod
     def _from_json_obj(json_obj: Dict) -> "SpanComponentsV3":
-        return SpanComponentsV3(
-            object_type=SpanObjectTypeV3(json_obj["object_type"]),
-            object_id=json_obj.get("object_id"),
-            compute_object_metadata_args=json_obj.get("compute_object_metadata_args"),
-            row_id=json_obj.get("row_id"),
-            span_id=json_obj.get("span_id"),
-            root_span_id=json_obj.get("root_span_id"),
-        )
+        kwargs = {
+            **json_obj,
+            "object_type": SpanObjectTypeV3(json_obj["object_type"]),
+        }
+        return SpanComponentsV3(**kwargs)


### PR DESCRIPTION
This allows someone to include a set of properties in a span which are propagated to all of its sub-spans. We include this data in the exported span slug, so that it works with distributed tracing too.