### PR TITLE
compress audit resources header with gzip

### DIFF
--- a/py/src/braintrust/__init__.py
+++ b/py/src/braintrust/__init__.py
@@ -48,6 +48,7 @@ BRAINTRUST_API_KEY=<YOUR_BRAINTRUST_API_KEY> braintrust eval eval_hello.py
 ### API Reference
 """
 
+from .audit import parse_audit_resources
 from .framework import *
 from .framework2 import *
 from .functions.invoke import *

--- a/py/src/braintrust/__init__.py
+++ b/py/src/braintrust/__init__.py
@@ -48,7 +48,7 @@ BRAINTRUST_API_KEY=<YOUR_BRAINTRUST_API_KEY> braintrust eval eval_hello.py
 ### API Reference
 """
 
-from .audit import parse_audit_resources
+from .audit import *
 from .framework import *
 from .framework2 import *
 from .functions.invoke import *

--- a/py/src/braintrust/audit.py
+++ b/py/src/braintrust/audit.py
@@ -1,0 +1,17 @@
+"""
+Utilities for working with audit headers.
+"""
+import base64
+import gzip
+import json
+from typing import List, TypedDict
+
+
+class AuditResource(TypedDict):
+    type: str
+    id: str
+    name: str
+
+
+def parse_audit_resources(marshaled: str) -> List[AuditResource]:
+    return json.loads(gzip.decompress(base64.b64decode(marshaled)))

--- a/py/src/braintrust/audit.py
+++ b/py/src/braintrust/audit.py
@@ -15,7 +15,7 @@ class AuditResource(TypedDict):
 
 def parse_audit_resources(hdr: str) -> List[AuditResource]:
     j = json.loads(hdr)
-    if j["metadata"]["version"] == 1:
-        return json.loads(gzip.decompress(base64.b64decode(j["payload"])))
+    if j["v"] == 1:
+        return json.loads(gzip.decompress(base64.b64decode(j["p"])))
     else:
-        raise ValueError(f'Unsupported audit resources protocol version: {j["metadata"]["version"]}')
+        raise ValueError(f'Unsupported audit resources protocol version: {j["v"]}')

--- a/py/src/braintrust/audit.py
+++ b/py/src/braintrust/audit.py
@@ -13,5 +13,9 @@ class AuditResource(TypedDict):
     name: str
 
 
-def parse_audit_resources(marshaled: str) -> List[AuditResource]:
-    return json.loads(gzip.decompress(base64.b64decode(marshaled)))
+def parse_audit_resources(hdr: str) -> List[AuditResource]:
+    j = json.loads(hdr)
+    if j["metadata"]["version"] == 1:
+        return json.loads(gzip.decompress(base64.b64decode(j["payload"])))
+    else:
+        raise ValueError(f'Unsupported audit resources protocol version: {j["metadata"]["version"]}')


### PR DESCRIPTION
and provide a utility function in the python SDK to parse it
