### PR TITLE
Remove dependency on `braintrust_core`

### DIFF
--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -13,12 +13,13 @@ ERROR_CODES = tuple(range(1, 256))
 
 # List your package here if it's not guaranteed to be installed. We'll (try to)
 # validate things work with or without them.
-VENDOR_PACKAGES = ("anthropic", "openai", "pydantic_ai")
+VENDOR_PACKAGES = ("anthropic", "openai", "pydantic_ai", "autoevals")
 
 # Test matrix
 ANTHROPIC_VERSIONS = (LATEST, "0.50.0", "0.49.0", "0.48.0")
 OPENAI_VERSIONS = (LATEST, "1.77.0", "1.71")
 PYDANTIC_AI_VERSIONS = (LATEST, "0.1.9")
+AUTOEVALS_VERSIONS = (LATEST, "0.0.129")
 
 
 @nox.session()
@@ -58,6 +59,17 @@ def test_openai(session, version):
     _install_test_deps(session)
     _install(session, "openai", version)
     session.run("pytest", f"{SRC}/wrappers/test_openai.py")
+
+
+@nox.session()
+@nox.parametrize("version", AUTOEVALS_VERSIONS)
+def test_autoevals(session, version):
+    # Run all of our core tests with autoevals installed. Some tests
+    # specifically validate scores from autoevals work properly, so
+    # we need some tests with it installed.
+    _install_test_deps(session)
+    _install(session, "autoevals", version)
+    session.run("pytest", SRC, f"--ignore={SRC}/wrappers")
 
 
 def _install_test_deps(session):

--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -8,6 +8,7 @@ import nox
 LATEST = "__latest__"
 SRC = "src/braintrust"
 
+SILENT_INSTALLS = True
 
 ERROR_CODES = tuple(range(1, 256))
 
@@ -102,4 +103,4 @@ def _install(session, package, version=LATEST):
     cmd = f"{package}=={version}"
     if version == LATEST or not version:
         cmd = package
-    session.run("pip", "install", cmd)
+    session.run("pip", "install", cmd, silent=SILENT_INSTALLS)

--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -13,7 +13,13 @@ ERROR_CODES = tuple(range(1, 256))
 
 # List your package here if it's not guaranteed to be installed. We'll (try to)
 # validate things work with or without them.
-VENDOR_PACKAGES = ("anthropic", "openai", "pydantic_ai", "autoevals")
+VENDOR_PACKAGES = (
+    "anthropic",
+    "openai",
+    "pydantic_ai",
+    "autoevals",
+    # "braintrust_core",
+)
 
 # Test matrix
 ANTHROPIC_VERSIONS = (LATEST, "0.50.0", "0.49.0", "0.48.0")
@@ -23,59 +29,76 @@ AUTOEVALS_VERSIONS = (LATEST, "0.0.129")
 
 
 @nox.session()
-def test_no_deps(session):
+def test(session):
     """Ensure that with no dependencies, we can still import and use the
     library.
     """
     _install_test_deps(session)
-
     # verify we haven't installed our 3p deps.
     for p in VENDOR_PACKAGES:
         session.run("python", "-c", f"import {p}", success_codes=ERROR_CODES, silent=True)
 
     session.run("python", "-c", "import braintrust")
-    session.run("pytest", SRC, f"--ignore={SRC}/wrappers")
+    _run_common_tests(session)
 
 
 @nox.session()
 @nox.parametrize("pydantic_ai_version", PYDANTIC_AI_VERSIONS)
-def test_pydantic_ai(session, pydantic_ai_version):
+def test_with_pydantic_ai(session, pydantic_ai_version):
     _install_test_deps(session)
     _install(session, "pydantic_ai", pydantic_ai_version)
     session.run("pytest", f"{SRC}/wrappers/test_pydantic_ai.py")
+    _run_common_tests(session)
 
 
 @nox.session()
 @nox.parametrize("version", ANTHROPIC_VERSIONS)
-def test_anthropic(session, version):
+def test_with_anthropic(session, version):
     _install_test_deps(session)
     _install(session, "anthropic", version)
     session.run("pytest", f"{SRC}/wrappers/test_anthropic.py")
