### PR TITLE
Matt/responses metrics

### DIFF
--- a/.github/workflows/py.yaml
+++ b/.github/workflows/py.yaml
@@ -24,6 +24,7 @@ jobs:
 
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY}}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY}}
 
     steps:
       - uses: actions/checkout@v4

--- a/js/src/wrappers/oai.test.ts
+++ b/js/src/wrappers/oai.test.ts
@@ -117,6 +117,8 @@ describe("openai client unit tests", () => {
     assert.isTrue(m.tokens > 0);
     assert.isTrue(m.prompt_tokens > 0);
     assert.isTrue(m.time_to_first_token > 0);
+    assert.isTrue(m.prompt_cached_tokens >= 0);
+    assert.isTrue(m.completion_reasoning_tokens >= 0);
   });
 
   test("openai.responses.create(stream=true)", async (context) => {

--- a/js/src/wrappers/oai_responses.ts
+++ b/js/src/wrappers/oai_responses.ts
@@ -157,6 +157,17 @@ function responsesStreamProxy(target: any): (params: any) => Promise<any> {
   });
 }
 
+const TOKEN_NAME_MAP: Record<string, string> = {
+  input_tokens: "prompt_tokens",
+  output_tokens: "completion_tokens",
+  total_tokens: "tokens",
+};
+
+const TOKEN_PREFIX_MAP: Record<string, string> = {
+  input: "prompt",
+  output: "completion",
+};
+
 function parseMetricsFromUsage(usage: any): Record<string, number> {
   if (!usage) {
     return {};
@@ -170,29 +181,24 @@ function parseMetricsFromUsage(usage: any): Record<string, number> {
   //   total_tokens: 22
   // }
 
-  const keys = [
-    ["input_tokens", "prompt_tokens"],
-    ["output_tokens", "completion_tokens"],
-    ["total_tokens", "tokens"],
-  ];
-
   const metrics: Record<string, number> = {};
-  for (const [src, target] of keys) {
-    const value = usage[src];
-    if (value !== undefined && value !== null) {
-      metrics[target] = value;
-    }
-  }
 
-  const details: string[] = ["input", "output"];
-  for (const src of details) {
-    const details = usage[`${src}_tokens_details`];
-    if (details) {
-      for (const [key, value] of Object.entries(details)) {
-        const metricName = `${src}_${key}` as string;
-        if (typeof value === "number") {
-          metrics[metricName] = value;
+  for (const [oai_name, value] of Object.entries(usage)) {
+    if (typeof value === "number") {
+      const metricName = TOKEN_NAME_MAP[oai_name] || oai_name;
+      metrics[metricName] = value;
+    } else if (oai_name.endsWith("_tokens_details")) {
+      const rawPrefix = oai_name.slice(0, -"_tokens_details".length);
+      const prefix = TOKEN_PREFIX_MAP[rawPrefix] || rawPrefix;
+      if (typeof value !== "object") {
+        continue;
+      }
+      for (const [key, n] of Object.entries(value)) {
+        if (typeof n !== "number") {
+          continue;
         }
+        const metricName = `${prefix}_${key}`;
+        metrics[metricName] = n;
       }
     }
   }

--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -15,8 +15,9 @@ ERROR_CODES = tuple(range(1, 256))
 # validate things work with or without them.
 VENDOR_PACKAGES = ("anthropic", "openai")
 
-
-ANTHROPIC_VERSIONS = ("0.48.0", "0.49.0", LATEST)
+# Test matrix
+ANTHROPIC_VERSIONS = (LATEST, "0.49.0", "0.48.0")
+OPENAI_VERSIONS = (LATEST, "1.71")
 
 
 @nox.session()
@@ -40,6 +41,14 @@ def test_anthropic(session, version):
     _install_test_deps(session)
     _install(session, "anthropic", version)
     session.run("pytest", f"{SRC}/wrappers/test_anthropic.py")
+
+
+@nox.session()
+@nox.parametrize("version", OPENAI_VERSIONS)
+def test_openai(session, version):
+    _install_test_deps(session)
+    _install(session, "openai", version)
+    session.run("pytest", f"{SRC}/wrappers/test_openai.py")
 
 
 def _install_test_deps(session):

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -600,9 +600,17 @@ class _MemoryBackgroundLogger(_BackgroundLogger):
         with self.lock:
             logs = [l.get() for l in self.logs]  # unwrap the LazyValues
             self.logs = []
+
+            if not logs:
+                return []
+
             # all the logs get merged before gettig sent to the server, so simulate that
             # here
-            return merge_row_batch(logs)
+            merged = merge_row_batch(logs)
+            first = merged[0]
+            for other in merged[1:]:
+                first.extend(other)
+            return first
 
 
 # We should only have one instance of this object in

--- a/py/src/braintrust/oai.py
+++ b/py/src/braintrust/oai.py
@@ -735,13 +735,16 @@ def _parse_metrics_from_usage(usage: Dict[str, Any]) -> Dict[str, Any]:
             if not isinstance(value, dict):
                 continue  # unexpected
             for k, v in value.items():
-                metrics[f"{prefix}_{k}"] = v
+                if _is_numeric(v):
+                    metrics[f"{prefix}_{k}"] = v
         else:
             # handle metrics
-            if not isinstance(value, (int, float)):
-                continue  # unexpected
-            # store all metrics, remap names if needed
-            name = TOKEN_NAME_MAP.get(oai_name, oai_name)
-            metrics[name] = value
+            if _is_numeric(value):
+                name = TOKEN_NAME_MAP.get(oai_name, oai_name)
+                metrics[name] = value
 
     return metrics
+
+
+def _is_numeric(v):
+    return isinstance(v, (int, float, complex))

--- a/py/src/braintrust/oai.py
+++ b/py/src/braintrust/oai.py
@@ -76,13 +76,10 @@ class ChatCompletionWrapper:
                 return gen()
             else:
                 log_response = raw_response if isinstance(raw_response, dict) else raw_response.dict()
+                metrics = _parse_metrics_from_usage(log_response.get("usage", {}))
+                metrics["time_to_first_token"] = time.time() - start
                 span.log(
-                    metrics={
-                        "time_to_first_token": time.time() - start,
-                        "tokens": log_response["usage"]["total_tokens"],
-                        "prompt_tokens": log_response["usage"]["prompt_tokens"],
-                        "completion_tokens": log_response["usage"]["completion_tokens"],
-                    },
+                    metrics=metrics,
                     output=log_response["choices"],
                 )
                 return raw_response
@@ -134,13 +131,10 @@ class ChatCompletionWrapper:
                 return gen()
             else:
                 log_response = raw_response if isinstance(raw_response, dict) else raw_response.dict()
+                metrics = _parse_metrics_from_usage(log_response.get("usage"))
+                metrics["time_to_first_token"] = time.time() - start
                 span.log(
-                    metrics={
-                        "tokens": log_response["usage"]["total_tokens"],
-                        "prompt_tokens": log_response["usage"]["prompt_tokens"],
-                        "completion_tokens": log_response["usage"]["completion_tokens"],
-                        "time_to_first_token": time.time() - start,
-                    },
+                    metrics=metrics,
                     output=log_response["choices"],
                 )
                 return raw_response
@@ -173,11 +167,7 @@ class ChatCompletionWrapper:
         metrics = {}
         for result in all_results:
             if "usage" in result and result["usage"] is not None:
-                metrics = {
-                    "tokens": result["usage"]["total_tokens"],
-                    "prompt_tokens": result["usage"]["prompt_tokens"],
-                    "completion_tokens": result["usage"]["completion_tokens"],
-                }
+                metrics = _parse_metrics_from_usage(result["usage"])
             choices = result["choices"]
             if not choices:
                 continue
@@ -269,13 +259,10 @@ class ResponseWrapper:
                 return gen()
             else:
                 log_response = raw_response if isinstance(raw_response, dict) else raw_response.dict()
+                metrics = _parse_metrics_from_usage(log_response.get("usage"))
+                metrics["time_to_first_token"] = time.time() - start
                 span.log(
-                    metrics={
-                        "time_to_first_token": time.time() - start,
-                        "tokens": log_response["usage"]["total_tokens"],
-                        "prompt_tokens": log_response["usage"]["input_tokens"],
-                        "completion_tokens": log_response["usage"]["output_tokens"],
-                    },
+                    metrics=metrics,
                     output=log_response["output"],
                 )
                 return raw_response
@@ -705,3 +692,56 @@ def wrap_openai(openai: Any):
         return OpenAIV1Wrapper(openai)
     else:
         return OpenAIV0Wrapper(openai)
+
+
+# OpenAI's representation to Braintrust's representation
+TOKEN_NAME_MAP = {
+    # chat API
+    "total_tokens": "tokens",
+    "prompt_tokens": "prompt_tokens",
+    "completion_tokens": "completion_tokens",
+    # responses API
+    "tokens": "tokens",
+    "input_tokens": "prompt_tokens",
+    "output_tokens": "completion_tokens",
+}
+
+TOKEN_PREFIX_MAP = {
+    "input": "prompt",
+    "output": "completion",
+}
+
+
+def _parse_metrics_from_usage(usage: Dict[str, Any]) -> Dict[str, Any]:
+    # For simplicity, this function handles all the different APIs
+
+    if not usage or not isinstance(usage, dict):
+        return {}
+
+    # example usage format:
+    # { 'input_tokens': 14,
+    # ' input_tokens_details': {'cached_tokens': 0},
+    # ' output_tokens_details': {'reasoning_tokens': 0},
+    # }
+    # we remap names and change detail tokens to names like
+    # input_cached_tokens.
+
+    metrics = {}
+    for oai_name, value in usage.items():
+        if oai_name.endswith("_tokens_details"):
+            # handle `_tokens_detail` dicts
+            raw_prefix = oai_name[: -len("_tokens_details")]
+            prefix = TOKEN_PREFIX_MAP.get(raw_prefix, raw_prefix)
+            if not isinstance(value, dict):
+                continue  # unexpected
+            for k, v in value.items():
+                metrics[f"{prefix}_{k}"] = v
+        else:
+            # handle metrics
+            if not isinstance(value, (int, float)):
+                continue  # unexpected
+            # store all metrics, remap names if needed
+            name = TOKEN_NAME_MAP.get(oai_name, oai_name)
+            metrics[name] = value
+
+    return metrics

--- a/py/src/braintrust/oai.py
+++ b/py/src/braintrust/oai.py
@@ -737,11 +737,9 @@ def _parse_metrics_from_usage(usage: Dict[str, Any]) -> Dict[str, Any]:
             for k, v in value.items():
                 if _is_numeric(v):
                     metrics[f"{prefix}_{k}"] = v
-        else:
-            # handle metrics
-            if _is_numeric(value):
-                name = TOKEN_NAME_MAP.get(oai_name, oai_name)
-                metrics[name] = value
+        elif _is_numeric(value):
+            name = TOKEN_NAME_MAP.get(oai_name, oai_name)
+            metrics[name] = value
 
     return metrics
 

--- a/py/src/braintrust/wrappers/test_anthropic.py
+++ b/py/src/braintrust/wrappers/test_anthropic.py
@@ -81,7 +81,7 @@ def test_anthropic_messages_create_stream_true(memory_logger):
 
     logs = memory_logger.pop()
     assert len(logs) == 1
-    log = logs[0][0]
+    log = logs[0]
     assert log["metadata"]["model"] == MODEL
     assert log["metadata"]["max_tokens"] == 300
     assert start < log["metrics"]["start"] < log["metrics"]["end"] < end
@@ -115,7 +115,7 @@ def test_anthropic_messages_model_params_inputs(memory_logger):
 
         logs = memory_logger.pop()
         assert len(logs) == 1
-        log = logs[0][0]
+        log = logs[0]
         import pprint
 
         pprint.pprint(log)
@@ -156,7 +156,7 @@ def test_anthropic_messages_system_prompt_inputs(memory_logger):
 
         logs = memory_logger.pop()
         assert len(logs) == 1
-        log = logs[0][0]
+        log = logs[0]
         inputs = log["input"]
         assert len(inputs) == 2
         inputs_by_role = {m["role"]: m["content"] for m in inputs}
@@ -182,7 +182,7 @@ async def test_anthropic_messages_streaming_async(memory_logger):
 
         logs = memory_logger.pop()
         assert len(logs) == 1
-        log = logs[0][0]
+        log = logs[0]
         assert "user" in str(log["input"])
         assert "1+1" in str(log["input"])
         assert "2" in str(log["output"])
@@ -219,7 +219,7 @@ def test_anthropic_client_error(memory_logger):
 
     logs = memory_logger.pop()
     assert len(logs) == 1
-    log = logs[0][0]
+    log = logs[0]
     assert log["project_id"] == PROJECT_NAME
     assert "404" in log["error"]
 
@@ -244,7 +244,7 @@ def test_anthropic_messages_streaming_sync(memory_logger):
 
     logs = memory_logger.pop()
     assert len(logs) == 1
-    log = logs[0][0]
+    log = logs[0]
     assert "user" in str(log["input"])
     assert "2+2" in str(log["input"])
     assert "4" in str(log["output"])
@@ -277,7 +277,7 @@ def test_anthropic_messages_sync(memory_logger):
     logs = memory_logger.pop()
 
     assert len(logs) == 1
-    log = logs[0][0]
+    log = logs[0]
     assert "2+2" in str(log["input"])
     assert "4" in str(log["output"])
     assert log["project_id"] == PROJECT_NAME

--- a/py/src/braintrust/wrappers/test_openai.py
+++ b/py/src/braintrust/wrappers/test_openai.py
@@ -1,0 +1,82 @@
+import time
+
+import openai
+import pytest
+
+from braintrust import logger, wrap_openai
+from braintrust.logger import ObjectMetadata, OrgProjectMetadata
+from braintrust.util import LazyValue
+from braintrust.wrappers.anthropic import wrap_anthropic
+
+TEST_ORG_ID = "test-org-openai-py-tracing"
+PROJECT_NAME = "test-project-openai-py-tracing"
+TEST_MODEL = "gpt-4o-mini"  # cheapest model for tests
+
+
+def _setup_test_logger():
+    # FIXME[matt] make reusable
+    project_metadata = ObjectMetadata(id=PROJECT_NAME, name=PROJECT_NAME, full_info=dict())
+    metadata = OrgProjectMetadata(org_id=TEST_ORG_ID, project=project_metadata)
+    lazy_metadata = LazyValue(lambda: metadata, use_mutex=False)
+    l = logger.init_logger(project=PROJECT_NAME)
+    l._lazy_metadata = lazy_metadata  # FIXME[matt] this is cheesy but it stops us from having to login
+
+
+@pytest.fixture
+def memory_logger():
+    _setup_test_logger()
+    with logger._internal_with_memory_background_logger() as bgl:
+        yield bgl
+
+
+def test_openai_chat_metrics(memory_logger):
+    assert not memory_logger.pop()
+
+    client = wrap_openai(openai.OpenAI())
+
+    start = time.time()
+    response = client.chat.completions.create(
+        model=TEST_MODEL, messages=[{"role": "user", "content": "What's 12 + 12?"}]
+    )
+    end = time.time()
+
+    assert response
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span
+    metrics = span["metrics"]
+    assert 0 < metrics["time_to_first_token"]
+    assert 0 < metrics["tokens"]
+    assert 0 < metrics["prompt_tokens"]
+    assert 0 < metrics["completion_tokens"]
+    assert start < metrics["start"] < metrics["end"] < end
+
+
+def test_openai_responses_metrics(memory_logger):
+    assert not memory_logger.pop()
+
+    client = wrap_openai(openai.OpenAI())
+
+    start = time.time()
+    response = client.responses.create(
+        model=TEST_MODEL,
+        input="What's 12 + 12?",
+        instructions="Just the number please",
+    )
+    end = time.time()
+
+    assert response
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span
+    metrics = span["metrics"]
+    assert 0 < metrics["time_to_first_token"]
+    assert 0 < metrics["tokens"]
+    assert 0 < metrics["prompt_tokens"]
+    assert 0 < metrics["completion_tokens"]
+    assert 0 <= metrics["prompt_cached_tokens"]
+    assert 0 <= metrics["completion_reasoning_tokens"]
+    assert start < metrics["start"] < metrics["end"] < end


### PR DESCRIPTION
Another crack at openai response.metrics. This time properly filtering 'None' metrics. 

It fixes this reverted PR https://github.com/braintrustdata/braintrust-sdk/pull/647