### PR TITLE
Add support for Brainstore in the CLI

### DIFF
--- a/py/src/braintrust/cli/install/api.py
+++ b/py/src/braintrust/cli/install/api.py
@@ -37,6 +37,12 @@ PARAMS = {
     "OutboundRateLimitMaxRequests": "outbound_rate_limit_max_requests",
     "UseGlobalProxy": "use_global_proxy",
     "EnableQuarantine": "enable_quarantine",
+    "EnableBrainstore": "enable_brainstore",
+    "BrainstoreInstanceKeyPairName": "brainstore_instance_key_pair_name",
+    "BrainstoreInstanceType": "brainstore_instance_type",
+    "BrainstoreInstanceCount": "brainstore_instance_count",
+    "BrainstoreMaxInstanceCount": "brainstore_max_instance_count",
+    "BrainstoreVersionOverride": "brainstore_version_override",
 }
 
 REMOVED_PARAMS = ["ThirdAZIndex"]
@@ -241,6 +247,41 @@ def build_parser(subparsers, parents):
         default=os.environ.get("BRAINTRUST_API_KEY", None),
     )
 
+    # Brainstore configuration
+    parser.add_argument(
+        "--enable-brainstore",
+        help="Enable Brainstore object-storage data backend",
+        choices=[None, "true", "false"],
+        default=None,
+    )
+    parser.add_argument(
+        "--brainstore-instance-key-pair-name",
+        help="The EC2 Key Pair to allow SSH access to the Brainstore instance",
+        default=None,
+    )
+    parser.add_argument(
+        "--brainstore-instance-type",
+        help="EC2 instance type for Brainstore. Must be a Graviton instance type.",
+        default=None,
+    )
+    parser.add_argument(
+        "--brainstore-instance-count",
+        help="Number of Brainstore instances to run",
+        type=int,
+        default=None,
+    )
+    parser.add_argument(
+        "--brainstore-max-instance-count",
+        help="Max scaling size for Brainstore instances",
+        type=int,
+        default=None,
+    )
+    parser.add_argument(
+        "--brainstore-version-override",
+        help="Lock Brainstore to a specific docker tag",
+        default=None,
+    )
+
     parser.set_defaults(func=main)
 
 
@@ -270,6 +311,12 @@ def main(args):
         PARAMS["ClickhouseCatchupEtlArn"] = "clickhouse_catchup_etl_arn"
         PARAMS["ClickhouseConnectUrl"] = "clickhouse_connect_url"
         PARAMS["ClickhousePGUrl"] = "clickhouse_pg_url"
+        PARAMS["EnableBrainstore"] = "enable_brainstore"
+        PARAMS["BrainstoreInstanceKeyPairName"] = "brainstore_instance_key_pair_name"
+        PARAMS["BrainstoreInstanceType"] = "brainstore_instance_type"
+        PARAMS["BrainstoreInstanceCount"] = "brainstore_instance_count"
+        PARAMS["BrainstoreMaxInstanceCount"] = "brainstore_max_instance_count"
+        PARAMS["BrainstoreVersionOverride"] = "brainstore_version_override"
 
         if args.template is None:
             template = "https://braintrust-cf.s3.amazonaws.com/braintrust-latest-vpc.yaml"

--- a/py/src/braintrust/cli/install/api.py
+++ b/py/src/braintrust/cli/install/api.py
@@ -399,9 +399,11 @@ def main(args):
             param_updates[param] = args.__dict__[arg_name]
     if len(param_updates) > 0 or args.update_template:
         template_kwargs = {"TemplateURL": template} if args.update_template else {"UsePreviousTemplate": True}
-        _logger.info(
-            f"Updating stack with name {args.name} with params: {param_updates} and template: {template_kwargs}"
-        )
+        _logger.info(f"Updating stack with name {args.name} with template: {template_kwargs}")
+
+        _logger.info("Using params:")
+        for param, value in param_updates.items():
+            _logger.info(f"  {param}: {value}")
 
         if args.template:
             new_template = cloudformation.get_template_summary(TemplateURL=template)

