### PR TITLE
New api

### DIFF
--- a/core/js/typespecs/view.ts
+++ b/core/js/typespecs/view.ts
@@ -48,6 +48,8 @@ export const tableViewOptionsSchema = z
   .strip()
   .openapi({ title: "TableViewOptions" });
 
+export type TableViewOptions = z.infer<typeof tableViewOptionsSchema>;
+
 export const monitorViewOptionsSchema = z
   .object({
     spanType: z.enum(["range", "frame"]).nullish(),


### PR DESCRIPTION
Second pass at updating this API. I still need to export the original type as some of the typescript code in the app uses it. 

It worked this time: https://github.com/braintrustdata/braintrust/pull/5946