### PR TITLE
Remove pytest-watch to unbreak builds with setuptools v78.0.0

### DIFF
--- a/integrations/langchain-py/setup.py
+++ b/integrations/langchain-py/setup.py
@@ -28,7 +28,6 @@ dev_requires = [
     "isort==5.12.0",
     "pre-commit",
     "pytest",
-    "pytest-watch",
     "responses",
     "respx",
     "tenacity",


### PR DESCRIPTION
https://github.com/joeyespo/pytest-watch/issues/134

Removing this package to unblock builds, we can investigate using `pytest-watcher` or some maintained replacement for `pytest-watch` later