--- a/py/src/braintrust/cli/install/api.py
+++ b/py/src/braintrust/cli/install/api.py
@@ -365,7 +365,7 @@ def main(args):
             Capabilities=CAPABILITIES,
         )
 
-        for _ in range(120):
+        for _ in range(240):
             status = cloudformation.describe_stacks(StackName=args.name)["Stacks"][0]
             if status["StackStatus"] != "CREATE_IN_PROGRESS":
                 exists = True

--- a/py/src/braintrust/cli/install/api.py
+++ b/py/src/braintrust/cli/install/api.py
@@ -43,6 +43,7 @@ PARAMS = {
     "BrainstoreInstanceCount": "brainstore_instance_count",
     "BrainstoreMaxInstanceCount": "brainstore_max_instance_count",
     "BrainstoreVersionOverride": "brainstore_version_override",
+    "BrainstoreLicenseKey": "brainstore_license_key",
 }
 
 REMOVED_PARAMS = ["ThirdAZIndex"]
@@ -255,6 +256,11 @@ def build_parser(subparsers, parents):
         default=None,
     )
     parser.add_argument(
+        "--brainstore-license-key",
+        help="The license key to use for Brainstore",
+        default=None,
+    )
+    parser.add_argument(
         "--brainstore-instance-key-pair-name",
         help="The EC2 Key Pair to allow SSH access to the Brainstore instance",
         default=None,
@@ -313,6 +319,7 @@ def main(args):
         PARAMS["ClickhousePGUrl"] = "clickhouse_pg_url"
         PARAMS["EnableBrainstore"] = "enable_brainstore"
         PARAMS["BrainstoreInstanceKeyPairName"] = "brainstore_instance_key_pair_name"
+        PARAMS["BrainstoreLicenseKey"] = "brainstore_license_key"
         PARAMS["BrainstoreInstanceType"] = "brainstore_instance_type"
         PARAMS["BrainstoreInstanceCount"] = "brainstore_instance_count"
         PARAMS["BrainstoreMaxInstanceCount"] = "brainstore_max_instance_count"

--- a/py/src/braintrust/cli/install/api.py
+++ b/py/src/braintrust/cli/install/api.py
@@ -358,6 +358,8 @@ def main(args):
         for param in params:
             _logger.info(f"  {param['ParameterKey']}: {param['ParameterValue']}")
 
+        _logger.info(f"Typical stack creation takes 10-15 minutes.")
+
         cloudformation.create_stack(
             StackName=args.name,
             TemplateURL=template,
@@ -365,13 +367,13 @@ def main(args):
             Capabilities=CAPABILITIES,
         )
 
-        for _ in range(240):
+        for _ in range(80):
             status = cloudformation.describe_stacks(StackName=args.name)["Stacks"][0]
             if status["StackStatus"] != "CREATE_IN_PROGRESS":
                 exists = True
                 break
             _logger.info("Waiting for stack to be created...")
-            time.sleep(5)
+            time.sleep(15)
         else:
             _logger.error(
                 textwrap.dedent(

--- a/py/src/braintrust/cli/install/api.py
+++ b/py/src/braintrust/cli/install/api.py
@@ -307,7 +307,9 @@ def main(args):
             ]
             if v is not None
         ]
-        _logger.info(f"Using params: {params}")
+        _logger.info("Using params:")
+        for param in params:
+            _logger.info(f"  {param['ParameterKey']}: {param['ParameterValue']}")
 
         cloudformation.create_stack(
             StackName=args.name,

--- a/py/src/braintrust/cli/install/logs.py
+++ b/py/src/braintrust/cli/install/logs.py
@@ -11,7 +11,7 @@ _logger = logging.getLogger("braintrust.install.logs")
 def build_parser(subparsers, parents):
     parser = subparsers.add_parser("logs", help="Capture recent logs", parents=parents)
     parser.add_argument("name", help="Name of the CloudFormation stack to collect logs from")
-    parser.add_argument("--service", help="Name of the service", default="api", choices=["api"])
+    parser.add_argument("--service", help="Name of the service", default="api", choices=["api", "brainstore", "all"])
     parser.add_argument("--hours", help="Number of hours in the past to collect logs from", default=1, type=float)
     parser.set_defaults(func=main)
 
@@ -25,23 +25,35 @@ def main(args):
     stack = stacks[0]
     _logger.debug(stack)
 
-    log_group_names = []
-    if args.service == "api":
-        for name in ["APIHandlerName", "APIHandlerJSName", "AIProxyFnName"]:
-            lambda_function = [x for x in stack["Outputs"] if x["OutputKey"] == name]
-            if len(lambda_function) > 1:
-                raise ValueError(f"Expected 1 APIHandlerName, found {len(lambda_function)} ({lambda_function}))")
-            if len(lambda_function) == 0:
-                _logger.warn(f"Could not find {name}, skipping...")
-                continue
-            log_group_names.append(f"/aws/lambda/{lambda_function[0]['OutputValue']}")
+    if args.service == "all":
+        services = ["api", "brainstore"]
     else:
-        raise ValueError(f"Unknown service {args.service}")
+        services = [args.service]
+
+    log_group_names = []
+    for service in services:
+        if service == "api":
+            for name in ["APIHandlerJSName", "AIProxyFnName"]:
+                lambda_function = [x for x in stack["Outputs"] if x["OutputKey"] == name]
+                if len(lambda_function) > 1:
+                    raise ValueError(f"Expected 1 APIHandlerName, found {len(lambda_function)} ({lambda_function}))")
+                if len(lambda_function) == 0:
+                    _logger.warning(f"Could not find {name}, skipping...")
+                    continue
+                log_group_names.append(f"/aws/lambda/{lambda_function[0]['OutputValue']}")
+        elif service == "brainstore":
+            log_group_names.append(f"/braintrust/{args.name}/brainstore")
 
     start_time = int(time.time() - 3600 * args.hours) * 1000
 
     for log_group_name in log_group_names:
         print(f"--- LOG GROUP: {log_group_name}")
+
+        log_groups = logs.describe_log_groups(logGroupNamePrefix=log_group_name)["logGroups"]
+        if not any(group["logGroupName"] == log_group_name for group in log_groups):
+            print(f"Log group {log_group_name} does not exist")
+            continue
+
         all_streams = []
         first_start_time = None
         nextToken = None


### PR DESCRIPTION
## Brainstore can now be created in the CLI 
`braintrust install api my-stack --create --org-name myorg --enable-brainstore true --brainstore-instance-key-pair-name my-keypair --brainstore-license-key "brainstore-xyz..."`

Full list of CLI args:
```
  --enable-brainstore {None,true,false}
                        Enable Brainstore object-storage data backend
  --brainstore-license-key BRAINSTORE_LICENSE_KEY
                        The license key to use for Brainstore
  --brainstore-instance-key-pair-name BRAINSTORE_INSTANCE_KEY_PAIR_NAME
                        The EC2 Key Pair to allow SSH access to the Brainstore instance
  --brainstore-instance-type BRAINSTORE_INSTANCE_TYPE
                        EC2 instance type for Brainstore. Must be a Graviton instance type.
  --brainstore-instance-count BRAINSTORE_INSTANCE_COUNT
                        Number of Brainstore instances to run
  --brainstore-max-instance-count BRAINSTORE_MAX_INSTANCE_COUNT
                        Max scaling size for Brainstore instances
  --brainstore-version-override BRAINSTORE_VERSION_OVERRIDE
                        Lock Brainstore to a specific docker tag
```

## Brainstore Logs can be dumped in the CLI
Additionally, `braintrust install logs` now supports outputting logs from the brainstore Cloudwatch log group with `--service all` or `--service brainstore`

## Other changes:
* Removed old unused log group for `APIHandler`
* Bump timeout for creating a new stack from 10m to 20m. Elasticache, RDS, and Cloudfront are typically extremely slow to create.
* Error handling for when a log group doesn't exist
* Pretty print parameters