### PR TITLE
Additional tool choice and response format options

### DIFF
--- a/core/js/typespecs/prompt.ts
+++ b/core/js/typespecs/prompt.ts
@@ -77,6 +77,7 @@ const openAIModelParamsSchema = z.object({
     .union([
       z.literal("auto").openapi({ title: "auto" }),
       z.literal("none").openapi({ title: "none" }),
+      z.literal("required").openapi({ title: "none" }),
       z
         .object({
           type: z.literal("function"),

--- a/core/js/typespecs/prompt.ts
+++ b/core/js/typespecs/prompt.ts
@@ -72,7 +72,21 @@ const openAIModelParamsSchema = z.object({
   max_tokens: z.number().optional(),
   frequency_penalty: z.number().optional(),
   presence_penalty: z.number().optional(),
-  response_format: z.object({ type: z.literal("json_object") }).nullish(),
+  response_format: z
+    .union([
+      z.object({ type: z.literal("json_object") }),
+      z.object({
+        type: z.literal("json_schema"),
+        json_schema: z.object({
+          name: z.string(),
+          description: z.string().optional(),
+          schema: z.record(z.unknown()).optional(),
+          strict: z.boolean().nullish(),
+        }),
+      }),
+      z.object({ type: z.literal("text") }),
+    ])
+    .nullish(),
   tool_choice: z
     .union([
       z.literal("auto").openapi({ title: "auto" }),


### PR DESCRIPTION
I noticed these while combing through some OTEL attributes and figured we could include these options since they're available in the OpenAI request types.