### PR TITLE
Python `--verbose` flag maps to INFO log level.

### DIFF
--- a/py/src/braintrust/cli/__main__.py
+++ b/py/src/braintrust/cli/__main__.py
@@ -22,9 +22,9 @@ def main(args=None):
     parent_parser.add_argument(
         "--verbose",
         "-v",
-        default=False,
-        action="store_true",
-        help="Include additional details, including full stack traces on errors.",
+        default=0,
+        action="count",
+        help="Include additional details, including full stack traces on errors. Pass twice (-vv) for debug logging.",
     )
 
     parser = argparse.ArgumentParser(
@@ -40,7 +40,7 @@ def main(args=None):
         module.build_parser(subparsers, parent_parser)
 
     args = parser.parse_args(args=args)
-    level = logging.DEBUG if args.verbose else logging.INFO
+    level = logging.DEBUG if args.verbose >= 2 else logging.INFO
     logging.basicConfig(format="%(asctime)s %(levelname)s [%(name)s]: %(message)s", level=level)
 
     return args.func(args)

--- a/py/src/braintrust/cli/eval.py
+++ b/py/src/braintrust/cli/eval.py
@@ -167,7 +167,7 @@ def add_report(eval_reports, reporter, report):
     eval_reports[reporter.name]["results"].append(report)
 
 
-async def run_once(handles, evaluator_opts):
+async def run_once(handles: list[FileHandle], evaluator_opts: EvaluatorOpts) -> bool:
     objects = EvaluatorState()
     update_evaluators(objects, handles, terminate_on_failure=evaluator_opts.terminate_on_failure)
 
@@ -260,7 +260,7 @@ def run(args):
         load_dotenv(args.env_file)
 
     evaluator_opts = EvaluatorOpts(
-        verbose=args.verbose,
+        verbose=args.verbose > 0,
         no_send_logs=args.no_send_logs,
         no_progress_bars=args.no_progress_bars,
         terminate_on_failure=args.terminate_on_failure,

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -379,7 +379,7 @@ def pluralize(n, singular, plural):
         return plural
 
 
-def report_failures(evaluator, failing_results, verbose, jsonl):
+def report_failures(evaluator: Evaluator, failing_results: Iterable[EvalResult], verbose: bool, jsonl: bool) -> None:
     eprint(
         f"{bcolors.FAIL}Evaluator {evaluator.eval_name} failed with {len(failing_results)} {pluralize(len(failing_results), 'error', 'errors')}{bcolors.ENDC}"
     )
@@ -402,7 +402,7 @@ def report_failures(evaluator, failing_results, verbose, jsonl):
         eprint(f"{bcolors.FAIL}Add --verbose to see full stack traces.{bcolors.ENDC}")
 
 
-def report_evaluator_result(evaluator: Evaluator, result, verbose, jsonl):
+def report_evaluator_result(evaluator: Evaluator, result: EvalResultWithSummary, verbose: bool, jsonl: bool) -> bool:
     results = result.results
     summary = result.summary
 
@@ -517,7 +517,7 @@ def Eval(
     if _lazy_load:
         _evals.evaluators[eval_name] = EvaluatorInstance(evaluator=evaluator, reporter=reporter)
     else:
-        if reporter is not None and isinstance(reporter, str):
+        if isinstance(reporter, str):
             raise ValueError(
                 "Must specify a reporter object, not a name. Can only specify reporter names when running 'braintrust eval'"
             )


### PR DESCRIPTION
Previously, the verbose flag was used for both DEBUG log level and printing full stack traces. Now it will only control printing full stack traces.

To see DEBUG logs, pass the `--verbose` flag twice.