### PR TITLE
Remove fallback to legacy `/logs` endpoint when logging

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,8 @@
 # Any changes to deps / build configuration need additional scrutiny.
+#
+# For example, adding a required dependency to core or SDK will make it required
+# for all users of the SDK, so we should be extremely careful about which
+# dependencies we add.
 py/setup.py @ankrgyl @manugoyal
 core/py/setup.py @ankrgyl @manugoyal
 js/package.json @ankrgyl @manugoyal

--- a/core/js/src/object.ts
+++ b/core/js/src/object.ts
@@ -203,26 +203,3 @@ export function ensureNewDatasetRecord(
   delete row.output;
   return row;
 }
-
-export function makeLegacyEvent(e: BackgroundLogEvent): BackgroundLogEvent {
-  if (!("dataset_id" in e) || !("expected" in e)) {
-    return e;
-  }
-
-  const event = {
-    ...e,
-    output: e.expected,
-  };
-  delete event.expected;
-
-  if (MERGE_PATHS_FIELD in event) {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    for (const path of (event[MERGE_PATHS_FIELD] || []) as string[][]) {
-      if (path.length > 0 && path[0] === "expected") {
-        path[0] = "output";
-      }
-    }
-  }
-
-  return event;
-}

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -19,7 +19,6 @@ import {
   IdField,
   IS_MERGE_FIELD,
   LogFeedbackFullArgs,
-  makeLegacyEvent,
   mergeDicts,
   mergeGitMetadataSettings,
   mergeRowBatch,
@@ -2130,16 +2129,8 @@ class HTTPBackgroundLogger implements BackgroundLogger {
       let error: unknown = undefined;
       try {
         await conn.post_json("logs3", dataStr);
-      } catch {
-        // Fallback to legacy API. Remove once all API endpoints are updated.
-        try {
-          const legacyDataS = constructJsonArray(
-            items.map((r) => JSON.stringify(makeLegacyEvent(JSON.parse(r)))),
-          );
-          await conn.post_json("logs", legacyDataS);
-        } catch (e) {
-          error = e;
-        }
+      } catch (e) {
+        error = e;
       }
       if (error === undefined) {
         return;

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -67,7 +67,7 @@ from .db_fields import (
 from .git_fields import GitMetadataSettings, RepoInfo
 from .gitutil import get_past_n_ancestors, get_repo_info
 from .merge_row_batch import batch_items, merge_row_batch
-from .object import DEFAULT_IS_LEGACY_DATASET, ensure_dataset_record, make_legacy_event
+from .object import DEFAULT_IS_LEGACY_DATASET, ensure_dataset_record
 from .prompt import BRAINTRUST_PARAMS, ImagePart, PromptBlockData, PromptMessage, PromptSchema, TextPart
 from .prompt_cache.disk_cache import DiskCache
 from .prompt_cache.lru_cache import LRUCache
@@ -831,9 +831,6 @@ class _HTTPBackgroundLogger:
         for i in range(self.num_tries):
             start_time = time.time()
             resp = conn.post("/logs3", data=dataStr)
-            if not resp.ok:
-                legacyDataS = construct_json_array([json.dumps(make_legacy_event(json.loads(r))) for r in items])
-                resp = conn.post("/logs", data=legacyDataS)
             if resp.ok:
                 return
             resp_errmsg = f"{resp.status_code}: {resp.text}"

--- a/py/src/braintrust/object.py
+++ b/py/src/braintrust/object.py
@@ -27,18 +27,3 @@ def ensure_new_dataset_record(r: DatasetEvent) -> DatasetEvent:
     row = r.copy()
     row["expected"] = row.pop("output")
     return row
-
-
-def make_legacy_event(e: Mapping[str, Any]) -> Mapping[str, Any]:
-    if "dataset_id" not in e or "expected" not in e:
-        return e
-
-    event = {**e}
-    event["output"] = event.pop("expected")
-
-    if MERGE_PATHS_FIELD in event:
-        for path in event[MERGE_PATHS_FIELD] or []:
-            if len(path) > 0 and path[0] == "expected":
-                path[0] = "output"
-
-    return event


### PR DESCRIPTION
Data planes have supported the `/logs3` endpoint for long-enough that we don't expect users of new SDKs to rely on this fallback. The fallback essentially doubles the number of retries against the data plane from 3 to 6, so this will also bring that down to 3. We can consider re-bumping that if necessary.