### PR TITLE
Remove user_id from span iframe creation API

### DIFF
--- a/core/js/typespecs/app_types.ts
+++ b/core/js/typespecs/app_types.ts
@@ -1102,6 +1102,7 @@ export const createSpanIframeSchema = spanIframeSchema
     id: true,
     created: true,
     deleted_at: true,
+    user_id: true,
   })
   .openapi("CreateSpanIFrame");
 


### PR DESCRIPTION
This is determined automatically by the caller of the method.