### PR TITLE
fix(ai-sdk): do not set time_to_first_token to the latest token

### DIFF
--- a/js/src/wrappers/ai-sdk.ts
+++ b/js/src/wrappers/ai-sdk.ts
@@ -220,7 +220,7 @@ class BraintrustLanguageModelWrapper implements LanguageModelV1 {
                   finishReason!,
                 ),
                 metrics: {
-                  time_to_first_token: getCurrentUnixTimestamp() - startTime,
+                  time_to_first_token,
                   tokens: !isEmpty(usage)
                     ? usage.promptTokens + usage.completionTokens
                     : undefined,


### PR DESCRIPTION
The AI SDK wrapper function `wrapAISDKModel` is setting `time_to_first_token` again after finishing the stream, causing wrong metrics in the dashboard.

This PR sends the correct one (the one set on first token).