### PR TITLE
Bump `isort` dev dependency.

### DIFF
--- a/py/setup.py
+++ b/py/setup.py
@@ -32,7 +32,7 @@ extras_require = {
         "flake8",
         "flake8-isort",
         "IPython",
-        "isort==5.10.1",
+        "isort==5.12.0",
         "pre-commit",
         "pytest",
         "twine",


### PR DESCRIPTION
To align with the dev dependency in the `autoevals` package.