### PR TITLE
Pass --no-ext-diff flag to git diff

### DIFF
--- a/js/src/gitutil.ts
+++ b/js/src/gitutil.ts
@@ -202,7 +202,7 @@ async function repoInfo() {
 
   if (dirty) {
     git_diff = await attempt(async () =>
-      truncateToByteLimit(await git.raw(["diff", "HEAD"])),
+      truncateToByteLimit(await git.raw(["--no-ext-diff", "diff", "HEAD"])),
     );
   }
 


### PR DESCRIPTION
If the user has an external diff provider setup in git the call to `git diff HEAD` hangs forever. The fix is to always pass the `--no-ext-diff` flag.