### PR TITLE
Pin Python Build Dependencies

### DIFF
--- a/.github/workflows/py.yaml
+++ b/.github/workflows/py.yaml
@@ -41,9 +41,11 @@ jobs:
         uses: pnpm/action-setup@v4
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools build twine openai pylint nox
+          cd py && make install-dev
       - name: Test whether the Python SDK can be installed
         run: |
+          # This is already done by make install-dev, but we're keeping this as a separate step
+          # to explicitly verify that installation works
           python -m pip install -e ./core/py[all]
           python -m pip install -e ./py[all]
           python -m pip install -e ./integrations/langchain-py[all]
@@ -74,12 +76,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-      - name: Install build dependencies
+      - name: Install build dependencies and build wheel
         run: |
-          python -m pip install --upgrade pip setuptools build
-      - name: Build wheel
-        run: |
-          python -m build --wheel ./py
+          cd py && make install-build-deps && make build
       - name: Upload wheel as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/py/Makefile
+++ b/py/Makefile
@@ -1,5 +1,5 @@
 .PHONY: lint test test-wheel _template-version clean fixup build verify help _check-git-clean
-.PHONY: publish-to-pypi publish-to-testpypi _verify-build-publish install-build-deps _publish
+.PHONY: publish-to-pypi publish-to-testpypi _verify-build-publish install-build-deps install-dev _publish
 
 clean:
 	rm -rf build dist
@@ -28,14 +28,16 @@ build: clean _template-version
 verify: lint test
 
 install-build-deps:
-	# FIXME[matt] build dependencies should be pinned (e.g. build,
-	# setuptools, twine) to ensure reproducible builds.
-	python -m pip install -e .[all]
-	python -m pip install --upgrade pip setuptools build twine pylint nox pre-commit
+	# Ensure pip is at a known version first for reproducible builds
+	python -m pip install pip==25.1.1
+	# Use 'python -m pip' to ensure we're using python's pip
+	# https://pip.pypa.io/en/latest/user_guide/
+	python -m pip install -e .
+	python -m pip install -r requirements-build.txt
 
 install-dev:
-	pip install -e .[all]
-	pip install pylint
+	pip install -e .
+	pip install -r requirements-dev.txt
 
 _publish:
 	./scripts/publish.sh

--- a/py/Makefile
+++ b/py/Makefile
@@ -47,7 +47,6 @@ _check-git-clean:
 	fi
 
 _verify-build-publish: _check-git-clean lint build test-wheel _publish
-
 publish-to-pypi: export PYPI_REPO := pypi
 publish-to-pypi: _verify-build-publish
 

--- a/py/Makefile
+++ b/py/Makefile
@@ -47,6 +47,7 @@ _check-git-clean:
 	fi
 
 _verify-build-publish: _check-git-clean lint build test-wheel _publish
+
 publish-to-pypi: export PYPI_REPO := pypi
 publish-to-pypi: _verify-build-publish
 

--- a/py/requirements-build.txt
+++ b/py/requirements-build.txt
@@ -1,0 +1,4 @@
+# Build and packaging tools with pinned versions for reproducible builds
+build==1.2.2.post1
+setuptools==80.7.1
+twine==5.0.0

--- a/py/requirements-dev.txt
+++ b/py/requirements-dev.txt
@@ -1,0 +1,13 @@
+# Also include build dependencies
+black
+flake8
+flake8-isort
+isort==5.12.0
+nox
+pre-commit
+pydoc-markdown
+pylint
+pytest
+pytest-asyncio
+
+-r requirements-build.txt

--- a/py/setup.py
+++ b/py/setup.py
@@ -25,23 +25,8 @@ install_requires = [
 
 extras_require = {
     "cli": ["boto3", "psycopg2-binary", "uv"],
-    "dev": [
-        "black",
-        "build",
-        "flake8",
-        "flake8-isort",
-        "IPython",
-        "isort==5.12.0",
-        "pre-commit",
-        "pytest",
-        "twine",
-        "pytest-asyncio",
-        "nox",
-    ],
     "doc": ["pydoc-markdown"],
     "openai-agents": ["openai-agents"],
-    # These should only be installed for linting import errors, not for tests.
-    "lint": ["anthropic"],
 }
 
 extras_require["all"] = sorted({package for packages in extras_require.values() for package in packages})


### PR DESCRIPTION
This PR makes a few changes:

- Pins all the of the critical build dependencies. This will help ensure that a new version of build, twine or setuptools doesn't have unexpected behaviour that changes our app.
- splits the dependencies by function:
    - `requirements-dev.txt` is the dependencies developers will want to install on their machine. These are loosely managed. `pylint`, `black`, etc. 
    - `requirements-build.txt` is the dependencies we need to build and ship the SDK. Everything in here is pinned and strictly managed. `build`, `setuptools`, etc.
    - `setup.py` is for actual dependencies of our library. I'm happy the dev stuff is gone from here because it's easier to read and understand.
  - Installs `pip` in a fixed way.
  - Updates github actions to install things the right way.