### PR TITLE
Fix global setFetch

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -408,7 +408,9 @@ export class BraintrustState {
     }
     const newState = await loginToState({
       ...this.loginParams,
-      ...loginParams,
+      ...Object.fromEntries(
+        Object.entries(loginParams).filter(([k, v]) => !isEmpty(v)),
+      ),
     });
     this.copyLoginInfo(newState);
   }


### PR DESCRIPTION
`initLogger` passes in login params which include `fetch: undefined` and they clobbered `this.loginParams`.