### PR TITLE
Add serialized_span_slugs to insert output. Fix mergeRowBatch.

### DIFF
--- a/core/js/src/merge_row_batch.ts
+++ b/core/js/src/merge_row_batch.ts
@@ -50,6 +50,18 @@ function popMergeRowSkipFields<T extends MergeRowSkipFieldObj>(
   return popped;
 }
 
+function restoreMergeRowSkipFields<T extends MergeRowSkipFieldObj>(
+  row: T,
+  skipFields: MergeRowSkipFieldObj,
+) {
+  for (const field of MERGE_ROW_SKIP_FIELDS) {
+    delete row[field];
+    if (field in skipFields) {
+      row[field] = skipFields[field];
+    }
+  }
+}
+
 export function mergeRowBatch<
   T extends {
     id: string;
@@ -73,7 +85,7 @@ export function mergeRowBatch<
       const skipFields = popMergeRowSkipFields(existingRow);
       const preserveNoMerge = !existingRow[IS_MERGE_FIELD];
       mergeDicts(existingRow, row);
-      Object.assign(existingRow, skipFields);
+      restoreMergeRowSkipFields(existingRow, skipFields);
       if (preserveNoMerge) {
         delete existingRow[IS_MERGE_FIELD];
       }

--- a/core/js/src/merge_row_batch.ts
+++ b/core/js/src/merge_row_batch.ts
@@ -26,7 +26,14 @@ function generateMergedRowKey(
 }
 
 // These fields will be retained as-is when merging rows.
-const MERGE_ROW_SKIP_FIELDS = ["created", "span_id", "root_span_id"] as const;
+const MERGE_ROW_SKIP_FIELDS = [
+  "created",
+  "span_id",
+  "root_span_id",
+  "span_parents",
+  "_parent_id",
+  // TODO: handle merge paths.
+] as const;
 type MergeRowSkipField = (typeof MERGE_ROW_SKIP_FIELDS)[number];
 type MergeRowSkipFieldObj = { [K in MergeRowSkipField]?: unknown };
 

--- a/core/js/typespecs/api_types.ts
+++ b/core/js/typespecs/api_types.ts
@@ -573,6 +573,18 @@ export const insertEventsResponseSchema = z
   })
   .openapi("InsertEventsResponse");
 
+export const insertEventsWithSpanSlugsResponseSchema =
+  insertEventsResponseSchema
+    .extend({
+      serialized_span_slugs: z
+        .string()
+        .array()
+        .describe(
+          "String slugs which line up 1-1 with the row_ids. These slugs can be used as the 'parent' specifier to attach spans underneath the row",
+        ),
+    })
+    .openapi("InsertEventsWithSpanSlugsResponse");
+
 export const feedbackResponseSchema = z
   .object({
     status: z.literal("success"),

--- a/py/src/braintrust/merge_row_batch.py
+++ b/py/src/braintrust/merge_row_batch.py
@@ -39,6 +39,13 @@ def _pop_merge_row_skip_fields(row: Dict) -> Dict:
     return popped
 
 
+def _restore_merge_row_skip_fields(row: Dict, skip_fields: Dict):
+    for field in MERGE_ROW_SKIP_FIELDS:
+        row.pop(field, None)
+        if field in skip_fields:
+            row[field] = skip_fields[field]
+
+
 def merge_row_batch(rows: List[Dict]) -> List[List[Dict]]:
     """Given a batch of rows, merges conflicting rows together to end up with a
     set of rows to insert. Returns a set of de-conflicted rows, as a list of
@@ -102,7 +109,7 @@ def merge_row_batch(rows: List[Dict]) -> List[List[Dict]]:
             # false.
             preserve_nomerge = not existing_row.get(IS_MERGE_FIELD)
             merge_dicts(existing_row, row)
-            existing_row.update(skip_fields)
+            _restore_merge_row_skip_fields(existing_row, skip_fields)
             if preserve_nomerge:
                 del existing_row[IS_MERGE_FIELD]
         else:

--- a/py/src/braintrust/merge_row_batch.py
+++ b/py/src/braintrust/merge_row_batch.py
@@ -25,6 +25,9 @@ MERGE_ROW_SKIP_FIELDS = [
     "created",
     "span_id",
     "root_span_id",
+    "span_parents",
+    "_parent_id",
+    # TODO: handle merge paths.
 ]
 
 

--- a/py/src/braintrust/merge_row_batch.py
+++ b/py/src/braintrust/merge_row_batch.py
@@ -28,11 +28,12 @@ MERGE_ROW_SKIP_FIELDS = [
 ]
 
 
-def _collect_merge_row_skip_fields(row: Dict) -> Dict:
-    out = {}
+def _pop_merge_row_skip_fields(row: Dict) -> Dict:
+    popped = {}
     for field in MERGE_ROW_SKIP_FIELDS:
-        out[field] = row.get(field)
-    return out
+        if field in row:
+            popped[field] = row.pop(field)
+    return popped
 
 
 def merge_row_batch(rows: List[Dict]) -> List[List[Dict]]:
@@ -93,7 +94,7 @@ def merge_row_batch(rows: List[Dict]) -> List[List[Dict]]:
         # True property, we merge it with the existing row. Otherwise we can
         # replace it.
         if existing_row is not None and row.get(IS_MERGE_FIELD):
-            skip_fields = _collect_merge_row_skip_fields(existing_row)
+            skip_fields = _pop_merge_row_skip_fields(existing_row)
             # Preserve IS_MERGE_FIELD == False if the existing_row had it set to
             # false.
             preserve_nomerge = not existing_row.get(IS_MERGE_FIELD)


### PR DESCRIPTION
The serialized_span_slugs output gives consumers parent span slugs that they can use to attach traces underneath.

When merging across rows with the same (object_id, row_id), we should preserve the original value of certain system fields, instead of using the merged version. This preserves the behavior we would have if we inserted those rows in separate batches.