### PR TITLE
Extract more typespecs into openapi schemas.

### DIFF
--- a/core/js/typespecs/api_types.ts
+++ b/core/js/typespecs/api_types.ts
@@ -232,7 +232,8 @@ export const fetchLimitParamSchema = z.coerce
       `Fetch queries may be paginated if the total result size is expected to be large (e.g. project_logs which accumulate over a long time). Note that fetch queries only support pagination in descending time order (from latest to earliest \`${TRANSACTION_ID_FIELD}\`. Furthermore, later pages may return rows which showed up in earlier pages, except with an earlier \`${TRANSACTION_ID_FIELD}\`. This happens because pagination occurs over the whole version history of the event log. You will most likely want to exclude any such duplicate, outdated rows (by \`id\`) from your combined result set.`,
       `The \`limit\` parameter controls the number of full traces to return. So you may end up with more individual rows than the specified limit if you are fetching events containing traces.`,
     ].join("\n\n"),
-  );
+  )
+  .openapi("FetchLimit");
 
 const fetchPaginationCursorDescription = [
   "DEPRECATION NOTICE: The manually-constructed pagination cursor is deprecated in favor of the explicit 'cursor' returned by object fetch requests. Please prefer the 'cursor' argument going forwards.",
@@ -242,11 +243,13 @@ const fetchPaginationCursorDescription = [
 
 export const maxXactIdSchema = z
   .string()
-  .describe(fetchPaginationCursorDescription);
+  .describe(fetchPaginationCursorDescription)
+  .openapi("MaxXactId");
 
 export const maxRootSpanIdSchema = z
   .string()
-  .describe(fetchPaginationCursorDescription);
+  .describe(fetchPaginationCursorDescription)
+  .openapi("MaxRootSpanId");
 
 export const fetchPaginationCursorSchema = z
   .string()
@@ -255,7 +258,8 @@ export const fetchPaginationCursorSchema = z
       "An opaque string to be used as a cursor for the next page of results, in order from latest to earliest.",
       "The string can be obtained directly from the `cursor` property of the previous fetch query",
     ].join("\n\n"),
-  );
+  )
+  .openapi("FetchPaginationCursor");
 
 export const versionSchema = z
   .string()
@@ -264,7 +268,8 @@ export const versionSchema = z
       "Retrieve a snapshot of events from a past time",
       "The version id is essentially a filter on the latest event transaction id. You can use the `max_xact_id` returned by a past fetch as the version to reproduce that exact fetch.",
     ].join("\n\n"),
-  );
+  )
+  .openapi("Version");
 
 const pathTypeFilterSchema = z
   .object({
@@ -286,7 +291,7 @@ const pathTypeFilterSchema = z
   )
   .openapi("PathLookupFilter");
 
-export const fetchFiltersSchema = pathTypeFilterSchema
+export const fetchEventsFiltersSchema = pathTypeFilterSchema
   .array()
   .describe(
     [
@@ -302,7 +307,7 @@ export const fetchEventsRequestSchema = z
     cursor: fetchPaginationCursorSchema.nullish(),
     max_xact_id: maxXactIdSchema.nullish(),
     max_root_span_id: maxRootSpanIdSchema.nullish(),
-    filters: fetchFiltersSchema.nullish(),
+    filters: fetchEventsFiltersSchema.nullish(),
     version: versionSchema.nullish(),
   })
   .openapi("FetchEventsRequest");
@@ -938,34 +943,38 @@ export const objectTypeSummarizeResponseSchemas: {
 
 // Section: async scoring.
 
-export const asyncScoringStateSchema = z.union([
-  z.object({
-    status: z.literal("enabled"),
-    token: z.string(),
-    function_ids: z.array(functionIdSchema).nonempty(),
-  }),
-  // Explicitly disabled.
-  z.object({
-    status: z.literal("disabled"),
-  }),
-  // Inactive but may be selected later.
-  z.null(),
-]);
+export const asyncScoringStateSchema = z
+  .union([
+    z.object({
+      status: z.literal("enabled"),
+      token: z.string(),
+      function_ids: z.array(functionIdSchema).nonempty(),
+    }),
+    // Explicitly disabled.
+    z.object({
+      status: z.literal("disabled"),
+    }),
+    // Inactive but may be selected later.
+    z.null(),
+  ])
+  .openapi("AsyncScoringState");
 
 export type AsyncScoringState = z.infer<typeof asyncScoringStateSchema>;
 
-export const asyncScoringControlSchema = z.discriminatedUnion("kind", [
-  z.object({
-    kind: z.literal("score_update"),
-    token: z.string(),
-  }),
-  z.object({
-    kind: z.literal("state_override"),
-    state: asyncScoringStateSchema,
-  }),
-  z.object({
-    kind: z.literal("state_force_reselect"),
-  }),
-]);
+export const asyncScoringControlSchema = z
+  .discriminatedUnion("kind", [
+    z.object({
+      kind: z.literal("score_update"),
+      token: z.string(),
+    }),
+    z.object({
+      kind: z.literal("state_override"),
+      state: asyncScoringStateSchema,
+    }),
+    z.object({
+      kind: z.literal("state_force_reselect"),
+    }),
+  ])
+  .openapi("AsyncScoringControl");
 
 export type AsyncScoringControl = z.infer<typeof asyncScoringControlSchema>;

--- a/core/js/typespecs/app_types.ts
+++ b/core/js/typespecs/app_types.ts
@@ -69,7 +69,8 @@ export const aclObjectTypeEnum = z
     "project_log",
     "org_project",
   ])