+    _run_common_tests(session)
 
 
 @nox.session()
 @nox.parametrize("version", OPENAI_VERSIONS)
-def test_openai(session, version):
+def test_with_openai(session, version):
     _install_test_deps(session)
     _install(session, "openai", version)
     session.run("pytest", f"{SRC}/wrappers/test_openai.py")
+    _run_common_tests(session)
 
 
 @nox.session()
 @nox.parametrize("version", AUTOEVALS_VERSIONS)
-def test_autoevals(session, version):
+def test_with_autoevals(session, version):
     # Run all of our core tests with autoevals installed. Some tests
     # specifically validate scores from autoevals work properly, so
     # we need some tests with it installed.
     _install_test_deps(session)
     _install(session, "autoevals", version)
-    session.run("pytest", SRC, f"--ignore={SRC}/wrappers")
+    _run_common_tests(session)
+
+
+@nox.session()
+def test_with_braintrust_core(session):
+    # Some tests to specific things if braintrust_core is installed, so run our
+    # common tests with it installed. Testing the latest (aka the last ever version)
+    # is enough.
+    _install_test_deps(session)
+    _install(session, "braintrust_core")
+    _run_common_tests(session)
 
 
 def _install_test_deps(session):
     session.install("pytest")
     session.install("pytest-asyncio")
     session.install("-e", ".[test]")
+
+
+def _run_common_tests(session):
+    """Run all the tests that don't require any special dependencies."""
+    session.run("pytest", SRC, f"--ignore={SRC}/wrappers")
 
 
 def _install(session, package, version=LATEST):

--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -30,7 +30,7 @@ def test_no_deps(session):
 
     # verify we haven't installed our 3p deps.
     for p in VENDOR_PACKAGES:
-        session.run("python", "-c", f"import {p}", success_codes=ERROR_CODES)
+        session.run("python", "-c", f"import {p}", success_codes=ERROR_CODES, silent=True)
 
     session.run("python", "-c", "import braintrust")
     session.run("pytest", SRC, f"--ignore={SRC}/wrappers")

--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -18,7 +18,7 @@ VENDOR_PACKAGES = (
     "openai",
     "pydantic_ai",
     "autoevals",
-    # "braintrust_core",
+    "braintrust_core",
 )
 
 # Test matrix
@@ -29,15 +29,12 @@ AUTOEVALS_VERSIONS = (LATEST, "0.0.129")
 
 
 @nox.session()
-def test(session):
-    """Ensure that with no dependencies, we can still import and use the
-    library.
-    """
+def test_core(session):
+    """Test the core library with no optional dependencies installed."""
     _install_test_deps(session)
     # verify we haven't installed our 3p deps.
     for p in VENDOR_PACKAGES:
         session.run("python", "-c", f"import {p}", success_codes=ERROR_CODES, silent=True)
-
     session.run("python", "-c", "import braintrust")
     _run_common_tests(session)
 

--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -79,7 +79,7 @@ def test_with_autoevals(session, version):
 
 @nox.session()
 def test_with_braintrust_core(session):
-    # Some tests to specific things if braintrust_core is installed, so run our
+    # Some tests do specific things if braintrust_core is installed, so run our
     # common tests with it installed. Testing the latest (aka the last ever version)
     # is enough.
     _install_test_deps(session)

