### PR TITLE
python release actions

### DIFF
--- a/.github/workflows/publish-py-sdk.yaml
+++ b/.github/workflows/publish-py-sdk.yaml
@@ -31,7 +31,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install -e "py[dev]"
+          python -m pip install -e "py[all]"
           python -m pip install --upgrade pip setuptools build twine pylint nox
       - name: Verify the code
         run: |

--- a/.github/workflows/publish-py-sdk.yaml
+++ b/.github/workflows/publish-py-sdk.yaml
@@ -1,71 +1,64 @@
-name: Release Python SDK
+name: publish-py-sdk
 
 on:
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: "Commit SHA or tag to release"
-        required: true
-        type: choice
-        options:
-          - ${{ github.event.repository.default_branch }}
-          - ${{ steps.get-tags.outputs.tags }}
-          - ${{ steps.get-commits.outputs.commits }}
+  # FIXME[matt] this is only for testing and needs to be removed before we actually
+  # push to PyPI.
+  pull_request:
 
 jobs:
-  get-refs:
+  test:
     runs-on: ubuntu-latest
-    outputs:
-      ref: ${{ steps.set-ref.outputs.ref }}
-    steps:
-      - name: Get tags
-        id: get-tags
-        run: |
-          echo "tags=$(git tag | tr '\n' ',' | sed 's/,$//')" >> $GITHUB_OUTPUT
 
-      - name: Get recent commits
-        id: get-commits
-        run: |
-          echo "commits=$(git log --pretty=format:'%H' -n 20 | tr '\n' ',' | sed 's/,$//')" >> $GITHUB_OUTPUT
+    strategy:
+      # As of 2024-11-08, this test takes roughly 60 seconds. There is not much benefit to fail-fast.
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
 
-      - name: Set ref
-        id: set-ref
-        run: |
-          echo "ref=${{ inputs.ref }}" >> $GITHUB_OUTPUT
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY}}
 
-  run-tests:
-    needs: get-refs
-    uses: ./.github/workflows/py.yaml
-    with:
-      ref: ${{ needs.get-refs.outputs.ref }}
-
-  publish:
-    needs: run-tests
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
-          ref: ${{ needs.get-refs.outputs.ref }}
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools build twine pylint nox
+      - name: Verify the code
+        run: |
+          make py-sdk-verify-ci
+  build:
+    needs: test
 
+    runs-on: ubuntu-latest
+
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY}}
+
+    steps:
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-
       - name: Install build dependencies
         run: |
-          python -m pip install --upgrade pip setuptools build twine
-
-      - name: Template git commit hash
-        run: make template-version
-
-      - name: Build wheel
+          python -m pip install --upgrade pip setuptools build twine pylint nox
+      - name: Build and test the wheel
         run: |
-          python -m build --wheel ./py
+          make py-sdk-build-and-test
 
