### PR TITLE
formatting quirk

### DIFF
--- a/py/src/braintrust/_types.py
+++ b/py/src/braintrust/_types.py
@@ -15,7 +15,8 @@ SpanType = Literal["llm", "score", "function", "eval", "task", "tool"]
 
 class Origin(TypedDict):
     object_type: Union[
-        Literal["experiment", "dataset", "prompt", "function", "prompt_session"], Literal["project_logs"]
+        Literal["experiment", "dataset", "prompt", "function", "prompt_session"],
+        Literal["project_logs"],
     ]
     """
     Type of the object the event is originating from.


### PR DESCRIPTION
datamodel-codegen generates its output according to the directory's
configured formatter.
We now always generate it in a temporary directory without
any configured formatter,
and format it with pre-commit.
Since our formatter is not completely normative, we have this one diff.