-  .describe("The object type that the ACL applies to");
+  .describe("The object type that the ACL applies to")
+  .openapi("AclObjectType");
 export type AclObjectType = z.infer<typeof aclObjectTypeEnum>;
 
 const userBaseSchema = generateBaseTableSchema("user");
@@ -180,12 +181,14 @@ export const apiKeySchema = z
   .openapi("ApiKey");
 export type ApiKey = z.infer<typeof apiKeySchema>;
 
-export const projectSettingsSchema = z.object({
-  comparison_key: z
-    .string()
-    .nullish()
-    .describe("The key used to join two experiments (defaults to `input`)."),
-});
+export const projectSettingsSchema = z
+  .object({
+    comparison_key: z
+      .string()
+      .nullish()
+      .describe("The key used to join two experiments (defaults to `input`)."),
+  })
+  .openapi("ProjectSettings");
 export type ProjectSettings = z.infer<typeof projectSettingsSchema>;
 
 const projectBaseSchema = generateBaseTableSchema("project");
@@ -256,71 +259,75 @@ const promptSchemaObject = z.object({
 export const promptSchema = promptSchemaObject.openapi("Prompt");
 export type Prompt = z.infer<typeof promptSchema>;
 
-export const codeBundleSchema = z.object({
-  runtime_context: runtimeContextSchema,
-  location: z.union([
-    z
-      .object({
-        type: z.literal("experiment"),
-        eval_name: z.string(),
-        position: z.union([
-          z.object({ type: z.literal("task") }),
-          z
-            .object({
-              type: z.literal("scorer"),
-              index: z.number().int().nonnegative(),
-            })
-            .openapi({ title: "scorer" }),
-        ]),
-      })
-      .openapi({ title: "experiment" }),
-    z
-      .object({
-        type: z.literal("function"),
-        index: z.number().int().nonnegative(),
-      })
-      .openapi({ title: "function" }),
-  ]),
-  bundle_id: z.string(),
-  preview: z.string().nullish().describe("A preview of the code"),
-});
+export const codeBundleSchema = z
+  .object({
+    runtime_context: runtimeContextSchema,
+    location: z.union([
+      z
+        .object({
+          type: z.literal("experiment"),
+          eval_name: z.string(),
+          position: z.union([
+            z.object({ type: z.literal("task") }),
+            z
+              .object({
+                type: z.literal("scorer"),
+                index: z.number().int().nonnegative(),
+              })
+              .openapi({ title: "scorer" }),
+          ]),
+        })
+        .openapi({ title: "experiment" }),
+      z
+        .object({
+          type: z.literal("function"),
+          index: z.number().int().nonnegative(),
+        })
+        .openapi({ title: "function" }),
+    ]),
+    bundle_id: z.string(),
+    preview: z.string().nullish().describe("A preview of the code"),
+  })
+  .openapi("CodeBundle");
 export type CodeBundle = z.infer<typeof codeBundleSchema>;
 
-export const functionDataSchema = z.union([
-  z
-    .object({
-      type: z.literal("prompt"),
-      // For backwards compatibility reasons, the prompt definition is hoisted out and stored
-      // in the outer object
-    })
-    .openapi({ title: "prompt" }),
-  z
-    .object({
-      type: z.literal("code"),
-      data: z.union([
-        z
-          .object({
-            type: z.literal("bundle"),
-          })
-          .and(codeBundleSchema)
-          .openapi({ title: "bundle" }),
-        z
-          .object({
-            type: z.literal("inline"),
-            runtime_context: runtimeContextSchema,
-            code: z.string(),
-          })
-          .openapi({ title: "inline" }),
-      ]),
-    })
-    .openapi({ title: "code" }),
-  z
-    .object({
-      type: z.literal("global"),
-      name: z.string(),
-    })
-    .openapi({ title: "global" }),
-]);
+export const functionDataSchema = z
+  .union([
+    z
+      .object({
+        type: z.literal("prompt"),
+        // For backwards compatibility reasons, the prompt definition is hoisted out and stored
+        // in the outer object
+      })
+      .openapi({ title: "prompt" }),
+    z
+      .object({
+        type: z.literal("code"),
+        data: z.union([
+          z
+            .object({
+              type: z.literal("bundle"),
+            })
+            .and(codeBundleSchema)
+            .openapi({ title: "bundle" }),
+          z
+            .object({
+              type: z.literal("inline"),
+              runtime_context: runtimeContextSchema,
+              code: z.string(),
+            })
+            .openapi({ title: "inline" }),
+        ]),
+      })
+      .openapi({ title: "code" }),
+    z
+      .object({
+        type: z.literal("global"),
+        name: z.string(),
+      })
+      .openapi({ title: "global" }),
+  ])
+  .openapi("FunctionData");
 
 export const functionSchema = promptSchemaObject
   .merge(
@@ -481,7 +488,8 @@ export const permissionEnum = z
       "Each permission permits a certain type of operation on an object in the system",
       "Permissions can be assigned to to objects on an individual basis, or grouped into roles",
     ].join("\n\n"),
-  );
+  )
+  .openapi("Permission");
 export type Permission = z.infer<typeof permissionEnum>;
 
 const roleBaseSchema = generateBaseTableSchema("role");