-      - name: Publish to TestPyPI
-        run: |
-          python -m twine upload --repository testpypi dist/*.whl
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
+      #- name: Publish to TestPyPI
+      #  run: |
+      #python -m twine upload --repository testpypi dist/*.whl
+      #  env:
+      #    TWINE_USERNAME: __token__
+      #    TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}

--- a/.github/workflows/publish-py-sdk.yaml
+++ b/.github/workflows/publish-py-sdk.yaml
@@ -1,0 +1,71 @@
+name: Release Python SDK
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Commit SHA or tag to release"
+        required: true
+        type: choice
+        options:
+          - ${{ github.event.repository.default_branch }}
+          - ${{ steps.get-tags.outputs.tags }}
+          - ${{ steps.get-commits.outputs.commits }}
+
+jobs:
+  get-refs:
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.set-ref.outputs.ref }}
+    steps:
+      - name: Get tags
+        id: get-tags
+        run: |
+          echo "tags=$(git tag | tr '\n' ',' | sed 's/,$//')" >> $GITHUB_OUTPUT
+
+      - name: Get recent commits
+        id: get-commits
+        run: |
+          echo "commits=$(git log --pretty=format:'%H' -n 20 | tr '\n' ',' | sed 's/,$//')" >> $GITHUB_OUTPUT
+
+      - name: Set ref
+        id: set-ref
+        run: |
+          echo "ref=${{ inputs.ref }}" >> $GITHUB_OUTPUT
+
+  run-tests:
+    needs: get-refs
+    uses: ./.github/workflows/py.yaml
+    with:
+      ref: ${{ needs.get-refs.outputs.ref }}
+
+  publish:
+    needs: run-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.get-refs.outputs.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools build twine
+
+      - name: Template git commit hash
+        run: make template-version
+
+      - name: Build wheel
+        run: |
+          python -m build --wheel ./py
+
+      - name: Publish to TestPyPI
+        run: |
+          python -m twine upload --repository testpypi dist/*.whl
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}

--- a/.github/workflows/publish-py-sdk.yaml
+++ b/.github/workflows/publish-py-sdk.yaml
@@ -31,6 +31,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
+          python -m pip install -e "py[dev]"
           python -m pip install --upgrade pip setuptools build twine pylint nox
       - name: Verify the code
         run: |

--- a/.github/workflows/publish-py-sdk.yaml
+++ b/.github/workflows/publish-py-sdk.yaml
@@ -1,12 +1,36 @@
 name: publish-py-sdk
 
 on:
-  # FIXME[matt] this is only for testing and needs to be removed before we actually
-  # push to PyPI.
-  pull_request:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Select tag or branch"
+        type: choice
+        required: true
+        options: ${{ steps.get_refs.outputs.refs }}
 
 jobs:
+  # First job to get available refs
+  get_refs:
+    runs-on: ubuntu-latest
+    outputs:
+      refs: ${{ steps.set_refs.outputs.refs }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: set_refs
+        run: |
+          # Get tags starting with v, sort descending
+          TAGS=$(git tag -l "v*" | sort -r)
+          # Get branches
+          BRANCHES=$(git branch -r | sed 's/origin\///')
+          # Combine and format as JSON array
+          REFS=$(echo -e "$TAGS\n$BRANCHES" | jq -R -s -c 'split("\n")[:-1]')
+          echo "refs=$REFS" >> $GITHUB_OUTPUT
+
   test:
+    needs: get_refs
     runs-on: ubuntu-latest
 
     strategy:
@@ -25,6 +49,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -36,9 +62,9 @@ jobs:
       - name: Verify the code
         run: |
           make py-sdk-verify-ci
+
   build:
     needs: test
-
     runs-on: ubuntu-latest
 
     env:
@@ -48,6 +74,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref }}
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/publish-py-sdk.yaml
+++ b/.github/workflows/publish-py-sdk.yaml
@@ -43,6 +43,8 @@ jobs:
 
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY}}
+      TWINE_USERNAME: __token__
+      TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -53,13 +55,6 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip setuptools build twine pylint nox
-      - name: Build and test the wheel
+      - name: Build, test and publish to TestPyPI
         run: |
-          make py-sdk-build-and-test
-
-      #- name: Publish to TestPyPI
-      #  run: |
-      #python -m twine upload --repository testpypi dist/*.whl
-      #  env:
-      #    TWINE_USERNAME: __token__
-      #    TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
+          make py-sdk-build-test-publish-testpypi

--- a/.github/workflows/publish-py-sdk.yaml
+++ b/.github/workflows/publish-py-sdk.yaml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   test:
-    needs: get_refs
     runs-on: ubuntu-latest
 
     strategy:
@@ -25,7 +24,8 @@ jobs:
           - "3.13"
 
     env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY}}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY}}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-py-sdk.yaml
+++ b/.github/workflows/publish-py-sdk.yaml
@@ -4,31 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "Select tag or branch"
-        type: choice
+        description: "Enter tag or branch name (e.g., 'v1.2.3', 'main')"
+        type: string
         required: true
-        options: ${{ steps.get_refs.outputs.refs }}
 
 jobs:
-  # First job to get available refs
-  get_refs:
-    runs-on: ubuntu-latest
-    outputs:
-      refs: ${{ steps.set_refs.outputs.refs }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - id: set_refs
-        run: |
-          # Get tags starting with v, sort descending
-          TAGS=$(git tag -l "v*" | sort -r)
-          # Get branches
-          BRANCHES=$(git branch -r | sed 's/origin\///')
-          # Combine and format as JSON array
-          REFS=$(echo -e "$TAGS\n$BRANCHES" | jq -R -s -c 'split("\n")[:-1]')
-          echo "refs=$REFS" >> $GITHUB_OUTPUT
-
   test:
     needs: get_refs
     runs-on: ubuntu-latest
@@ -45,7 +25,7 @@ jobs:
           - "3.13"
 
     env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY}}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
     steps:
       - uses: actions/checkout@v4
@@ -68,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY}}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       TWINE_USERNAME: __token__
       TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
 

--- a/.github/workflows/py.yaml
+++ b/.github/workflows/py.yaml
@@ -64,3 +64,25 @@ jobs:
       - name: Run nox tests
         run: |
           make nox
+
+  upload-wheel:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools build
+      - name: Build wheel
+        run: |
+          python -m build --wheel ./py
+      - name: Upload wheel as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-wheel
+          path: py/dist/*.whl
+          retention-days: 5

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test-js:
 	pnpm install && pnpm test
 
 nox:
-	nox -f py/noxfile.py
+	nox -f py/noxfile.py -k code
 	nox -f integrations/langchain-py/noxfile.py
 
 pylint:

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ develop: ${VENV_PRE_COMMIT}
 fixup:
 	source env.sh && pre-commit run --all-files
 
-.PHONY: test test-py test-js nox pylint
+.PHONY: test test-py test-js nox pylint template-version
 
 test: test-py-core test-py-sdk test-js
 
@@ -53,3 +53,6 @@ nox:
 
 pylint:
 	@pylint --errors-only $(shell git ls-files 'py/**/*.py')
