### PR TITLE
Propagate tags and metadata to invoke

### DIFF
--- a/core/js/typespecs/functions.ts
+++ b/core/js/typespecs/functions.ts
@@ -252,8 +252,13 @@ export const invokeFunctionNonIdArgsSchema = z.object({
   metadata: z
     .record(z.string(), z.unknown())
     .nullish()
-    .describe("Any relevant metadata"),
-  tags: z.array(z.string()).nullish().describe("Any relevant tags"),
+    .describe(
+      "Any relevant metadata. This will be logged and available as the `metadata` argument.",
+    ),
+  tags: z
+    .array(z.string())
+    .nullish()
+    .describe("Any relevant tags to log on the span."),
   messages: z
     .array(chatCompletionMessageParamSchema)
     .optional()

--- a/core/js/typespecs/functions.ts
+++ b/core/js/typespecs/functions.ts
@@ -253,6 +253,7 @@ export const invokeFunctionNonIdArgsSchema = z.object({
     .record(z.string(), z.unknown())
     .nullish()
     .describe("Any relevant metadata"),
+  tags: z.array(z.string()).nullish().describe("Any relevant tags"),
   messages: z
     .array(chatCompletionMessageParamSchema)
     .optional()

--- a/js/examples/anthropic_tools_example.ts
+++ b/js/examples/anthropic_tools_example.ts
@@ -35,6 +35,9 @@ async function main() {
   const tool = message.content.find(
     (content): content is Anthropic.ToolUseBlock => content.type === "tool_use",
   );
+  if (!tool) {
+    throw new Error("No tool used");
+  }
 
   const result = await client.messages.create({
     model: "claude-3-5-sonnet-latest",

--- a/js/src/functions/invoke.ts
+++ b/js/src/functions/invoke.ts
@@ -67,6 +67,17 @@ export interface InvokeFunctionArgs<
   messages?: Message[];
 
   /**
+   * Additional metadata to add to the span. This will be logged as the `metadata` field in the span.
+   * It will also be available as the {{metadata}} field in the prompt and as the `metadata` argument
+   * to the function.
+   */
+  metadata?: Record<string, unknown>;
+  /**
+   * Tags to add to the span. This will be logged as the `tags` field in the span.
+   */
+  tags?: string[];
+
+  /**
    * The parent of the function. This can be an existing span, logger, or experiment, or
    * the output of `.export()` if you are distributed tracing. If unspecified, will use
    * the same semantics as `traced()` to determine the parent and no-op if not in a tracing
@@ -131,6 +142,8 @@ export async function invoke<Input, Output, Stream extends boolean = false>(
     input,
     messages,
     parent: parentArg,
+    metadata,
+    tags,
     state: stateArg,
     stream,
     mode,
@@ -174,6 +187,8 @@ export async function invoke<Input, Output, Stream extends boolean = false>(
     input,
     messages,
     parent,
+    metadata,
+    tags,
     stream,
     mode,
     strict,
@@ -237,6 +252,7 @@ export function initFunction({
   slug: string;
   version?: string;
 }) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const f = async (input: any): Promise<any> => {
     return await invoke({
       projectName,

--- a/js/src/logger.test.ts
+++ b/js/src/logger.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { vi, expect, test, describe, beforeEach, afterEach } from "vitest";
 import {
   _exportsForTestingOnly,
@@ -12,7 +13,6 @@ import {
   Prompt,
   permalink,
   BraintrustState,
-  FailedHTTPResponse,
 } from "./logger";
 import { SpanObjectTypeV3 } from "@braintrust/core";
 import { LazyValue } from "./util";
@@ -48,6 +48,7 @@ test("verify MemoryBackgroundLogger intercepts logs", async () => {
 
   await memoryLogger.flush();
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any
   const events = (await memoryLogger.drain()) as any[]; // FIXME[matt] what type should this be?
   expect(events).toHaveLength(2);
 
@@ -374,7 +375,9 @@ test("disable logging", async () => {
 
   let submittedItems = [];
   const submitLogsRequestSpy = vi
+    // @ts-ignore
     .spyOn(bgLogger, "submitLogsRequest")
+    // @ts-ignore
     .mockImplementation((items: string[]) => {
       submittedItems = items;
       return Promise.resolve();
@@ -497,6 +500,7 @@ describe("span.link", () => {
     // Get the link
     const link1 = span.link();
     expect(link1).toBe(
+      // @ts-ignore
       `https://braintrust.dev/app/test-org-name/p/test-project/logs?oid=${span._id}`,
     );
   });
@@ -574,11 +578,11 @@ describe("span.link", () => {
   });
 
   test("span.link handles missing experiment id", async () => {
-    const state = await _exportsForTestingOnly.simulateLoginForTests();
     const experiment = initExperiment("test-experiment");
     const span = experiment.startSpan({ name: "test-span" });
     span.end();
     // Force parentObjectId to be undefined
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (span as any).parentObjectId = { getSync: () => ({ value: undefined }) };
     const link = span.link();
     expect(link).toBe(
@@ -587,12 +591,13 @@ describe("span.link", () => {
   });
 
   test("span.link handles missing project id and name", async () => {
-    const state = await _exportsForTestingOnly.simulateLoginForTests();
     const logger = initLogger({});
     const span = logger.startSpan({ name: "test-span" });
     span.end();
     // Force parentObjectId to be undefined and remove project metadata
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (span as any).parentObjectId = { getSync: () => ({ value: undefined }) };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (span as any).parentComputeObjectMetadataArgs = {};
     const link = span.link();
     expect(link).toBe(
@@ -601,11 +606,11 @@ describe("span.link", () => {
   });
 
   test("span.link handles playground logs", async () => {
-    const state = await _exportsForTestingOnly.simulateLoginForTests();
     const logger = initLogger({});
     const span = logger.startSpan({ name: "test-span" });
     span.end();
     // Force parentObjectType to be PLAYGROUND_LOGS
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (span as any).parentObjectType = SpanObjectTypeV3.PLAYGROUND_LOGS;
     const link = span.link();
     expect(link).toBe("https://braintrust.dev/noop-span");

--- a/js/src/logger.test.ts
+++ b/js/src/logger.test.ts
@@ -578,6 +578,7 @@ describe("span.link", () => {
   });
 
   test("span.link handles missing experiment id", async () => {
+    const _state = await _exportsForTestingOnly.simulateLoginForTests();
     const experiment = initExperiment("test-experiment");
     const span = experiment.startSpan({ name: "test-span" });
     span.end();
@@ -591,6 +592,7 @@ describe("span.link", () => {
   });
 
   test("span.link handles missing project id and name", async () => {
+    const _state = await _exportsForTestingOnly.simulateLoginForTests();
     const logger = initLogger({});
     const span = logger.startSpan({ name: "test-span" });
     span.end();
@@ -606,6 +608,7 @@ describe("span.link", () => {
   });
 
   test("span.link handles playground logs", async () => {
+    const _state = await _exportsForTestingOnly.simulateLoginForTests();
     const logger = initLogger({});
     const span = logger.startSpan({ name: "test-span" });
     span.end();

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -1897,7 +1897,7 @@ interface BackgroundLogger {
   flush(): Promise<void>;
 }
 
-class TestBackgroundLogger implements BackgroundLogger {
+export class TestBackgroundLogger implements BackgroundLogger {
   private items: LazyValue<BackgroundLogEvent>[][] = [];
 
   log(items: LazyValue<BackgroundLogEvent>[]): void {

--- a/js/src/prompt-cache/disk-cache.test.ts
+++ b/js/src/prompt-cache/disk-cache.test.ts
@@ -4,12 +4,12 @@ import { DiskCache } from "./disk-cache";
 import { tmpdir } from "os";
 import { beforeEach, describe, it, afterEach, expect } from "vitest";
 import { configureNode } from "../node";
-import iso from "../isomorph";
 
 describe("DiskCache", () => {
   configureNode();
 
   let cacheDir: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let cache: DiskCache<any>;
 
   beforeEach(async () => {
@@ -20,7 +20,7 @@ describe("DiskCache", () => {
   afterEach(async () => {
     try {
       await fs.rm(cacheDir, { recursive: true, force: true });
-    } catch (e) {
+    } catch {
       // Ignore errors if directory doesn't exist.
     }
   });

--- a/js/src/prompt-cache/disk-cache.ts
+++ b/js/src/prompt-cache/disk-cache.ts
@@ -64,7 +64,7 @@ export class DiskCache<T> {
     this.logWarnings = options.logWarnings ?? true;
   }
 
-  private getEntryPath(key: string): string {
+  public getEntryPath(key: string): string {
     const hashed = iso.hash!(key);
     return iso.pathJoin!(this.dir, hashed);
   }
@@ -84,6 +84,7 @@ export class DiskCache<T> {
       await iso.utimes!(filePath, new Date(), new Date());
       return JSON.parse(data.toString());
     } catch (e) {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       if ((e as NodeJS.ErrnoException).code === "ENOENT") {
         return undefined;
       }

--- a/py/src/braintrust/functions/invoke.py
+++ b/py/src/braintrust/functions/invoke.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Literal, Optional, TypeVar, Union, overload
+from typing import Any, Dict, List, Literal, Optional, TypeVar, Union, overload
 
 from sseclient import SSEClient
 
@@ -24,6 +24,8 @@ def invoke(
     # arguments to the function
     input: Any = None,
     messages: Optional[List[Any]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    tags: Optional[List[str]] = None,
     parent: Optional[Union[Exportable, str]] = None,
     stream: Optional[Literal[False]] = None,
     mode: Optional[ModeType] = None,
@@ -49,6 +51,8 @@ def invoke(
     # arguments to the function
     input: Any = None,
     messages: Optional[List[Any]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    tags: Optional[List[str]] = None,
     parent: Optional[Union[Exportable, str]] = None,
     stream: Literal[True] = True,
     mode: Optional[ModeType] = None,
@@ -73,6 +77,8 @@ def invoke(
     # arguments to the function
     input: Any = None,
     messages: Optional[List[Any]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    tags: Optional[List[str]] = None,
     parent: Optional[Union[Exportable, str]] = None,
     stream: bool = False,
     mode: Optional[ModeType] = None,
@@ -89,6 +95,10 @@ def invoke(
     Args:
         input: The input to the function. This will be logged as the `input` field in the span.
         messages: Additional OpenAI-style messages to add to the prompt (only works for llm functions).
+        metadata: Additional metadata to add to the span. This will be logged as the `metadata` field in the span.
+            It will also be available as the {{metadata}} field in the prompt and as the `metadata` argument
+            to the function.
+        tags: Tags to add to the span. This will be logged as the `tags` field in the span.
         parent: The parent of the function. This can be an existing span, logger, or experiment, or
             the output of `.export()` if you are distributed tracing. If unspecified, will use
             the same semantics as `traced()` to determine the parent and no-op if not in a tracing
@@ -144,6 +154,8 @@ def invoke(
 
     request = dict(
         input=input,
+        metadata=metadata,
+        tags=tags,
         parent=parent,
         stream=stream,
         api_version=INVOKE_API_VERSION,


### PR DESCRIPTION
To make it easier to add tags/metadata to the logged spans for `invoke`.

Also fixed a bunch of typescript errors that were blocking docs updates.