### PR TITLE
Add an attribute check for `responses` in OpenAI 

### DIFF
--- a/py/src/braintrust/oai.py
+++ b/py/src/braintrust/oai.py
@@ -677,10 +677,11 @@ class OpenAIV1Wrapper(NamedWrapper):
         if hasattr(openai, "beta"):
             self.beta = BetaV1Wrapper(openai.beta)
 
-        if type(openai.responses) == oai.resources.responses.responses.AsyncResponses:
-            self.responses = AsyncResponsesV1Wrapper(openai.responses)
-        else:
-            self.responses = ResponsesV1Wrapper(openai.responses)
+        if hasattr(openai, "responses"):
+            if type(openai.responses) == oai.resources.responses.responses.AsyncResponses:
+                self.responses = AsyncResponsesV1Wrapper(openai.responses)
+            else:
+                self.responses = ResponsesV1Wrapper(openai.responses)
 
         if type(openai.embeddings) == oai.resources.embeddings.AsyncEmbeddings:
             self.embeddings = AsyncEmbeddingV1Wrapper(openai.embeddings)


### PR DESCRIPTION
Running `LLMClassifier` eval in Python produces the following traceback on `openai==1.65.2` for me.

```
Traceback (most recent call last):
  File "/Users/.../agent-backend/classifier.py", line 32, in <module>
    result = classifier.eval(output="""
  File "/Users/.../agent-backend/.venv/lib/python3.10/site-packages/braintrust_core/score.py", line 47, in eval
    return self._run_eval_sync(output, expected, **kwargs)
  File "/Users/.../agent-backend/.venv/lib/python3.10/site-packages/autoevals/llm.py", line 261, in _run_eval_sync
    return self._postprocess_response(run_cached_request(**self._request_args(output, expected, **kwargs)))
  File "/Users/.../agent-backend/.venv/lib/python3.10/site-packages/autoevals/oai.py", line 383, in run_cached_request
    wrapper = prepare_openai(client=client, is_async=False, api_key=api_key, base_url=base_url)
  File "/Users/.../agent-backend/.venv/lib/python3.10/site-packages/autoevals/oai.py", line 358, in prepare_openai
    return LLMClient(openai=openai_obj, is_async=is_async)
  File "<string>", line 10, in __init__
  File "/Users/.../agent-backend/.venv/lib/python3.10/site-packages/autoevals/oai.py", line 178, in __post_init__
    self.openai = wrap_openai(self.openai)
  File "/Users/.../agent-backend/.venv/lib/python3.10/site-packages/braintrust/oai.py", line 705, in wrap_openai
    return OpenAIV1Wrapper(openai)
  File "/Users/.../agent-backend/.venv/lib/python3.10/site-packages/braintrust/oai.py", line 681, in __init__
    if type(openai.responses) == oai.resources.responses.responses.AsyncResponses:
AttributeError: 'OpenAI' object has no attribute 'responses'
```

This PR adds a check for the ‘responses’ attribute before accessing it which fixed the error for me. 

Please let me know if there's any formatting or best practices this PR needs to follow. I wasn't able to find anything on contributing guidelines in the repo. 