### PR TITLE
`Prompt.build` should only render `tools` when non-empty.

### DIFF
--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -2820,11 +2820,8 @@ class Prompt:
                 }
                 for m in self.prompt.messages
             ]
-            ret["tools"] = (
-                json.loads(chevron.render(self.prompt.tools, data=build_args))
-                if (self.prompt.tools or "").strip()
-                else None
-            )
+            if self.prompt.tools and self.prompt.tools.strip():
+                ret["tools"] = json.loads(chevron.render(self.prompt.tools, data=build_args))
 
         return ret
 


### PR DESCRIPTION
The existing behavior outputs `"tools": None` when there are no tools, which is not supported by the OpenAI API. Now it will not be rendered.

Re-land #371.