### PR TITLE
Proposal: Add ability to quickly run starter project on Val Town

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository contains the Python and Javascript SDKs for Braintrust. The SDKs
 - Manage an on-premises installation of Braintrust (Python)
 
 ## Quickstart: TypeScript
+[![Open Val Town Template](https://stevekrouse-badge.web.val.run/?3)](https://www.val.town/v/charmaine/braintrustSDK)
 
 First, install the Braintrust SDK:
 


### PR DESCRIPTION
Hey! I'd like to propose adding a [Val Town](https://www.val.town/dashboard) badge to your docs for new users to optionally have the `TypeScript Quickstart` up and running in 1-click. 

I work here at Val Town and it would mean the world to us to have a place in Braintrust's docs / open source repos! We're very open to any edits you'd like us to make here. 

Proposed badge in README:
[![Open Val Town Template](https://stevekrouse-badge.web.val.run/?3)](https://www.val.town/v/charmaine/braintrustSDK) 

In action:
![Clipboard-20250204-164701-118](https://github.com/user-attachments/assets/6bde6af2-4cf6-4fe9-bbde-0140951104eb)

The main benefits are:
1.  Users can see the full example code immediately and optionally fork the example code snippet
2.  Users can make changes and have it running in their account in 1-click. 
3.  Eliminates the need for users to set up their local dev environment (ie. node, npm) and run into errors outside of your SDK's control

We recently did this with [Steel's Cookbook](https://github.com/steel-dev/steel-cookbook/blob/main/examples/steel-puppeteer-starter/README.md) and they were [stoked about it](https://x.com/hussufo/status/1884332147122766090), so we wanted to try the same for Braintrust. We're all users and huge fans of Braintrust here!

We're happy to help maintain this starter in Val Town as your docs / SDK changes. You're also welcome to fork it so you have full control over the Val Town project and can make any changes as necessary. 

This PR should be ready-to-use as-is. We'd love to hear what you think!