### PR TITLE
anthropic: ensure the library runs without anthropic

### DIFF
--- a/.github/workflows/py.yaml
+++ b/.github/workflows/py.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: pnpm/action-setup@v4
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools build twine openai pylint anthropic nox
+          python -m pip install --upgrade pip setuptools build twine openai pylint nox
       - name: Test whether the Python SDK can be installed
         run: |
           python -m pip install -e ./core/py[all]

--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -3,11 +3,17 @@ Define our tests to run against different combinations of
 Python & library versions.
 """
 
-
 import nox
 
 LATEST = "__latest__"
 SRC = "src/braintrust"
+
+
+ERROR_CODES = tuple(range(1, 256))
+
+# List your package here if it's not guaranteed to be installed. We'll (try to)
+# validate things work with or with them.
+VENDOR_PACKAGES = ("anthropic", "openai")
 
 
 ANTHROPIC_VERSIONS = ("0.48.0", "0.49.0", LATEST)
@@ -18,7 +24,12 @@ def test_no_deps(session):
     """Ensure that with no dependencies, we can still import and use the
     library.
     """
-    _install_deps(session)
+    _install_test_deps(session)
+
+    # verify we haven't installed our 3p deps.
+    for p in VENDOR_PACKAGES:
+        session.run("python", "-c", f"import {p}", success_codes=ERROR_CODES)
+
     session.run("python", "-c", "import braintrust")
     session.run("pytest", SRC, f"--ignore={SRC}/wrappers")
 
@@ -26,19 +37,17 @@ def test_no_deps(session):
 @nox.session()
 @nox.parametrize("version", ANTHROPIC_VERSIONS)
 def test_anthropic(session, version):
-    _install_deps(session)
+    _install_test_deps(session)
     _install(session, "anthropic", version)
     session.run("pytest", f"{SRC}/wrappers/test_anthropic.py")
 
 
-def _install_deps(session):
-    # Install our test dependencies in this session's venv.
+def _install_test_deps(session):
     session.install("pytest")
     session.install("-e", ".[test]")
 
 
 def _install(session, package, version=LATEST):
-    # install into this session's venv
     cmd = f"{package}=={version}"
     if version == LATEST or not version:
         cmd = package

--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -12,7 +12,7 @@ SRC = "src/braintrust"
 ERROR_CODES = tuple(range(1, 256))
 
 # List your package here if it's not guaranteed to be installed. We'll (try to)
-# validate things work with or with them.
+# validate things work with or without them.
 VENDOR_PACKAGES = ("anthropic", "openai")
 
 

--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -18,32 +18,27 @@ def test_no_deps(session):
     """Ensure that with no dependencies, we can still import and use the
     library.
     """
-    session.install("pytest")
-    session.install("-e", ".[test]")
-
-    # make sure we can import the library
+    _install_deps(session)
     session.run("python", "-c", "import braintrust")
-
-    # run tests that don't require any dependencies
     session.run("pytest", SRC, f"--ignore={SRC}/wrappers")
 
 
 @nox.session()
 @nox.parametrize("version", ANTHROPIC_VERSIONS)
 def test_anthropic(session, version):
-    """Run pytest against a specific version of
-    the anthropic SDK."""
-
-    session.install("pytest")
-    session.install("-e", ".[test]")
-
+    _install_deps(session)
     _install(session, "anthropic", version)
-
-    # Run your tests
     session.run("pytest", f"{SRC}/wrappers/test_anthropic.py")
 
 
+def _install_deps(session):
+    # Install our test dependencies in this session's venv.
+    session.install("pytest")
+    session.install("-e", ".[test]")
+
+
 def _install(session, package, version=LATEST):
+    # install into this session's venv
     cmd = f"{package}=={version}"
     if version == LATEST or not version:
         cmd = package

--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -14,14 +14,33 @@ ANTHROPIC_VERSIONS = ("0.48.0", "0.49.0", LATEST)
 
 
 @nox.session()
+def test_no_deps(session):
+    """Ensure that with no dependencies, we can still import and use the
+    library.
+    """
+    session.install("pytest")
+    session.install("-e", ".[test]")
+
+    # make sure we can import the library
+    session.run("python", "-c", "import braintrust")
+
+    # run tests that don't require any dependencies
+    session.run("pytest", SRC, f"--ignore={SRC}/wrappers")
+
+
+@nox.session()
 @nox.parametrize("version", ANTHROPIC_VERSIONS)
 def test_anthropic(session, version):
-    """Run pytest against a specific version of the anthropic SDK."""
+    """Run pytest against a specific version of
+    the anthropic SDK."""
+
+    session.install("pytest")
+    session.install("-e", ".[test]")
 
     _install(session, "anthropic", version)
 
     # Run your tests
-    session.run("pytest", f"{SRC}/wrappers/test_anthropic.py", external=True)
+    session.run("pytest", f"{SRC}/wrappers/test_anthropic.py")
 
 
 def _install(session, package, version=LATEST):

--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -44,6 +44,7 @@ def test_anthropic(session, version):
 
 def _install_test_deps(session):
     session.install("pytest")
+    session.install("pytest-asyncio")
     session.install("-e", ".[test]")
 
 

--- a/py/setup.py
+++ b/py/setup.py
@@ -41,6 +41,8 @@ extras_require = {
     ],
     "doc": ["pydoc-markdown"],
     "openai-agents": ["openai-agents"],
+    # These should only be installed for linting import errors, not for tests.
+    "lint": ["anthropic"],
 }
 
 extras_require["all"] = sorted({package for packages in extras_require.values() for package in packages})

--- a/py/src/braintrust/wrappers/anthropic.py
+++ b/py/src/braintrust/wrappers/anthropic.py
@@ -1,8 +1,6 @@
 import logging
 from typing import Any
 
-import anthropic
-
 from braintrust import span_types
 from braintrust.logger import start_span
 
@@ -31,7 +29,7 @@ class Wrapper:
 
 
 class TracedAnthropic(Wrapper):
-    def __init__(self, client: anthropic.Anthropic):
+    def __init__(self, client):
         super().__init__(client)
         self.__client = client
 
@@ -218,6 +216,6 @@ def wrap_anthropic(client):
     return TracedAnthropic(client)
 
 
-def wrap_anthropic_client(client: anthropic.Anthropic):
+def wrap_anthropic_client(client):
     # for backwards compatibility
     return TracedAnthropic(client)


### PR DESCRIPTION
- `wrap_anthropic` would fail if anthropic wasn't installed
-  fixed the nox tests (which weren't quite running properly)
- added some tests to ensure our library can always be imported and run core tests without extra dependencies