### PR TITLE
Fix init args between cli/framework

### DIFF
--- a/js/src/cli.ts
+++ b/js/src/cli.ts
@@ -26,6 +26,7 @@ import {
 
 // Re-use the module resolution logic from Jest
 import {
+  EvalData,
   EvaluatorDef,
   EvaluatorFile,
   Filter,
@@ -101,10 +102,12 @@ function evaluateBuildResults(
 
 async function initExperiment(
   evaluator: EvaluatorDef<unknown, unknown, unknown, BaseMetadata>,
+  evaluatorData: {
+    data: EvalData<unknown, unknown, BaseMetadata>;
+    baseExperiment: string | undefined;
+  },
 ) {
-  const { data, baseExperiment: defaultBaseExperiment } = callEvaluatorData(
-    evaluator.data,
-  );
+  const { data, baseExperiment: defaultBaseExperiment } = evaluatorData;
   // NOTE: This code is duplicated with initExperiment in js/src/framework.ts.
   // Make sure to update that if you change this.
   const logger = _initExperiment({
@@ -237,16 +240,16 @@ function buildWatchPluginForEvaluator(
         > = {};
         for (const evaluatorDef of Object.values(evalResult.evaluators)) {
           const { evaluator, reporter } = evaluatorDef;
+          const evalData = callEvaluatorData(evaluator.data);
           const logger = opts.noSendLogs
             ? null
-            : await initExperiment(
-                evaluator.projectName,
-                evaluator.experimentName,
-                evaluator.metadata,
-              );
+            : await initExperiment(evaluator, evalData);
           const evaluatorResult = await runEvaluator(
             logger,
-            evaluator,
+            {
+              ...evaluator,
+              data: evalData.data,
+            },
             opts.progressReporter,
             opts.filters,
           );
@@ -325,6 +328,7 @@ async function initFile({
         };
         return { type: "success", result, evaluator, sourceFile: inFile };
       } catch (e) {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         return { type: "failure", error: e as Error, sourceFile: inFile };
       }
     },
@@ -419,6 +423,7 @@ function updateEvaluators(
     for (const evaluator of Object.values(result.evaluator.evaluators)) {
       evaluators.evaluators.push({
         sourceFile: result.sourceFile,
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         evaluator: evaluator.evaluator as EvaluatorDef<
           unknown,
           unknown,
@@ -511,26 +516,19 @@ async function runOnce(
   const evalToExperiment: Record<string, Record<string, Experiment>> = {};
 
   const resultPromises = evaluators.evaluators.map(async (evaluator) => {
-    const { data, baseExperiment } = callEvaluatorData(
-      evaluator.evaluator.data,
-    );
+    const evalData = callEvaluatorData(evaluator.evaluator.data);
     // TODO: For now, use the eval name as the project. However, we need to evolve
     // the definition of a project and create a new concept called run, so that we
     // can name the experiment/evaluation within the run the evaluator's name.
     const logger = opts.noSendLogs
       ? null
-      : await initExperiment(
-          evaluator.evaluator.projectName,
-          evaluator.evaluator.experimentName,
-          evaluator.evaluator.metadata,
-          baseExperiment,
-        );
+      : await initExperiment(evaluator.evaluator, evalData);
     try {
       return await runEvaluator(
         logger,
         {
           ...evaluator.evaluator,
-          data,
+          data: evalData.data,
         },
         opts.progressReporter,
         opts.filters,
@@ -569,6 +567,7 @@ async function runOnce(
 
     const report = resolvedReporter.reportEval(
       evaluator.evaluator,
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       allEvalsResults[idx as number],
       {
         verbose: opts.verbose,

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -439,6 +439,8 @@ export async function Eval<
     const { data, baseExperiment: defaultBaseExperiment } = callEvaluatorData(
       evaluator.data,
     );
+    // NOTE: This code is duplicated with initExperiment in js/src/cli.ts. Make sure
+    // to update that if you change this.
     const experiment = initExperiment(evaluator.state, {
       ...(evaluator.projectId
         ? { projectId: evaluator.projectId }

--- a/py/src/braintrust/cli/eval.py
+++ b/py/src/braintrust/cli/eval.py
@@ -24,6 +24,7 @@ from ..framework import (
     run_evaluator,
     set_thread_pool_max_workers,
 )
+from ..logger import Dataset
 from ..util import eprint
 
 INCLUDE = [
@@ -127,13 +128,25 @@ async def run_evaluator_task(evaluator, position, opts: EvaluatorOpts):
         base_experiment_name = None
         if isinstance(evaluator.data, BaseExperiment):
             base_experiment_name = evaluator.data.name
+
+        dataset = None
+        if isinstance(evaluator.data, Dataset):
+            dataset = evaluator.data
+
+        # NOTE: This code is duplicated with _EvalCommon in py/src/braintrust/framework.py.
+        # Make sure to update those arguments if you change this.
         experiment = init_experiment(
-            evaluator.project_name,
-            evaluator.experiment_name,
+            project_name=evaluator.project_name,
+            project_id=evaluator.project_id,
+            experiment_name=evaluator.experiment_name,
             metadata=evaluator.metadata,
             is_public=evaluator.is_public,
             update=evaluator.update,
             base_experiment=base_experiment_name,
+            base_experiment_id=evaluator.base_experiment_id,
+            git_metadata_settings=evaluator.git_metadata_settings,
+            repo_info=evaluator.repo_info,
+            dataset=dataset,
         )
 
     try:

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -556,7 +556,6 @@ def _EvalCommon(
     )
 
     if _lazy_load:
-        print("SAVING EVALUATOR")
         _evals.evaluators[eval_name] = EvaluatorInstance(evaluator=evaluator, reporter=reporter)
 
         # Better to return this empty object than have an annoying-to-use signature.
@@ -579,6 +578,8 @@ def _EvalCommon(
         if isinstance(evaluator.data, Dataset):
             dataset = evaluator.data
 
+        # NOTE: This code is duplicated with run_evaluator_task in py/src/braintrust/cli/eval.py.
+        # Make sure to update those arguments if you change this.
         experiment = init_experiment(
             project_name=evaluator.project_name if evaluator.project_id is None else None,
             project_id=evaluator.project_id,


### PR DESCRIPTION
The two ways of initializing experiments (directly through `Eval()` and through `braintrust eval`) have gotten out of sync. There's likely a better consolidation we can do here, but as a first step, I sync'd them back up and added a comment describing that we should keep them in sync