### PR TITLE
update view to match new DB schema

### DIFF
--- a/core/js/typespecs/view.ts
+++ b/core/js/typespecs/view.ts
@@ -62,14 +62,16 @@ export const monitorViewOptionsSchema = z
 
 export const viewOptionsSchema = z
   .union([
-    // Future options must have a viewType
-    tableViewOptionsSchema,
+    // Monitor view with explicit type
     z
       .object({
         viewType: z.literal(viewTypeEnum.Values.monitor),
         options: monitorViewOptionsSchema,
       })
       .openapi({ title: "MonitorViewOptions" }),
+    // All other views (including legacy table views without viewType)
+    tableViewOptionsSchema,
+  ])
   ])
   .openapi("ViewOptions");
 

--- a/core/js/typespecs/view.ts
+++ b/core/js/typespecs/view.ts
@@ -36,7 +36,7 @@ export const viewDataSchema = z
   .strip()
   .openapi("ViewData");
 export type ViewData = z.infer<typeof viewDataSchema>;
-export const baseViewOptionsSchema = z
+export const tableViewOptionsSchema = z
   .object({
     columnVisibility: z.record(z.boolean()).nullish(),
     columnOrder: z.array(z.string()).nullish(),
@@ -62,10 +62,10 @@ export const monitorViewOptionsSchema = z
 export const viewOptionsSchema = z
   .union([
     // Future options must have a viewType
-    baseViewOptionsSchema,
+    tableViewOptionsSchema,
     z.object({
       viewType: z.literal(viewTypeEnum.Values.monitor),
-      options: baseViewOptionsSchema,
+      options: monitorViewOptionsSchema,
     }),
   ])
   .openapi("ViewOptions");

--- a/core/js/typespecs/view.ts
+++ b/core/js/typespecs/view.ts
@@ -15,6 +15,7 @@ export const viewTypeEnum = z
     "scorers",
     "logs",
     "agents",
+    "monitor"
   ])
   .describe("Type of table that the view corresponds to.");
 export type ViewType = z.infer<typeof viewTypeEnum>;

--- a/core/js/typespecs/view.ts
+++ b/core/js/typespecs/view.ts
@@ -46,7 +46,7 @@ export const tableViewOptionsSchema = z
     layout: z.string().nullish(),
   })
   .strip()
-  .openapi("TableViewOptions");
+  .openapi({ title: "TableViewOptions" });
 
 export const monitorViewOptionsSchema = z
   .object({
@@ -59,7 +59,7 @@ export const monitorViewOptionsSchema = z
     type: z.enum(["project", "experiment"]).nullish(),
   })
   .strip()
-  .openapi("MonitorViewOptions");
+  .openapi({ title: "MonitorViewOptions" });
 
 export const viewOptionsSchema = z
   .union([

--- a/core/js/typespecs/view.ts
+++ b/core/js/typespecs/view.ts
@@ -69,7 +69,7 @@ export const viewOptionsSchema = z
         options: monitorViewOptionsSchema,
       })
       .openapi({ title: "MonitorViewOptions" }),
-    // All other views (including legacy table views without viewType)
+    // All other views (legacy)
     tableViewOptionsSchema,
   ])
   .openapi("ViewOptions");

--- a/core/js/typespecs/view.ts
+++ b/core/js/typespecs/view.ts
@@ -36,8 +36,7 @@ export const viewDataSchema = z
   .strip()
   .openapi("ViewData");
 export type ViewData = z.infer<typeof viewDataSchema>;
-
-export const viewOptionsSchema = z
+export const baseViewOptionsSchema = z
   .object({
     columnVisibility: z.record(z.boolean()).nullish(),
     columnOrder: z.array(z.string()).nullish(),
@@ -46,6 +45,29 @@ export const viewOptionsSchema = z
     rowHeight: z.string().nullish(),
     layout: z.string().nullish(),
   })
