### PR TITLE
Allow propagating description and summarize_scores

### DIFF
--- a/js/src/cli.ts
+++ b/js/src/cli.ts
@@ -116,6 +116,7 @@ async function initExperiment(
       ? { projectId: evaluator.projectId }
       : { project: evaluator.projectName }),
     experiment: evaluator.experimentName,
+    description: evaluator.description,
     metadata: evaluator.metadata,
     isPublic: evaluator.isPublic,
     update: evaluator.update,

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -267,6 +267,12 @@ export interface Evaluator<
    * A default implementation is exported as `defaultErrorScoreHandler` which will log a 0 score to the root span for any scorer that was not run.
    */
   errorScoreHandler?: ErrorScoreHandler;
+
+  /**
+   * Whether to summarize the scores of the experiment after it has run.
+   * Defaults to true.
+   */
+  summarizeScores?: boolean;
 }
 
 export class EvalResultWithSummary<
@@ -1059,7 +1065,7 @@ async function runEvaluatorInternal(
   }
 
   const summary = experiment
-    ? await experiment.summarize()
+    ? await experiment.summarize({ summarizeScores: evaluator.summarizeScores })
     : buildLocalSummary(evaluator, results);
 
   return new EvalResultWithSummary(summary, results);

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -186,6 +186,11 @@ export interface Evaluator<
   experimentName?: string;
 
   /**
+   * An optional description for the experiment.
+   */
+  description?: string;
+
+  /**
    * The number of times to run the evaluator per input. This is useful for evaluating applications that
    * have non-deterministic behavior and gives you both a stronger aggregate measure and a sense of the
    * variance in the results.
@@ -529,6 +534,7 @@ export async function Eval<
             ? { projectId: evaluator.projectId }
             : { project: name }),
           experiment: evaluator.experimentName,
+          description: evaluator.description,
           metadata: evaluator.metadata,
           isPublic: evaluator.isPublic,
           update: evaluator.update,

--- a/py/src/braintrust/cli/eval.py
+++ b/py/src/braintrust/cli/eval.py
@@ -139,6 +139,7 @@ async def run_evaluator_task(evaluator, position, opts: EvaluatorOpts):
             project_name=evaluator.project_name,
             project_id=evaluator.project_id,
             experiment_name=evaluator.experiment_name,
+            description=evaluator.description,
             metadata=evaluator.metadata,
             is_public=evaluator.is_public,
             update=evaluator.update,

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -248,11 +248,6 @@ class Evaluator(Generic[Input, Output]):
     A name that describes the experiment. You do not need to change it each time the experiment runs.
     """
 
-    description: Optional[str] = None
-    """
-    An optional description for the experiment.
-    """
-
     data: EvalData[Input, Output]
     """
     Returns an iterator over the evaluation dataset. Each element of the iterator should be an `EvalCase` or a dict
@@ -273,6 +268,11 @@ class Evaluator(Generic[Input, Output]):
     experiment_name: Optional[str]
     """
     Optional experiment name. If not specified, a name will be generated automatically.
+    """
+
+    description: Optional[str] = None
+    """
+    An optional description for the experiment.
     """
 
     metadata: Optional[Metadata]

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -270,7 +270,7 @@ class Evaluator(Generic[Input, Output]):
     Optional experiment name. If not specified, a name will be generated automatically.
     """
 
-    description: Optional[str] = None
+    description: Optional[str]
     """
     An optional description for the experiment.
     """

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -248,6 +248,11 @@ class Evaluator(Generic[Input, Output]):
     A name that describes the experiment. You do not need to change it each time the experiment runs.
     """
 
+    description: Optional[str] = None
+    """
+    An optional description for the experiment.
+    """
+
     data: EvalData[Input, Output]
     """
     Returns an iterator over the evaluation dataset. Each element of the iterator should be an `EvalCase` or a dict
@@ -625,6 +630,7 @@ def _EvalCommon(
             project_name=evaluator.project_name if evaluator.project_id is None else None,
             project_id=evaluator.project_id,
             experiment_name=evaluator.experiment_name,
+            description=evaluator.description,
             metadata=evaluator.metadata,
             is_public=evaluator.is_public,
             update=evaluator.update,


### PR DESCRIPTION
We've supported this forever but just didn't propagate it through `Eval(...)`