@@ -577,7 +585,8 @@ export type Group = z.infer<typeof groupSchema>;
 
 export const projectScoreTypeEnum = z
   .enum(["slider", "categorical", "weighted", "minimum", "online"])
-  .describe("The type of the configured score");
+  .describe("The type of the configured score")
+  .openapi("ProjectScoreType");
 export type ProjectScoreType = z.infer<typeof projectScoreTypeEnum>;
 
 export const projectScoreCategory = z
@@ -776,7 +785,8 @@ export const appLimitParamSchema = z.coerce
   .number()
   .int()
   .nonnegative()
-  .describe("Limit the number of objects to return");
+  .describe("Limit the number of objects to return")
+  .openapi("AppLimit");
 
 function generateBaseTableOpSchema(objectName: string) {
   return z.object({
@@ -920,7 +930,9 @@ const patchFunctionSchema = z
     name: functionSchema.shape.name.nullish(),
     description: functionSchema.shape.description.nullish(),
     prompt_data: functionSchema.shape.prompt_data.nullish(),
-    function_data: functionSchema.shape.function_data.nullish(),
+    function_data: functionSchema.shape.function_data
+      .nullish()
+      .openapi("FunctionDataNullish"),
     tags: functionSchema.shape.tags.nullish(),
   })
   .openapi("PatchFunction");
@@ -1012,17 +1024,21 @@ export const aclItemSchema = aclSchema
 
 export type AclItem = z.infer<typeof aclItemSchema>;
 
-export const aclBatchUpdateRequestSchema = z.object({
-  add_acls: aclItemSchema.array().nullish(),
-  remove_acls: aclItemSchema.array().nullish(),
-});
+export const aclBatchUpdateRequestSchema = z
+  .object({
+    add_acls: aclItemSchema.array().nullish(),
+    remove_acls: aclItemSchema.array().nullish(),
+  })
+  .openapi("AclBatchUpdateRequest");
 
 export type AclBatchUpdateRequest = z.infer<typeof aclBatchUpdateRequestSchema>;
 
-export const aclBatchUpdateResponseSchema = z.object({
-  added_acls: aclSchema.array(),
-  removed_acls: aclSchema.array(),
-});
+export const aclBatchUpdateResponseSchema = z
+  .object({
+    added_acls: aclSchema.array(),
+    removed_acls: aclSchema.array(),
+  })
+  .openapi("AclBatchUpdateResponse");
 
 export type AclBatchUpdateResponse = z.infer<
   typeof aclBatchUpdateResponseSchema
@@ -1189,41 +1205,49 @@ export const patchOrganizationMembersSchema = z
   })
   .openapi("PatchOrganizationMembers");
 