--- a/py/setup.py
+++ b/py/setup.py
@@ -15,7 +15,6 @@ install_requires = [
     "GitPython",
     "requests",
     "chevron",
-    "braintrust_core",
     "tqdm",
     "exceptiongroup>=1.2.0",
     "python-dotenv",

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -32,7 +32,6 @@ from typing import (
 
 import exceptiongroup
 from braintrust_core.score import Score, Scorer
-from braintrust_core.serializable_data_class import SerializableDataClass
 from tqdm.asyncio import tqdm as async_tqdm
 from tqdm.auto import tqdm as std_tqdm
 from typing_extensions import NotRequired, TypedDict
@@ -51,6 +50,7 @@ from .logger import (
 )
 from .logger import init as _init_experiment
 from .resource_manager import ResourceManager
+from .serializable_data_class import SerializableDataClass
 from .span_types import SpanTypeAttribute
 from .util import bt_iscoroutinefunction, eprint
 

--- a/py/src/braintrust/git_fields.py
+++ b/py/src/braintrust/git_fields.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import List, Literal, Optional
 
-from braintrust_core.serializable_data_class import SerializableDataClass
+from .serializable_data_class import SerializableDataClass
 
 
 @dataclass

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -47,7 +47,6 @@ import chevron
 import exceptiongroup
 import requests
 import urllib3
-from braintrust_core.serializable_data_class import SerializableDataClass
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
@@ -72,6 +71,7 @@ from .prompt import BRAINTRUST_PARAMS, ImagePart, PromptBlockData, PromptMessage
 from .prompt_cache.disk_cache import DiskCache
 from .prompt_cache.lru_cache import LRUCache
 from .prompt_cache.prompt_cache import PromptCache
+from .serializable_data_class import SerializableDataClass
 from .span_identifier_v3 import SpanComponentsV3, SpanObjectTypeV3
 from .span_types import SpanTypeAttribute
 from .types import AttachmentReference, AttachmentStatus, DatasetEvent, ExperimentEvent, PromptOptions, SpanAttributes

--- a/py/src/braintrust/prompt.py
+++ b/py/src/braintrust/prompt.py
@@ -1,8 +1,7 @@
 from dataclasses import dataclass
 from typing import List, Literal, Optional, Union
 
-from braintrust_core.serializable_data_class import SerializableDataClass
-
+from .serializable_data_class import SerializableDataClass
 from .types import PromptOptions
 
 # Keep these definitions in sync with sdk/core/js/typespecs/prompt.ts.

--- a/py/src/braintrust/score.py
+++ b/py/src/braintrust/score.py
@@ -1,0 +1,64 @@
+import dataclasses
+import sys
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+from .serializable_data_class import SerializableDataClass
+
+
+@dataclasses.dataclass
+class Score(SerializableDataClass):
+    """A score for an evaluation. The score is a float between 0 and 1."""
+
+    name: str
+    """The name of the score. This should be a unique name for the scorer."""
+
+    score: Optional[float]
+    """The score for the evaluation. This should be a float between 0 and 1. If the score is None, the evaluation is considered to be skipped."""
+
+    metadata: Dict[str, Any] = dataclasses.field(default_factory=dict)
+    """Metadata for the score. This can be used to store additional information about the score."""
+
+    # DEPRECATION_NOTICE: this field is deprecated, as errors are propagated up to the caller.
+    error: Optional[Exception] = None
+    """Deprecated: The error field is deprecated, as errors are now propagated to the caller. The field will be removed in a future version of the library."""
+
+    def as_dict(self):
+        return {
+            "score": self.score,
+            "metadata": self.metadata,
+        }
+
+    def __post_init__(self):
+        if self.score is not None and (self.score < 0 or self.score > 1):
+            raise ValueError(f"score ({self.score}) must be between 0 and 1")
+        if self.error is not None:
+            print(
+                "The error field is deprecated, as errors are now propagated to the caller. The field will be removed in a future version of the library",
+                sys.stderr,
+            )
+
+
+class Scorer(ABC):
+    async def eval_async(self, output: Any, expected: Any = None, **kwargs: Any) -> Score:
+        return await self._run_eval_async(output, expected, **kwargs)
+
+    def eval(self, output: Any, expected: Any = None, **kwargs: Any) -> Score:
+        return self._run_eval_sync(output, expected, **kwargs)
+
+    def __call__(self, output: Any, expected: Any = None, **kwargs: Any) -> Score:
+        return self.eval(output, expected, **kwargs)
+
+    async def _run_eval_async(self, output: Any, expected: Any = None, **kwargs: Any) -> Score:
+        # By default we just run the sync version in a thread
+        return self._run_eval_sync(output, expected, **kwargs)
+
+    def _name(self) -> str:
+        return self.__class__.__name__
+
+    @abstractmethod
+    def _run_eval_sync(self, output: Any, expected: Any = None, **kwargs: Any) -> Score:
+        ...
+
+
+__all__ = ["Score", "Scorer"]

--- a/py/src/braintrust/score.py
+++ b/py/src/braintrust/score.py
@@ -1,6 +1,7 @@
 import dataclasses
 import inspect
 import sys
+import warnings
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
 
@@ -42,9 +43,9 @@ class Score(SerializableDataClass):
         if self.score is not None and (self.score < 0 or self.score > 1):
             raise ValueError(f"score ({self.score}) must be between 0 and 1")
         if self.error is not None:
-            print(
-                "The error field is deprecated, as errors are now propagated to the caller. The field will be removed in a future version of the library",
-                sys.stderr,
+            warnings.warn(
+                "The error field is deprecated, as errors are now propagated to the caller."
+                " The field will be removed in a future version of the library"
             )
 
 

--- a/py/src/braintrust/score.py
+++ b/py/src/braintrust/score.py
@@ -50,7 +50,6 @@ class Score(SerializableDataClass):
 
 
 def is_score(obj):
-    """Return true if the object satisfies the Score interface, false otherwise."""
     return hasattr(obj, "name") and hasattr(obj, "score") and hasattr(obj, "metadata") and hasattr(obj, "as_dict")
 
 
@@ -77,10 +76,6 @@ class Scorer(ABC):
 
 
 def is_scorer(obj):
-    """
-    Duck-typing check to see if an object is a valid scorer.
-    Works with scorers from braintrust_core, autoevals, or this library.
-    """
     # For class objects, check for appropriate methods
     if inspect.isclass(obj):
         return (

--- a/py/src/braintrust/serializable_data_class.py
+++ b/py/src/braintrust/serializable_data_class.py
@@ -1,0 +1,65 @@
+import dataclasses
+import json
+from typing import Dict, Union, get_origin
+
+
+class SerializableDataClass:
+    def as_dict(self):
+        """Serialize the object to a dictionary."""
+        return dataclasses.asdict(self)
+
+    def as_json(self, **kwargs):
+        """Serialize the object to JSON."""
+        return json.dumps(self.as_dict(), **kwargs)
+
+    def __getitem__(self, item: str):
+        return getattr(self, item)
+
+    @classmethod
+    def from_dict(cls, d: Dict):
+        """Deserialize the object from a dictionary. This method
+        is shallow and will not call from_dict() on nested objects."""
+        fields = set(f.name for f in dataclasses.fields(cls))
+        filtered = {k: v for k, v in d.items() if k in fields}
+        return cls(**filtered)
+
+    @classmethod
+    def from_dict_deep(cls, d: Dict):
+        """Deserialize the object from a dictionary. This method
+        is deep and will call from_dict_deep() on nested objects."""
+        fields = {f.name: f for f in dataclasses.fields(cls)}
+        filtered = {}
+        for k, v in d.items():
+            if k not in fields:
+                continue
+
+            if (
+                isinstance(v, dict)
+                and isinstance(fields[k].type, type)
+                and issubclass(fields[k].type, SerializableDataClass)
+            ):
+                filtered[k] = fields[k].type.from_dict_deep(v)
+            elif get_origin(fields[k].type) == Union:
+                for t in fields[k].type.__args__:
+                    if t == type(None) and v is None:
+                        filtered[k] = None
+                        break
+                    if isinstance(t, type) and issubclass(t, SerializableDataClass) and v is not None:
+                        try:
+                            filtered[k] = t.from_dict_deep(v)
+                            break
+                        except TypeError:
+                            pass
+                else:
+                    filtered[k] = v
+            elif (
+                isinstance(v, list)
+                and get_origin(fields[k].type) == list
+                and len(fields[k].type.__args__) == 1
+                and isinstance(fields[k].type.__args__[0], type)
+                and issubclass(fields[k].type.__args__[0], SerializableDataClass)
+            ):
+                filtered[k] = [fields[k].type.__args__[0].from_dict_deep(i) for i in v]
+            else:
+                filtered[k] = v
+        return cls(**filtered)

--- a/py/src/braintrust/test_framework.py
+++ b/py/src/braintrust/test_framework.py
@@ -125,6 +125,8 @@ async def test_run_evaluator_with_many_scorers():
 
         scorers.append(Levenshtein())
         scorer_names.append("Levenshtein")
+        scorers.append(Levenshtein)
+        scorer_names.append("Levenshtein")
     except ImportError:
         pass
 

--- a/py/src/braintrust/test_framework.py
+++ b/py/src/braintrust/test_framework.py
@@ -1,0 +1,143 @@
+import asyncio
+from typing import List, Optional
+
+import pytest
+
+try:
+    from autoevals import Score as AutoevalsScore
+except ImportError:
+    # Use local Score if autoevals is not available
+    from .score import Score as AutoevalsScore
+try:
+    from braintrust_core.score import Score as BraintrustCoreScore
+except ImportError:
+    from .score import Score as BraintrustCoreScore
+from .framework import (
+    EvalCase,
+    EvalResultWithSummary,
+    Evaluator,
+    build_local_summary,
+    run_evaluator,
+)
+from .score import Score
+
+
+@pytest.mark.asyncio
+async def test_run_evaluator_basic():
+    """Test that run_evaluator correctly processes a simple evaluation."""
+    # Define test data
+    data = [
+        EvalCase(input=1, expected=2),
+        EvalCase(input=2, expected=4),
+        EvalCase(input=3, expected=6),
+    ]
+
+    # Define a simple task function
+    def multiply_by_two(input_value):
+        return input_value * 2
+
+    # Define a simple scoring function
+    def exact_match(input_value, output, expected):
+        return 1.0 if output == expected else 0.0
+
+    # Create evaluator
+    evaluator = Evaluator(
+        project_name="test-project",
+        eval_name="test-evaluator",
+        data=data,
+        task=multiply_by_two,
+        scores=[exact_match],
+        experiment_name=None,
+        metadata=None,
+    )
+
+    # Run evaluator
+    result = await run_evaluator(experiment=None, evaluator=evaluator, position=None, filters=[])
+
+    # Verify results
+    assert isinstance(result, EvalResultWithSummary)
+    assert len(result.results) == 3
+
+    # Check individual results
+    for i, eval_result in enumerate(result.results):
+        input_value = i + 1
+        expected_value = input_value * 2
+
+        assert eval_result.input == input_value
+        assert eval_result.expected == expected_value
+        assert eval_result.output == expected_value
+        assert eval_result.scores.get("exact_match") == 1.0
+        assert eval_result.error is None
+
+    # Verify summary
+    assert result.summary.project_name == "test-project"
+    assert "exact_match" in result.summary.scores
+    assert result.summary.scores["exact_match"].score == 1.0
+
+
+@pytest.mark.asyncio
+async def test_run_evaluator_with_both_score_classes():
+    """Test that run_evaluator works with scorers that return both Score class types."""
+    # Define test data
+    data = [
+        EvalCase(input="Calculate 2+2", expected="4"),
+        EvalCase(input="What is the capital of France?", expected="Paris"),
+    ]
+
+    # Define a simple task function that returns fixed responses
+    def simple_task(input_value):
+        if "2+2" in input_value:
+            return "The answer is 4"
+        elif "capital of France" in input_value:
+            return "The capital of France is Paris"
+        return "I don't know"
+
+    # Define a scorer that returns an autoevals Score object
+    def autoevals_scorer(input_value, output, expected):
+        contains_expected = expected.lower() in output.lower()
+        return AutoevalsScore(name="autoevals_scorer", score=1.0 if contains_expected else 0.0)
+
+    # Define a scorer that returns a braintrust_core Score object
+    def core_scorer(input_value, output, expected):
+        contains_expected = expected.lower() in output.lower()
+        return BraintrustCoreScore(name="core_scorer", score=1.0 if contains_expected else 0.0)
+
+    def scorer(input_value, output, expected):
+        contains_expected = expected.lower() in output.lower()
+        return Score(name="scorer", score=1.0 if contains_expected else 0.0)
+
+    # Create evaluator with all three scorers
+    evaluator = Evaluator(
+        project_name="test-project",
+        eval_name="test-multiple-score-classes",
+        data=data,
+        task=simple_task,
+        scores=[autoevals_scorer, core_scorer, scorer],
+        experiment_name=None,
+        metadata=None,
+    )
+
+    # Run evaluator
+    result = await run_evaluator(None, evaluator, None, [])
+
+    # Verify results
+    assert isinstance(result, EvalResultWithSummary)
+    assert len(result.results) == 2
+
+    # Both scorers should produce the same scores
+    for eval_result in result.results:
+        assert "autoevals_scorer" in eval_result.scores
+        assert "core_scorer" in eval_result.scores
+        assert "scorer" in eval_result.scores
+        assert eval_result.scores["autoevals_scorer"] == 1.0
+        assert eval_result.scores["core_scorer"] == 1.0
+        assert eval_result.scores["scorer"] == 1.0
+
+    # Verify summary
+    assert result.summary.project_name == "test-project"
+    assert "autoevals_scorer" in result.summary.scores
+    assert "core_scorer" in result.summary.scores
+    assert "scorer" in result.summary.scores
+    assert result.summary.scores["autoevals_scorer"].score == 1.0
+    assert result.summary.scores["core_scorer"].score == 1.0
+    assert result.summary.scores["scorer"].score == 1.0

--- a/py/src/braintrust/test_framework.py
+++ b/py/src/braintrust/test_framework.py
@@ -144,7 +144,6 @@ async def test_run_evaluator_with_many_scorers():
     # Run evaluator
     result = await run_evaluator(None, evaluator, None, [])
 
-    # Verify results
     assert isinstance(result, EvalResultWithSummary)
     assert len(result.results) == 2
 
@@ -155,7 +154,6 @@ async def test_run_evaluator_with_many_scorers():
             assert scorer_name in eval_result.scores
             assert eval_result.scores[scorer_name] == 1.0
 
-    # Verify summary
     assert result.summary.project_name == "test-project"
     for scorer_name in scorer_names:
         assert scorer_name in result.summary.scores

--- a/py/src/braintrust/test_serializable_data_class.py
+++ b/py/src/braintrust/test_serializable_data_class.py
@@ -1,0 +1,62 @@
+import unittest
+from dataclasses import dataclass
+from typing import List, Optional
+
+from .serializable_data_class import SerializableDataClass
+
+
+@dataclass
+class PromptData(SerializableDataClass):
+    prompt: Optional[str] = None
+    options: Optional[dict] = None
+
+
+@dataclass
+class PromptSchema(SerializableDataClass):
+    id: str
+    project_id: str
+    _xact_id: str
+    name: str
+    slug: str
+    description: Optional[str]
+    prompt_data: PromptData
+    tags: Optional[List[str]]
+
+
+class TestSerializableDataClass(unittest.TestCase):
+    def test_from_dict_deep_with_none_values(self):
+        """Test that from_dict_deep correctly handles None values in nested objects."""
+        test_dict = {
+            "id": "456",
+            "project_id": "123",
+            "_xact_id": "789",
+            "name": "test-prompt",
+            "slug": "test-prompt",
+            "description": None,
+            "prompt_data": {"prompt": None, "options": None},
+            "tags": None,
+        }
+
+        prompt = PromptSchema.from_dict_deep(test_dict)
+
+        # Verify all fields were set correctly.
+        self.assertEqual(prompt.id, "456")
+        self.assertEqual(prompt.project_id, "123")
+        self.assertEqual(prompt._xact_id, "789")
+        self.assertEqual(prompt.name, "test-prompt")
+        self.assertEqual(prompt.slug, "test-prompt")
+        self.assertIsNone(prompt.description)
+        self.assertIsNone(prompt.tags)
+
+        # Verify nested object was created and its fields are None.
+        self.assertIsInstance(prompt.prompt_data, PromptData)
+        self.assertIsNone(prompt.prompt_data.prompt)
+        self.assertIsNone(prompt.prompt_data.options)
+
+        # Verify round-trip serialization works.
+        round_trip = PromptSchema.from_dict_deep(prompt.as_dict())
+        self.assertEqual(round_trip.as_dict(), test_dict)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This simplifies our deployment and ensures our users can't end up in dependency well between `braintrust_core`, `braintrust` and `autoevals`. 

- copy `serialized dataclass` since it's a util
- duck-type of `Score` and `Scorer` objects rather than checking `isinstance`
- add tests for both classes and runs them with and without braintrust core and autoevals installed. 