+
+save-git-commit-id:
+	@GIT_COMMIT=$$(git rev-parse HEAD) && sed -i '' "s/__GIT_COMMIT__/$$GIT_COMMIT/g" py/src/braintrust/version.py

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,8 @@ pylint:
 	@pylint --errors-only $(shell git ls-files 'py/**/*.py')
 
 save-git-commit-id:
-	@GIT_COMMIT=$$(git rev-parse HEAD) && sed -i '' "s/__GIT_COMMIT__/$$GIT_COMMIT/g" py/src/braintrust/version.py
+	# a bit verbose but works on linux and osx
+	@REF=$$(git rev-parse HEAD) && sed -i.bak "s/__GIT_COMMIT__/$$REF/g" py/src/braintrust/version.py && rm -f py/src/braintrust/version.py.bak
 
 
 #----------------------
@@ -68,9 +69,8 @@ py-sdk-lint:
 	@pylint --errors-only py/src py/examples
 
 # Build our wheel with the current git commit hash baked in.
-py-sdk-build:
+py-sdk-build: save-git-commit-id
 	rm -rf dist
-	@GIT_COMMIT=$$(git rev-parse HEAD) && sed -i '' "s/__GIT_COMMIT__/$$GIT_COMMIT/g" py/src/braintrust/version.py
 	cd py && python -m build
 	git checkout py/src/braintrust/version.py
 
@@ -78,6 +78,7 @@ py-sdk-build:
 py-sdk-test-code:
 	nox -f py/noxfile.py -k code
 
+# Run all tests against the most recently built wheel.
 py-sdk-test-wheel:
 	nox -f py/noxfile.py -k wheel
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test-js:
 	pnpm install && pnpm test
 
 nox:
-	nox -f py/noxfile.py -k code
+	nox -f py/noxfile.py
 	nox -f integrations/langchain-py/noxfile.py
 
 pylint:

--- a/Makefile
+++ b/Makefile
@@ -72,11 +72,11 @@ py-sdk-build: update-sdk-version-py
 
 # Run all tests against the current source.
 py-sdk-test-code:
-	nox -f py/noxfile.py -k code
+	nox -f py/noxfile.py
 
 # Run all tests against the most recently built wheel.
 py-sdk-test-wheel:
-	nox -f py/noxfile.py -k wheel
+	nox -f py/noxfile.py -- --wheel
 
 # do everything the ci needs to do to check our code
 py-sdk-verify-ci: fixup py-sdk-lint py-sdk-test-code

--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -3,14 +3,23 @@ Define our tests to run against different combinations of
 Python & library versions.
 """
 
+import glob
+
 import nox
 
 LATEST = "__latest__"
 SRC = "src/braintrust"
+DIST = "dist"
 
 SILENT_INSTALLS = True
 
 ERROR_CODES = tuple(range(1, 256))
+
+# The source of the braintrust package. We can test it against source code
+# or a built wheel. Run `nox -k code` for your normal dev flow.
+CODE = "code"
+WHEEL = "wheel"
+BT_SOURCES = (CODE, WHEEL)
 
 # List your package here if it's not guaranteed to be installed. We'll (try to)
 # validate things work with or without them.
@@ -30,9 +39,19 @@ AUTOEVALS_VERSIONS = (LATEST, "0.0.129")
 
 
 @nox.session()
-def test_core(session):
+@nox.parametrize("source", BT_SOURCES)
+def test_core(session, source):
     """Test the core library with no optional dependencies installed."""
-    _install_test_deps(session)
+    _install_test_deps(session, source)
+
+    if source == WHEEL:
+        # sanity check we have installed from the wheel.
+        lines = [
+            "import sys, braintrust as b",
+            "sys.exit(0 if 'site-packages' in b.__file__ else 1)",
+        ]
+        session.run("python", "-c", ";".join(lines), silent=True)
+
     # verify we haven't installed our 3p deps.
     for p in VENDOR_PACKAGES:
         session.run("python", "-c", f"import {p}", success_codes=ERROR_CODES, silent=True)
@@ -42,8 +61,9 @@ def test_core(session):
 
 @nox.session()
 @nox.parametrize("pydantic_ai_version", PYDANTIC_AI_VERSIONS)
-def test_with_pydantic_ai(session, pydantic_ai_version):
-    _install_test_deps(session)
+@nox.parametrize("source", BT_SOURCES)
+def test_with_pydantic_ai(session, pydantic_ai_version, source):
+    _install_test_deps(session, source)
     _install(session, "pydantic_ai", pydantic_ai_version)
     session.run("pytest", f"{SRC}/wrappers/test_pydantic_ai.py")
     _run_common_tests(session)
@@ -51,8 +71,9 @@ def test_with_pydantic_ai(session, pydantic_ai_version):
 
 @nox.session()
 @nox.parametrize("version", ANTHROPIC_VERSIONS)
-def test_with_anthropic(session, version):
-    _install_test_deps(session)
+@nox.parametrize("source", BT_SOURCES)
+def test_with_anthropic(session, version, source):
+    _install_test_deps(session, source)
     _install(session, "anthropic", version)
     session.run("pytest", f"{SRC}/wrappers/test_anthropic.py")
     _run_common_tests(session)
@@ -60,8 +81,9 @@ def test_with_anthropic(session, version):
 
 @nox.session()
 @nox.parametrize("version", OPENAI_VERSIONS)
-def test_with_openai(session, version):
-    _install_test_deps(session)
+@nox.parametrize("source", BT_SOURCES)
+def test_with_openai(session, version, source):
+    _install_test_deps(session, source)
     _install(session, "openai", version)
     session.run("pytest", f"{SRC}/wrappers/test_openai.py")
     _run_common_tests(session)
@@ -69,29 +91,46 @@ def test_with_openai(session, version):
 
 @nox.session()
 @nox.parametrize("version", AUTOEVALS_VERSIONS)
-def test_with_autoevals(session, version):
+@nox.parametrize("source", BT_SOURCES)
+def test_with_autoevals(session, version, source):
     # Run all of our core tests with autoevals installed. Some tests
     # specifically validate scores from autoevals work properly, so
     # we need some tests with it installed.
-    _install_test_deps(session)
+    _install_test_deps(session, source)
     _install(session, "autoevals", version)
     _run_common_tests(session)
 
 
 @nox.session()
-def test_with_braintrust_core(session):
+@nox.parametrize("source", BT_SOURCES)
+def test_with_braintrust_core(session, source):
     # Some tests do specific things if braintrust_core is installed, so run our
     # common tests with it installed. Testing the latest (aka the last ever version)
     # is enough.
-    _install_test_deps(session)
+    _install_test_deps(session, source)
     _install(session, "braintrust_core")
     _run_common_tests(session)
 
 
-def _install_test_deps(session):
+def _install_test_deps(session, source):
     session.install("pytest")
     session.install("pytest-asyncio")
-    session.install("-e", ".[test]")
+    if source == CODE:
+        session.install("-e", ".[test]")
+    elif source == WHEEL:
+        wheel_path = _get_braintrust_wheel()
+        session.install(wheel_path)
+    else:
+        raise Exception(f"Invalid source: {source}")
+
+
+def _get_braintrust_wheel():
+    path = "dist/braintrust-*.whl"
+    wheels = glob.glob(path)
+    if len(wheels) != 1:
+        msg = f"There should be one wheel in {path}. Got {len(wheels)}"
+        raise Exception(msg)
+    return wheels[0]
 
 
 def _run_common_tests(session):

--- a/py/src/braintrust/test_version.py
+++ b/py/src/braintrust/test_version.py
@@ -1,0 +1,8 @@
+from braintrust import version
+
+
+def test_version():
+    # Not the most interesting test, but it's a quick sanity check
+    # that the templating during the build process works.
+    assert version.VERSION
+    assert version.GIT_COMMIT

--- a/py/src/braintrust/version.py
+++ b/py/src/braintrust/version.py
@@ -1,1 +1,4 @@
 VERSION = "0.1.0"
+
+# this will be templated during the build
+GIT_COMMIT = "__GIT_COMMIT__"

--- a/template-version.sh
+++ b/template-version.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+
+VERSION_FILE="py/src/braintrust/version.py"
+
+GIT_COMMIT=$(git rev-parse HEAD)
+
+sed_inplace() {
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' "$@"
+    else
+        sed -i "$@"
+    fi
+}
+
+# Update git commit hash
+sed_inplace "s/__GIT_COMMIT__/$GIT_COMMIT/g" "$VERSION_FILE"
+
+# Get current version
+CURRENT_VERSION=$(grep 'VERSION = ' "$VERSION_FILE" | cut -d'"' -f2)
+
+# If we're uploading to testpypi, add a run number to the version so we can
+# test multiple times.
+if [[ "$PYPI_REPO" == "testpypi" ]] && [[ -n "$GITHUB_RUN_NUMBER" ]]; then
+    NEW_VERSION="${CURRENT_VERSION}rc${GITHUB_RUN_NUMBER}"
+    sed_inplace "s/VERSION = \".*\"/VERSION = \"$NEW_VERSION\"/" "$VERSION_FILE"
+fi


### PR DESCRIPTION
This is a proof of concept for building and publishing python wheels in CI. It only runs againsttest.pypi.org until the kinks are ironed out.

What's in this PR:

- moves all python SDK build and test code into this repo.
- adds the version and git commit into version.py (and a suffix to allow repeatedly test uploads to `test.pypi`
- allows us to run all of our tests against a built wheel and not just the code with `nox -- --wheel`
- adds a job to build and push a wheel to `test.pypi`.  This is a step towards an automated release of the CI. 


If we like the idea we can make it real by:

- Trigger the build job to `pypi` with a tag a PR or something else. 

test the current product with:

` pip install -i https://test.pypi.org/simple/ braintrust==0.0.197rc8`