### PR TITLE
Add nox tests.

### DIFF
--- a/.github/workflows/py.yaml
+++ b/.github/workflows/py.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: pnpm/action-setup@v4
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools build twine openai pylint anthropic
+          python -m pip install --upgrade pip setuptools build twine openai pylint anthropic nox
       - name: Test whether the Python SDK can be installed
         run: |
           python -m pip install -e ./core/py[all]
@@ -62,3 +62,6 @@ jobs:
           python -m unittest discover ./py/src
           pytest ./integrations/langchain-py/src
           pytest ./py/src
+      - name: Run nox tests
+        run: |
+          make nox

--- a/Makefile
+++ b/Makefile
@@ -34,15 +34,18 @@ develop: ${VENV_PRE_COMMIT}
 fixup:
 	source env.sh && pre-commit run --all-files
 
-.PHONY: test test-py test-js
+.PHONY: test test-py test-js nox
 
 test: test-py-core test-py-sdk test-js
 
 test-py-core:
 	source env.sh && python -m unittest discover ./core/py/src
 
-test-py-sdk:
+test-py-sdk: nox
 	source env.sh && cd py && pytest
 
 test-js:
 	pnpm install && pnpm test
+
+nox:
+	nox -f py/noxfile.py

--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -1,0 +1,31 @@
+"""
+Define our tests to run against different combinations of
+Python & library versions.
+"""
+
+
+import nox
+
+LATEST = "__latest__"
+SRC = "src/braintrust"
+
+
+ANTHROPIC_VERSIONS = ("0.48.0", "0.49.0", LATEST)
+
+
+@nox.session()
+@nox.parametrize("version", ANTHROPIC_VERSIONS)
+def test_anthropic(session, version):
+    """Run pytest against a specific version of the anthropic SDK."""
+
+    _install(session, "anthropic", version)
+
+    # Run your tests
+    session.run("pytest", f"{SRC}/wrappers/test_anthropic.py", external=True)
+
+
+def _install(session, package, version=LATEST):
+    cmd = f"{package}=={version}"
+    if version == LATEST or not version:
+        cmd = package
+    session.run("pip", "install", cmd)

--- a/py/setup.py
+++ b/py/setup.py
@@ -37,6 +37,7 @@ extras_require = {
         "pytest",
         "twine",
         "pytest-asyncio",
+        "nox",
     ],
     "doc": ["pydoc-markdown"],
     "openai-agents": ["openai-agents"],


### PR DESCRIPTION
Nox is used for scriptable testing. We're using it to test against multiple versions of the anthropic library and most importantly always the latest version of the library so we'll catch any updates that we don't play nicely with.