### PR TITLE
Fix: faulty token count dict lookup in openai-agents wrapper for python sdk

### DIFF
--- a/py/src/braintrust/wrappers/openai.py
+++ b/py/src/braintrust/wrappers/openai.py
@@ -152,20 +152,17 @@ class BraintrustTracingProcessor(tracing.TracingProcessor):
             metrics["prompt_tokens"] = usage["prompt_tokens"]
         elif "input_tokens" in usage:
             metrics["prompt_tokens"] = usage["input_tokens"]
-        else:
-            metrics["prompt_tokens"] = 0
 
         if "completion_tokens" in usage:
             metrics["completion_tokens"] = usage["completion_tokens"]
         elif "output_tokens" in usage:
             metrics["completion_tokens"] = usage["output_tokens"]
-        else:
-            metrics["completion_tokens"] = 0
 
         if "total_tokens" in usage:
             metrics["tokens"] = usage["total_tokens"]
-        else:
-            metrics["tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
+        elif "input_tokens" in usage and "output_tokens" in usage:
+            metrics["tokens"] = usage["input_tokens"] + usage["output_tokens"]
+        
 
         return {
             "input": span.span_data.input,

--- a/py/src/braintrust/wrappers/openai.py
+++ b/py/src/braintrust/wrappers/openai.py
@@ -162,7 +162,6 @@ class BraintrustTracingProcessor(tracing.TracingProcessor):
             metrics["tokens"] = usage["total_tokens"]
         elif "input_tokens" in usage and "output_tokens" in usage:
             metrics["tokens"] = usage["input_tokens"] + usage["output_tokens"]
-        
 
         return {
             "input": span.span_data.input,
@@ -173,7 +172,6 @@ class BraintrustTracingProcessor(tracing.TracingProcessor):
             },
             "metrics": metrics,
         }
-
 
     def _custom_log_data(self, span: tracing.Span[tracing.CustomSpanData]) -> Dict[str, Any]:
         return span.span_data.data


### PR DESCRIPTION
**Issue**:
When using the OpenRouter API, token usage data only includes the keys input_tokens and output_tokens, rather than the standard OpenAI keys (prompt_tokens, completion_tokens, total_tokens). This mismatch resulted in KeyError exceptions in the Braintrust tracing implementation.

code snippet:
```python
from agents import Agent, Runner, AsyncOpenAI, OpenAIChatCompletionsModel, set_trace_processors
from braintrust import init_logger
from braintrust.wrappers.openai import BraintrustTracingProcessor
from src.config import settings


openai_provider = AsyncOpenAI(
  api_key=settings.OPENROUTER_API_KEY,
  base_url=settings.OPENROUTER_BASE_URL,
)

tool_model = OpenAIChatCompletionsModel(
    openai_client=openai_provider,
    model="google/gemini-2.0-flash-lite-preview-02-05:free"
)
tool_agent = Agent(
    name="Tool Agent",
    instructions="You are a tool agent that can answer questions.",
    model=tool_model,
)

async def main():
    result = await Runner.run(tool_agent, "How do you predict the chinese EV stock market will perform in 2025?")
    print(result.raw_responses)
        

if __name__ == "__main__":
    import asyncio
    set_trace_processors([BraintrustTracingProcessor(init_logger("test"))])
    asyncio.run(main())
```

**Solution**:
This PR adds explicit conditional checks for each token key. If the expected keys (prompt_tokens, completion_tokens, total_tokens) are missing, it safely defaults their values to 0. This ensures robust handling across different API providers.

**Additional considerations**:
A future improvement would be logging a warning when expected token usage keys are missing, to aid debugging and transparency.

**error log**
```RAW
(base) kristianernst@MacBookPro agent % python -m src.graphs.ag
**** DEBUG::USAGE KEYS: dict_keys(['input_tokens', 'output_tokens'])
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/kristianernst/Work/Learning/projects/co/ClariQ/services/agent/src/graphs/ag.py", line 105, in <module>
    asyncio.run(main())
  File "/Users/kristianernst/miniconda3/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/Users/kristianernst/miniconda3/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kristianernst/miniconda3/lib/python3.12/asyncio/base_events.py", line 685, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/kristianernst/Work/Learning/projects/co/ClariQ/services/agent/src/graphs/ag.py", line 98, in main
    result = await Runner.run(tool_agent, "How do you predict the chinese EV stock market will perform in 2025?")
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kristianernst/miniconda3/lib/python3.12/site-packages/agents/run.py", line 210, in run
    input_guardrail_results, turn_result = await asyncio.gather(
                                           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kristianernst/miniconda3/lib/python3.12/site-packages/agents/run.py", line 719, in _run_single_turn
    new_response = await cls._get_new_response(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kristianernst/miniconda3/lib/python3.12/site-packages/agents/run.py", line 862, in _get_new_response
    new_response = await model.get_response(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kristianernst/miniconda3/lib/python3.12/site-packages/agents/models/openai_chatcompletions.py", line 112, in get_response
    with generation_span(
  File "/Users/kristianernst/miniconda3/lib/python3.12/site-packages/agents/tracing/spans.py", line 237, in __exit__
    self.finish(reset_current=reset_current)
  File "/Users/kristianernst/miniconda3/lib/python3.12/site-packages/agents/tracing/spans.py", line 222, in finish
    self._processor.on_span_end(self)
  File "/Users/kristianernst/miniconda3/lib/python3.12/site-packages/agents/tracing/setup.py", line 65, in on_span_end
    processor.on_span_end(span)
  File "/Users/kristianernst/miniconda3/lib/python3.12/site-packages/braintrust/wrappers/openai.py", line 198, in on_span_end
    s.log(error=span.error, **self._log_data(span))
                              ^^^^^^^^^^^^^^^^^^^^
  File "/Users/kristianernst/miniconda3/lib/python3.12/site-packages/braintrust/wrappers/openai.py", line 178, in _log_data
    return self._generation_log_data(span)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kristianernst/miniconda3/lib/python3.12/site-packages/braintrust/wrappers/openai.py", line 149, in _generation_log_data
    metrics["tokens"] = span.span_data.usage["total_tokens"]
                        ~~

```

