### PR TITLE
Python: Improve `EvalData` type annotation.

### DIFF
--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -183,7 +183,10 @@ class BaseExperiment:
 
 
 _AnyEvalCase = Union[
-    EvalCase[Input, Output], _EvalCaseDict[Input, Output], _EvalCaseDictNoOutput[Input], _ExperimentDatasetEvent
+    EvalCase[Input, Output],
+    _EvalCaseDict[Input, Output],
+    _EvalCaseDictNoOutput[Input],
+    _ExperimentDatasetEvent,
 ]
 
 _EvalDataObject = Union[

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -2292,9 +2292,9 @@ class _ExperimentDatasetEvent(TypedDict):
 
     id: str
     _xact_id: str
-    input: NotRequired[Optional[Any]]
-    expected: NotRequired[Optional[Any]]
-    tags: NotRequired[Optional[Sequence[str]]]
+    input: Optional[Any]
+    expected: Optional[Any]
+    tags: Optional[Sequence[str]]
 
 
 class ExperimentDatasetIterator:

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -45,7 +45,6 @@ import exceptiongroup
 import requests
 from braintrust_core.serializable_data_class import SerializableDataClass
 from requests.adapters import HTTPAdapter
-from typing_extensions import NotRequired
 from urllib3.util.retry import Retry
 
 from braintrust.functions.stream import BraintrustStream


### PR DESCRIPTION
1. Split `_EvalCaseDict` to work around an issue where Pylance still tries to check the type of an unspecified but `NotRequired` field of a `TypedDict`.
1. Explicitly allow `_ExperimentDatasetEvent` so the type checker does not have to check compatibility between `_ExperimentDatasetEvent` and `_EvalCaseDict`.