-  .strip()
+  .strip();
+
+export const monitorViewOptionsSchema = z
+  .object({
+    spanType: z.enum(["range", "frame"]).nullish(),
+    rangeValue: z.string().nullish(),
+    frameStart: z.string().nullish(),
+    frameEnd: z.string().nullish(),
+    chartVisibility: z.record(z.boolean()).nullish(),
+    projectId: z.string().nullish(),
+    type: z.enum(["project", "experiment"]).nullish(),
+  })
+  .strip();
+
+export const viewOptionsSchema = z
+  .union([
+    // Future options must have a viewType
+    baseViewOptionsSchema,
+    z.object({
+      viewType: z.literal(viewTypeEnum.Values.monitor),
+      options: baseViewOptionsSchema,
+    }),
+  ])
   .openapi("ViewOptions");
+
 export type ViewOptions = z.infer<typeof viewOptionsSchema>;

--- a/core/js/typespecs/view.ts
+++ b/core/js/typespecs/view.ts
@@ -72,7 +72,6 @@ export const viewOptionsSchema = z
     // All other views (including legacy table views without viewType)
     tableViewOptionsSchema,
   ])
-  ])
   .openapi("ViewOptions");
 
 export type ViewOptions = z.infer<typeof viewOptionsSchema>;

--- a/core/js/typespecs/view.ts
+++ b/core/js/typespecs/view.ts
@@ -15,7 +15,7 @@ export const viewTypeEnum = z
     "scorers",
     "logs",
     "agents",
-    "monitor"
+    "monitor",
   ])
   .describe("Type of table that the view corresponds to.");
 export type ViewType = z.infer<typeof viewTypeEnum>;

--- a/core/js/typespecs/view.ts
+++ b/core/js/typespecs/view.ts
@@ -45,7 +45,8 @@ export const tableViewOptionsSchema = z
     rowHeight: z.string().nullish(),
     layout: z.string().nullish(),
   })
-  .strip();
+  .strip()
+  .openapi("TableViewOptions");
 
 export const monitorViewOptionsSchema = z
   .object({
@@ -57,7 +58,8 @@ export const monitorViewOptionsSchema = z
     projectId: z.string().nullish(),
     type: z.enum(["project", "experiment"]).nullish(),
   })
-  .strip();
+  .strip()
+  .openapi("MonitorViewOptions");
 
 export const viewOptionsSchema = z
   .union([

--- a/core/js/typespecs/view.ts
+++ b/core/js/typespecs/view.ts
@@ -58,17 +58,18 @@ export const monitorViewOptionsSchema = z
     projectId: z.string().nullish(),
     type: z.enum(["project", "experiment"]).nullish(),
   })
-  .strip()
-  .openapi({ title: "MonitorViewOptions" });
+  .strip();
 
 export const viewOptionsSchema = z
   .union([
     // Future options must have a viewType
     tableViewOptionsSchema,
-    z.object({
-      viewType: z.literal(viewTypeEnum.Values.monitor),
-      options: monitorViewOptionsSchema,
-    }),
+    z
+      .object({
+        viewType: z.literal(viewTypeEnum.Values.monitor),
+        options: monitorViewOptionsSchema,
+      })
+      .openapi({ title: "MonitorViewOptions" }),
   ])
   .openapi("ViewOptions");
 

--- a/core/js/typespecs/view.ts
+++ b/core/js/typespecs/view.ts
@@ -17,7 +17,7 @@ export const viewTypeEnum = z
     "agents",
     "monitor",
   ])
-  .describe("Type of table that the view corresponds to.");
+  .describe("Type of object that the view corresponds to.");
 export type ViewType = z.infer<typeof viewTypeEnum>;
 
 export const viewDataSearchSchema = z


### PR DESCRIPTION
Adding a new type that can be used for saving monitoring page views. Shooting for backwards compatibility.

Also bringing this in line with https://github.com/braintrustdata/braintrust/pull/5907

