### PR TITLE
Revert "`Prompt.build` should only render `tools` when non-empty."

### DIFF
--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -2820,8 +2820,11 @@ class Prompt:
                 }
                 for m in self.prompt.messages
             ]
-            if self.prompt.tools and self.prompt.tools.strip():
-                ret["tools"] = json.loads(chevron.render(self.prompt.tools, data=build_args))
+            ret["tools"] = (
+                json.loads(chevron.render(self.prompt.tools, data=build_args))
+                if (self.prompt.tools or "").strip()
+                else None
+            )
 
         return ret
 


### PR DESCRIPTION
Reverts braintrustdata/braintrust-sdk#371