### PR TITLE
[BRA-1834] feat: Add hooks.metadata and deprecate hooks.meta

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "braintrust",
-  "version": "0.0.161",
+  "version": "0.0.160",
   "description": "SDK for integrating Braintrust",
   "repository": {
     "type": "git",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "braintrust",
-  "version": "0.0.160",
+  "version": "0.0.161",
   "description": "SDK for integrating Braintrust",
   "repository": {
     "type": "git",

--- a/js/src/framework.test.ts
+++ b/js/src/framework.test.ts
@@ -10,12 +10,12 @@ test("runEvaluator rejects on timeout", async () => {
         projectName: "proj",
         evalName: "eval",
         data: [{ input: 1, expected: 2 }],
-        task: async (input) => {
+        task: async (input: number) => {
           await new Promise((r) => setTimeout(r, 100000));
-          return (input as number) * 2;
+          return input * 2;
         },
         scores: [],
-        timeout: 1000,
+        timeout: 100,
       },
       new BarProgressReporter(),
       [],
@@ -30,9 +30,9 @@ test("runEvaluator works with no timeout", async () => {
       projectName: "proj",
       evalName: "eval",
       data: [{ input: 1, expected: 2 }],
-      task: async (input) => {
+      task: async (input: number) => {
         await new Promise((r) => setTimeout(r, 100));
-        return (input as number) * 2;
+        return input * 2;
       },
       scores: [],
     },

--- a/js/src/framework.test.ts
+++ b/js/src/framework.test.ts
@@ -86,14 +86,11 @@ test("metadata (read/write) is passed to task", async () => {
       projectName: "proj",
       evalName: "eval",
       data: [{ input: 1, metadata }],
-      task: async (input: number, { metadata }) => {
-        metadata((m) => {
-          passedIn = m;
-          return {
-            ...m,
-            foo: "barbar",
-          };
-        });
+      task: async (input: number, { metadata: m }) => {
+        passedIn = { ...m };
+
+        // modify the metadata object
+        m.foo = "barbar";
 
         return input * 2;
       },

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -83,7 +83,7 @@ export interface EvalHooks {
    */
   meta: (info: Record<string, unknown>) => void;
   /**
-   * The metadata object for the current evaluation. Mutate this to add/remote metadata.
+   * The metadata object for the current evaluation. You can mutate this object to add or remove metadata.
    */
   metadata: Record<string, unknown>;
   span: Span;

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -1,31 +1,31 @@
-import chalk from "chalk";
-import {
-  NOOP_SPAN,
-  Experiment,
-  ExperimentSummary,
-  Span,
-  init as _initExperiment,
-  EvalCase,
-  BaseMetadata,
-  DefaultMetadataType,
-  ScoreSummary,
-  MetricSummary,
-  currentSpan,
-  FullInitOptions,
-  BraintrustState,
-  logError as logSpanError,
-  withCurrent,
-  startSpan,
-  Dataset,
-} from "./logger";
 import { Score, SpanTypeAttribute, mergeDicts } from "@braintrust/core";
 import { GitMetadataSettings, RepoInfo } from "@braintrust/core/typespecs";
-import { BarProgressReporter, ProgressReporter } from "./progress";
-import pluralize from "pluralize";
-import { isEmpty } from "./util";
 import { queue } from "async";
-import { CodeFunction, CodePrompt } from "./framework2";
+import chalk from "chalk";
+import pluralize from "pluralize";
 import { GenericFunction } from "./framework-types";
+import { CodeFunction, CodePrompt } from "./framework2";
+import {
+  BaseMetadata,
+  BraintrustState,
+  Dataset,
+  DefaultMetadataType,
+  EvalCase,
+  Experiment,
+  ExperimentSummary,
+  FullInitOptions,
+  MetricSummary,
+  NOOP_SPAN,
+  ScoreSummary,
+  Span,
+  init as _initExperiment,
+  currentSpan,
+  logError as logSpanError,
+  startSpan,
+  withCurrent,
+} from "./logger";
+import { BarProgressReporter, ProgressReporter } from "./progress";
+import { isEmpty } from "./util";
 
 export type BaseExperiment<
   Input,
@@ -78,7 +78,16 @@ export type EvalTask<Input, Output> =
   | ((input: Input, hooks: EvalHooks) => Output);
 
 export interface EvalHooks {
+  /**
+   * @deprecated Use `metadata` instead.
+   */
   meta: (info: Record<string, unknown>) => void;
+  /**
+   * A function that takes the current metadata and returns the new metadata.
+   */
+  metadata: (
+    fn: (metadata: Record<string, unknown>) => Record<string, unknown>,
+  ) => void;
   span: Span;
 }
 
@@ -684,12 +693,20 @@ async function runEvaluatorInternal(
         let error: unknown | undefined = undefined;
         const scores: Record<string, number | null> = {};
         try {
-          const meta = (o: Record<string, unknown>) =>
-            (metadata = { ...metadata, ...o });
+          const readWrite = (
+            fn: (o: Record<string, unknown>) => Record<string, unknown>,
+          ) => (metadata = fn(metadata));
+
+          const write = (o: Record<string, unknown>) =>
+            readWrite((m) => ({ ...m, ...o }));
 
           await rootSpan.traced(
             async (span: Span) => {
-              const outputResult = evaluator.task(datum.input, { meta, span });
+              const outputResult = evaluator.task(datum.input, {
+                meta: write,
+                metadata: readWrite,
+                span,
+              });
               if (outputResult instanceof Promise) {
                 output = await outputResult;
               } else {

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -134,7 +134,7 @@ class EvalHooks(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def metadata(self) -> dict[str, Any]:
+    def metadata(self) -> Dict[str, Any]:
         """
         The metadata object for the current evaluation. You can mutate this object to add or remove metadata.
         """

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -7,9 +7,11 @@ import json
 import re
 import sys
 import traceback
+import warnings
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from importlib import metadata
 from multiprocessing import cpu_count
 from typing import (
     Any,
@@ -130,6 +132,11 @@ class EvalHooks(abc.ABC):
     An object that can be used to add metadata to an evaluation. This is passed to the `task` function.
     """
 
+    """
+    The metadata object for the current evaluation. You can mutate this object to add or remove metadata.
+    """
+    metadata: dict[str, Any]
+
     @property
     @abc.abstractmethod
     def span(self) -> Span:
@@ -140,6 +147,8 @@ class EvalHooks(abc.ABC):
     @abc.abstractmethod
     def meta(self, **info) -> None:
         """
+        DEPRECATED: Use the metadata field on the hook directly.
+
         Adds metadata to the evaluation. This metadata will be logged to the Braintrust. You can pass in metadaa
         as keyword arguments, e.g. `hooks.meta(foo="bar")`.
         """
@@ -904,6 +913,10 @@ class DictEvalHooks(EvalHooks):
         self._span = span
 
     def meta(self, **info):
+        warnings.warn(
+            "meta() is deprecated. Use the metadata field directly instead.", DeprecationWarning, stacklevel=2
+        )
+
         self.metadata.update(info)
 
 

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -132,10 +132,12 @@ class EvalHooks(abc.ABC):
     An object that can be used to add metadata to an evaluation. This is passed to the `task` function.
     """
 
-    """
-    The metadata object for the current evaluation. You can mutate this object to add or remove metadata.
-    """
-    metadata: dict[str, Any]
+    @property
+    @abc.abstractmethod
+    def metadata(self) -> dict[str, Any]:
+        """
+        The metadata object for the current evaluation. You can mutate this object to add or remove metadata.
+        """
 
     @property
     @abc.abstractmethod
@@ -902,8 +904,12 @@ def evaluate_filter(object, filter: Filter):
 
 class DictEvalHooks(EvalHooks):
     def __init__(self, metadata):
-        self.metadata = metadata
+        self._metadata = metadata
         self._span = None
+
+    @property
+    def metadata(self):
+        return self._metadata
 
     @property
     def span(self):


### PR DESCRIPTION
## Changes
- Introduces new `hooks.metadata` (a reference to the metadata for the eval)
- Deprecates existing `hooks.meta` in favor of metadata
- Improves existing framework tests

## Why
This change provides a way for developers to read metadata and allows them a chance to mutate it without calling a function. 

## Testing
- Updated framework tests to verify new metadata functionality
- Verified backward compatibility with existing `hooks.meta` usage