### PR TITLE
Print but do not fail when scorers fail

### DIFF
--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -988,9 +988,9 @@ async function runEvaluatorInternal(
             const names = Object.keys(scorerErrors).join(", ");
             const errors = failingScorersAndResults.map((item) => item.error);
             unhandledScores = Object.keys(scorerErrors);
-            throw new AggregateError(
-              errors,
+            console.warn(
               `Found exceptions for the following scorers: ${names}`,
+              errors,
             );
           }
         } catch (e) {

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -1187,8 +1187,9 @@ async def _run_evaluator_internal(experiment, evaluator: Evaluator, position: Op
                     names = ", ".join(scorer_errors.keys())
                     exceptions = [x[1] for x in failing_scorers_and_exceptions]
                     unhandled_scores = list(scorer_errors.keys())
-                    raise exceptiongroup.ExceptionGroup(
-                        f"Found exceptions for the following scorers: {names}", exceptions
+                    eprint(
+                        f"Found exceptions for the following scorers: {names}",
+                        exceptions,
                     )
             except Exception as e:
                 exc_type, exc_value, tb = sys.exc_info()


### PR DESCRIPTION
We historically fail the whole eval case when a scorer fails. But now that we can report errors more granularly (per scorer), we don't really need to do this.

We still print the error to the terminal, but now let just the individual scorer fail. 

In the UI, it looks like this:

![CleanShot 2025-03-01 at 10 09 50](https://github.com/user-attachments/assets/fb04ef8f-2a57-43ab-aa63-dd83f2ddc1f8)
