### PR TITLE
Populate a prompt's id, version, and project_id in `braintrust pull`

### DIFF
--- a/js/src/cli-util/pull.ts
+++ b/js/src/cli-util/pull.ts
@@ -124,6 +124,7 @@ export async function pullCommand(args: PullArgs) {
 
     const projectFileContents = await makeProjectFile({
       projectName,
+      projectId: await projectNameIdMap.getId(projectName),
       fileName: projectFile,
       functions: projectNameToFunctions[projectName],
       hasSpecifiedFunction: !!args.slug || !!args.id,
@@ -135,11 +136,13 @@ export async function pullCommand(args: PullArgs) {
 
 async function makeProjectFile({
   projectName,
+  projectId,
   fileName,
   functions,
   hasSpecifiedFunction,
 }: {
   projectName: string;
+  projectId: string;
   fileName: string;
   functions: FunctionObject[];
   hasSpecifiedFunction: boolean;
@@ -160,6 +163,7 @@ async function makeProjectFile({
 import braintrust from "braintrust";
 
 const project = braintrust.projects.create({
+  id: ${doubleQuote(projectId)},
   name: ${doubleQuote(projectName)},
 });
 
@@ -257,6 +261,7 @@ function makeFunctionDefinition({
       : "";
 
   return `export const ${varName} = project.${pluralize(objectType)}.create({
+  id: ${doubleQuote(func.id)},
   name: ${doubleQuote(func.name)},
   slug: ${doubleQuote(func.slug)},${printOptionalField("description", func.description)}${printOptionalField("model", model)}
 ${indent(promptContents, 2)},

--- a/js/src/cli-util/pull.ts
+++ b/js/src/cli-util/pull.ts
@@ -14,7 +14,7 @@ import util from "util";
 import slugify from "slugify";
 import path from "path";
 import { currentRepo } from "../gitutil";
-import { isEmpty, loadPrettyXact } from "@braintrust/core";
+import { isEmpty, loadPrettyXact, prettifyXact } from "@braintrust/core";
 import {
   ToolFunctionDefinition,
   toolFunctionDefinitionSchema,
@@ -263,7 +263,8 @@ function makeFunctionDefinition({
   return `export const ${varName} = project.${pluralize(objectType)}.create({
   id: ${doubleQuote(func.id)},
   name: ${doubleQuote(func.name)},
-  slug: ${doubleQuote(func.slug)},${printOptionalField("description", func.description)}${printOptionalField("model", model)}
+  slug: ${doubleQuote(func.slug)},
+  version: ${doubleQuote(prettifyXact(func._xact_id))}, ${printOptionalField("description", func.description)}${printOptionalField("model", model)}
 ${indent(promptContents, 2)},
 ${indent(paramsString, 2)}
 ${indent(toolsString, 2)}

--- a/js/src/framework2.ts
+++ b/js/src/framework2.ts
@@ -13,7 +13,7 @@ import {
   chatCompletionMessageParamSchema,
   modelParamsSchema,
 } from "@braintrust/core/typespecs";
-import { TransactionId } from "@braintrust/core";
+import { loadPrettyXact, TransactionId } from "@braintrust/core";
 import { Prompt, PromptRowWithId } from "./logger";
 import { GenericFunction } from "./framework-types";
 
@@ -408,7 +408,7 @@ export class PromptBuilder {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const promptRow: PromptRowWithId<HasId, HasVersion> = {
       id: opts.id,
-      _xact_id: opts.version,
+      _xact_id: opts.version ? loadPrettyXact(opts.version) : undefined,
       name: opts.name,
       slug: slug,
       prompt_data: promptData,

--- a/js/src/framework2.ts
+++ b/js/src/framework2.ts
@@ -412,6 +412,7 @@ export class PromptBuilder {
       name: opts.name,
       slug: slug,
       prompt_data: promptData,
+      ...(this.project.id !== undefined ? { project_id: this.project.id } : {}),
     } as PromptRowWithId<HasId, HasVersion>;
 
     const prompt = new Prompt<HasId, HasVersion>(


### PR DESCRIPTION
This makes the "Try prompt" experience fully rich and accurate.