### PR TITLE
Added trycatch for diff check

### DIFF
--- a/py/src/braintrust/gitutil.py
+++ b/py/src/braintrust/gitutil.py
@@ -145,7 +145,7 @@ def repo_info():
         branch = None
         git_diff = None
 
-        dirty = repo.is_dirty()
+        dirty = attempt(lambda: repo.is_dirty())
 
         commit = attempt(lambda: repo.head.commit.hexsha.strip())
         commit_message = attempt(lambda: repo.head.commit.message.strip())


### PR DESCRIPTION
In Python, the diff check includes a `--cached` flag which triggers an error when an invalid git repository is in the same directory as your experiments. In these cases, the experiments would've failed to initialize. By catching the error, the experiments can properly initialize.