### PR TITLE
Fix init dataset in `npx braintrust eval`

### DIFF
--- a/js/src/cli.ts
+++ b/js/src/cli.ts
@@ -123,7 +123,7 @@ async function initExperiment(
     baseExperimentId: evaluator.baseExperimentId,
     gitMetadataSettings: evaluator.gitMetadataSettings,
     repoInfo: evaluator.repoInfo,
-    dataset: data instanceof Dataset ? data : undefined,
+    dataset: Dataset.isDataset(data) ? data : undefined,
     setCurrent: false,
   });
   const info = await logger.summarize({ summarizeScores: false });

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -519,7 +519,7 @@ export async function Eval<
           baseExperimentId: evaluator.baseExperimentId,
           gitMetadataSettings: evaluator.gitMetadataSettings,
           repoInfo: evaluator.repoInfo,
-          dataset: data instanceof Dataset ? data : undefined,
+          dataset: Dataset.isDataset(data) ? data : undefined,
         });
 
     if (experiment && options.onStart) {
@@ -768,7 +768,7 @@ async function runEvaluatorInternal(
     async (datum: EvalCase<any, any, any>) => {
       const eventDataset: Dataset | undefined = experiment
         ? experiment.dataset
-        : evaluator.data instanceof Dataset
+        : Dataset.isDataset(evaluator.data)
           ? evaluator.data
           : undefined;
 

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -4313,6 +4313,7 @@ export class Dataset<
   IsLegacyDataset extends boolean = typeof DEFAULT_IS_LEGACY_DATASET,
 > extends ObjectFetcher<DatasetRecord<IsLegacyDataset>> {
   private readonly lazyMetadata: LazyValue<ProjectDatasetMetadata>;
+  private readonly __braintrust_dataset_marker = true;
 
   constructor(
     private state: BraintrustState,
@@ -4587,6 +4588,14 @@ export class Dataset<
       "close is deprecated and will be removed in a future version of braintrust. It is now a no-op and can be removed",
     );
     return this.id;
+  }
+
+  public static isDataset(data: unknown): data is Dataset {
+    return (
+      typeof data === "object" &&
+      data !== null &&
+      "__braintrust_dataset_marker" in data
+    );
   }
 }
 


### PR DESCRIPTION
Because we bundle when we run `npx braintrust eval`, `instanceof Dataset` will return false (since it's technically a different symbol in the bundled JS).

Instead, we perform a specific check to see if it's our Dataset class, and if so, trick typescript into thinking so.