### PR TITLE
Initialize global background logger lazily.

### DIFF
--- a/js/src/util.ts
+++ b/js/src/util.ts
@@ -81,6 +81,35 @@ export class LazyValue<T> {
   }
 }
 
+// Synchronous version of LazyValue.
+export class SyncLazyValue<T> {
+  private callable: () => T;
+  private value:
+    | { computedState: "succeeded"; val: T }
+    | { computedState: "uninitialized" } = {
+    computedState: "uninitialized",
+  };
+
+  constructor(callable: () => T) {
+    this.callable = callable;
+  }
+
+  get(): T {
+    if (this.value.computedState !== "uninitialized") {
+      return this.value.val;
+    }
+    const result = this.callable();
+    this.value = { computedState: "succeeded", val: result };
+    return result;
+  }
+
+  // If this is true, the caller should be able to obtain the SyncLazyValue without
+  // it throwing.
+  public get hasSucceeded(): boolean {
+    return this.value.computedState === "succeeded";
+  }
+}
+
 export function addAzureBlobHeaders(
   headers: Record<string, string>,
   url: string,

--- a/py/src/braintrust/__init__.py
+++ b/py/src/braintrust/__init__.py
@@ -54,7 +54,7 @@ from .framework2 import *
 from .functions.invoke import *
 from .functions.stream import *
 from .logger import *
-from .logger import _internal_reset_global_state, _internal_with_custom_background_logger
+from .logger import _internal_get_global_state, _internal_reset_global_state, _internal_with_custom_background_logger
 from .oai import wrap_openai
 from .types import *
 from .util import BT_IS_ASYNC_ATTRIBUTE, MarkAsyncWrapper


### PR DESCRIPTION
This way it will pick up any initialization-time environment variable settings the first time it is used, rather than when the module is first imported.