-export const patchOrganizationMembersOutputSchema = z.object({
-  status: z.literal("success"),
-  send_email_error: z
-    .string()
-    .nullish()
-    .describe(
-      "If invite emails failed to send for some reason, the patch operation will still complete, but we will return an error message here",
-    ),
-});
+export const patchOrganizationMembersOutputSchema = z
+  .object({
+    status: z.literal("success"),
+    send_email_error: z
+      .string()
+      .nullish()
+      .describe(
+        "If invite emails failed to send for some reason, the patch operation will still complete, but we will return an error message here",
+      ),
+  })
+  .openapi("PatchOrganizationMembersOutput");
 
 const createAISecretBaseSchema = generateBaseTableOpSchema("AI Secret");
-export const createAISecretSchema = z.object({
-  name: aiSecretSchema.shape.name,
-  type: aiSecretSchema.shape.type,
-  metadata: aiSecretSchema.shape.metadata,
-  secret: z
-    .string()
-    .nullish()
-    .describe(
-      "Secret value. If omitted in a PUT request, the existing secret value will be left intact, not replaced with null.",
-    ),
-  org_name: createAISecretBaseSchema.shape.org_name,
-});
+export const createAISecretSchema = z
+  .object({
+    name: aiSecretSchema.shape.name,
+    type: aiSecretSchema.shape.type,
+    metadata: aiSecretSchema.shape.metadata,
+    secret: z
+      .string()
+      .nullish()
+      .describe(
+        "Secret value. If omitted in a PUT request, the existing secret value will be left intact, not replaced with null.",
+      ),
+    org_name: createAISecretBaseSchema.shape.org_name,
+  })
+  .openapi("CreateAISecret");
 
-export const deleteAISecretSchema = z.object({
-  name: aiSecretSchema.shape.name,
-  org_name: createAISecretBaseSchema.shape.org_name,
-});
+export const deleteAISecretSchema = z
+  .object({
+    name: aiSecretSchema.shape.name,
+    org_name: createAISecretBaseSchema.shape.org_name,
+  })
+  .openapi("DeleteAISecret");
 
-export const patchAISecretSchema = z.object({
-  name: aiSecretSchema.shape.name.nullish(),
-  type: aiSecretSchema.shape.type,
-  metadata: aiSecretSchema.shape.metadata,
-  secret: z.string().nullish(),
-});
+export const patchAISecretSchema = z
+  .object({
+    name: aiSecretSchema.shape.name.nullish(),
+    type: aiSecretSchema.shape.type,
+    metadata: aiSecretSchema.shape.metadata,
+    secret: z.string().nullish(),
+  })
+  .openapi("PatchAISecret");
 
 export const createEnvVarSchema = envVarSchema
   .pick({ object_type: true, object_id: true, name: true })

--- a/core/js/typespecs/function_id.ts
+++ b/core/js/typespecs/function_id.ts
@@ -1,19 +1,23 @@
+import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
+extendZodWithOpenApi(z);
 
-export const savedFunctionIdSchema = z.union([
-  z
-    .object({
-      type: z.literal("function"),
-      id: z.string(),
-    })
-    .openapi({ title: "function" }),
-  z
-    .object({
-      type: z.literal("global"),
-      name: z.string(),
-    })
-    .openapi({ title: "global" }),
-]);
+export const savedFunctionIdSchema = z
+  .union([
+    z
+      .object({
+        type: z.literal("function"),
+        id: z.string(),
+      })
+      .openapi({ title: "function" }),
+    z
+      .object({
+        type: z.literal("global"),
+        name: z.string(),
+      })
+      .openapi({ title: "global" }),
+  ])
+  .openapi("SavedFunctionId");
 
 export type SavedFunctionId = z.infer<typeof savedFunctionIdSchema>;
 

