### PR TITLE
Propagate error rather than exception

### DIFF
--- a/js/src/functions/stream.ts
+++ b/js/src/functions/stream.ts
@@ -332,11 +332,11 @@ export function createFinalValuePassThroughStream<
             break;
           default:
             const _type: never = chunkType;
-            throw new Error(`Unknown chunk type ${_type}`);
+            onError(`Unknown chunk type: ${_type}`);
         }
         controller.enqueue(chunk);
       } else {
-        throw new Error(`Unknown chunk type ${chunk}`);
+        onError(`Unknown chunk type ${JSON.stringify(chunk)}`);
       }
     },
     flush(controller) {


### PR DESCRIPTION
Streams can't fail. Propagating an error, rather than throwing an exception, allows us to surface it on the other end of the stream properly.