### PR TITLE
Add anthropic message typespecs

### DIFF
--- a/core/js/typespecs/anthropic/messages.ts
+++ b/core/js/typespecs/anthropic/messages.ts
@@ -224,7 +224,7 @@ export const anthropicContentPartSchema = z.union([
 
 // system isn't technically a role, per Anthropic's docs, but we have users making use of it,
 // so we'll support it for parsing purposes
-const anthropicMessageParamSchema = z.object({
+export const anthropicMessageParamSchema = z.object({
   role: z.enum(["system", "user", "assistant"]),
   content: z.union([z.string(), z.array(anthropicContentPartSchema)]),
 });

--- a/core/js/typespecs/anthropic/messages.ts
+++ b/core/js/typespecs/anthropic/messages.ts
@@ -130,6 +130,7 @@ const anthropicMCPToolResultContentPartSchema = z.object({
       z.object({
         type: z.literal("text"),
         text: z.string(),
+        // This is a simplification of the strict citation schema
         citations: z.array(z.record(z.any())).nullish(),
         cache_control: cacheControlSchema.nullish(),
       }),
@@ -222,8 +223,8 @@ export const anthropicContentPartSchema = z.union([
   anthropicContainerUploadContentPartSchema,
 ]);
 
-// system isn't technically a role, per Anthropic's docs, but we have users making use of it,
-// so we'll support it for parsing purposes
+// System blocks are provided as a separate parameter to the Anthropic client, rather than in the messages parameter.
+// However, we include it as an input on LLM spans created by the anthropic wrapper, so we need to support it here.
 export const anthropicMessageParamSchema = z.object({
   role: z.enum(["system", "user", "assistant"]),
   content: z.union([z.string(), z.array(anthropicContentPartSchema)]),

--- a/core/js/typespecs/anthropic/messages.ts
+++ b/core/js/typespecs/anthropic/messages.ts
@@ -1,0 +1,98 @@
+import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
+import { cacheControlSchema } from "typespecs/openai/messages";
+import { z } from "zod";
+
+export const anthropicImageSourceSchema = z.object({
+  type: z.literal("base64"),
+  media_type: z.enum(["image/jpeg", "image/png", "image/gif", "image/webp"]),
+  data: z.string(),
+});
+
+export const anthropicContentPartTextSchema = z.object({
+  type: z.literal("text"),
+  text: z.string(),
+  cache_control: cacheControlSchema.optional(),
+});
+
+export const anthropicContentPartImageSchema = z.object({
+  type: z.literal("image"),
+  source: anthropicImageSourceSchema,
+  cache_control: cacheControlSchema.optional(),
+});
+
+export const anthropicToolUseContentPartSchema = z.object({
+  type: z.literal("tool_use"),
+  id: z.string(),
+  name: z.string(),
+  input: z.record(z.any()),
+  cache_control: cacheControlSchema.optional(),
+});
+
+export const anthropicToolResultContentPartSchema = z.object({
+  type: z.literal("tool_result"),
+  tool_use_id: z.string(),
+  content: z
+    .union([
+      z.string(),
+      z.array(
+        z.union([
+          anthropicContentPartTextSchema,
+          anthropicContentPartImageSchema,
+        ]),
+      ),
+    ])
+    .optional(),
+  is_error: z.boolean().optional(),
+  cache_control: cacheControlSchema.optional(),
+});
+
+export const anthropicContentPartSchema = z.union([
+  anthropicContentPartTextSchema.openapi({ title: "text" }),
+  anthropicContentPartImageSchema.openapi({ title: "image" }),
+  anthropicToolUseContentPartSchema.openapi({ title: "tool_use" }),
+  anthropicToolResultContentPartSchema.openapi({ title: "tool_result" }),
+]);
+
+const anthropicSystemMessageParamSchema = z.object({
+  role: z.literal("system"),
+  content: z.union([z.string(), z.array(anthropicContentPartTextSchema)]),
+  cache_control: cacheControlSchema.optional(),
+});
+
+const anthropicUserMessageParamSchema = z.object({
+  role: z.literal("user"),
+  content: z.union([
+    z.string(),
+    z.array(
+      z.union([
+        anthropicContentPartTextSchema,
+        anthropicContentPartImageSchema,
+        anthropicToolResultContentPartSchema,
+      ]),
+    ),
+  ]),
+  cache_control: cacheControlSchema.optional(),
+});
+
+const anthropicAssistantMessageParamSchema = z.object({
+  role: z.literal("assistant"),
+  content: z.union([
+    z.string(),
+    z.array(
+      z.union([
+        anthropicContentPartTextSchema,
+        anthropicToolUseContentPartSchema,
+      ]),
+    ),
+  ]),
+  cache_control: cacheControlSchema.optional(),
+});
+
+export const anthropicMessageParamSchema = z.union([
+  anthropicSystemMessageParamSchema.openapi({ title: "system" }),
+  anthropicUserMessageParamSchema.openapi({ title: "user" }),
+  anthropicAssistantMessageParamSchema.openapi({ title: "assistant" }),
+]);
+
+export type AnthropicContentPart = z.infer<typeof anthropicContentPartSchema>;
+export type AnthropicMessageParam = z.infer<typeof anthropicMessageParamSchema>;

--- a/core/js/typespecs/openai/messages.ts
+++ b/core/js/typespecs/openai/messages.ts
@@ -83,15 +83,12 @@ export const anthropicToolResultContentPartSchema = z
     type: z.literal("tool_result"),
     tool_use_id: z.string(),
     content: z
-      .union([
-        z.string(),
-        z.array(
-          z.union([
-            anthropicContentPartTextSchema,
-            anthropicContentPartImageSchema,
-          ]),
-        ),
-      ])
+      .array(
+        z.union([
+          anthropicContentPartTextSchema,
+          anthropicContentPartImageSchema,
+        ]),
+      )
       .optional(),
     is_error: z.boolean().optional(),
     cache_control: cacheControlSchema.optional(),

--- a/core/js/typespecs/openai/messages.ts
+++ b/core/js/typespecs/openai/messages.ts
@@ -46,67 +46,6 @@ export const chatCompletionContentPartImageSchema = z
   })
   .openapi("ChatCompletionContentPartImage");
 
-export const anthropicImageSourceSchema = z.object({
-  type: z.literal("base64"),
-  media_type: z.enum(["image/jpeg", "image/png", "image/gif", "image/webp"]),
-  data: z.string(),
-});
-
-export const anthropicContentPartTextSchema = z
-  .object({
-    type: z.literal("text"),
-    text: z.string(),
-    cache_control: cacheControlSchema.optional(),
-  })
-  .openapi("AnthropicContentPartText");
-
-export const anthropicContentPartImageSchema = z
-  .object({
-    type: z.literal("image"),
-    source: anthropicImageSourceSchema,
-    cache_control: cacheControlSchema.optional(),
-  })
-  .openapi("AnthropicContentPartImage");
-
-export const anthropicToolUseContentPartSchema = z
-  .object({
-    type: z.literal("tool_use"),
-    id: z.string(),
-    name: z.string(),
-    input: z.record(z.any()),
-    cache_control: cacheControlSchema.optional(),
-  })
-  .openapi("AnthropicToolUseContentPart");
-
-export const anthropicToolResultContentPartSchema = z
-  .object({
-    type: z.literal("tool_result"),
-    tool_use_id: z.string(),
-    content: z
-      .union([
-        z.string(),
-        z.array(
-          z.union([
-            anthropicContentPartTextSchema,
-            anthropicContentPartImageSchema,
-          ]),
-        ),
-      ])
-      .optional(),
-    is_error: z.boolean().optional(),
-    cache_control: cacheControlSchema.optional(),
-  })
-  .openapi("AnthropicToolResultContentPart");
-
-export const anthropicContentPartSchema = z
-  .union([
-    anthropicContentPartTextSchema.openapi({ title: "text" }),
-    anthropicContentPartImageSchema.openapi({ title: "image" }),
-    anthropicToolUseContentPartSchema.openapi({ title: "tool_use" }),
-    anthropicToolResultContentPartSchema.openapi({ title: "tool_result" }),
-  ])
-  .openapi("AnthropicContentPart");
-
 export const chatCompletionContentPartSchema = z
   .union([
     chatCompletionContentPartTextSchema.openapi({ title: "text" }),
@@ -126,49 +65,6 @@ export const chatCompletionContentSchema = z
       .openapi({ title: "array" }),
   ])
   .openapi("ChatCompletionContent");
-
-const anthropicSystemMessageParamSchema = z.object({
-  role: z.literal("system"),
-  content: z.union([z.string(), z.array(anthropicContentPartTextSchema)]),
-  cache_control: cacheControlSchema.optional(),
-});
-
-const anthropicUserMessageParamSchema = z.object({
-  role: z.literal("user"),
-  content: z.union([
-    z.string(),
-    z.array(
-      z.union([
-        anthropicContentPartTextSchema,
-        anthropicContentPartImageSchema,
-        anthropicToolResultContentPartSchema,
-      ]),
-    ),
-  ]),
-  cache_control: cacheControlSchema.optional(),
-});
-
-const anthropicAssistantMessageParamSchema = z.object({
-  role: z.literal("assistant"),
-  content: z.union([
-    z.string(),
-    z.array(
-      z.union([
-        anthropicContentPartTextSchema,
-        anthropicToolUseContentPartSchema,
-      ]),
-    ),
-  ]),
-  cache_control: cacheControlSchema.optional(),
-});
-
-export const anthropicMessageParamSchema = z
-  .union([
-    anthropicSystemMessageParamSchema.openapi({ title: "system" }),
-    anthropicUserMessageParamSchema.openapi({ title: "user" }),
-    anthropicAssistantMessageParamSchema.openapi({ title: "assistant" }),
-  ])
-  .openapi("AnthropicMessageParam");
 
 const chatCompletionUserMessageParamSchema = z.object({
   content: chatCompletionContentSchema,
@@ -269,29 +165,8 @@ export const chatCompletionOpenAIMessageParamSchema = z.union([
 export const chatCompletionMessageParamSchema = z
   .union([
     chatCompletionOpenAIMessageParamSchema.openapi({ title: "openai" }),
-    anthropicMessageParamSchema.openapi({ title: "anthropic" }),
     chatCompletionFallbackMessageParamSchema.openapi({ title: "fallback" }),
   ])
   .openapi("ChatCompletionMessageParam");
 
-export const anthropicToolSchema = z.object({
-  name: z.string(),
-  description: z.string().optional(),
-  input_schema: z.record(z.any()), // JSON Schema for the tool's input
-  cache_control: cacheControlSchema.optional(),
-});
-
-export const anthropicToolChoiceSchema = z.union([
-  z.literal("auto"),
-  z.literal("any"),
-  z.object({
-    type: z.literal("tool"),
-    name: z.string(),
-  }),
-]);
-
 export type ToolCall = z.infer<typeof chatCompletionMessageToolCallSchema>;
-export type AnthropicContentPart = z.infer<typeof anthropicContentPartSchema>;
-export type AnthropicMessageParam = z.infer<typeof anthropicMessageParamSchema>;
-export type AnthropicTool = z.infer<typeof anthropicToolSchema>;
-export type AnthropicToolChoice = z.infer<typeof anthropicToolChoiceSchema>;

--- a/core/js/typespecs/openai/messages.ts
+++ b/core/js/typespecs/openai/messages.ts
@@ -38,12 +38,74 @@ const imageURLSchema = z.object({
     ])
     .optional(),
 });
+
 export const chatCompletionContentPartImageSchema = z
   .object({
     image_url: imageURLSchema,
     type: z.literal("image_url"),
   })
   .openapi("ChatCompletionContentPartImage");
+
+export const anthropicImageSourceSchema = z.object({
+  type: z.literal("base64"),
+  media_type: z.enum(["image/jpeg", "image/png", "image/gif", "image/webp"]),
+  data: z.string(),
+});
+
+export const anthropicContentPartTextSchema = z
+  .object({
+    type: z.literal("text"),
+    text: z.string(),
+    cache_control: cacheControlSchema.optional(),
+  })
+  .openapi("AnthropicContentPartText");
+
+export const anthropicContentPartImageSchema = z
+  .object({
+    type: z.literal("image"),
+    source: anthropicImageSourceSchema,
+    cache_control: cacheControlSchema.optional(),
+  })
+  .openapi("AnthropicContentPartImage");
+
+export const anthropicToolUseContentPartSchema = z
+  .object({
+    type: z.literal("tool_use"),
+    id: z.string(),
+    name: z.string(),
+    input: z.record(z.any()),
+    cache_control: cacheControlSchema.optional(),
+  })
+  .openapi("AnthropicToolUseContentPart");
+
+export const anthropicToolResultContentPartSchema = z
+  .object({
+    type: z.literal("tool_result"),
+    tool_use_id: z.string(),
+    content: z
+      .union([
+        z.string(),
+        z.array(
+          z.union([
+            anthropicContentPartTextSchema,
+            anthropicContentPartImageSchema,
+          ]),
+        ),
+      ])
+      .optional(),
+    is_error: z.boolean().optional(),
+    cache_control: cacheControlSchema.optional(),
+  })
+  .openapi("AnthropicToolResultContentPart");
+
+export const anthropicContentPartSchema = z
+  .union([
+    anthropicContentPartTextSchema.openapi({ title: "text" }),
+    anthropicContentPartImageSchema.openapi({ title: "image" }),
+    anthropicToolUseContentPartSchema.openapi({ title: "tool_use" }),
+    anthropicToolResultContentPartSchema.openapi({ title: "tool_result" }),
+  ])
+  .openapi("AnthropicContentPart");
 
 export const chatCompletionContentPartSchema = z
   .union([
@@ -65,19 +127,65 @@ export const chatCompletionContentSchema = z
   ])
   .openapi("ChatCompletionContent");
 
+const anthropicSystemMessageParamSchema = z.object({
+  role: z.literal("system"),
+  content: z.union([z.string(), z.array(anthropicContentPartTextSchema)]),
+  cache_control: cacheControlSchema.optional(),
+});
+
+const anthropicUserMessageParamSchema = z.object({
+  role: z.literal("user"),
+  content: z.union([
+    z.string(),
+    z.array(
+      z.union([
+        anthropicContentPartTextSchema,
+        anthropicContentPartImageSchema,
+        anthropicToolResultContentPartSchema,
+      ]),
+    ),
+  ]),
+  cache_control: cacheControlSchema.optional(),
+});
+
+const anthropicAssistantMessageParamSchema = z.object({
+  role: z.literal("assistant"),
+  content: z.union([
+    z.string(),
+    z.array(
+      z.union([
+        anthropicContentPartTextSchema,
+        anthropicToolUseContentPartSchema,
+      ]),
+    ),
+  ]),
+  cache_control: cacheControlSchema.optional(),
+});
+
+export const anthropicMessageParamSchema = z
+  .union([
+    anthropicSystemMessageParamSchema.openapi({ title: "system" }),
+    anthropicUserMessageParamSchema.openapi({ title: "user" }),
+    anthropicAssistantMessageParamSchema.openapi({ title: "assistant" }),
+  ])
+  .openapi("AnthropicMessageParam");
+
 const chatCompletionUserMessageParamSchema = z.object({
   content: chatCompletionContentSchema,
   role: z.literal("user"),
   name: z.string().optional(),
 });
+
 const functionCallSchema = z.object({
   arguments: z.string(),
   name: z.string(),
 });
+
 const functionSchema = z.object({
   arguments: z.string(),
   name: z.string(),
 });
+
 const chatCompletionToolMessageParamSchema = z.object({
   content: z.union([
     z.string().default("").openapi({ title: "text" }),
@@ -86,11 +194,13 @@ const chatCompletionToolMessageParamSchema = z.object({
   role: z.literal("tool"),
   tool_call_id: z.string().default(""),
 });
+
 const chatCompletionFunctionMessageParamSchema = z.object({
   content: z.string().nullable(),
   name: z.string(),
   role: z.literal("function"),
 });
+
 export const chatCompletionMessageToolCallSchema = z
   .object({
     id: z.string(),
@@ -136,6 +246,7 @@ const chatCompletionAssistantMessageParamSchema = z.object({
     .nullish()
     .transform((x) => x ?? undefined),
 });
+
 const chatCompletionFallbackMessageParamSchema = z.object({
   role: messageRoleSchema.exclude([
     "system",
@@ -146,6 +257,7 @@ const chatCompletionFallbackMessageParamSchema = z.object({
   ]),
   content: z.string().nullish(),
 });
+
 export const chatCompletionOpenAIMessageParamSchema = z.union([
   chatCompletionSystemMessageParamSchema.openapi({ title: "system" }),
   chatCompletionUserMessageParamSchema.openapi({ title: "user" }),
@@ -157,8 +269,29 @@ export const chatCompletionOpenAIMessageParamSchema = z.union([
 export const chatCompletionMessageParamSchema = z
   .union([
     chatCompletionOpenAIMessageParamSchema.openapi({ title: "openai" }),
+    anthropicMessageParamSchema.openapi({ title: "anthropic" }),
     chatCompletionFallbackMessageParamSchema.openapi({ title: "fallback" }),
   ])
   .openapi("ChatCompletionMessageParam");
 
+export const anthropicToolSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  input_schema: z.record(z.any()), // JSON Schema for the tool's input
+  cache_control: cacheControlSchema.optional(),
+});
+
+export const anthropicToolChoiceSchema = z.union([
+  z.literal("auto"),
+  z.literal("any"),
+  z.object({
+    type: z.literal("tool"),
+    name: z.string(),
+  }),
+]);
+
 export type ToolCall = z.infer<typeof chatCompletionMessageToolCallSchema>;
+export type AnthropicContentPart = z.infer<typeof anthropicContentPartSchema>;
+export type AnthropicMessageParam = z.infer<typeof anthropicMessageParamSchema>;
+export type AnthropicTool = z.infer<typeof anthropicToolSchema>;
+export type AnthropicToolChoice = z.infer<typeof anthropicToolChoiceSchema>;

--- a/core/js/typespecs/openai/messages.ts
+++ b/core/js/typespecs/openai/messages.ts
@@ -83,12 +83,15 @@ export const anthropicToolResultContentPartSchema = z
     type: z.literal("tool_result"),
     tool_use_id: z.string(),
     content: z
-      .array(
-        z.union([
-          anthropicContentPartTextSchema,
-          anthropicContentPartImageSchema,
-        ]),
-      )
+      .union([
+        z.string(),
+        z.array(
+          z.union([
+            anthropicContentPartTextSchema,
+            anthropicContentPartImageSchema,
+          ]),
+        ),
+      ])
       .optional(),
     is_error: z.boolean().optional(),
     cache_control: cacheControlSchema.optional(),

--- a/core/js/typespecs/prompt.ts
+++ b/core/js/typespecs/prompt.ts
@@ -26,7 +26,10 @@ export {
   type MessageRole,
 } from "./openai/messages";
 
-export { anthropicMessageParamSchema } from "./anthropic/messages";
+export {
+  anthropicMessageParamSchema,
+  anthropicContentPartImageSchema,
+} from "./anthropic/messages";
 
 export { toolsSchema } from "./openai/tools";
 export type { Tools } from "./openai/tools";

--- a/core/js/typespecs/prompt.ts
+++ b/core/js/typespecs/prompt.ts
@@ -26,6 +26,8 @@ export {
   type MessageRole,
 } from "./openai/messages";
 
+export { anthropicMessageParamSchema } from "./anthropic/messages";
+
 export { toolsSchema } from "./openai/tools";
 export type { Tools } from "./openai/tools";
 

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -3059,7 +3059,9 @@ export async function loadPrompt({
     });
     if (!prompt) {
       throw new Error(
-        `Prompt ${slug} (version ${version ?? "latest"}) not found in ${[projectName ?? projectId]} (not found on server or in local cache): ${e}`,
+        `Prompt ${slug} (version ${version ?? "latest"}) not found in ${[
+          projectName ?? projectId,
+        ]} (not found on server or in local cache): ${e}`,
       );
     }
     return prompt;
@@ -5189,6 +5191,11 @@ export function renderMessage<T extends Message>(
                           url: render(c.image_url.url),
                         },
                       };
+                    // TODO - what needs to be rendered
+                    case "image":
+                    case "tool_use":
+                    case "tool_result":
+                      return c;
                     default:
                       const _exhaustiveCheck: never = c;
                       return _exhaustiveCheck;

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -5191,11 +5191,6 @@ export function renderMessage<T extends Message>(
                           url: render(c.image_url.url),
                         },
                       };
-                    // TODO - what needs to be rendered
-                    case "image":
-                    case "tool_use":
-                    case "tool_result":
-                      return c;
                     default:
                       const _exhaustiveCheck: never = c;
                       return _exhaustiveCheck;

--- a/js/src/wrappers/anthropic.test.ts
+++ b/js/src/wrappers/anthropic.test.ts
@@ -19,7 +19,7 @@ import { initLogger, _exportsForTestingOnly, login } from "../logger";
 import { configureNode } from "../node";
 import { getCurrentUnixTimestamp } from "../util";
 import { L } from "vitest/dist/chunks/reporters.nr4dxCkA";
-import { anthropicMessageParamSchema } from "@braintrust/core/typespecs/dist";
+import { anthropicMessageParamSchema } from "../../../core/js/typespecs/anthropic/messages";
 
 // use the cheapest model for tests
 const TEST_MODEL = "claude-3-haiku-20240307";

--- a/js/src/wrappers/anthropic.test.ts
+++ b/js/src/wrappers/anthropic.test.ts
@@ -19,6 +19,7 @@ import { initLogger, _exportsForTestingOnly, login } from "../logger";
 import { configureNode } from "../node";
 import { getCurrentUnixTimestamp } from "../util";
 import { L } from "vitest/dist/chunks/reporters.nr4dxCkA";
+import { anthropicMessageParamSchema } from "@braintrust/core/typespecs/dist";
 
 // use the cheapest model for tests
 const TEST_MODEL = "claude-3-haiku-20240307";
@@ -76,6 +77,7 @@ describe("anthropic client unit tests", () => {
       temperature: 0.01,
     });
     expect(response).toBeDefined();
+    expect(anthropicMessageParamSchema.safeParse(response).success).toBe(true);
 
     const spans = await backgroundLogger.drain();
     expect(spans).toHaveLength(1);
@@ -88,7 +90,12 @@ describe("anthropic client unit tests", () => {
     }
     const userInput = inputsByRole["user"];
     expect(userInput).toBeDefined();
+    expect(anthropicMessageParamSchema.safeParse(userInput).success).toBe(true);
+
     const systemInput = inputsByRole["system"];
+    expect(anthropicMessageParamSchema.safeParse(systemInput).success).toBe(
+      true,
+    );
     expect(systemInput.role).toEqual("system");
     expect(systemInput.content).toEqual(system);
   });


### PR DESCRIPTION
For use in client LLM viewer. 

Initially, I unioned the anthropic schema into `chatCompletionMessageParamSchema`, but that caused changes that rippled everywhere (I want to constrain the scope of these changes to fix the customer feedback so I can go back to wrapping up prompt editor cleanup). 

Ideally, we'd support anthropic format messages in the SDK, but have that broader type be a superset of e.g. the message schema used by the playground, so that the playground can continue to speak openAI-ish braintrust spec and doesn't need a bunch of extra type coercion. 

I'm keeping these schemas here so that if/when we ultimately add that support, these types are already in the SDK rather than living on the client.