### PR TITLE
Account for weird types that are returned by error.stack

### DIFF
--- a/js/src/stackutil.ts
+++ b/js/src/stackutil.ts
@@ -8,7 +8,7 @@ export interface StackTraceEntry {
 
 export function getStackTrace(): StackTraceEntry[] {
   const trace = new Error().stack;
-  if (trace === undefined) {
+  if (typeof trace !== "string") {
     return [];
   }
   const traceLines = trace.split("\n");


### PR DESCRIPTION
We have seen intermittent issues where trace.split seems to be running on something that is not a string. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack seems to indicate that the behavior may not be consistent. This is an attempt to address that.