--- a/core/js/typespecs/functions.ts
+++ b/core/js/typespecs/functions.ts
@@ -1,4 +1,6 @@
+import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
+extendZodWithOpenApi(z);
 import { promptDataSchema } from "./prompt";
 import { chatCompletionMessageParamSchema } from "./openai/messages";
 import { customTypes } from "./custom_types";
@@ -67,7 +69,8 @@ export const functionIdSchema = z
       })
       .describe("Inline prompt definition"),
   ])
-  .describe("Options for identifying a function");
+  .describe("Options for identifying a function")
+  .openapi("FunctionId");
 
 export type FunctionId = z.infer<typeof functionIdSchema>;
 
@@ -132,9 +135,9 @@ export const invokeFunctionNonIdArgsSchema = z.object({
     .describe("The mode format of the returned value (defaults to 'auto')"),
 });
 
-export const invokeFunctionSchema = functionIdSchema.and(
-  invokeFunctionNonIdArgsSchema,
-);
+export const invokeFunctionSchema = functionIdSchema
+  .and(invokeFunctionNonIdArgsSchema)
+  .openapi("InvokeFunction");
 export type InvokeFunctionRequest = z.infer<typeof invokeFunctionSchema>;
 
 export const invokeApiSchema = invokeFunctionNonIdArgsSchema
@@ -143,50 +146,53 @@ export const invokeApiSchema = invokeFunctionNonIdArgsSchema
       version: z.string().optional().describe("The version of the function"),
     }),
   )
-  .describe("The request to invoke a function");
+  .describe("The request to invoke a function")
+  .openapi("InvokeApi");
 
-export const runEvalSchema = z.object({
-  project_id: z
-    .string()
-    .describe("Unique identifier for the project to run the eval in"),
-  data: z
-    .union([
-      z
-        .object({
-          dataset_id: z.string(),
-        })
-        .describe("Dataset id"),
-      z
-        .object({
-          project_name: z.string(),
-          dataset_name: z.string(),
-        })
-        .describe("Project and dataset name"),
-    ])
-    .describe("The dataset to use"),
-  task: functionIdSchema.describe("The function to evaluate"),
-  scores: z
-    .array(functionIdSchema)
-    .describe("The functions to score the eval on"),
-  experiment_name: z
-    .string()
-    .optional()
-    .describe(
-      "An optional name for the experiment created by this eval. If it conflicts with an existing experiment, it will be suffixed with a unique identifier.",
-    ),
-  metadata: z
-    .record(customTypes.unknown)
-    .optional()
-    .describe(
-      "Optional experiment-level metadata to store about the evaluation. You can later use this to slice & dice across experiments.",
-    ),
-  stream: z
-    .boolean()
-    .optional()
-    .describe(
-      "Whether to stream the results of the eval. If true, the request will return two events: one to indicate the experiment has started, and another upon completion. If false, the request will return the evaluation's summary upon completion.",
-    ),
-});
+export const runEvalSchema = z
+  .object({
+    project_id: z
+      .string()
+      .describe("Unique identifier for the project to run the eval in"),
+    data: z
+      .union([
+        z
+          .object({
+            dataset_id: z.string(),
+          })
+          .describe("Dataset id"),
+        z
+          .object({
+            project_name: z.string(),
+            dataset_name: z.string(),
+          })
+          .describe("Project and dataset name"),
+      ])
+      .describe("The dataset to use"),
+    task: functionIdSchema.describe("The function to evaluate"),
+    scores: z
+      .array(functionIdSchema)
+      .describe("The functions to score the eval on"),
+    experiment_name: z
+      .string()
+      .optional()
+      .describe(
+        "An optional name for the experiment created by this eval. If it conflicts with an existing experiment, it will be suffixed with a unique identifier.",
+      ),
+    metadata: z
+      .record(customTypes.unknown)
+      .optional()
+      .describe(
+        "Optional experiment-level metadata to store about the evaluation. You can later use this to slice & dice across experiments.",
+      ),
+    stream: z
+      .boolean()
+      .optional()
+      .describe(
+        "Whether to stream the results of the eval. If true, the request will return two events: one to indicate the experiment has started, and another upon completion. If false, the request will return the evaluation's summary upon completion.",
+      ),
+  })
+  .openapi("RunEval");
 
 export type RunEvalRequest = z.infer<typeof runEvalSchema>;
 
