### PR TITLE
[python] Make run_evaluator public

### DIFF
--- a/py/src/braintrust/cli/eval.py
+++ b/py/src/braintrust/cli/eval.py
@@ -12,6 +12,7 @@ from .. import login
 from ..framework import (
     BaseExperiment,
     Evaluator,
+    EvaluatorOpts,
     EvaluatorInstance,
     ReporterDef,
     _evals,
@@ -63,19 +64,6 @@ class FileHandle:
 
     def watch(self):
         raise NotImplementedError
-
-
-@dataclass
-class EvaluatorOpts:
-    verbose: bool
-    no_send_logs: bool
-    no_progress_bars: bool
-    terminate_on_failure: bool
-    watch: bool
-    filters: List[str]
-    list: bool
-    jsonl: bool
-
 
 @dataclass
 class LoadedEvaluator:

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -354,6 +354,17 @@ class Evaluator(Generic[Input, Output]):
 
 
 @dataclasses.dataclass
+class EvaluatorOpts:
+    verbose: bool
+    no_send_logs: bool
+    no_progress_bars: bool
+    terminate_on_failure: bool
+    watch: bool
+    filters: List[str]
+    list: bool
+    jsonl: bool
+
+@dataclasses.dataclass
 class EvalResultWithSummary(SerializableDataClass, Generic[Input, Output]):
     summary: ExperimentSummary
     results: List[EvalResult[Input, Output]]
@@ -1353,4 +1364,4 @@ def build_local_summary(
     )
 
 
-__all__ = ["Evaluator", "Eval", "EvalAsync", "Score", "EvalCase", "EvalHooks", "BaseExperiment", "Reporter"]
+__all__ = ["Evaluator", "Eval", "EvalAsync", "EvaluatorOpts", "EvalResultWithSummary", "Experiment", "Filter", "Score", "EvalCase", "EvalHooks", "BaseExperiment", "Reporter", "run_evaluator"]


### PR DESCRIPTION
run_evaluator provides more control over logging - via EvaluatorOpts - for users that need more flexibility than `Eval` or `EvalAsync` provides. This PR exposes it and all types necessary to call it.

## Changes:
* Move `EvaluatorOpts` from evals.py => framework.py.
* Expose `Filter`, `EvalResultWithSummary`, `run_evaluator`, and `EvaluatorOpts` in `__all__`

## Testing:
* Locally in a dependent repository that executes `framework.Eval`.