@@ -236,53 +242,60 @@ export const sseDoneEventSchema = baseSSEEventSchema.omit({ data: true }).merge(
   }),
 );
 
-export const functionObjectTypeEnum = z.enum([
-  "prompt",
-  "tool",
-  "scorer",
-  "task",
-]);
+export const functionObjectTypeEnum = z
+  .enum(["prompt", "tool", "scorer", "task"])
+  .openapi("FunctionObjectType");
 export type FunctionObjectType = z.infer<typeof functionObjectTypeEnum>;
-export const functionFormatEnum = z.enum(["llm", "code", "global"]);
+export const functionFormatEnum = z
+  .enum(["llm", "code", "global"])
+  .openapi("FunctionFormat");
 export type FunctionFormat = z.infer<typeof functionFormatEnum>;
-export const functionOutputTypeEnum = z.enum(["completion", "score", "any"]);
+export const functionOutputTypeEnum = z
+  .enum(["completion", "score", "any"])
+  .openapi("FunctionOutputType");
 export type FunctionOutputType = z.infer<typeof functionOutputTypeEnum>;
 
-export const sseProgressEventDataSchema = z.object({
-  id: z.string().describe("The id of the span this event is for"),
-  object_type: functionObjectTypeEnum,
-  format: functionFormatEnum,
-  output_type: functionOutputTypeEnum,
-  name: z.string(),
-  event: z.enum(["text_delta", "json_delta", "error", "start", "done"]),
-  data: z.string(), // This is the text_delta or json_delta
-});
+export const sseProgressEventDataSchema = z
+  .object({
+    id: z.string().describe("The id of the span this event is for"),
+    object_type: functionObjectTypeEnum,
+    format: functionFormatEnum,
+    output_type: functionOutputTypeEnum,
+    name: z.string(),
+    event: z.enum(["text_delta", "json_delta", "error", "start", "done"]),
+    data: z.string(), // This is the text_delta or json_delta
+  })
+  .openapi("SSEProgressEventData");
 export type SSEProgressEventData = z.infer<typeof sseProgressEventDataSchema>;
 
-export const callEventSchema = z.union([
-  sseTextEventSchema.openapi({ title: "text_delta" }),
-  sseDataEventSchema.openapi({ title: "json_delta" }),
-  sseProgressEventSchema.openapi({ title: "progress" }),
-  sseErrorEventSchema.openapi({ title: "error" }),
-  sseStartEventSchema.openapi({ title: "start" }),
-  sseDoneEventSchema.openapi({ title: "done" }),
-]);
+export const callEventSchema = z
+  .union([
+    sseTextEventSchema.openapi({ title: "text_delta" }),
+    sseDataEventSchema.openapi({ title: "json_delta" }),
+    sseProgressEventSchema.openapi({ title: "progress" }),
+    sseErrorEventSchema.openapi({ title: "error" }),
+    sseStartEventSchema.openapi({ title: "start" }),
+    sseDoneEventSchema.openapi({ title: "done" }),
+  ])
+  .openapi("CallEvent");
 
 export type CallEventSchema = z.infer<typeof callEventSchema>;
 
-export const scoreSchema = z.union([
-  z.object({
-    name: z.string(),
-    score: z.number().min(0).max(1).nullable().default(null), // Sometimes we get an empty value over the wire
-    metadata: z
-      .record(customTypes.unknown)
-      .optional()
-      .transform((data) => data ?? undefined),
-  }),
-  z.number().min(0).max(1),
-  z.boolean().transform((b) => (b ? 1 : 0)),
-  z.null(),
-]);
+export const scoreSchema = z
+  .union([
+    z.object({
+      name: z.string(),
+      score: z.number().min(0).max(1).nullable().default(null), // Sometimes we get an empty value over the wire
+      metadata: z
+        .record(customTypes.unknown)
+        .optional()
+        .transform((data) => data ?? undefined),
+    }),
+    z.number().min(0).max(1),
+    z.boolean().transform((b) => (b ? 1 : 0)),
+    z.null(),
+  ])
+  .openapi("ScorerScore");
 
 export const ifExistsEnum = z.enum(["error", "ignore", "replace"]);
 export type IfExists = z.infer<typeof ifExistsEnum>;

--- a/core/js/typespecs/openai/messages.ts
+++ b/core/js/typespecs/openai/messages.ts
@@ -1,13 +1,10 @@
+import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
+extendZodWithOpenApi(z);
 
-export const messageRoleSchema = z.enum([
-  "system",
-  "user",
-  "assistant",
-  "function",
-  "tool",
-  "model",
-]);
+export const messageRoleSchema = z
+  .enum(["system", "user", "assistant", "function", "tool", "model"])
+  .openapi("MessageRole");
 export type MessageRole = z.infer<typeof messageRoleSchema>;
 
 const chatCompletionSystemMessageParamSchema = z.object({
@@ -15,10 +12,12 @@ const chatCompletionSystemMessageParamSchema = z.object({
   role: z.literal("system"),
   name: z.string().optional(),
 });
-export const chatCompletionContentPartTextSchema = z.object({
-  text: z.string().default(""),
-  type: z.literal("text"),
-});
+export const chatCompletionContentPartTextSchema = z
+  .object({
+    text: z.string().default(""),
+    type: z.literal("text"),
+  })
+  .openapi("ChatCompletionContentPartText");
 
 const imageURLSchema = z.object({
   url: z.string(),
@@ -30,26 +29,32 @@ const imageURLSchema = z.object({
     ])
     .optional(),
 });
-export const chatCompletionContentPartImageSchema = z.object({
-  image_url: imageURLSchema,
-  type: z.literal("image_url"),
-});
+export const chatCompletionContentPartImageSchema = z
+  .object({
+    image_url: imageURLSchema,
+    type: z.literal("image_url"),
+  })
+  .openapi("ChatCompletionContentPartImage");
 
-export const chatCompletionContentPartSchema = z.union([
-  chatCompletionContentPartTextSchema.openapi({ title: "text" }),
-  chatCompletionContentPartImageSchema.openapi({ title: "image_url" }),
-]);
+export const chatCompletionContentPartSchema = z
+  .union([
+    chatCompletionContentPartTextSchema.openapi({ title: "text" }),
+    chatCompletionContentPartImageSchema.openapi({ title: "image_url" }),
+  ])
+  .openapi("ChatCompletionContentPart");
 
-export const chatCompletionContentSchema = z.union([
-  z.string().default("").openapi({ title: "text" }),
-  z
-    .array(
-      chatCompletionContentPartSchema.openapi({
-        title: "chat_completion_content_part",
-      }),
-    )
-    .openapi({ title: "array" }),
-]);
+export const chatCompletionContentSchema = z
+  .union([
+    z.string().default("").openapi({ title: "text" }),
+    z
+      .array(
+        chatCompletionContentPartSchema.openapi({
+          title: "chat_completion_content_part",
+        }),
+      )
+      .openapi({ title: "array" }),
+  ])
+  .openapi("ChatCompletionContent");
 
 const chatCompletionUserMessageParamSchema = z.object({
   content: chatCompletionContentSchema,
@@ -74,11 +79,13 @@ const chatCompletionFunctionMessageParamSchema = z.object({
   name: z.string(),
   role: z.literal("function"),
 });
-export const chatCompletionMessageToolCallSchema = z.object({
-  id: z.string(),
-  function: functionSchema,
-  type: z.literal("function"),
-});
+export const chatCompletionMessageToolCallSchema = z
+  .object({
+    id: z.string(),
+    function: functionSchema,
+    type: z.literal("function"),
+  })
+  .openapi("ChatCompletionMessageToolCall");
 
 const chatCompletionAssistantMessageParamSchema = z.object({
   role: z.literal("assistant"),
@@ -113,9 +120,11 @@ export const chatCompletionOpenAIMessageParamSchema = z.union([
   chatCompletionFunctionMessageParamSchema.openapi({ title: "function" }),
 ]);
 
-export const chatCompletionMessageParamSchema = z.union([
-  chatCompletionOpenAIMessageParamSchema.openapi({ title: "openai" }),
-  chatCompletionFallbackMessageParamSchema.openapi({ title: "fallback" }),
-]);
+export const chatCompletionMessageParamSchema = z
+  .union([
+    chatCompletionOpenAIMessageParamSchema.openapi({ title: "openai" }),
+    chatCompletionFallbackMessageParamSchema.openapi({ title: "fallback" }),
+  ])
+  .openapi("ChatCompletionMessageParam");
 
 export type ToolCall = z.infer<typeof chatCompletionMessageToolCallSchema>;

--- a/core/js/typespecs/prompt.ts
+++ b/core/js/typespecs/prompt.ts
@@ -1,4 +1,6 @@
+import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
+extendZodWithOpenApi(z);
 import {
   chatCompletionContentPartSchema,
   chatCompletionContentPartImageSchema,
@@ -93,50 +95,58 @@ const openAIModelParamsSchema = z.object({
 });
 export type OpenAIModelParams = z.infer<typeof openAIModelParamsSchema>;
 
-const anthropicModelParamsSchema = z.object({
-  max_tokens: z.number(),
-  temperature: z.number(),
-  top_p: z.number().optional(),
-  top_k: z.number().optional(),
-  stop_sequences: z.array(z.string()).optional(),
-  max_tokens_to_sample: z
-    .number()
-    .optional()
-    .describe("This is a legacy parameter that should not be used."),
-});
-const googleModelParamsSchema = z.object({
-  temperature: z.number().optional(),
-  maxOutputTokens: z.number().optional(),
-  topP: z.number().optional(),
-  topK: z.number().optional(),
-});
-const windowAIModelParamsSchema = z.object({
-  temperature: z.number().optional(),
-  topK: z.number().optional(),
-});
-const jsCompletionParamsSchema = z.object({});
-export const modelParamsSchema = z.union([
-  braintrustModelParamsSchema
-    .merge(openAIModelParamsSchema)
-    .passthrough()
-    .openapi({ title: "OpenAIModelParams" }),
-  braintrustModelParamsSchema
-    .merge(anthropicModelParamsSchema)
-    .passthrough()
-    .openapi({ title: "AnthropicModelParams" }),
-  braintrustModelParamsSchema
-    .merge(googleModelParamsSchema)
-    .passthrough()
-    .openapi({ title: "GoogleModelParams" }),
-  braintrustModelParamsSchema
-    .merge(windowAIModelParamsSchema)
-    .passthrough()
-    .openapi({ title: "WindowAIModelParams" }),
-  braintrustModelParamsSchema
-    .merge(jsCompletionParamsSchema)
-    .passthrough()
-    .openapi({ title: "JsCompletionParams" }),
-]);
+const anthropicModelParamsSchema = z
+  .object({
+    max_tokens: z.number(),
+    temperature: z.number(),
+    top_p: z.number().optional(),
+    top_k: z.number().optional(),
+    stop_sequences: z.array(z.string()).optional(),
+    max_tokens_to_sample: z
+      .number()
+      .optional()
+      .describe("This is a legacy parameter that should not be used."),
+  })
+  .openapi("AntrhopicModelParams");
+const googleModelParamsSchema = z
+  .object({
+    temperature: z.number().optional(),
+    maxOutputTokens: z.number().optional(),
+    topP: z.number().optional(),
+    topK: z.number().optional(),
+  })
+  .openapi("GoogleModelParams");
+const windowAIModelParamsSchema = z
+  .object({
+    temperature: z.number().optional(),
+    topK: z.number().optional(),
+  })
+  .openapi("WindowAIModelParams");
+const jsCompletionParamsSchema = z.object({}).openapi("JsCompletionParams");
+export const modelParamsSchema = z
+  .union([
+    braintrustModelParamsSchema
+      .merge(openAIModelParamsSchema)
+      .passthrough()
+      .openapi({ title: "OpenAIModelParams" }),
+    braintrustModelParamsSchema
+      .merge(anthropicModelParamsSchema)
+      .passthrough()
+      .openapi({ title: "AnthropicModelParams" }),
+    braintrustModelParamsSchema
+      .merge(googleModelParamsSchema)
+      .passthrough()
+      .openapi({ title: "GoogleModelParams" }),
+    braintrustModelParamsSchema
+      .merge(windowAIModelParamsSchema)
+      .passthrough()
+      .openapi({ title: "WindowAIModelParams" }),
+    braintrustModelParamsSchema
+      .merge(jsCompletionParamsSchema)
+      .passthrough()
+      .openapi({ title: "JsCompletionParams" }),
+  ])
+  .openapi("ModelParams");
 
 export type ModelParams = z.infer<typeof modelParamsSchema>;
 


### PR DESCRIPTION
This helps reduce redundancy in the openapi spec.