### PR TITLE
CI Speed ups

### DIFF
--- a/.github/workflows/py.yaml
+++ b/.github/workflows/py.yaml
@@ -33,9 +33,9 @@ jobs:
         run: |
           # This is already done by make install-dev, but we're keeping this as a separate step
           # to explicitly verify that installation works
-          python -m pip install -e ./core/py[all]
-          python -m pip install -e ./py[all]
-          python -m pip install -e ./integrations/langchain-py[all]
+          python -m uv pip install -e ./core/py[all]
+          python -m uv pip install -e ./py[all]
+          python -m uv pip install -e ./integrations/langchain-py[all]
       - name: Test whether the Python SDK can be imported
         run: |
           python -c 'import braintrust'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
               .*\.(json|prisma|svg)
               |.*pnpm-lock.yaml
               |.*deno.lock
+              |.*.yaml
           )$
         args:
           - "-L"

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test-js:
 	pnpm install && pnpm test
 
 nox:
-	nox -f py/noxfile.py
+	cd py && make test
 	nox -f integrations/langchain-py/noxfile.py
 
 pylint:

--- a/py/Makefile
+++ b/py/Makefile
@@ -13,9 +13,6 @@ lint: fixup
 
 test:
 	nox -x
-	# by default, do one run of our code with actual request
-	# to openai, anthropic, etc so we have some testing of reality.
-	nox -s "test_latest_wrappers" -- --disable-vcr
 
 test-wheel: build
 	nox -x -- --wheel

--- a/py/Makefile
+++ b/py/Makefile
@@ -31,16 +31,17 @@ verify: lint test
 install-build-deps:
 	# Ensure pip is at a known version first for reproducible builds
 	python -m pip install pip==25.1.1
+	python -m pip install uv==0.7.8
 	# Use 'python -m pip' to ensure we're using python's pip
 	# https://pip.pypa.io/en/latest/user_guide/
-	python -m pip install -e .
-	python -m pip install -r requirements-build.txt
+	python -m uv pip install -e .
+	python -m uv pip install -r requirements-build.txt
 
 install-dev: install-build-deps
-	python -m pip install -r requirements-dev.txt
+	python -m uv pip install -r requirements-dev.txt
 
 install-optional:
-	python -m pip install anthropic openai pydantic_ai
+	python -m uv pip install anthropic openai pydantic_ai
 
 _publish:
 	./scripts/publish.sh

--- a/py/Makefile
+++ b/py/Makefile
@@ -13,6 +13,7 @@ lint: fixup
 
 test:
 	nox -x
+	nox -s "test_wrappers" -- --disable-vcr
 
 test-wheel: build
 	nox -x -- --wheel

--- a/py/Makefile
+++ b/py/Makefile
@@ -13,7 +13,9 @@ lint: fixup
 
 test:
 	nox -x
-	nox -s "test_wrappers" -- --disable-vcr
+	# by default, do one run of our code with actual request
+	# to openai, anthropic, etc so we have some testing of reality.
+	nox -s "test_latest_wrappers" -- --disable-vcr
 
 test-wheel: build
 	nox -x -- --wheel

--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -18,6 +18,9 @@ import tempfile
 
 import nox
 
+# much faster than pip
+nox.options.default_venv_backend = "uv"
+
 SRC_DIR = "braintrust"
 WRAPPER_DIR = "braintrust/wrappers"
 

--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -201,7 +201,7 @@ def _run_tests(session, test_path, ignore_path=""):
         # It proved very helpful because it's very easy
         # to accidentally import local modules from the source directory.
         env = {"BRAINTRUST_TESTING_WHEEL": "1"}
-        session.run(pytest_path, abs_test_path, ignore, *vcr_args, env=env)
+        session.run(pytest_path, abs_test_path, ignore, *common_args, env=env)
 
     # And a final note ... if it's not clear from above, we include test files in our wheel, which
     # is perhaps not ideal?

--- a/py/requirements-dev.txt
+++ b/py/requirements-dev.txt
@@ -9,5 +9,6 @@ pydoc-markdown
 pylint
 pytest
 pytest-asyncio
+pytest-vcr
 
 -r requirements-build.txt

--- a/py/src/braintrust/wrappers/cassettes/test_anthropic_client_error.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_anthropic_client_error.yaml
@@ -1,0 +1,80 @@
+interactions:
+  - request:
+      body: '{"max_tokens":999,"messages":[{"role":"user","content":"who are you?"}],"model":"there-is-no-such-model"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        anthropic-version:
+          - "2023-06-01"
+        connection:
+          - keep-alive
+        content-length:
+          - "105"
+        content-type:
+          - application/json
+        host:
+          - api.anthropic.com
+        user-agent:
+          - Anthropic/Python 0.52.1
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 0.52.1
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+        x-stainless-timeout:
+          - "600"
+      method: POST
+      uri: https://api.anthropic.com/v1/messages
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAwAAAP//qlYqqSxIVbJSSi0qyi9S0oHSVtUw8bz8kvi0/NK8lHiYitzU4uLEdJBc
+          bn5Kao6VQklGalGqbmaxbl6+bnFpcoYuWFypthYAAAD//wMAowdmMl0AAAA=
+      headers:
+        CF-RAY:
+          - 9472c8a12ade1b53-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:07:49 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Robots-Tag:
+          - none
+        anthropic-organization-id:
+          - 27796668-7351-40ac-acc4-024aee8995a5
+        cf-cache-status:
+          - DYNAMIC
+        request-id:
+          - req_011CPb5rA13qiZ2bwi1DTVZp
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        via:
+          - 1.1 google
+        x-should-retry:
+          - "false"
+      status:
+        code: 404
+        message: Not Found
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_anthropic_messages_create_async.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_anthropic_messages_create_async.yaml
@@ -1,0 +1,107 @@
+interactions:
+  - request:
+      body:
+        '{"max_tokens":100,"messages":[{"role":"user","content":"what is 6+1?, just
+        return the number"}],"model":"claude-3-haiku-20240307"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        anthropic-version:
+          - "2023-06-01"
+        connection:
+          - keep-alive
+        content-length:
+          - "130"
+        content-type:
+          - application/json
+        host:
+          - api.anthropic.com
+        user-agent:
+          - AsyncAnthropic/Python 0.52.1
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 0.52.1
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+        x-stainless-timeout:
+          - "600"
+      method: POST
+      uri: https://api.anthropic.com/v1/messages
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAwAAAP//ZI9RS8QwEIT/yzyn0OuplTwKouiLiOCDSAjJchevt6nZjXiW/nfp4YHi
+          08J8M8POhBRhsZeNa1ePV28X5frp5vn+Iekd3XaRv/oDDPQw0uIiEb8hGJQ8LIIXSaKeFQb7HGmA
+          RRh8jdSsm61Pu9p0bXfWrtseBiGzEivsy3RqVPpcssdj0WN+NRDNoyvkJTMsiKPTWhg/QOi9EgeC
+          5ToMBvX4kZ2QeKzqNO+IBXZ1aRB82JILhbymzO6voT3xQj7+Z7nqb+XcQKh8pEBOExVYLLOjLxHz
+          /A0AAP//AwAb9FnuRAEAAA==
+      headers:
+        CF-RAY:
+          - 9472c8992b3941cf-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:07:48 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Robots-Tag:
+          - none
+        anthropic-organization-id:
+          - 27796668-7351-40ac-acc4-024aee8995a5
+        anthropic-ratelimit-input-tokens-limit:
+          - "8000000"
+        anthropic-ratelimit-input-tokens-remaining:
+          - "8000000"
+        anthropic-ratelimit-input-tokens-reset:
+          - "2025-05-29T03:07:48Z"
+        anthropic-ratelimit-output-tokens-limit:
+          - "1500000"
+        anthropic-ratelimit-output-tokens-remaining:
+          - "1500000"
+        anthropic-ratelimit-output-tokens-reset:
+          - "2025-05-29T03:07:48Z"
+        anthropic-ratelimit-requests-limit:
+          - "10000"
+        anthropic-ratelimit-requests-remaining:
+          - "9999"
+        anthropic-ratelimit-requests-reset:
+          - "2025-05-29T03:07:48Z"
+        anthropic-ratelimit-tokens-limit:
+          - "9500000"
+        anthropic-ratelimit-tokens-remaining:
+          - "9500000"
+        anthropic-ratelimit-tokens-reset:
+          - "2025-05-29T03:07:48Z"
+        cf-cache-status:
+          - DYNAMIC
+        request-id:
+          - req_011CPb5r4YP1DCcYkkUYE4am
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        via:
+          - 1.1 google
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_anthropic_messages_create_async_stream_true.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_anthropic_messages_create_async_stream_true.yaml
@@ -1,0 +1,137 @@
+interactions:
+  - request:
+      body:
+        '{"max_tokens":100,"messages":[{"role":"user","content":"what is 6+1?, just
+        return the number"}],"model":"claude-3-haiku-20240307","stream":true}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        anthropic-version:
+          - "2023-06-01"
+        connection:
+          - keep-alive
+        content-length:
+          - "144"
+        content-type:
+          - application/json
+        host:
+          - api.anthropic.com
+        user-agent:
+          - AsyncAnthropic/Python 0.52.1
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 0.52.1
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+        x-stainless-timeout:
+          - NOT_GIVEN
+      method: POST
+      uri: https://api.anthropic.com/v1/messages
+    response:
+      body:
+        string: 'event: message_start
+
+          data: {"type":"message_start","message":{"id":"msg_01MWFaVNqKdU45YCBTgbHDLj","type":"message","role":"assistant","model":"claude-3-haiku-20240307","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":18,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":2,"service_tier":"standard"}}             }
+
+
+          event: content_block_start
+
+          data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}               }
+
+
+          event: ping
+
+          data: {"type": "ping"}
+
+
+          event: content_block_delta
+
+          data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"7"}          }
+
+
+          event: content_block_stop
+
+          data: {"type":"content_block_stop","index":0     }
+
+
+          event: message_delta
+
+          data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}            }
+
+
+          event: message_stop
+
+          data: {"type":"message_stop"             }
+
+
+          '
+      headers:
+        CF-RAY:
+          - 9472c89bd9c932e8-EWR
+        Cache-Control:
+          - no-cache
+        Connection:
+          - keep-alive
+        Content-Type:
+          - text/event-stream; charset=utf-8
+        Date:
+          - Thu, 29 May 2025 03:07:48 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Robots-Tag:
+          - none
+        anthropic-organization-id:
+          - 27796668-7351-40ac-acc4-024aee8995a5
+        anthropic-ratelimit-input-tokens-limit:
+          - "8000000"
+        anthropic-ratelimit-input-tokens-remaining:
+          - "8000000"
+        anthropic-ratelimit-input-tokens-reset:
+          - "2025-05-29T03:07:48Z"
+        anthropic-ratelimit-output-tokens-limit:
+          - "1500000"
+        anthropic-ratelimit-output-tokens-remaining:
+          - "1500000"
+        anthropic-ratelimit-output-tokens-reset:
+          - "2025-05-29T03:07:48Z"
+        anthropic-ratelimit-requests-limit:
+          - "10000"
+        anthropic-ratelimit-requests-remaining:
+          - "9999"
+        anthropic-ratelimit-requests-reset:
+          - "2025-05-29T03:07:48Z"
+        anthropic-ratelimit-tokens-limit:
+          - "9500000"
+        anthropic-ratelimit-tokens-remaining:
+          - "9500000"
+        anthropic-ratelimit-tokens-reset:
+          - "2025-05-29T03:07:48Z"
+        cf-cache-status:
+          - DYNAMIC
+        request-id:
+          - req_011CPb5r6N2HCkaPWJii33N1
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        via:
+          - 1.1 google
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_anthropic_messages_create_stream_true.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_anthropic_messages_create_stream_true.yaml
@@ -1,0 +1,148 @@
+interactions:
+  - request:
+      body: '{"max_tokens":300,"messages":[{"role":"user","content":"What is 3*4?"}],"model":"claude-3-haiku-20240307","stream":true}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        anthropic-version:
+          - "2023-06-01"
+        connection:
+          - keep-alive
+        content-length:
+          - "120"
+        content-type:
+          - application/json
+        host:
+          - api.anthropic.com
+        user-agent:
+          - Anthropic/Python 0.52.1
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 0.52.1
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+        x-stainless-timeout:
+          - NOT_GIVEN
+      method: POST
+      uri: https://api.anthropic.com/v1/messages
+    response:
+      body:
+        string: 'event: message_start
+
+          data: {"type":"message_start","message":{"id":"msg_012gPZeSmoemYgX2fdPcZFVH","type":"message","role":"assistant","model":"claude-3-haiku-20240307","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":14,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":4,"service_tier":"standard"}}       }
+
+
+          event: content_block_start
+
+          data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}  }
+
+
+          event: ping
+
+          data: {"type": "ping"}
+
+
+          event: content_block_delta
+
+          data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"3
+          *"}          }
+
+
+          event: content_block_delta
+
+          data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+          4 ="}          }
+
+
+          event: content_block_delta
+
+          data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+          12"} }
+
+
+          event: content_block_stop
+
+          data: {"type":"content_block_stop","index":0         }
+
+
+          event: message_delta
+
+          data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":13}               }
+
+
+          event: message_stop
+
+          data: {"type":"message_stop"  }
+
+
+          '
+      headers:
+        CF-RAY:
+          - 9472c88a8f806a50-EWR
+        Cache-Control:
+          - no-cache
+        Connection:
+          - keep-alive
+        Content-Type:
+          - text/event-stream; charset=utf-8
+        Date:
+          - Thu, 29 May 2025 03:07:45 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Robots-Tag:
+          - none
+        anthropic-organization-id:
+          - 27796668-7351-40ac-acc4-024aee8995a5
+        anthropic-ratelimit-input-tokens-limit:
+          - "8000000"
+        anthropic-ratelimit-input-tokens-remaining:
+          - "8000000"
+        anthropic-ratelimit-input-tokens-reset:
+          - "2025-05-29T03:07:45Z"
+        anthropic-ratelimit-output-tokens-limit:
+          - "1500000"
+        anthropic-ratelimit-output-tokens-remaining:
+          - "1500000"
+        anthropic-ratelimit-output-tokens-reset:
+          - "2025-05-29T03:07:45Z"
+        anthropic-ratelimit-requests-limit:
+          - "10000"
+        anthropic-ratelimit-requests-remaining:
+          - "9999"
+        anthropic-ratelimit-requests-reset:
+          - "2025-05-29T03:07:45Z"
+        anthropic-ratelimit-tokens-limit:
+          - "9500000"
+        anthropic-ratelimit-tokens-remaining:
+          - "9500000"
+        anthropic-ratelimit-tokens-reset:
+          - "2025-05-29T03:07:45Z"
+        cf-cache-status:
+          - DYNAMIC
+        request-id:
+          - req_011CPb5qta7AfiZd2KcxncsY
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        via:
+          - 1.1 google
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_anthropic_messages_model_params_inputs.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_anthropic_messages_model_params_inputs.yaml
@@ -1,0 +1,244 @@
+interactions:
+  - request:
+      body:
+        '{"max_tokens":300,"messages":[{"role":"user","content":"what is 1+1?"}],"model":"claude-3-haiku-20240307","system":"just
+        return the number","temperature":0.5,"top_p":0.5}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        anthropic-version:
+          - "2023-06-01"
+        connection:
+          - keep-alive
+        content-length:
+          - "170"
+        content-type:
+          - application/json
+        host:
+          - api.anthropic.com
+        user-agent:
+          - Anthropic/Python 0.52.1
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 0.52.1
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+        x-stainless-timeout:
+          - "600"
+      method: POST
+      uri: https://api.anthropic.com/v1/messages
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA2SPUUsDMRCE/8s8p3B3VSp5E6QF0ae+CCIhJEsb77o5sxuxHPff5YoFxaeF+WaG
+          nQkpwuIkB9e09y/1/L7dbfqH8tw/7vb7J9rWFgZ6HmlxkYg/EAxKHhbBiyRRzwqDU440wCIMvkZa
+          rVdHn/q66pruplk3GxiEzEqssK/TtVHpa8lejkWH+c1ANI+ukJfMsCCOTmth/AChj0ocCJbrMBjU
+          y0d2QuKxqtPcEwtse2cQfDiSC4W8pszur6G58kI+/me56m/l1kCofKZAThMVWCyzoy8R8/wNAAD/
+          /wMAqgv+NkQBAAA=
+      headers:
+        CF-RAY:
+          - 9472c88d58827864-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:07:46 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Robots-Tag:
+          - none
+        anthropic-organization-id:
+          - 27796668-7351-40ac-acc4-024aee8995a5
+        anthropic-ratelimit-input-tokens-limit:
+          - "8000000"
+        anthropic-ratelimit-input-tokens-remaining:
+          - "8000000"
+        anthropic-ratelimit-input-tokens-reset:
+          - "2025-05-29T03:07:46Z"
+        anthropic-ratelimit-output-tokens-limit:
+          - "1500000"
+        anthropic-ratelimit-output-tokens-remaining:
+          - "1500000"
+        anthropic-ratelimit-output-tokens-reset:
+          - "2025-05-29T03:07:46Z"
+        anthropic-ratelimit-requests-limit:
+          - "10000"
+        anthropic-ratelimit-requests-remaining:
+          - "9999"
+        anthropic-ratelimit-requests-reset:
+          - "2025-05-29T03:07:46Z"
+        anthropic-ratelimit-tokens-limit:
+          - "9500000"
+        anthropic-ratelimit-tokens-remaining:
+          - "9500000"
+        anthropic-ratelimit-tokens-reset:
+          - "2025-05-29T03:07:46Z"
+        cf-cache-status:
+          - DYNAMIC
+        request-id:
+          - req_011CPb5qvTxhUkgwBuYcB2SN
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        via:
+          - 1.1 google
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"max_tokens":300,"messages":[{"role":"user","content":"what is 1+1?"}],"model":"claude-3-haiku-20240307","system":"just
+        return the number","temperature":0.5,"top_p":0.5,"stream":true}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        anthropic-version:
+          - "2023-06-01"
+        connection:
+          - keep-alive
+        content-length:
+          - "184"
+        content-type:
+          - application/json
+        host:
+          - api.anthropic.com
+        user-agent:
+          - Anthropic/Python 0.52.1
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 0.52.1
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+        x-stainless-stream-helper:
+          - messages
+        x-stainless-timeout:
+          - NOT_GIVEN
+      method: POST
+      uri: https://api.anthropic.com/v1/messages
+    response:
+      body:
+        string: 'event: message_start
+
+          data: {"type":"message_start","message":{"id":"msg_01FGmwpHyhVL53CxVbrx6KCD","type":"message","role":"assistant","model":"claude-3-haiku-20240307","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":18,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":4,"service_tier":"standard"}}         }
+
+
+          event: content_block_start
+
+          data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}          }
+
+
+          event: ping
+
+          data: {"type": "ping"}
+
+
+          event: content_block_delta
+
+          data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"2"}              }
+
+
+          event: content_block_stop
+
+          data: {"type":"content_block_stop","index":0    }
+
+
+          event: message_delta
+
+          data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}  }
+
+
+          event: message_stop
+
+          data: {"type":"message_stop"           }
+
+
+          '
+      headers:
+        CF-RAY:
+          - 9472c88fee7e7864-EWR
+        Cache-Control:
+          - no-cache
+        Connection:
+          - keep-alive
+        Content-Type:
+          - text/event-stream; charset=utf-8
+        Date:
+          - Thu, 29 May 2025 03:07:46 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Robots-Tag:
+          - none
+        anthropic-organization-id:
+          - 27796668-7351-40ac-acc4-024aee8995a5
+        anthropic-ratelimit-input-tokens-limit:
+          - "8000000"
+        anthropic-ratelimit-input-tokens-remaining:
+          - "8000000"
+        anthropic-ratelimit-input-tokens-reset:
+          - "2025-05-29T03:07:46Z"
+        anthropic-ratelimit-output-tokens-limit:
+          - "1500000"
+        anthropic-ratelimit-output-tokens-remaining:
+          - "1500000"
+        anthropic-ratelimit-output-tokens-reset:
+          - "2025-05-29T03:07:46Z"
+        anthropic-ratelimit-requests-limit:
+          - "10000"
+        anthropic-ratelimit-requests-remaining:
+          - "9999"
+        anthropic-ratelimit-requests-reset:
+          - "2025-05-29T03:07:46Z"
+        anthropic-ratelimit-tokens-limit:
+          - "9500000"
+        anthropic-ratelimit-tokens-remaining:
+          - "9500000"
+        anthropic-ratelimit-tokens-reset:
+          - "2025-05-29T03:07:46Z"
+        cf-cache-status:
+          - DYNAMIC
+        request-id:
+          - req_011CPb5qxBQ9po6M9MsWga8m
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        via:
+          - 1.1 google
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_anthropic_messages_stream_errors.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_anthropic_messages_stream_errors.yaml
@@ -1,0 +1,139 @@
+interactions:
+  - request:
+      body:
+        '{"max_tokens":300,"messages":[{"role":"user","content":"what is 2+2? (just
+        the number)"}],"model":"claude-3-haiku-20240307","stream":true}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        anthropic-version:
+          - "2023-06-01"
+        connection:
+          - keep-alive
+        content-length:
+          - "138"
+        content-type:
+          - application/json
+        host:
+          - api.anthropic.com
+        user-agent:
+          - Anthropic/Python 0.52.1
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 0.52.1
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+        x-stainless-stream-helper:
+          - messages
+        x-stainless-timeout:
+          - NOT_GIVEN
+      method: POST
+      uri: https://api.anthropic.com/v1/messages
+    response:
+      body:
+        string: 'event: message_start
+
+          data: {"type":"message_start","message":{"id":"msg_019YzLeF9bnSTwHRpHPNEbid","type":"message","role":"assistant","model":"claude-3-haiku-20240307","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":19,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":3,"service_tier":"standard"}}        }
+
+
+          event: content_block_start
+
+          data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}  }
+
+
+          event: ping
+
+          data: {"type": "ping"}
+
+
+          event: content_block_delta
+
+          data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"4"}        }
+
+
+          event: content_block_stop
+
+          data: {"type":"content_block_stop","index":0          }
+
+
+          event: message_delta
+
+          data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}     }
+
+
+          event: message_stop
+
+          data: {"type":"message_stop" }
+
+
+          '
+      headers:
+        CF-RAY:
+          - 9472c8a1fea943f1-EWR
+        Cache-Control:
+          - no-cache
+        Connection:
+          - keep-alive
+        Content-Type:
+          - text/event-stream; charset=utf-8
+        Date:
+          - Thu, 29 May 2025 03:07:50 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Robots-Tag:
+          - none
+        anthropic-organization-id:
+          - 27796668-7351-40ac-acc4-024aee8995a5
+        anthropic-ratelimit-input-tokens-limit:
+          - "8000000"
+        anthropic-ratelimit-input-tokens-remaining:
+          - "8000000"
+        anthropic-ratelimit-input-tokens-reset:
+          - "2025-05-29T03:07:50Z"
+        anthropic-ratelimit-output-tokens-limit:
+          - "1500000"
+        anthropic-ratelimit-output-tokens-remaining:
+          - "1500000"
+        anthropic-ratelimit-output-tokens-reset:
+          - "2025-05-29T03:07:50Z"
+        anthropic-ratelimit-requests-limit:
+          - "10000"
+        anthropic-ratelimit-requests-remaining:
+          - "9999"
+        anthropic-ratelimit-requests-reset:
+          - "2025-05-29T03:07:50Z"
+        anthropic-ratelimit-tokens-limit:
+          - "9500000"
+        anthropic-ratelimit-tokens-remaining:
+          - "9500000"
+        anthropic-ratelimit-tokens-reset:
+          - "2025-05-29T03:07:50Z"
+        cf-cache-status:
+          - DYNAMIC
+        request-id:
+          - req_011CPb5rAezEMDtahaZ57coa
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        via:
+          - 1.1 google
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_anthropic_messages_streaming_async.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_anthropic_messages_streaming_async.yaml
@@ -1,0 +1,140 @@
+interactions:
+  - request:
+      body:
+        '{"max_tokens":1024,"messages":[{"role":"user","content":"what is 1+1?,
+        just return the number"}],"model":"claude-3-haiku-20240307","stream":true}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        anthropic-version:
+          - "2023-06-01"
+        connection:
+          - keep-alive
+        content-length:
+          - "145"
+        content-type:
+          - application/json
+        host:
+          - api.anthropic.com
+        user-agent:
+          - AsyncAnthropic/Python 0.52.1
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 0.52.1
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+        x-stainless-stream-helper:
+          - messages
+        x-stainless-timeout:
+          - NOT_GIVEN
+      method: POST
+      uri: https://api.anthropic.com/v1/messages
+    response:
+      body:
+        string: 'event: message_start
+
+          data: {"type":"message_start","message":{"id":"msg_01Hwq7nXVJreMkdBttJ9H46B","type":"message","role":"assistant","model":"claude-3-haiku-20240307","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":18,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":2,"service_tier":"standard"}}    }
+
+
+          event: content_block_start
+
+          data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}     }
+
+
+          event: ping
+
+          data: {"type": "ping"}
+
+
+          event: content_block_delta
+
+          data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"2"}
+          }
+
+
+          event: content_block_stop
+
+          data: {"type":"content_block_stop","index":0         }
+
+
+          event: message_delta
+
+          data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}       }
+
+
+          event: message_stop
+
+          data: {"type":"message_stop"           }
+
+
+          '
+      headers:
+        CF-RAY:
+          - 9472c89e6a908c63-EWR
+        Cache-Control:
+          - no-cache
+        Connection:
+          - keep-alive
+        Content-Type:
+          - text/event-stream; charset=utf-8
+        Date:
+          - Thu, 29 May 2025 03:07:49 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Robots-Tag:
+          - none
+        anthropic-organization-id:
+          - 27796668-7351-40ac-acc4-024aee8995a5
+        anthropic-ratelimit-input-tokens-limit:
+          - "8000000"
+        anthropic-ratelimit-input-tokens-remaining:
+          - "8000000"
+        anthropic-ratelimit-input-tokens-reset:
+          - "2025-05-29T03:07:48Z"
+        anthropic-ratelimit-output-tokens-limit:
+          - "1500000"
+        anthropic-ratelimit-output-tokens-remaining:
+          - "1499000"
+        anthropic-ratelimit-output-tokens-reset:
+          - "2025-05-29T03:07:49Z"
+        anthropic-ratelimit-requests-limit:
+          - "10000"
+        anthropic-ratelimit-requests-remaining:
+          - "9999"
+        anthropic-ratelimit-requests-reset:
+          - "2025-05-29T03:07:48Z"
+        anthropic-ratelimit-tokens-limit:
+          - "9500000"
+        anthropic-ratelimit-tokens-remaining:
+          - "9499000"
+        anthropic-ratelimit-tokens-reset:
+          - "2025-05-29T03:07:48Z"
+        cf-cache-status:
+          - DYNAMIC
+        request-id:
+          - req_011CPb5r8E8kny9TZdxz4Q6v
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        via:
+          - 1.1 google
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_anthropic_messages_streaming_sync.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_anthropic_messages_streaming_sync.yaml
@@ -1,0 +1,139 @@
+interactions:
+  - request:
+      body:
+        '{"max_tokens":300,"messages":[{"role":"user","content":"what is 2+2? (just
+        the number)"}],"model":"claude-3-haiku-20240307","stream":true}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        anthropic-version:
+          - "2023-06-01"
+        connection:
+          - keep-alive
+        content-length:
+          - "138"
+        content-type:
+          - application/json
+        host:
+          - api.anthropic.com
+        user-agent:
+          - Anthropic/Python 0.52.1
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 0.52.1
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+        x-stainless-stream-helper:
+          - messages
+        x-stainless-timeout:
+          - NOT_GIVEN
+      method: POST
+      uri: https://api.anthropic.com/v1/messages
+    response:
+      body:
+        string: 'event: message_start
+
+          data: {"type":"message_start","message":{"id":"msg_01NR8LiXqHhf3PCEc3k3m3hJ","type":"message","role":"assistant","model":"claude-3-haiku-20240307","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":19,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":4,"service_tier":"standard"}}            }
+
+
+          event: content_block_start
+
+          data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}              }
+
+
+          event: ping
+
+          data: {"type": "ping"}
+
+
+          event: content_block_delta
+
+          data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"4"}  }
+
+
+          event: content_block_stop
+
+          data: {"type":"content_block_stop","index":0   }
+
+
+          event: message_delta
+
+          data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}       }
+
+
+          event: message_stop
+
+          data: {"type":"message_stop"  }
+
+
+          '
+      headers:
+        CF-RAY:
+          - 9472c8a8e81323dd-EWR
+        Cache-Control:
+          - no-cache
+        Connection:
+          - keep-alive
+        Content-Type:
+          - text/event-stream; charset=utf-8
+        Date:
+          - Thu, 29 May 2025 03:07:50 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Robots-Tag:
+          - none
+        anthropic-organization-id:
+          - 27796668-7351-40ac-acc4-024aee8995a5
+        anthropic-ratelimit-input-tokens-limit:
+          - "8000000"
+        anthropic-ratelimit-input-tokens-remaining:
+          - "8000000"
+        anthropic-ratelimit-input-tokens-reset:
+          - "2025-05-29T03:07:50Z"
+        anthropic-ratelimit-output-tokens-limit:
+          - "1500000"
+        anthropic-ratelimit-output-tokens-remaining:
+          - "1500000"
+        anthropic-ratelimit-output-tokens-reset:
+          - "2025-05-29T03:07:50Z"
+        anthropic-ratelimit-requests-limit:
+          - "10000"
+        anthropic-ratelimit-requests-remaining:
+          - "9999"
+        anthropic-ratelimit-requests-reset:
+          - "2025-05-29T03:07:50Z"
+        anthropic-ratelimit-tokens-limit:
+          - "9500000"
+        anthropic-ratelimit-tokens-remaining:
+          - "9500000"
+        anthropic-ratelimit-tokens-reset:
+          - "2025-05-29T03:07:50Z"
+        cf-cache-status:
+          - DYNAMIC
+        request-id:
+          - req_011CPb5rFK3186WDZPzKJEuC
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        via:
+          - 1.1 google
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_anthropic_messages_sync.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_anthropic_messages_sync.yaml
@@ -1,0 +1,105 @@
+interactions:
+  - request:
+      body: '{"max_tokens":300,"messages":[{"role":"user","content":"what''s 2+2?"}],"model":"claude-3-haiku-20240307"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        anthropic-version:
+          - "2023-06-01"
+        connection:
+          - keep-alive
+        content-length:
+          - "105"
+        content-type:
+          - application/json
+        host:
+          - api.anthropic.com
+        user-agent:
+          - Anthropic/Python 0.52.1
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 0.52.1
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+        x-stainless-timeout:
+          - "600"
+      method: POST
+      uri: https://api.anthropic.com/v1/messages
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA2SPQUsDMRSE/8ucs2W7XRRyKx4KVYseeqlICMljG7tN1rwXUZb977LFguLpwXwz
+          w5sRwUPjzJ2pl0/dw/5wv2n228fd3fN6sw4+H96gIF8DzS5ith1BIad+FixzYLFRoHBOnnpouN4W
+          T9WqOtpwKlVTN229qm+h4FIUigL9Ml4bhT7n7OVotAtMrwosaTCZLKcIDYreSMkRP4DpvVB0BB1L
+          3yuUy0t6RIhDESPpRJGhl62Cs+5IxmWyElI0fw31lWey/j9LRX4rNwpM+SM4MhIoQ2Pe7W32mKZv
+          AAAA//8DAOBQupxFAQAA
+      headers:
+        CF-RAY:
+          - 9472c8abe82e4346-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:07:51 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Robots-Tag:
+          - none
+        anthropic-organization-id:
+          - 27796668-7351-40ac-acc4-024aee8995a5
+        anthropic-ratelimit-input-tokens-limit:
+          - "8000000"
+        anthropic-ratelimit-input-tokens-remaining:
+          - "8000000"
+        anthropic-ratelimit-input-tokens-reset:
+          - "2025-05-29T03:07:51Z"
+        anthropic-ratelimit-output-tokens-limit:
+          - "1500000"
+        anthropic-ratelimit-output-tokens-remaining:
+          - "1500000"
+        anthropic-ratelimit-output-tokens-reset:
+          - "2025-05-29T03:07:51Z"
+        anthropic-ratelimit-requests-limit:
+          - "10000"
+        anthropic-ratelimit-requests-remaining:
+          - "9999"
+        anthropic-ratelimit-requests-reset:
+          - "2025-05-29T03:07:51Z"
+        anthropic-ratelimit-tokens-limit:
+          - "9500000"
+        anthropic-ratelimit-tokens-remaining:
+          - "9500000"
+        anthropic-ratelimit-tokens-reset:
+          - "2025-05-29T03:07:51Z"
+        cf-cache-status:
+          - DYNAMIC
+        request-id:
+          - req_011CPb5rJW239uEPcCN6bpZm
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        via:
+          - 1.1 google
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_anthropic_messages_system_prompt_inputs.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_anthropic_messages_system_prompt_inputs.yaml
@@ -1,0 +1,252 @@
+interactions:
+  - request:
+      body:
+        '{"max_tokens":300,"messages":[{"role":"user","content":"what is tomorrow''s
+        date? only return the date"}],"model":"claude-3-haiku-20240307","system":"Today''s
+        date is 2024-03-26. Only return the date","temperature":0}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        anthropic-version:
+          - "2023-06-01"
+        connection:
+          - keep-alive
+        content-length:
+          - "215"
+        content-type:
+          - application/json
+        host:
+          - api.anthropic.com
+        user-agent:
+          - Anthropic/Python 0.52.1
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 0.52.1
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+        x-stainless-timeout:
+          - "600"
+      method: POST
+      uri: https://api.anthropic.com/v1/messages
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAwAAAP//ZJBBS8QwEIX/yzunkDbuFnPWo6CsehEJIRm2cdukJhNRSv+7dHFB8TTw
+          vm+G4S0IHhpTORrZ9je7/fXh7enhcL+fdurxrn2+HToI8NdMm0Wl2CNBIKdxC2wpobCNDIEpeRqh
+          4UZbPTWqGWw41aaT3ZVUsoeAS5EpMvTLcrnI9LntnofG5jZSNV2P9VWgcJpNJltShAZFb7jmiB9Q
+          6L1SdAQd6zgK1PNrekGIc2XD6USxQCsl4KwbyLhMlkOK5q8gLzyT9f9Zqvw7aaVAofwRHBkOlKGx
+          FeBt9ljXbwAAAP//AwBr6Z3cTgEAAA==
+      headers:
+        CF-RAY:
+          - 9472c8932947f834-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:07:47 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Robots-Tag:
+          - none
+        anthropic-organization-id:
+          - 27796668-7351-40ac-acc4-024aee8995a5
+        anthropic-ratelimit-input-tokens-limit:
+          - "8000000"
+        anthropic-ratelimit-input-tokens-remaining:
+          - "8000000"
+        anthropic-ratelimit-input-tokens-reset:
+          - "2025-05-29T03:07:47Z"
+        anthropic-ratelimit-output-tokens-limit:
+          - "1500000"
+        anthropic-ratelimit-output-tokens-remaining:
+          - "1500000"
+        anthropic-ratelimit-output-tokens-reset:
+          - "2025-05-29T03:07:47Z"
+        anthropic-ratelimit-requests-limit:
+          - "10000"
+        anthropic-ratelimit-requests-remaining:
+          - "9999"
+        anthropic-ratelimit-requests-reset:
+          - "2025-05-29T03:07:47Z"
+        anthropic-ratelimit-tokens-limit:
+          - "9500000"
+        anthropic-ratelimit-tokens-remaining:
+          - "9500000"
+        anthropic-ratelimit-tokens-reset:
+          - "2025-05-29T03:07:47Z"
+        cf-cache-status:
+          - DYNAMIC
+        request-id:
+          - req_011CPb5qzRayPPoo8L1mPdh1
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        via:
+          - 1.1 google
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"max_tokens":300,"messages":[{"role":"user","content":"what is tomorrow''s
+        date? only return the date"}],"model":"claude-3-haiku-20240307","system":"Today''s
+        date is 2024-03-26. Only return the date","temperature":0,"stream":true}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        anthropic-version:
+          - "2023-06-01"
+        connection:
+          - keep-alive
+        content-length:
+          - "229"
+        content-type:
+          - application/json
+        host:
+          - api.anthropic.com
+        user-agent:
+          - Anthropic/Python 0.52.1
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 0.52.1
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+        x-stainless-stream-helper:
+          - messages
+        x-stainless-timeout:
+          - NOT_GIVEN
+      method: POST
+      uri: https://api.anthropic.com/v1/messages
+    response:
+      body:
+        string: 'event: message_start
+
+          data: {"type":"message_start","message":{"id":"msg_016SfgyEMZw26QGn6irgmFJL","type":"message","role":"assistant","model":"claude-3-haiku-20240307","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":33,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":1,"service_tier":"standard"}}
+          }
+
+
+          event: content_block_start
+
+          data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}           }
+
+
+          event: ping
+
+          data: {"type": "ping"}
+
+
+          event: content_block_delta
+
+          data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"2024-03"}   }
+
+
+          event: content_block_delta
+
+          data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-27"}           }
+
+
+          event: content_block_stop
+
+          data: {"type":"content_block_stop","index":0          }
+
+
+          event: message_delta
+
+          data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":10}               }
+
+
+          event: message_stop
+
+          data: {"type":"message_stop"     }
+
+
+          '
+      headers:
+        CF-RAY:
+          - 9472c8964fd2f834-EWR
+        Cache-Control:
+          - no-cache
+        Connection:
+          - keep-alive
+        Content-Type:
+          - text/event-stream; charset=utf-8
+        Date:
+          - Thu, 29 May 2025 03:07:47 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Robots-Tag:
+          - none
+        anthropic-organization-id:
+          - 27796668-7351-40ac-acc4-024aee8995a5
+        anthropic-ratelimit-input-tokens-limit:
+          - "8000000"
+        anthropic-ratelimit-input-tokens-remaining:
+          - "8000000"
+        anthropic-ratelimit-input-tokens-reset:
+          - "2025-05-29T03:07:47Z"
+        anthropic-ratelimit-output-tokens-limit:
+          - "1500000"
+        anthropic-ratelimit-output-tokens-remaining:
+          - "1500000"
+        anthropic-ratelimit-output-tokens-reset:
+          - "2025-05-29T03:07:47Z"
+        anthropic-ratelimit-requests-limit:
+          - "10000"
+        anthropic-ratelimit-requests-remaining:
+          - "9999"
+        anthropic-ratelimit-requests-reset:
+          - "2025-05-29T03:07:47Z"
+        anthropic-ratelimit-tokens-limit:
+          - "9500000"
+        anthropic-ratelimit-tokens-remaining:
+          - "9500000"
+        anthropic-ratelimit-tokens-reset:
+          - "2025-05-29T03:07:47Z"
+        cf-cache-status:
+          - DYNAMIC
+        request-id:
+          - req_011CPb5r2ZpUAFf1mRX9YxyY
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        via:
+          - 1.1 google
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_async_parallel_requests.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_async_parallel_requests.yaml
@@ -1,0 +1,320 @@
+interactions:
+  - request:
+      body: '{"messages":[{"role":"user","content":"What is 5 + 5?"}],"model":"gpt-4o-mini"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "79"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAwAAAP//jJJBb9swDIXv/hUCr4uLOLERN8deCgzYEAzYaSgMVaIdrrKkSnS3osh/
+          H2Snsdt1wC4+8OOj3qP5kgkBpGEvQB0lq96b/EZ9/XVzwMNnOujqkb+HuvgW6PbL5rB+eoZVUrj7
+          n6j4VXWlXO8NMjk7YRVQMqapxa6sy7oudtcj6J1Gk2Sd57x0eU+W8s16U+brXV7UZ/XRkcIIe/Ej
+          E0KIl/GbfFqNv2Ev1qvXSo8xyg5hf2kSAoIzqQIyRoosLcNqhspZRjtar8QnUQl8HKSJolhfLdsC
+          tkOUyaodjFkAaa1jmaKOBu/O5HSxZFzng7uP76TQkqV4bALK6Gx6PrLzMNJTJsTdGH14kwZ8cL3n
+          ht0Djs8V1TQO5oXPsD4zdizNXN5sVx8MazSyJBMXmwMl1RH1rJzXLAdNbgGyReS/vXw0e4pNtvuf
+          8TNQCj2jbnxATept3rktYLrGf7VdVjwahojhiRQ2TBjSb9DYysFMNwLxOTL2TUu2w+ADTYfS+mZb
+          yqqUeL1VkJ2yPwAAAP//AwAbCHd7NgMAAA==
+      headers:
+        CF-RAY:
+          - 9472cb4d79f27277-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:39 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=l7mbGZ3Egstfh3PVdZpsOkqxw0vgJZvR00yYcXnuUj0-1748488179-1.0.1.1-zGkugr7nCARwHeGFg9XPlc7ChjTjH6Av35tx.ewtqIg7hpn2SeuueDeV0sMixwIHsE7zECshDr4vaV2fXQpOBETRL98mLwHcpljBSJOCszo;
+            path=/; expires=Thu, 29-May-25 03:39:39 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=wRUFkIxH7r5aq8YviVboE1R1m74GbxwHWRDWa9j1tGU-1748488179468-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "419"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "424"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999993"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_c9e62f050322730d68d7df78f9b4144e
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: '{"messages":[{"role":"user","content":"What is 4 + 4?"}],"model":"gpt-4o-mini"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "79"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAwAAAP//jJJBb5wwEIXv/Aprrl0iIFR49xj1VimRkp5aRcixB9apsb320LSK9r9X
+          hs1C0lTKhcN888bvDfOcMQZawY6B3AuSgzf5lbx+utpu+beb74fbr93BdKi4qitBX+6eYJMU7uER
+          Jb2oLqQbvEHSzs5YBhSEaWrZ1LzmvGy2ExicQpNkvae8dvmgrc6roqrzoslLflLvnZYYYcd+ZIwx
+          9jx9k0+r8DfsWLF5qQwYo+gRducmxiA4kyogYtSRhCXYLFA6S2gn6zX7xGqGh1GYyPjFuitgN0aR
+          nNrRmBUQ1joSKenk7/5EjmdHxvU+uIf4Rgqdtjru24AiOptej+Q8TPSYMXY/JR9fhQEf3OCpJfcT
+          p+fKz/M4WPa9QH5i5EiYpVxdbt4Z1iokoU1cLQ6kkHtUi3LZshiVdiuQrSL/6+W92XNsbfuPjF+A
+          lOgJVesDKi1f513aAqZj/F/becWTYYgYfmmJLWkM6Tco7MRo5hOB+CcSDm2nbY/BBz3fSefbbYXF
+          ZdMUvITsmP0FAAD//wMAHCTDkDUDAAA=
+      headers:
+        CF-RAY:
+          - 9472cb4d795e5f74-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:39 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=D5wymTQyeow3dD83thuE0eWShdgxY38D0kJXHd.ZMUs-1748488179-1.0.1.1-3bJsQ2EFtzxrDG1vWH33upwDiXRf3MLCgHZtvF2S2Z8eeqnEXgubmRS67THCTKIsxmdeS7xfGAclinCKqjvVrqhIqzYV9maCn8wdpz.gn7s;
+            path=/; expires=Thu, 29-May-25 03:39:39 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=62gNDFO6c1qtFW93mdU_wkFNdaV989TC7j.Q3x9737c-1748488179939-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "940"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "944"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999993"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_18867c173fff6d22299475f3b28f4309
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: '{"messages":[{"role":"user","content":"What is 3 + 3?"}],"model":"gpt-4o-mini"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "79"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAwAAAP//jJJNb9QwEIbv+RXWXNlUmw+66R4LSIVDhZAQB1RFU2eSGBzba0/4qva/
+          IyfbTQpF4pLDPPOO33cyD4kQoBrYC5A9shycTq/l7fdrf3ODH37dvj8Ur/r808c3r4fDu7flYYRN
+          VNj7LyT5UXUh7eA0sbJmxtITMsWp2a6syqrKdlcTGGxDOso6x2lp00EZlebbvEy3uzSrTureKkkB
+          9uJzIoQQD9M3+jQN/YC92G4eKwOFgB3B/twkBHirYwUwBBUYDcNmgdIaJjNZL8QLUQg6jKiDuLxY
+          d3lqx4DRqRm1XgE0xjLGpJO/uxM5nh1p2zlv78MfUmiVUaGvPWGwJr4e2DqY6DER4m5KPj4JA87b
+          wXHN9itNz2Uv53Gw7HuB1YmxZdRLOS82zwyrG2JUOqwWBxJlT82iXLaMY6PsCiSryH97eW72HFuZ
+          7n/GL0BKckxN7Tw1Sj7Nu7R5isf4r7bziifDEMh/U5JqVuTjb2ioxVHPJwLhZ2Aa6laZjrzzar6T
+          1tWXOeYFVhm1kByT3wAAAP//AwCBHV+XNQMAAA==
+      headers:
+        CF-RAY:
+          - 9472cb4d78470cba-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:40 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=EulnPVDmBHvrBtVkP1Jb.FV9nLpFLLHSlsHyw3.ExiY-1748488180-1.0.1.1-ATZmk8OiTX7FxVt2AmMY6VbrIgBwJDUz.dZ3VuyP9F6AjARSsy1P35lGfqBnpwotplfQSvSeQGravGggG2YZCr9jsTkOHPjEPqtFv2XzaEQ;
+            path=/; expires=Thu, 29-May-25 03:39:40 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=yZeym3GpRkVaB2a4ERNO5W9Sg71J9kZgzB6.k9C_7Hc-1748488180353-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "1267"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "1272"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999993"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_fa5dfb6ce3a2637a5f9803efbf54bef0
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_chat_async.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_chat_async.yaml
@@ -1,0 +1,212 @@
+interactions:
+  - request:
+      body: '{"messages":[{"role":"user","content":"What''s 12 + 12?"}],"model":"gpt-4o-mini"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "80"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAwAAAP//jJJBb9QwEIXv+RXWXNlUm5B2o71BhVQBggNHVEWuPUkMjse1J9VW1f53
+          5GS7SUuRuOQw37zJe+N5yoQAo2EvQPWS1eBt/lF9ezjckP56bW4eP3+4/t7/6NvdYffp8kt9D5uk
+          oLtfqPhZdaFo8BbZkJuxCigZ09RiV9VVXRdXlxMYSKNNss5zXlE+GGfycltW+XaXF/VJ3ZNRGGEv
+          fmZCCPE0fZNPp/EAe7HdPFcGjFF2CPtzkxAQyKYKyBhNZOkYNgtU5BjdZL0oxTtRlALvR2mjKKuL
+          dWPAdowymXWjtSsgnSOWKexk8fZEjmdTljof6C6+kkJrnIl9E1BGcslAZPIw0WMmxO0UfnyRB3yg
+          wXPD9Bun3xXVPA6WlS+wPjEmlnYpl+XmjWGNRpbGxtXuQEnVo16Uy6LlqA2tQLaK/LeXt2bPsY3r
+          /mf8ApRCz6gbH1Ab9TLv0hYw3eO/2s4rngxDxPBgFDZsMKRn0NjK0c5XAvExMg5Na1yHwQczn0rr
+          m6tSlu9lXWAL2TH7AwAA//8DAJIFUrc4AwAA
+      headers:
+        CF-RAY:
+          - 9472caf81ef08186-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:25 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=1jp7iu46cC7LTzqfTym6.GB7A38C8xsrwWCjGlyW.Zs-1748488165-1.0.1.1-HUMCsywTN7YO6EKTIJZBdpCNIKJbjNNrSu76iNiGcTdFQkL91RARv0WBpbFFLhM0V.ZRhO6vrlHps9b3sW9wPC03ieo_Omlh6SDn4Sr1g0k;
+            path=/; expires=Thu, 29-May-25 03:39:25 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=7HAy0drHIm.KI.NGoj.O5wWMpmoB_UvJpQNPf0GUxSY-1748488165900-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "650"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "654"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999993"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_1372de4ff197f2ab5467d8fa1aa9ba33
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: '{"messages":[{"role":"user","content":"What''s 12 + 12?"}],"model":"gpt-4o-mini"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "80"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAwAAAP//jJJBb9swDIXv/hUCr42L2PNSN8cht2LBDgMGbCgMRaIdpbKkiXSxrsh/
+          H+Sksdt1wC4+8OOj36P4nAkBRsNagNpLVn2w+Se1fXw6HL5vN/T7rg0b+3mz/fqNbr90hwcFi6Tw
+          uwMqflFdK98Hi2y8O2EVUTKmqcVNVVd1XaxWI+i9RptkXeC88nlvnMnLZVnly5u8qM/qvTcKCdbi
+          RyaEEM/jN/l0Gn/BWiwXL5UeiWSHsL40CQHR21QBSWSIpWNYTFB5x+hG60UprkRRCvw5SEuirK7n
+          jRHbgWQy6wZrZ0A651mmsKPF+zM5XkxZ34Xod/RGCq1xhvZNREneJQPEPsBIj5kQ92P44VUeCNH3
+          gRv2Dzj+rqhO42Ba+QTrM2PP0k7lsly8M6zRyNJYmu0OlFR71JNyWrQctPEzkM0i/+3lvdmn2MZ1
+          /zN+AkphYNRNiKiNep13aouY7vFfbZcVj4aBMD4ahQ0bjOkZNLZysKcrAXoixr5pjeswhmhOp9KG
+          5mOFu2qnV7cfIDtmfwAAAP//AwAHOUbKOAMAAA==
+      headers:
+        CF-RAY:
+          - 9472cafdb8d5429a-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:26 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=2tnlCSvS2cImTavzOy04_sA9uLoEZqsYBxshBl0yKeI-1748488166-1.0.1.1-FhGNAXq.70IxLpdlPsUUkGWLHBbuBNGktxhq7YkqzDJ3lvBvOSdSCBeJ0Nrw7CicajhN6AQUCFcUJsxtUrNayxIJeVI9uewXP1kiftTII2g;
+            path=/; expires=Thu, 29-May-25 03:39:26 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=xICitKMNXIOl.kF9pYQEx_CxCHvrsE7JnXnPdFpUGUo-1748488166544-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "377"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "382"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999993"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_597e214218a53799245347330be413a9
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_chat_async_context_manager.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_chat_async_context_manager.yaml
@@ -1,0 +1,271 @@
+interactions:
+  - request:
+      body: '{"messages":[{"role":"user","content":"What''s 12 + 12?"}],"model":"gpt-4o-mini","stream":true,"stream_options":{"include_usage":true}}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "134"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string:
+          'data: {"id":"chatcmpl-BcNw6be6DuhpHqDlc8nKm7x3iMAL6","object":"chat.completion.chunk","created":1748488174,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw6be6DuhpHqDlc8nKm7x3iMAL6","object":"chat.completion.chunk","created":1748488174,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"12"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw6be6DuhpHqDlc8nKm7x3iMAL6","object":"chat.completion.chunk","created":1748488174,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"
+          +"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw6be6DuhpHqDlc8nKm7x3iMAL6","object":"chat.completion.chunk","created":1748488174,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"
+          "},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw6be6DuhpHqDlc8nKm7x3iMAL6","object":"chat.completion.chunk","created":1748488174,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"12"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw6be6DuhpHqDlc8nKm7x3iMAL6","object":"chat.completion.chunk","created":1748488174,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"
+          equals"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw6be6DuhpHqDlc8nKm7x3iMAL6","object":"chat.completion.chunk","created":1748488174,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"
+          "},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw6be6DuhpHqDlc8nKm7x3iMAL6","object":"chat.completion.chunk","created":1748488174,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"24"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw6be6DuhpHqDlc8nKm7x3iMAL6","object":"chat.completion.chunk","created":1748488174,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw6be6DuhpHqDlc8nKm7x3iMAL6","object":"chat.completion.chunk","created":1748488174,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw6be6DuhpHqDlc8nKm7x3iMAL6","object":"chat.completion.chunk","created":1748488174,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[],"usage":{"prompt_tokens":14,"completion_tokens":8,"total_tokens":22,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+
+
+          data: [DONE]
+
+
+          '
+      headers:
+        CF-RAY:
+          - 9472cb30e8d5e56c-EWR
+        Connection:
+          - keep-alive
+        Content-Type:
+          - text/event-stream; charset=utf-8
+        Date:
+          - Thu, 29 May 2025 03:09:34 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=AIq4yjX3ru.J9gwNR6zSYLQNorConUZa5qtJ6wXxuvE-1748488174-1.0.1.1-KquMaoYitsL5z76ow2IPzasSn98mtC1_QEt9VOT1pvvQt_obPUDugNtsEGJCc_wP50_X4wP.kC7nYuf98KX8dCPpiq2ZqY5vwVCdgocqRxU;
+            path=/; expires=Thu, 29-May-25 03:39:34 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=o0LrLIiV.VvLFX1H1bbtbV01AjzSfXrfrVn0fU7pANY-1748488174648-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "313"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "317"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999993"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_7718454117290f001d635e2ea50bf0b5
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: '{"messages":[{"role":"user","content":"What''s 12 + 12?"}],"model":"gpt-4o-mini","stream":true,"stream_options":{"include_usage":true}}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "134"
+        content-type:
+          - application/json
+        cookie:
+          - __cf_bm=AIq4yjX3ru.J9gwNR6zSYLQNorConUZa5qtJ6wXxuvE-1748488174-1.0.1.1-KquMaoYitsL5z76ow2IPzasSn98mtC1_QEt9VOT1pvvQt_obPUDugNtsEGJCc_wP50_X4wP.kC7nYuf98KX8dCPpiq2ZqY5vwVCdgocqRxU;
+            _cfuvid=o0LrLIiV.VvLFX1H1bbtbV01AjzSfXrfrVn0fU7pANY-1748488174648-0.0.1.1-604800000
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string:
+          'data: {"id":"chatcmpl-BcNw7TPkf33tHhtv5BBYd6zunIaPW","object":"chat.completion.chunk","created":1748488175,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw7TPkf33tHhtv5BBYd6zunIaPW","object":"chat.completion.chunk","created":1748488175,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"12"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw7TPkf33tHhtv5BBYd6zunIaPW","object":"chat.completion.chunk","created":1748488175,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"
+          +"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw7TPkf33tHhtv5BBYd6zunIaPW","object":"chat.completion.chunk","created":1748488175,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"
+          "},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw7TPkf33tHhtv5BBYd6zunIaPW","object":"chat.completion.chunk","created":1748488175,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"12"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw7TPkf33tHhtv5BBYd6zunIaPW","object":"chat.completion.chunk","created":1748488175,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"
+          equals"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw7TPkf33tHhtv5BBYd6zunIaPW","object":"chat.completion.chunk","created":1748488175,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"
+          "},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw7TPkf33tHhtv5BBYd6zunIaPW","object":"chat.completion.chunk","created":1748488175,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"24"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw7TPkf33tHhtv5BBYd6zunIaPW","object":"chat.completion.chunk","created":1748488175,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw7TPkf33tHhtv5BBYd6zunIaPW","object":"chat.completion.chunk","created":1748488175,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw7TPkf33tHhtv5BBYd6zunIaPW","object":"chat.completion.chunk","created":1748488175,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[],"usage":{"prompt_tokens":14,"completion_tokens":8,"total_tokens":22,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+
+
+          data: [DONE]
+
+
+          '
+      headers:
+        CF-RAY:
+          - 9472cb34d8b0e56c-EWR
+        Connection:
+          - keep-alive
+        Content-Type:
+          - text/event-stream; charset=utf-8
+        Date:
+          - Thu, 29 May 2025 03:09:35 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "324"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "328"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999993"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_8e14ac90b3fc7df08ab71458200c0b80
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_chat_async_with_system_prompt.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_chat_async_with_system_prompt.yaml
@@ -1,0 +1,213 @@
+interactions:
+  - request:
+      body:
+        '{"messages":[{"role":"system","content":"You are a helpful assistant that
+        only responds with numbers."},{"role":"user","content":"What''s 12 + 12?"}],"model":"gpt-4o-mini"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "171"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAwAAAP//jJJPj9MwEMXv+RTWnDeoSbO02+MKDgiJG0gIrSLHnqQGx2PZEyha9bsj
+          O6VJ+SPtJYf5zXt+M5nnQggwGg4C1FGyGr0tH9WHHzXeV5vGfKaO33za8cfTsHn77n21PcFdUlD3
+          FRX/Vr1SNHqLbMjNWAWUjMm12jX7Zr+vdpsMRtJok2zwXDZUjsaZst7UTbnZldX+oj6SURjhIL4U
+          QgjxnL8pp9N4goPIXrkyYoxyQDhcm4SAQDZVQMZoIkvHcLdARY7R5eh1swYB+ynKFM5N1q6AdI5Y
+          puFypKcLOV9DWBp8oC7+IYXeOBOPbUAZyaUHI5OHTM+FEE952OkmP/hAo+eW6Rvm5+qH2Q6WFS+w
+          ujAmlnYpby/7uTVrNbI0Nq52BUqqI+pFuSxWTtrQChSrkf/O8i/veWzjhpfYL0Ap9Iy69QG1Ubfz
+          Lm0B0/39r+264hwYIobvRmHLBkP6DRp7Odn5KiD+jIxj2xs3YPDBzKfR+/a+wa7p9OuHLRTn4hcA
+          AAD//wMAVr/YZSgDAAA=
+      headers:
+        CF-RAY:
+          - 9472cb184e500f9d-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:30 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=z2Ic8fUwpskhLoChFn0SfEzhOfgA51ECWEr8bGcDOAU-1748488170-1.0.1.1-3G3XcIq9Svq616YfoviWP1tBVFUnyK5oqEpmdqksGBJYjIpBO8NytkA_b8eFnYmWdJAuXvn06hw7i4HrfgFfaPFiUHbQbgYYAVNOsIV3dAI;
+            path=/; expires=Thu, 29-May-25 03:39:30 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=veSl_gK4UARU6LJElYKitkIBU5I0K75WBw7EYDdP338-1748488170636-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "220"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "224"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999978"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_d06b62c50c671827b21d6ed9f0358cbb
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"messages":[{"role":"system","content":"You are a helpful assistant that
+        only responds with numbers."},{"role":"user","content":"What''s 12 + 12?"}],"model":"gpt-4o-mini"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "171"
+        content-type:
+          - application/json
+        cookie:
+          - __cf_bm=z2Ic8fUwpskhLoChFn0SfEzhOfgA51ECWEr8bGcDOAU-1748488170-1.0.1.1-3G3XcIq9Svq616YfoviWP1tBVFUnyK5oqEpmdqksGBJYjIpBO8NytkA_b8eFnYmWdJAuXvn06hw7i4HrfgFfaPFiUHbQbgYYAVNOsIV3dAI;
+            _cfuvid=veSl_gK4UARU6LJElYKitkIBU5I0K75WBw7EYDdP338-1748488170636-0.0.1.1-604800000
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAwAAAP//jJJPb9swDMXv/hQCz/XgOB6c5lgMvRTY0NuAoTAUiXa0yqIg0e2KIt99
+          kJzFzv4Au/jAH9/TI833QggwGvYC1FGyGr0t79Tn17r9eseP1XP1EKq3x9cvptWH+08voYGbpKDD
+          d1T8S/VB0egtsiE3YxVQMibXTdvsmt1u01YZjKTRJtnguWyoHI0zZV3VTVm15WZ3Vh/JKIywF98K
+          IYR4z9+U02n8AXuRvXJlxBjlgLC/NAkBgWyqgIzRRJaO4WaBihyjy9HrZg0C9lOUKZybrF0B6Ryx
+          TMPlSE9ncrqEsDT4QIf4mxR640w8dgFlJJcejEweMj0VQjzlYaer/OADjZ47pmfMz9W3sx0sK17g
+          5syYWNqlvD3v59qs08jS2LjaFSipjqgX5bJYOWlDK1CsRv4zy9+857GNG/7HfgFKoWfUnQ+ojbqe
+          d2kLmO7vX22XFefAEDG8GIUdGwzpN2js5WTnq4D4FhnHrjduwOCDmU+j9922kR8bibdbBcWp+AkA
+          AP//AwA8d/+VKAMAAA==
+      headers:
+        CF-RAY:
+          - 9472cb1ab8300f9d-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:30 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "178"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "180"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999978"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_80e6fc88a032fe8f219ac811f814ab16
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_chat_error_in_async_context.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_chat_error_in_async_context.yaml
@@ -1,0 +1,136 @@
+interactions:
+  - request:
+      body: '{"messages":[{"role":"user","content":"What''s 12 + 12?"}],"model":"gpt-4o-mini","stream":true}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "94"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string:
+          'data: {"id":"chatcmpl-BcNw8NWjpuphnc6XUr373KNPztVnm","object":"chat.completion.chunk","created":1748488176,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}]}
+
+
+          data: {"id":"chatcmpl-BcNw8NWjpuphnc6XUr373KNPztVnm","object":"chat.completion.chunk","created":1748488176,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"12"},"logprobs":null,"finish_reason":null}]}
+
+
+          data: {"id":"chatcmpl-BcNw8NWjpuphnc6XUr373KNPztVnm","object":"chat.completion.chunk","created":1748488176,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+          +"},"logprobs":null,"finish_reason":null}]}
+
+
+          data: {"id":"chatcmpl-BcNw8NWjpuphnc6XUr373KNPztVnm","object":"chat.completion.chunk","created":1748488176,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+          "},"logprobs":null,"finish_reason":null}]}
+
+
+          data: {"id":"chatcmpl-BcNw8NWjpuphnc6XUr373KNPztVnm","object":"chat.completion.chunk","created":1748488176,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"12"},"logprobs":null,"finish_reason":null}]}
+
+
+          data: {"id":"chatcmpl-BcNw8NWjpuphnc6XUr373KNPztVnm","object":"chat.completion.chunk","created":1748488176,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+          equals"},"logprobs":null,"finish_reason":null}]}
+
+
+          data: {"id":"chatcmpl-BcNw8NWjpuphnc6XUr373KNPztVnm","object":"chat.completion.chunk","created":1748488176,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+          "},"logprobs":null,"finish_reason":null}]}
+
+
+          data: {"id":"chatcmpl-BcNw8NWjpuphnc6XUr373KNPztVnm","object":"chat.completion.chunk","created":1748488176,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"24"},"logprobs":null,"finish_reason":null}]}
+
+
+          data: {"id":"chatcmpl-BcNw8NWjpuphnc6XUr373KNPztVnm","object":"chat.completion.chunk","created":1748488176,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
+
+
+          data: {"id":"chatcmpl-BcNw8NWjpuphnc6XUr373KNPztVnm","object":"chat.completion.chunk","created":1748488176,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
+
+
+          data: [DONE]
+
+
+          '
+      headers:
+        CF-RAY:
+          - 9472cb3e4a3143a3-EWR
+        Connection:
+          - keep-alive
+        Content-Type:
+          - text/event-stream; charset=utf-8
+        Date:
+          - Thu, 29 May 2025 03:09:36 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=6F6f.fzRO5zVOYUAiT5bcPPwUQdXa4rd1.Y.JWbab3c-1748488176-1.0.1.1-3rRtjM2olNTj900mSmISyfar8.oJ7t1cim.lqyhd9WsTQRoOq15s9vIei1qlGpc0RNSE.k.NfV_pB6V7u14_8d65UPjg_T9XMxWxmzikiek;
+            path=/; expires=Thu, 29-May-25 03:39:36 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=sjaMQlGTaX81GpiBljyaHhtJFsUc2w0XMik._kxjX0I-1748488176747-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "258"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "264"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999993"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_65937b46a3e55615088e7d7ffa7eecee
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_chat_metrics.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_chat_metrics.yaml
@@ -1,0 +1,209 @@
+interactions:
+  - request:
+      body: '{"messages":[{"role":"user","content":"What''s 12 + 12?"}],"model":"gpt-4o-mini"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "80"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - OpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAwAAAP//jJJBb9QwEIXv+RXWXNlUm5B20z2CFgkhcWHFAVRFXnuSGByPsScFVO1/
+          R85uNym0Epcc5ps3eW88D5kQYDRsBaheshq8zd+oj/dk97u37/TPDe/Hz5/elx++yN1u36sRVklB
+          h2+o+FF1pWjwFtmQO2EVUDKmqcWmqqu6Lq5vJjCQRptknee8onwwzuTluqzy9SYv6rO6J6MwwlZ8
+          zYQQ4mH6Jp9O4y/YivXqsTJgjLJD2F6ahIBANlVAxmgiS8ewmqEix+gm60UpXomiFPhjlDaKsrpa
+          NgZsxyiTWTdauwDSOWKZwk4W787keDFlqfOBDvEvKbTGmdg3AWUklwxEJg8TPWZC3E3hxyd5wAca
+          PDdM33H6XVGdxsG88hnWZ8bE0s7lslw9M6zRyNLYuNgdKKl61LNyXrQctaEFyBaR//Xy3OxTbOO6
+          /xk/A6XQM+rGB9RGPc07twVM9/hS22XFk2GIGO6NwoYNhvQMGls52tOVQPwdGYemNa7D4IM5nUrr
+          m+sKD9VB39y+huyY/QEAAP//AwCneqYZOAMAAA==
+      headers:
+        CF-RAY:
+          - 9472cac2a9b5de94-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:17 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=sWxznHK8dnr1ZZ08z5I2ZQmEwYjE4jBJk7LVdWYJUuE-1748488157-1.0.1.1-OMtXQYC8D6Je324xeQLIUyQlY9MIs6utypvJSWqa3uNwhZaotZS8o0MSpWREfvi.DwtHSvqh.5PBYGEJIksaBKTyEJYL0Z9U4okloVN4Ly4;
+            path=/; expires=Thu, 29-May-25 03:39:17 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=BxEHCUb89UDvpZLsyNEYKOkIyI9A.ZgoPKiVXOWNsaY-1748488157116-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "431"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "436"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999993"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_0bcc2689dc900e9e3399c07d7a3c0f76
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: '{"messages":[{"role":"user","content":"What''s 12 + 12?"}],"model":"gpt-4o-mini"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "80"
+        content-type:
+          - application/json
+        cookie:
+          - __cf_bm=sWxznHK8dnr1ZZ08z5I2ZQmEwYjE4jBJk7LVdWYJUuE-1748488157-1.0.1.1-OMtXQYC8D6Je324xeQLIUyQlY9MIs6utypvJSWqa3uNwhZaotZS8o0MSpWREfvi.DwtHSvqh.5PBYGEJIksaBKTyEJYL0Z9U4okloVN4Ly4;
+            _cfuvid=BxEHCUb89UDvpZLsyNEYKOkIyI9A.ZgoPKiVXOWNsaY-1748488157116-0.0.1.1-604800000
+        host:
+          - api.openai.com
+        user-agent:
+          - OpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAwAAAP//jJJPT+MwEMXv+RTWXGlQE1IaegTxRystB067WqHItSeJwbGNPUEg1O++
+          clKasAsSlxzmN2/y3njeEsZASdgwEC0n0TmdnovbZ3ftz3/J1xdxcdH+PL25dOr31d2q+SFhERV2
+          +4CC3lXHwnZOIylrRiw8csI4NVsXZVGW2Wo9gM5K1FHWOEoLm3bKqDRf5kW6XKdZuVe3VgkMsGF/
+          EsYYexu+0aeR+AIbtly8VzoMgTcIm0MTY+CtjhXgIahA3BAsJiisITSD9SxnRyzLGT71XAeWF8fz
+          Ro91H3g0a3qtZ4AbY4nHsIPF+z3ZHUxp2zhvt+EfKdTKqNBWHnmwJhoIZB0MdJcwdj+E7z/kAedt
+          56gi+4jD77JiHAfTyidY7hlZ4noq5/nik2GVROJKh9nuQHDRopyU06J5L5WdgWQW+X8vn80eYyvT
+          fGf8BIRARygr51Eq8THv1OYx3uNXbYcVD4YhoH9WAitS6OMzSKx5r8crgfAaCLuqVqZB77waT6V2
+          1arAbbGVp2cnkOySvwAAAP//AwAdEpQmOAMAAA==
+      headers:
+        CF-RAY:
+          - 9472cac67e58de94-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:17 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "618"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "622"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999993"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_0a8ccc08cb9b28094ef71fec29946dbe
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_chat_streaming_async.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_chat_streaming_async.yaml
@@ -1,0 +1,271 @@
+interactions:
+  - request:
+      body: '{"messages":[{"role":"user","content":"What''s 12 + 12?"}],"model":"gpt-4o-mini","stream":true,"stream_options":{"include_usage":true}}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "134"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string:
+          'data: {"id":"chatcmpl-BcNw1TcpT45K1JBmXqRdGP8bWXEsg","object":"chat.completion.chunk","created":1748488169,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw1TcpT45K1JBmXqRdGP8bWXEsg","object":"chat.completion.chunk","created":1748488169,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"12"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw1TcpT45K1JBmXqRdGP8bWXEsg","object":"chat.completion.chunk","created":1748488169,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"
+          +"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw1TcpT45K1JBmXqRdGP8bWXEsg","object":"chat.completion.chunk","created":1748488169,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"
+          "},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw1TcpT45K1JBmXqRdGP8bWXEsg","object":"chat.completion.chunk","created":1748488169,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"12"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw1TcpT45K1JBmXqRdGP8bWXEsg","object":"chat.completion.chunk","created":1748488169,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"
+          equals"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw1TcpT45K1JBmXqRdGP8bWXEsg","object":"chat.completion.chunk","created":1748488169,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"
+          "},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw1TcpT45K1JBmXqRdGP8bWXEsg","object":"chat.completion.chunk","created":1748488169,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"24"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw1TcpT45K1JBmXqRdGP8bWXEsg","object":"chat.completion.chunk","created":1748488169,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw1TcpT45K1JBmXqRdGP8bWXEsg","object":"chat.completion.chunk","created":1748488169,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw1TcpT45K1JBmXqRdGP8bWXEsg","object":"chat.completion.chunk","created":1748488169,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[],"usage":{"prompt_tokens":14,"completion_tokens":8,"total_tokens":22,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+
+
+          data: [DONE]
+
+
+          '
+      headers:
+        CF-RAY:
+          - 9472cb0fba02b295-EWR
+        Connection:
+          - keep-alive
+        Content-Type:
+          - text/event-stream; charset=utf-8
+        Date:
+          - Thu, 29 May 2025 03:09:29 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=UOMiv.S868Q9si.6iaHrxb9QmtUMkB6hpbJdsfYbS2I-1748488169-1.0.1.1-fRHbvwvzOTQqhRsu4RPT5ZyfaUX_DwxyHENDo7.X0zOBcWu_niWJBD5cmvDBWjXfEB3YZRU9cxHmPtmjyhG3rSIJPTUAkTnO_UdVjq_ocow;
+            path=/; expires=Thu, 29-May-25 03:39:29 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=VP44b.RP9HAvddSD71w9WOG9EnO.dwBkkNkzRK76STg-1748488169490-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "467"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "471"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999993"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_456232b7d84706bbb08d9f97e42c8aaf
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: '{"messages":[{"role":"user","content":"What''s 12 + 12?"}],"model":"gpt-4o-mini","stream":true,"stream_options":{"include_usage":true}}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "134"
+        content-type:
+          - application/json
+        cookie:
+          - __cf_bm=UOMiv.S868Q9si.6iaHrxb9QmtUMkB6hpbJdsfYbS2I-1748488169-1.0.1.1-fRHbvwvzOTQqhRsu4RPT5ZyfaUX_DwxyHENDo7.X0zOBcWu_niWJBD5cmvDBWjXfEB3YZRU9cxHmPtmjyhG3rSIJPTUAkTnO_UdVjq_ocow;
+            _cfuvid=VP44b.RP9HAvddSD71w9WOG9EnO.dwBkkNkzRK76STg-1748488169490-0.0.1.1-604800000
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string:
+          'data: {"id":"chatcmpl-BcNw1HPqJBzP7RFEwiJU8Vr0fOlA7","object":"chat.completion.chunk","created":1748488169,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw1HPqJBzP7RFEwiJU8Vr0fOlA7","object":"chat.completion.chunk","created":1748488169,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"12"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw1HPqJBzP7RFEwiJU8Vr0fOlA7","object":"chat.completion.chunk","created":1748488169,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"
+          +"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw1HPqJBzP7RFEwiJU8Vr0fOlA7","object":"chat.completion.chunk","created":1748488169,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"
+          "},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw1HPqJBzP7RFEwiJU8Vr0fOlA7","object":"chat.completion.chunk","created":1748488169,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"12"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw1HPqJBzP7RFEwiJU8Vr0fOlA7","object":"chat.completion.chunk","created":1748488169,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"
+          equals"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw1HPqJBzP7RFEwiJU8Vr0fOlA7","object":"chat.completion.chunk","created":1748488169,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"
+          "},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw1HPqJBzP7RFEwiJU8Vr0fOlA7","object":"chat.completion.chunk","created":1748488169,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"24"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw1HPqJBzP7RFEwiJU8Vr0fOlA7","object":"chat.completion.chunk","created":1748488169,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw1HPqJBzP7RFEwiJU8Vr0fOlA7","object":"chat.completion.chunk","created":1748488169,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNw1HPqJBzP7RFEwiJU8Vr0fOlA7","object":"chat.completion.chunk","created":1748488169,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[],"usage":{"prompt_tokens":14,"completion_tokens":8,"total_tokens":22,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+
+
+          data: [DONE]
+
+
+          '
+      headers:
+        CF-RAY:
+          - 9472cb14bcb3b295-EWR
+        Connection:
+          - keep-alive
+        Content-Type:
+          - text/event-stream; charset=utf-8
+        Date:
+          - Thu, 29 May 2025 03:09:30 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "237"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "240"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999993"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_136a017bdaa43b7493f0c1484fc1e487
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_chat_streaming_sync.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_chat_streaming_sync.yaml
@@ -1,0 +1,271 @@
+interactions:
+  - request:
+      body: '{"messages":[{"role":"user","content":"What''s 12 + 12?"}],"model":"gpt-4o-mini","stream":true,"stream_options":{"include_usage":true}}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "134"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - OpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string:
+          'data: {"id":"chatcmpl-BcNvsUEkWF6Xk2kAAUSi21kgVYyER","object":"chat.completion.chunk","created":1748488160,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNvsUEkWF6Xk2kAAUSi21kgVYyER","object":"chat.completion.chunk","created":1748488160,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"12"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNvsUEkWF6Xk2kAAUSi21kgVYyER","object":"chat.completion.chunk","created":1748488160,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"
+          +"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNvsUEkWF6Xk2kAAUSi21kgVYyER","object":"chat.completion.chunk","created":1748488160,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"
+          "},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNvsUEkWF6Xk2kAAUSi21kgVYyER","object":"chat.completion.chunk","created":1748488160,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"12"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNvsUEkWF6Xk2kAAUSi21kgVYyER","object":"chat.completion.chunk","created":1748488160,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"
+          equals"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNvsUEkWF6Xk2kAAUSi21kgVYyER","object":"chat.completion.chunk","created":1748488160,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"
+          "},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNvsUEkWF6Xk2kAAUSi21kgVYyER","object":"chat.completion.chunk","created":1748488160,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"24"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNvsUEkWF6Xk2kAAUSi21kgVYyER","object":"chat.completion.chunk","created":1748488160,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNvsUEkWF6Xk2kAAUSi21kgVYyER","object":"chat.completion.chunk","created":1748488160,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNvsUEkWF6Xk2kAAUSi21kgVYyER","object":"chat.completion.chunk","created":1748488160,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[],"usage":{"prompt_tokens":14,"completion_tokens":8,"total_tokens":22,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+
+
+          data: [DONE]
+
+
+          '
+      headers:
+        CF-RAY:
+          - 9472cadbaa3a6109-EWR
+        Connection:
+          - keep-alive
+        Content-Type:
+          - text/event-stream; charset=utf-8
+        Date:
+          - Thu, 29 May 2025 03:09:21 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=TaY3Tidv7pN1rwXifsEbRpgiJBSYyZmtrqFVhID5fxU-1748488161-1.0.1.1-yge4Qd_h2Czeue_4iHBseCabVMKErLW_dzyoNMs9A2ATm_3je1fFN03F_YfpeLqu1yq_W7BFbR0dqQpI_OxzTmh2tTKXdQDjQLoJP5ivPHI;
+            path=/; expires=Thu, 29-May-25 03:39:21 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=hV6VthxryE_9X2dzgxNwp6TyFZV.fQvAIpOzE5TrGpU-1748488161396-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "681"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "686"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999993"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_301ee2fbed0944b5203d0a79fc80645b
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: '{"messages":[{"role":"user","content":"What''s 12 + 12?"}],"model":"gpt-4o-mini","stream":true,"stream_options":{"include_usage":true}}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "134"
+        content-type:
+          - application/json
+        cookie:
+          - __cf_bm=TaY3Tidv7pN1rwXifsEbRpgiJBSYyZmtrqFVhID5fxU-1748488161-1.0.1.1-yge4Qd_h2Czeue_4iHBseCabVMKErLW_dzyoNMs9A2ATm_3je1fFN03F_YfpeLqu1yq_W7BFbR0dqQpI_OxzTmh2tTKXdQDjQLoJP5ivPHI;
+            _cfuvid=hV6VthxryE_9X2dzgxNwp6TyFZV.fQvAIpOzE5TrGpU-1748488161396-0.0.1.1-604800000
+        host:
+          - api.openai.com
+        user-agent:
+          - OpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string:
+          'data: {"id":"chatcmpl-BcNvt62bH7Bdi0CHQVKMIhuQTFiFp","object":"chat.completion.chunk","created":1748488161,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNvt62bH7Bdi0CHQVKMIhuQTFiFp","object":"chat.completion.chunk","created":1748488161,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"12"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNvt62bH7Bdi0CHQVKMIhuQTFiFp","object":"chat.completion.chunk","created":1748488161,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"
+          +"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNvt62bH7Bdi0CHQVKMIhuQTFiFp","object":"chat.completion.chunk","created":1748488161,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"
+          "},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNvt62bH7Bdi0CHQVKMIhuQTFiFp","object":"chat.completion.chunk","created":1748488161,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"12"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNvt62bH7Bdi0CHQVKMIhuQTFiFp","object":"chat.completion.chunk","created":1748488161,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"
+          equals"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNvt62bH7Bdi0CHQVKMIhuQTFiFp","object":"chat.completion.chunk","created":1748488161,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"
+          "},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNvt62bH7Bdi0CHQVKMIhuQTFiFp","object":"chat.completion.chunk","created":1748488161,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"24"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNvt62bH7Bdi0CHQVKMIhuQTFiFp","object":"chat.completion.chunk","created":1748488161,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNvt62bH7Bdi0CHQVKMIhuQTFiFp","object":"chat.completion.chunk","created":1748488161,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
+
+
+          data: {"id":"chatcmpl-BcNvt62bH7Bdi0CHQVKMIhuQTFiFp","object":"chat.completion.chunk","created":1748488161,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_62a23a81ef","choices":[],"usage":{"prompt_tokens":14,"completion_tokens":8,"total_tokens":22,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+
+
+          data: [DONE]
+
+
+          '
+      headers:
+        CF-RAY:
+          - 9472cae2792a6109-EWR
+        Connection:
+          - keep-alive
+        Content-Type:
+          - text/event-stream; charset=utf-8
+        Date:
+          - Thu, 29 May 2025 03:09:21 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "192"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "195"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999993"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_2d19c07b9dca45eb4d8ba0070cf1d930
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_chat_with_system_prompt.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_chat_with_system_prompt.yaml
@@ -1,0 +1,213 @@
+interactions:
+  - request:
+      body:
+        '{"messages":[{"role":"system","content":"You are a helpful assistant that
+        only responds with numbers."},{"role":"user","content":"What''s 12 + 12?"}],"model":"gpt-4o-mini"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "171"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - OpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAwAAAP//jJJPb9swDMXv/hQCz3ERO0br5rjbFmCXod3QoTAUiXbUyaIg0UGHIt99
+          kJ3Gzv4Au/jAHx/1+My3TAgwGrYC1EGy6r3NP6jPx2HzZefXxX738PXjp5fXQh0f73ffnmIJq6Sg
+          /QsqflfdKOq9RTbkJqwCSsY0tbir6qqui9tyBD1ptEnWec4rynvjTF6uyypf3+VFfVYfyCiMsBXf
+          MyGEeBu/yafT+ApbsV69V3qMUXYI20uTEBDIpgrIGE1k6RhWM1TkGN1ovayWIGA7RJnMucHaBZDO
+          Ecu03Gjp+UxOFxOWOh9oH3+TQmuciYcmoIzk0oORycNIT5kQz+Oyw5V/8IF6zw3TDxyfK++ncTBH
+          PMPizJhY2rm8OedzPazRyNLYuMgKlFQH1LNyDlYO2tACZIuV//Tyt9nT2sZ1/zN+BkqhZ9SND6iN
+          ut53bguY7u9fbZeIR8MQMRyNwoYNhvQbNLZysNNVQPwZGfumNa7D4IOZTqP1zW0py42sC2whO2W/
+          AAAA//8DAPUSQJ0oAwAA
+      headers:
+        CF-RAY:
+          - 9472cae638e8729e-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:22 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=ZjFMv.ZBiAaxl1Viuy0f5jRd8ixQZ19ec_8wpRze.bM-1748488162-1.0.1.1-e3N5dLdVbtE2fHmcn5YnBArdFCyaNfIiqKi7O4Lm6KI_Bh8XD0YdOM7ae78nsBWU9JrmS.z5cjoWY0WEFiX1_cogG4FtdPT0icCthH6KmIM;
+            path=/; expires=Thu, 29-May-25 03:39:22 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=wb9yw2JAvgu0HpK0Nc1hbHujFW3ggVyfVof1qMIIYD8-1748488162935-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "522"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "528"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999978"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_0f090d58b49555167feb876d72030990
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"messages":[{"role":"system","content":"You are a helpful assistant that
+        only responds with numbers."},{"role":"user","content":"What''s 12 + 12?"}],"model":"gpt-4o-mini"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "171"
+        content-type:
+          - application/json
+        cookie:
+          - __cf_bm=ZjFMv.ZBiAaxl1Viuy0f5jRd8ixQZ19ec_8wpRze.bM-1748488162-1.0.1.1-e3N5dLdVbtE2fHmcn5YnBArdFCyaNfIiqKi7O4Lm6KI_Bh8XD0YdOM7ae78nsBWU9JrmS.z5cjoWY0WEFiX1_cogG4FtdPT0icCthH6KmIM;
+            _cfuvid=wb9yw2JAvgu0HpK0Nc1hbHujFW3ggVyfVof1qMIIYD8-1748488162935-0.0.1.1-604800000
+        host:
+          - api.openai.com
+        user-agent:
+          - OpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAwAAAP//jJJPb9swDMXv/hQCz/GQP+6a5DgUxXYZsAJbgRaFoUq0zVWWNInOFhT5
+          7oXsNHbaDdjFB/74qMdnPmdCAGnYClCNZNV6k39SX3e7u92Xq/2Pz/b2qtl/v+brm1/0+1v9tIFZ
+          UrjHn6j4VfVBudYbZHJ2wCqgZExTF5fFulivFx9XPWidRpNktee8cHlLlvLlfFnk88t8sT6qG0cK
+          I2zFfSaEEM/9N/m0Gv/AVsxnr5UWY5Q1wvbUJAQEZ1IFZIwUWVqG2QiVs4y2t74spiBg1UWZzNnO
+          mAmQ1jqWabne0sORHE4mjKt9cI/xjRQqshSbMqCMzqYHIzsPPT1kQjz0y3Zn/sEH13ou2T1h/9xy
+          M4yDMeIRLo6MHUszllfHfM6HlRpZkomTrEBJ1aAelWOwstPkJiCbrPzey99mD2uTrf9n/AiUQs+o
+          Sx9Qkzrfd2wLmO7vX22niHvDEDHsSGHJhCH9Bo2V7MxwFRD3kbEtK7I1Bh9oOI3Kl6tCXhQSNysF
+          2SF7AQAA//8DAPAiMEYoAwAA
+      headers:
+        CF-RAY:
+          - 9472caea8b03729e-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:23 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "506"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "516"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999978"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_5e8e2c038b495d648c008856b7457541
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_client_async_comparison.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_client_async_comparison.yaml
@@ -1,0 +1,212 @@
+interactions:
+  - request:
+      body: '{"messages":[{"role":"user","content":"What''s 12 + 12?"}],"model":"gpt-4o-mini","seed":42,"temperature":0}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "106"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAwAAAP//jJJBb9QwEIXv+RXWXLupEhORsMce2iIBQogDCFWRa0+ybh3b2BNaqPa/
+          IyfbTQqt1EsO882bvDeeh4wx0Aq2DOROkBy8yc/kp7sqfPzz/tv9Z3759a64/X75RVUX52f8w1vY
+          JIW7vkFJj6pT6QZvkLSzM5YBBWGaWtZVUzVNWfMJDE6hSbLeU165fNBW57zgVV7Uedkc1DunJUbY
+          sh8ZY4w9TN/k0yq8hy0rNo+VAWMUPcL22MQYBGdSBUSMOpKwBJsFSmcJ7WS95OyElZzhz1GYyHh1
+          um4M2I1RJLN2NGYFhLWORAo7Wbw6kP3RlHG9D+46/iOFTlsdd21AEZ1NBiI5DxPdZ4xdTeHHJ3nA
+          Bzd4asnd4vS7sprHwbLyBTYHRo6EWcqcb54Z1iokoU1c7Q6kkDtUi3JZtBiVdiuQrSL/7+W52XNs
+          bfvXjF+AlOgJVesDKi2f5l3aAqZ7fKntuOLJMEQMv7TEljSG9AwKOzGa+Uog/o6EQ9tp22PwQc+n
+          0vn2HcfiTV0XTQnZPvsLAAD//wMAdPse5DgDAAA=
+      headers:
+        CF-RAY:
+          - 9472cb1dff31728a-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:32 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=ACvanrvDDdClYpufGDkvW3WdIRGVOem0UIhBjCRp4HE-1748488172-1.0.1.1-EbrqjqvlfugpDE5yBVbLhKNcI5siYyYyO1_gfUyFH19kF.u4BAL5vgjZ1YR_NXBIlbzchla2gDsOD8lMbVoeZzL977owwr85YNr6LjdeJkg;
+            path=/; expires=Thu, 29-May-25 03:39:32 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=NfWilA6YB4UOd_P4xU1o9cre4ute9B0ASs9R0fnJpKQ-1748488172895-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "426"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "429"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999993"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_001a33a36414defefecd0088fcc9672e
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: '{"messages":[{"role":"user","content":"What''s 12 + 12?"}],"model":"gpt-4o-mini","seed":42,"temperature":0}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "106"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAwAAAP//jJJBT9wwEIXv+RXWXNmgjUnZdI+IS4taFS49IBR57UnW4NjGntBWaP87
+          crK7CRQkLjnMN2/y3nieM8ZAK1gzkFtBsvMmv5A//3y5+n3xXd/YR7U8v3n6el3+uPz26zpsrmCR
+          FG5zj5IOqlPpOm+QtLMjlgEFYZparMqqrKpidTaAzik0SdZ6ykuXd9rqnC95mS9XeVHt1VunJUZY
+          s9uMMcaeh2/yaRX+hTVbLg6VDmMULcL62MQYBGdSBUSMOpKwBIsJSmcJ7WC94OyEFZzhYy9MZLw8
+          nTcGbPooklnbGzMDwlpHIoUdLN7tye5oyrjWB7eJb6TQaKvjtg4oorPJQCTnYaC7jLG7IXz/Kg/4
+          4DpPNbkHHH5XlOM4mFY+wWrPyJEwU5nzxTvDaoUktImz3YEUcotqUk6LFr3SbgayWeT/vbw3e4yt
+          bfuZ8ROQEj2hqn1ApeXrvFNbwHSPH7UdVzwYhojhSUusSWNIz6CwEb0ZrwTiv0jY1Y22LQYf9Hgq
+          ja/PueBnoiqwgWyXvQAAAP//AwAEquOGOAMAAA==
+      headers:
+        CF-RAY:
+          - 9472cb291a25d826-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:33 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=YVSQNhGU5D_XZKKHlGiF2ASuyzAJ6dCDpQHNZ0PK45Y-1748488173-1.0.1.1-6Fwa3GoGwXMRDtobRN38cHAxxT.1JgwMWTJ8NyXBuRGzdJEkZt7GiwmbWmxIXXzJe0nsxMGCcP7gxTKgOw_ZmAwoh_dRaKeQqI3tYMpKZgQ;
+            path=/; expires=Thu, 29-May-25 03:39:33 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=qt53dwZTdoU.J1LuD_WqqiwsjRgIE6Lh9ziMs5KTO0s-1748488173691-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "605"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "608"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999993"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_454870f19e34ada2f4d3403f7a46ba71
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_client_async_error.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_client_async_error.yaml
@@ -1,0 +1,83 @@
+interactions:
+  - request:
+      body: '{"messages":[{"role":"user","content":"What''s 12 + 12?"}],"model":"non-existent-model"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "87"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA0yOQQ6DMBAD77zCyrn0Abyj9xCRbYkUdmmyQUWIv1faHsrRY1v20QGAo1KkuAGH
+          SUML1Rpe5Aa4x0xYJFLGyMI9fVJVYu2NjYhCFSwKMyAFuzREMTaHjRCmiWqFCpLe3e0/ovtqC4m3
+          kFP0hd6Nqvrfn0twDSUsbgC3nC94kmh9e+JZ1D+lcXSWOLuz+wIAAP//AwDwJ9T24AAAAA==
+      headers:
+        CF-RAY:
+          - 9472cb2e5cc31a2c-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Thu, 29 May 2025 03:09:34 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=GTQ9lK9aXIagrFFLKxGeQ4yhPX4.lqMiHUg2tpn490s-1748488174-1.0.1.1-UjbQXOzWFJv3y_C9.kzpGt0eEcKc0AhkeNO1KD1i3oD2g6PUQkx_FyTPdHmt9YmN2xQ0cch2zfV5plYuuMeCXgPtbRPZ4iACGpmMp.mwVwA;
+            path=/; expires=Thu, 29-May-25 03:39:34 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=2FR2R_eFbznKP3sn24Ec_2XMfvCR.7ohFqG6v9C1COM-1748488174092-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        vary:
+          - Origin
+        x-request-id:
+          - req_98c81147f2f025a021ed636bd814c3e3
+      status:
+        code: 404
+        message: Not Found
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_client_comparison.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_client_comparison.yaml
@@ -1,0 +1,209 @@
+interactions:
+  - request:
+      body: '{"messages":[{"role":"user","content":"What''s 12 + 12?"}],"model":"gpt-4o-mini","seed":42,"temperature":0}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "106"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - OpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAwAAAP//jJJBb9QwEIXv+RXWXNlUSRrYsMflAhwqBEgcUBW59iRrcGzjmayKqv3v
+          yMl2k5YicclhvnmT98bzkAkBRsNOgDpIVkOw+V7dHI/f9h/ku7p8/+Xz65t9Q1/H7t7Qp489bJLC
+          3/1AxY+qK+WHYJGNdzNWESVjmlpu66ZumvLN9QQGr9EmWR84r30+GGfyqqjqvNjmZXNWH7xRSLAT
+          3zMhhHiYvsmn03gPO1FsHisDEskeYXdpEgKit6kCksgQS8ewWaDyjtFN1stKvBJlJfDXKC2Jqr5a
+          N0bsRpLJrButXQHpnGeZwk4Wb8/kdDFlfR+iv6NnUuiMM3RoI0ryLhkg9gEmesqEuJ3Cj0/yQIh+
+          CNyy/4nT78p6HgfLyhfYnBl7lnYpV9XmhWGtRpbG0mp3oKQ6oF6Uy6LlqI1fgWwV+W8vL82eYxvX
+          /8/4BSiFgVG3IaI26mnepS1iusd/tV1WPBkGwng0Cls2GNMzaOzkaOcrAfpNjEPbGddjDNHMp9KF
+          9m2FxfV2WzQlZKfsDwAAAP//AwCwMJgnOAMAAA==
+      headers:
+        CF-RAY:
+          - 9472caeefc07c674-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:24 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=JTYI3VmC3Z.1ZeFlZm0UnBhg2e9UAoSRy3zE2PqNvx8-1748488164-1.0.1.1-2a78CsWXdJSzVCF.0zBiK_lG_F1SKSU1dLyaFM.ijiP5Y0sgwpUrntITdlPTueXdgaijiedgYyvNt358XySz3XlnJVzWagAeB8kWr.0GzPI;
+            path=/; expires=Thu, 29-May-25 03:39:24 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=Q79oKiMDrSwA4zGocgHI.nmRNlEbok1i5HNAivxJMOM-1748488164364-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "575"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "580"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999993"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_49fc0026e0914ff639e48ccfac1f6b2f
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: '{"messages":[{"role":"user","content":"What''s 12 + 12?"}],"model":"gpt-4o-mini","seed":42,"temperature":0}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "106"
+        content-type:
+          - application/json
+        cookie:
+          - __cf_bm=JTYI3VmC3Z.1ZeFlZm0UnBhg2e9UAoSRy3zE2PqNvx8-1748488164-1.0.1.1-2a78CsWXdJSzVCF.0zBiK_lG_F1SKSU1dLyaFM.ijiP5Y0sgwpUrntITdlPTueXdgaijiedgYyvNt358XySz3XlnJVzWagAeB8kWr.0GzPI;
+            _cfuvid=Q79oKiMDrSwA4zGocgHI.nmRNlEbok1i5HNAivxJMOM-1748488164364-0.0.1.1-604800000
+        host:
+          - api.openai.com
+        user-agent:
+          - OpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAwAAAP//jJJPb9QwEMXv+RTWXNlUG9fQsEekIiEkTggkUBW59iTrxf+wJ6Wo2u+O
+          nGw3aSkSlxzmN2/y3ngeKsbAaNgxUHtJykVbv1Of7n69H7aHr+ra8Y/fWqfuuRWHzx+u3RfYFEW4
+          PaCiR9WFCi5aJBP8jFVCSVimNleiFW3bvBETcEGjLbIhUi1C7Yw3Nd9yUW+v6qY9qffBKMywY98r
+          xhh7mL7Fp9d4Dzu23TxWHOYsB4TduYkxSMGWCsicTSbpCTYLVMET+sl6w9kr1nCGP0dpM+PiYt2Y
+          sB+zLGb9aO0KSO8DyRJ2snhzIsezKRuGmMJtfiaF3niT911CmYMvBjKFCBM9VozdTOHHJ3kgpuAi
+          dRR+4PS7RszjYFn5AtsTo0DSLmXONy8M6zSSNDavdgdKqj3qRbksWo7ahBWoVpH/9vLS7Dm28cP/
+          jF+AUhgJdRcTaqOe5l3aEpZ7/FfbecWTYciY7ozCjgym8gwaezna+Uog/86EruuNHzDFZOZT6WN3
+          KeRrIfHtpYLqWP0BAAD//wMAEKy8gTgDAAA=
+      headers:
+        CF-RAY:
+          - 9472caf36d88c674-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:24 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "319"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "321"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999993"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_aed77d6d5688f5c0ab576274999fdb80
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_client_error.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_client_error.yaml
@@ -1,0 +1,83 @@
+interactions:
+  - request:
+      body: '{"messages":[{"role":"user","content":"What''s 12 + 12?"}],"model":"non-existent-model"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "87"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - OpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA0yOQQ6DMBAD77zCyrn0Abyj9xCRbYkUdmmyQUWIv1faHsrRY1v20QGAo1KkuAGH
+          SUML1Rpe5Aa4x0xYJFLGyMI9fVJVYu2NjYhCFSwKMyAFuzREMTaHjRCmiWqFCpLe3e0/ovtqC4m3
+          kFP0hd6Nqvrfn0twDSUsbgC3nC94kmh9e+JZ1D+lcXSWOLuz+wIAAP//AwDwJ9T24AAAAA==
+      headers:
+        CF-RAY:
+          - 9472caf6acdb42e9-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Thu, 29 May 2025 03:09:25 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=tw5RpvNcilfwjUjOiCvIStwbXJbeRE_xXCqPZ.4RX7I-1748488165-1.0.1.1-FMTa0ZJqNJbuNSSA6DphhFklanxkVYlP.JqvtvujJtr4sYPh9SpE3tA0RGm.xS6wbQPTr3XYwQizdw4hssI3nii8ASbX11MhrVl9x0YOMrE;
+            path=/; expires=Thu, 29-May-25 03:39:25 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=2B8C1K9X3JEAGR.xZd9FRJAYUg1T1ogs5tZIZzvxNiI-1748488165031-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        vary:
+          - Origin
+        x-request-id:
+          - req_51b61b333398d569debb6e253ba8335a
+      status:
+        code: 404
+        message: Not Found
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_embeddings.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_embeddings.yaml
@@ -1,0 +1,426 @@
+interactions:
+  - request:
+      body: '{"input":"This is a test","model":"text-embedding-ada-002","encoding_format":"base64"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "86"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - OpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/embeddings
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA1SXy9KyOhaG530VX/1Tu0pEIMs9AznIyQTkoPZIUBHEE5AE0jff5beruqsnDMKa
+          rCTv86z8+x8/P39eRXMphz9//fxp637488/v2vk0nP789fOvf/z8/Pz8+/f7f5WXR3E5n+tn9Vv+
+          +7N+ni/jn79+pP+u/K/or58/nn6w2JZ0RddHMTqpiSIrVK6uU8HD8yGC9HkTjOhZiwYpU9YaRnrI
+          it25aqY8e0mA+3vGrKY3xFAfI4CsXhwwofbY8MsJ3dWZfPeJlcIsGPxFZ6HVsJnwdB1JN0ZNf4d6
+          nD+Zs8xYx6Pd444kkCJ24sen4IZb+/D6yIKEu3dTTPt8sLRl7WbskD1I04U7aQY0O3RM/+Cm4Lct
+          T0HSdYmFbWWbo0yUCpbT9YPlu92hyWiPMqrjh0FLJa8bOgp1B5/0VTHLfg/J+NycSqBCEWwdOUYg
+          maY1aVazqajwrFfCUikM0TELemIfPl4ivL2CUaK8bHZ0rkYj1Od9BsmnaTC/Gr3JdTe20KI4vYml
+          vRTBvOvFQt48GTEo+4cYL914B/lpNti8Ag7YXRYSHLwupfL22Recnj0LxTyNiVtJXTC0adYDbZst
+          CzbRu5jurf+CdlFecC64VtBNUqTa1jQH4s6zfTA1vXMCbSkohcF9mpN1lUrYl4sl2ThuVUxb7agD
+          uosZvqkvo1lsjNgBc98d2TaJOOrtVb5DO/2ZYXGd5V1veFkOT8PYsO2Q2B1d3A4vFC3Ilfi9wAmd
+          mWsHHvZQE/+44mg4zgx/dZrxljhxt0rORoFrrXqfKLNmWxpwErsYjs2BEw8/rsl4T9wDDMr7ymx2
+          XzaTu/U56mYPyvwXNzrJlo0L1OPqSReeAoLvNeeA7MjmJGj3zJxWHkxA3mxDQs4sxLu3bq3a9rBl
+          sZtUHbdl74K6KjkRO15vCr69bigYxKpYOHhdMn3CTwWq9gHmoSVJ+EsuT6BzlWLRhZP5lNTTAQzQ
+          r7Qal+9GnHElre6FSHA3Gmp38xeNA/JjujLvbV0Ei+ZvC6naeKHyrH4g0XJIYe0fbJJc0VuMohQc
+          bvlhRukjWRS0C9EDHjariX7VN2ihWX0PqJYJs0o3Nod9MP+gowUqXT28IuDfvKLA5R67nJ518t3P
+          EGbeJyCbuScln9BoNfS9/8S2pQCN9fGja8hZT3QxO/TNNErFAdbqRsf9ptiIfmGbzrzRI8CXAVAz
+          LV5DiW4Sckh404Jm+W6vJXjrpMbL+PhqhmFxB0gC6cU2Hl8nYs2jHLa3Y8LC4THrhsw/7qBa9iYL
+          dtd3MN6TY4mO45STACtdQm/jqQfX9jmeW3ta9HEgNDg2+RXXK7kXfHsZ7siL7ksS5n1kUvPx9KHv
+          TgGxy11X3KEXAPO2eBLfH0LEpRDLaJILjc6pkwmuTm4Eh5dXMv3Ta2JYxlsJivORkC08T91Edbhr
+          +5PikkAJrEDUq/CAbvmZ4ClqpGKIz62DRv9zoWOzxeKDJfeC+u4QMKKLczJmMbUgjrUT5o2ZNiP+
+          OBgCf1CIndlS0Cs6kdG3P7Yu6FqMWXxeg1hDQs7Q7sxeUbQZalZJgKfUG0S/s7gPiyI9MJNhrRFf
+          3sBMaVS8qs1bNyzyDqOz/aiJr1hyd//2p5Z+hpmxGnLE23VSwrzFEtOLUkbi6qUVolnkYeUY3AU3
+          vHMKItHvZCuhZzeexfWCTtU5Jmsjlbrhm0+kV7VLNj5WhSizxQuokGs6yVFS0OTNJG07p09id9Wj
+          oTHLI3jGwRsrO102RRAr/W/+2PbN0oaerccDivO1YuaXn49JWlSwV8sb2zWHoWDLITmADS+XWM3w
+          CKbQKCWwrFLGY2qAOUlPLQIO4RPPxy4wO+IksvY9D7b++kMcbqcKhTY/UhUVVcGwrfZwL5Z3CoNP
+          mjHz3RCRt6qRIL+NDY0WDwnkRfRk4ebUdONxBilEbjYy1xnzRAjVS1GYe3NmFG2PRv2oYvDm8Uj3
+          X1526rPQYCMLH+dlaXcjLKMU/EL2GV44j2Aw09UM5UZC2Lpgz4Aj8fgAq5BJ2yoVgvaOrsFLW2X4
+          PS/v3bR4zWo0z/yG+WaVNVyevU9wbtGSOQe5D0SZ3e9IfsicfXluTkSq70CFVNNppWTFZFV2jS6R
+          smHWk+/QpOUU0OXmaLi1ZSmh9Ue1ILxHt799I3759ahPZ4KTCwT0kM9cxOpuTrWLvmo+armsQfMs
+          QWyN+x2nZ8NBK5TKzL/o56Z35F2lbR6fF7FmvpEsWZiF8PZyRAz1deum3okBdphvWPo9z57e6QxV
+          6nsi2ySKhKC7tId9ybJfPweLzD9GMG8TmxjquxUTR44DThFNxN84JBgPNrNQ0b0SZgsvFOKMRwX2
+          6ili5iQY4lN8D0HdIk7sMlqLxS5/p/D1K7MOTYHGqFm8IAkUFWfGZBbM6eahOnjSmmByCszJvBoR
+          wtjakjQ9r5PpujRcKJfxlmCgrrlsOeTItYlBTMobc4TZ4MKUgcks7Sl1w+0alauvf+hczz8mTeti
+          jeLa3mJu1a+Ga9Pxy8MiYcZ+xoJX/8kOQN5II8Em3jaToIkCNLsAnoP2QUJSmxIW3TCjq3Gfd4+I
+          6gAHuRzZ2lreCqFVbwzaszz++tMc8QdjTV/rOskZjcW4jC8KbB6vF9k4wWCOb/fJQTfVC+afXkM8
+          PN9SYLsTwqsxn5Ju04Y1XPsLYy5i52Zs08eE/G3rYJTbdTdMTXZCLw1Z+Hs/ulGcQwklwdwnxnRF
+          yZDsywp9fca8jN4K/pblCvbhJcZwVhpzelzb3d95niet103vJPTRL5/8N1aDzz5fA7ofZw7RR2UQ
+          49PhOcqNYqRyjD/mGN2vXFuVfcj8DLnJ2KbnHk6UpsS9xZdCVOubDEkw7ZkTE5ow9yJg9WTPK1mv
+          lrEpjjf4oDANI2Y2t6aY0jpZrxRmJSzI7XXDF5amI6LoJdYUS26o5xwsqG+0oUzNsoZXaQwAM2xR
+          5bzdFqO/OOmIQ+ZR9Shp4tVsFAk92WWF23U8N1m1PnBQS1+iXL9Zyat8yjKayQ+fPsqy7Sbzusth
+          LmqP6FbtNqw/zFIE5nZBeXH8mLzZKDIYgygwH5Wt+O0P3TarDVnT5xAMzcnyoZtdQuaUpd3wTHmt
+          UeSUCQtOjiPExY12yC8kn2Fy6r7zUEdRZ1SYOfbqhsZyVC0Qc1knev24FZPRxvLf87K77MJuuQ2T
+          fCXW2pp5t0Lp2P7ZOBDdNZ+5jpihUT/5O3jL/oEZssW77/x1gszazSlbxPduvPQFhfK59r7vgZvg
+          wldr1ZS309/z1Oe8qicwiE6IvdyeBbt6wwOCZfugNLmUgVilRx99+U22Q9I2fHZVeqiWPCWmfLC/
+          Ppgi+KSLhG0vlSRofsYUfvniovgRjM0pC2F9KnO2YUoYjFu+7bXdRXvTedK+uwmRnQ9gRA7xe2nX
+          cOg/GsL9I6PyQUmbyT56E+zDzqKg7B3EwuTqgEHckTiadkf8bqgpusJNJ0TNVdHrrq6vvvliZP+5
+          fN8X+qQ63d5kVpc2gk1zSYeNPPrk62cxXtvbGpEAz5nZ/AcAAP//TJpbz4K8uq7Px68Y+U7JiIBK
+          H+YZAiLbFkFRkpkZcI8i+0KbzP++gu/Kyjo1GhDae3M9LVrErff+gNAhO1NzqSV8Mg5vBZicKtR+
+          p1ouG3cn+vWRQXEbzViO2/SC1H7L6O6YTx7b060PH7scB3XOM3+/r/wwo/dXpiPOtcT/7Xeqre9e
+          wdHzcAZrPdQD3A7M4zHnLsz+M0z3at0y+XVQgE81HpTxbBTSWLFRpbpvk3Rx673m5xexN56I+R3c
+          nFdv3YVTayGqy9hF4+IRyfBM7gRXneFyShZnDaI+eQzMXDucQ8ZGRNJKJl6FHt7UiesRnZ3+Q/X7
+          8TH7+eb20zu8qm7HlhHJ7CAtnhE1H84x59S/+hDsjzrRN1FndFt5cwF/O9gEv/DDGwt7owDbTSEJ
+          XhaOO+heCpSHnY1RUmQeE/S1Du3DXRHnevbQKHyDB9yh0AbIIqfgx8HswBDPH6LbqoKG9WXxQPYx
+          Ff/WS1fsRhnx59mlKS4XeR8lSgbtY5+R3RtvuLQluxc8XKUkpvI9tGxUVB2un/VykPfBlg9tYFbq
+          IlFHYoT0ZPArrkRojbs6lIo6tWx9RCPMeksxTAc0bLpFB4oNe3LTnMKbvviGUfixVPy6ixCPiweA
+          MudH+rvf76x/v/yNaXk/e1xUgnKdCDbQc7RR4iYc5nf1GELqjLjOmRXrEfqqckG1pk2KyZU0QW3v
+          gkm28vAyJm9YZdCheu4fOx/V0ilI4HyCemCq7PPp1umV+svHq3f6iAeMlmewJwhwR8zBG6F7rcDy
+          RUS9OkN83NGVAv62s+lW4ct8sDKsobN8m/CivLQ5/YxFBD6rdnRbLB/5FCXsDG6QxcTdbV0+Zcux
+          BEUSnsMkW6k34pOiKIGx6f/0aRC/LIIFH4AST/22rNecTAkWKBtkRXlzth/ARpvr60R1OSiLiV9N
+          EfrzwaWXbL+NeaQcmNIUdoWXx8xHw/qovUHKbwqWzt2EWBWFoHZ4elInCVSPX4kr/PWnSu8/8SSH
+          mxKd1i82CJJVGlXa1fP+X6hYuHWnYmqR9AJtnHzi6KuC10HtgFIetvbwUcamHWsaNmjWK7ykyy9q
+          Oks0QUhlYX6/GRplITyAHZdf8vNbmuWSC7/3b+npiBq6SQZ4lsVjCExdaru0Y3Oeihj1kkLx6Gqw
+          SjDN547sHlWVs34X2EvYtx3VzPfk9WbAsKpnrUO35172OrbvfBSv2HfuB4d2ml4NBuOzuuIlv21b
+          mYnqC3jsWXTHlUPLiIga5AZfCy9O/jdn5b0PYV5vmH8/YsyF43BDAW0S6o6ZbzB398kg0NceITkR
+          jfbnB9J6oVMM41jwLO9M9M6lN7EE4chZONgCwsi6UnKT+nZ4tbGPGn7KcZ9dK4MW8n5A/Jm51Jh5
+          BZv7JXoHaT+Mk7QxZn/AMGUDxatlY+dTtWsfaAQ7oYdN+Wj7pbPWYaU+XLqroogz1SkGOJ/EHd3E
+          6BVP0yu1UWkIJfVvidJ2opdXMOsj/r67NO6FiQko2EfTgOozj3s9rhpgiX6gW0FELZ+skinTem/T
+          QFSKfOTRPUOz3hI8rw/aXNclkPR1GBTDLNvJhcUKXY+9SbC0faJh1kPlGD0MunuHTcxe7AbQXb0d
+          9dzl1+uRcDBh5itkY1JaNL++Nfsvec/8rRWO1wwdo/JASKO/+fjEm7N6D8Qtlq0NQ8Oc31Eb6glx
+          9LVtLAO/O6OkFxz8EURUtPX18YLr22yov7t0Xr/T/QiouSuptfc3rQTL5xkhbujUW3lvY9R17QXD
+          p6bECqqwZeA4Jai4SLEw8wpeTskFtOh0pJr2NHP+GR37p39YhXc/95lSADMCgbjX5xONlaSEIIZe
+          MvCffj50pih7o02wdAl1xAIF2UhwKu/H29DsVy4cvgXHsvMp+F8eTYT9DaPPiRh9ttpUwGNyIlqe
+          Nt7YNYsHLD7HhAYi2hXslFw0dGodnzopYzH/jG0ExulrEwe/ZfTrj4qwOlnUyNebfOolWYO7Mpq4
+          iWIrH8r7BYNiKxrZoUJBfYvUF1yPDZ/z/CZeelG7Atx1S5L/eIhguNbv+fzxVy4pdAA7vmxpuriY
+          7fJUBT7SKyUY1OmIPV6/pQTYrrxS7+ae0LRydQuoHqV/PIunr6CDorfOM2+lxTi8S0HZx9Nq1rcO
+          jU69PsPHbjfEdRvNo773cCFeDQmGLNx49S//17J9xsKqL1DDh05A8/Onuo2ieN7fkaJ8S4THu/ad
+          ++1eUNiOh9RdLp5Gu22vFgIq3sgmL8z4Tx+2dwXwIi571K1WTIC8lSyqmZ9jPmB0DCHpwaFhWQ9G
+          11A2Ko+l/CGGnAUtFY5mghbJYsShajn5+MTZDf34bTqSvuhToQ3hym7hkF8HGzHpGTaodvx0ELzp
+          jSZS6Bd1V3ZriqVdk0/SaTvnue/+T0+azGErdFqfQ6IrEeJTlDwTpTlwndrdRs8la2Nr4IR9OvzW
+          m3Tylg1axiMllyxyWm4ywuAeKMkw3je+t8Z1rkH2+PC//NBraeUi+fzthi8qFD4erG8JQ9FpeHk1
+          T3EzKqqmjHByqCZdC49p7f6AYNwVWCx6y+h7SdBRnX4W1IWtwv/47Qj4S/xdvpv7XRiqt8VjpO5K
+          x8a03Acyqr9LY+CCtjOkTSbd0MX1O+o8FvXcx64+splJiYNWvOi6xjzANtyNWF29trE481LAtyun
+          wer1iZn4PduwHfAeo1205/P3E2j4Mae6/2z5dPIWFVjrrh5WOINiylfZAD/+vT1uD97MBwR4LAeD
+          mg5+FdNxf9SA7ZqBakN0iBldr8Zf/xmkc9sXny9OMGxhSIe1+9iiaZNbrz+eIlcOoGmTdWf0SA9X
+          vFq2XdGhTmMQ8nNE3Y8fzvOH5qFcxcAnFh+znFbFQ1eV9Lgk+CPr3hS+TyPM/oc392pdMPORvNE7
+          n2KCPeYY3fP4DZEirUIa9AcH9bAME9Q+7NU8bzDi5ZX0FpiRINCZZ+Zc7h4YfPEjk00jhWjWlwYO
+          NnKwMD38gu9uGgPEd/HAz6e1x4y7M/PJWCBESxqvi3xTQGYkXwieXpIxoe1phQ4SW1K9VF9t++Nr
+          tYNTsg0uwdyXVwcwTnVKbL3f5kxJTBHm+cQgbaXQkPvFGEF1SdqfvxvsTOrDX36d+1UrJxepUW+L
+          74aYNLvGcvGuHmj5Mk1yg0nkTH5dVtDu1yLdfkEqqJd+G9iV5Ym6zy/Kp1RwXDic0j0uD2JR/OW/
+          +lSF1MXRy5uKlJtq1EeEBqJwiMe092y04FVL49aPvMnEh+Svr2TJaRmPJXp0sO5O39n/rHbs36YM
+          lbI2Z57/RjOPbGD/iDRCPDByCRYkQlcxvhLD2R09ljm1iGA0IuKm4LfMsUJLVVJyxHfzHLWjwvYH
+          eNSXBQmSFUN9ZQcNzPmABqYpeMNVtRtgJ+lJDL9z43E6UwHN/k+u8A74pK6M12//U33ml+NWTUIY
+          LEH809sxG0iGdP8oEheP63a8PEIBAl1WiBE4atHJwjkBEVZPYqd+bfQzn0E/P79k9MJ5dsEY7t2F
+          0tjZdsV061RRmedD1A7QA3HqIQt974ec7htp5PQFqQ/utZ95j63lXU3PFfz2f3K5fIr6cyhHmPWD
+          2G+Zt1xfChi+qlgQ55od4unoar6CmDAR/Np3fBC/oata6+Y88/IMSa/0DHD4NEfiVN+2nVzJBjT3
+          qaF8v+5eJ5mKDq/ncjsIa3dpdCXoMoTJW8LyPI+ipy+4yPLHZtYzw+vF46ipUuB8hnXKk4KNSiGs
+          ZTupiG6utjOPzXw088HZHwL0vTveBfjUYrqznHfBvJ1w++kB1da3XVx3gEvYDv6eBtpmH7PjJX/B
+          7UkuGAyxmftBLf7mVWTTrK5Fj4SLpWi6uf9bb/QtIxmu24tGr7fXNZ75swxcX+nEYKJosKv6GuGm
+          P55EN9f1H59SfcbqYXk1YmOMt22CzCfWB0kedI8FSmOiYI8f1OsWe2PZnS8+2u+FlphKGeb9IaxF
+          OE7WhdjVdR+XE58i2N7VgBBSbDzJxF6kDHxhDhO7nebr7zvwtyz96wv8/CzeYOxeS1wFQtDyQtYq
+          9fhansnGPx85e7W6q6ZHpyMk/tQF/7Zb5ceH8GTHj4KK6+IG83wESxcqtGO8zUJk5XZIgrr3Dd7v
+          WQmezRxKXqts5m1+gy7ZfST41tA5zzXVjxfi5THfe616sC0I6HtL9fC9Krq2tq0/vh8HjtoOrsV8
+          qE/Dk/z8oyP71wGs9mgQV7xdPdb4rwf85hee0Z3jCQmeDnV6vxLdRiynar7QlLhJRuJVYObzegGo
+          T90Tq5H45MwoqQs72yTkl89Zlcrin/7av+cTapcEuotwoMGU3r1u8XAYzPkbA9E/7RSf5ErtUEtw
+          Fh2adrw+TRts5mjEvNiTMX50/Qy/eapxRzWicldhMM22JoGpH4vxsNg0YF23C2rckYMkB44jrLRu
+          oO7HtWe/fgtAvNNzmIbcjf/mI7Vs7YgWT7bBFlBlyJwyaRjNouNj2ikWLF/ukVozDxhPbP2GH9/9
+          8ezRHiUXeKy/iSeWGM3/Z1TWubAZgGyjmP3mM+FbyOc+sSymBfP1nz5Ty9pEfKq1UYZViJ50Z30v
+          xo8Ho39+pwL+91///vd//04YlNX19pkPBvS3qf/P/zsq8J/smv1HFOX/UPnvJMLQZY/bP//1fw8h
+          /FO3VVn3/9NX79u3++e//r36O23wT1/12ef/+/hf87X+91//BwAA//8DAHFvCBnhIAAA
+      headers:
+        CF-RAY:
+          - 9472cad75e7d1dc7-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:20 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=mOY1pyZf5R_Fm39ytE7OEGT0QQqo6zcG8W19tabX30s-1748488160-1.0.1.1-mhciSfzy_b3DeaPf5BbNjbQXsXXkBtmfbXvDmkldQhBHTSfebdNABaEhP6tSrC2uGK40q3ben8eanuh.gGR6X1bzC7s3dZ_dyQMZvWltzs4;
+            path=/; expires=Thu, 29-May-25 03:39:20 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=TrlgR7KvGJcRBCctTJMQIWVZDzxtCcOkEArqx2kI7eo-1748488160236-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-allow-origin:
+          - "*"
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-model:
+          - text-embedding-ada-002-v2
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "56"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        via:
+          - envoy-router-6b84dbcf9f-jlp7n
+        x-envoy-upstream-service-time:
+          - "59"
+        x-ratelimit-limit-requests:
+          - "10000"
+        x-ratelimit-limit-tokens:
+          - "10000000"
+        x-ratelimit-remaining-requests:
+          - "9999"
+        x-ratelimit-remaining-tokens:
+          - "9999996"
+        x-ratelimit-reset-requests:
+          - 6ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_309a25382e85b3986be08f54747ad1ff
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: '{"input":"This is a test","model":"text-embedding-ada-002","encoding_format":"base64"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "86"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - OpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/embeddings
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA1R6ybKyTLfm/L+KN94p9YeISC6/GdJJm4nSqBUVFWCDoKg0mUCeOPd+gr0rTlVN
+          HGAamM16upX/8a8/f/5+8up26f/+8+fvq+z6v/9jfnbN+uzvP3/+57/+/Pnz5z9+Pv+/kbc6v12v
+          5bv4Gf7zZfm+3sa///wR//vJ/x30z5+/jnoyWEDavO3CPcrWkSzJVCruUz7411MI8fvBGVGTF+rF
+          RNYUjFSf5YdrUU1p8hEBd8+EGVW35X15DgGScnnChJpjNdwy9FwL0tMlRgyC17vL1kCbfjfh6T6S
+          dgyr7gnluHgza5WwdggP9ROJIIYsG85vPmzt0oVPI3HiH75VPh3T3lBWpZ2wU1KTqvUPogA0ObVM
+          bXCVD49giEFUVZH5r8LUR4nIBayme4Olp9miafs6S6jc11t6kdOyoiNfH6CJPwUzzG8fje9ddgHK
+          Zc600Np6oq4bk2JUu4Jyx/hELBZ9H50TryPmqXEi7hxljCL5Y7Kzdd9WfP1+ChA1VYWH+7bTB9Xe
+          G2iZZ19iKB+ZM+d+M5CziEYM8rHm460dnyC99Qrrd8Aee0pchJPTxlQK3l0+0KtjoP0Q74ldiK3X
+          v+KkA/qqAubtwm8+PV/uB17Lyw2nfFByuovyWAl0vSf2Ijl6U9VZGSgrTin09lufjLt4geNluSI7
+          yy7yKVDOKqAnF/Bj/dlWy912b4F+bM8siMIBdeYmPaCD+k4wvwtp222dJIX3drtjQR+ZLV0+Th8U
+          LsmduB3HERV0zYLa7EvinjcD6s/C1t1kwvAi1r7dRNdtjkul+GaUGUJAvYHsbQzn6jQQB9f3aHxG
+          9gl6+XtnJnuuqskO3AG1Qk2Z+xm2rWhK2xuU4+ZNl44MfDgq1gmZoTkQ73Vk+rRxYALyZTviD8xA
+          Q/tVjc3rdQrY3o6KdjAl54baIsqIudd2+RDcdxS2xCiY3zttNDV+U8BaaYA5aEWi4SNdMlCHNcW8
+          9Sf9La6zE2xBvdNiXH0rfsWFuHnmPMLtuF23D3dZWSDV0505X+PGWbj4GmitjDcqCWWN+GuAGDT3
+          ZJLojr585Bc+wCM9CZTW0TKnrY9qqE1WEvWu7tBSMboOUCkRZlzsvd4fvUWDzgas6aZ2cm+Y6xV5
+          9uCwW/Yuo3k9fRCcxiO7hSNGjb99KWg+/8Q0RQ+N5blRFWRpE10Kp66aRjE/gbbeqbjb5TveLU3d
+          WlRqCPjWA6qm5ae/oIeILOI/FK9afV/3CzhaVOLV/vyp+n75BIg88cN2zqBFXBvCFILHOWJ+Xwtt
+          n7jnAxSrTmfe4f71xmd0vqDzOKXEw3Ib0ceYdWCb7oAXxpHm3d7jCpyr9I7LjdTxIbj1T+SEzxXx
+          0y7UqV6/XejazCPm5dDmT+g4wOKVv4nr9j4aRB9LaJJyhS6olfBhPdkhnD7OhalNp/B+tQ9EyK9n
+          QgJ4Z+1EVXgqx0y2iSd7hsfLjX9Cj/RK8BRWYt7vry8LjW5zo2MVYN5g0b6hrj15jKj8Go3Jnhqw
+          3ysZHio9rkbcWBg8t5eJmZii18kqkdA8P6blVONjsr9qwDWIyBVeB72TZUVA1Sby8BQ7Pe8OxuDC
+          Mo9PTGdYqfiMNyDI1RpvSv3R9su0xehq1iVxZUNqn/P81hc3wWy76VM0vLToAosXFpmaXyTE705c
+          IJqEDpbP3pMPW+caA4/UJwlE9G7HK7/fUFZc90TbxmLbz/WJ1KK0yc7Fa84vyfIDlEslnaQwymn0
+          ZaISLOibmG1RV3TP0hDee++L5YMq6dzby91P/bHgy+KKXo26hvx6L5g+42c9icsCjuvLgx2qU5+z
+          VR+dwISPTYyqr73J315EMIyLhMd4C/okvpUQBvDfeDG2nt4SK5KUeT+YNvMHPz2yAvnmcKZrlBc5
+          w+a6g2e+elLoXVKNiWv7iHzXCvHSx1jRcFmLIC3DN/N3WdWOZwFiCO1kZLY1phHnaydGfuos2DZ/
+          dWhUz2sMzmI/0uOMl+36nSuwk7iL08vFbEdYhTG4ueQyvLRqr9fjjYDSbUSYlrO3NyBeN8AKpNNX
+          EXNOO0tV4KNsEvxdXJ7ttPwIJVokbsVcvUiqQRK+GVxfaMWsk9R5/JI8n0iqpYHNeK5PRCyfQLlY
+          0mkjJ/lkFGaJbqG8Y8Z7OKBJSSmg28NS8MuUxIiWzdoA/xk+fvmG/+BXXWZXgqMbePSUCjZiZbug
+          yk3dVM36sipBcQxOTGVw24FetxbaoFhi7k29Vp0lHQplVzcfYgjuNloxP/Hh66SIbNefRzt11h7g
+          gIcdi+f97OiTCqhYfycSRGHIOT3EHRwvLPnhZ2+ZuOcQFq/IJNv198WnAVkWWHk4EXdnEW88mcxA
+          efuJmMkdn/MrHmU4rrOQ6RNnaJj2Tx/WARqIeQk1vjyk3xhmfmXGqcrRGFbLD0SevMbJdtJzZrUL
+          f907okYwyTx90u/bEGFsBCSOr1o03VdbGy6rfUAwUFtfvQZIkW2SLdHpUOkjCL0NUwI6M5S32PaP
+          e3jZzPxDF2ra6DQucw3tSzPAg1F+qkGZzjMe5hHbHgXmfbomOQH5IoV4u31QTZxGMtDkBngBSoO4
+          uK4usGx7gW7GY9rWIVUBTtJlZJqxeuRcKb4YlPfl/MOf+ogbjBVVU1WSMrrn42p/k2FXfz5kZ3m9
+          Pn7t9wCqvr7hoekUNPjXRwzskCG8GdMpancvv4R7d2PMRuxaja+4npAbvCyMUrNs+6lKMvRRkIHn
+          89GO/OqLKPIWLtlOdxT10fFSoJnPmJPQRz58JamAo3/bY7jKlT7V99fht54X0ctpp2/ku+gHn9wv
+          XnvNMdUAPc+CRdRR7vn4toYUpdt8pNIeN/oYPu+Dsrl0PnMTZEfjK752kFEaE/uxv+W80B4SRN50
+          ZNae0IjZNw6bN3vfibZZ7XV+fkCD/NgPmV49qnyKy0jbyMyImJeaWjUsDUVFRFYvWJENqaKOdTKg
+          fNCKsnWSVEMR7wFAwAaVr0GQj+4yU9EAiUPXZ1Hhn2oni+jNbhv80vYLnRXaaYD1xRXpoD6M6HN5
+          SxISpNql9eXyaif9fkhhwUuHqEZpV6w7CTECPVjSIT83+lDtZAm2Pc/xMMoB/5kfeuw2O6LRd+/1
+          VWa40Ao3n1mXi1kNifzRUGhdIuZllsX5zQ4PyM1Fl2GStbMeailqtwVmlrl5oPEyrg3gC0klalk/
+          8mn72ku/etletX67Cvwo3XBN0ZjzyOWWHd+VBeFTcZltcQGNauYe4Cu5J7aVjKGd9VcGiXFYULbc
+          P9vx1uUULm/Nmf3Agw/cXZdrXQqmXz3VXDflBFuiEmKugitnd6evwVu9akqj28Xjm/jsohm/SdBH
+          r2oQ7nIHxWqIiS6dzJkPphCaeBmx4FaInKZXTOEHX2y0r72xyhIftOySsh2TfW8MhqBTDjflSxfR
+          69tOiBxcgG1oEbcTD9UAXaMg3NUJlU5yXE3m2Zng6LcGBfloIeZHdwu2xB6JpShPNDy36xjd4aES
+          sk7XvFNtVd3M9cXIsbnN/kKd1lZ71JnRxhVn00JUYSeNLpn5mY/310NDxMMLpldVi7j13McIxdmJ
+          GSs15aMePxWYpLPC7OdZzSX97hx+/AhV3EbVV4N5vqBNb05sl+SjN+2Z6cPLrge6mfXM7+8/fpix
+          e5lpiHM19X/qnanru1dx9IhPYK3pl8Itnjwece7CzD90vH/W7SSVsQJ8/GKqDCe9Wg6fadgwzbfJ
+          eXHrveaHLyJvOBLjTd2cf56aC8fWQkyTsIuGRXGQ4JHeCf50ussZWZxUOPRpQSdj7XAO2TQgcv5I
+          xPugwhs7cT2gk9O/mHZPipnPt7cfvMPy55a0E1kaHZyrx4EZhZPknPlXH4J9ohFte+j0zpS2F/BN
+          ahNc4sIbKnurwLQbQxKUFo466EoF6nhnY5RWmTcJ2lqDtnBl4lxPHhqEd1DAHSqVQnZwKp5QowNd
+          PL2IZm8URNeXRYHs5Cz+npeu2g0S4o+Ty864XuT9IVUyaIt9RnZPvOVLk+xKKFylJobyjttpUDYa
+          XF/rFZX2gclpGxifzSLdDEQP2VHnV/wRodXvG1orm7Gd1gkaYMZbhmGMEd12iw4UG/bkpjqVN77x
+          DaPwZW1weRchGhYFgDLrR/bzf98z/v3ob8zq+8njohLU61SwgZ0OWyVqQjrvVUFD5gz4m09WpB3Q
+          eyNVTG3atBrdpSps2rtgEFOipT56VM6gQ9/Zf+x89F0egxROR/jSaSP5fLx12mfzo4/l57mIKEar
+          E9gjBLgjBvUG6EoZLF9EzPtmiA87Jivgm53NTIWvcmplWEUn6TbiRX1pc/YaqgP402fHzGpV5OMh
+          nU7gBllE3J3p8jFbDTUoS+FBR8k6ewM+KooS6Nv+F5+o+J4OsOAUGPE273bqVSdTggXKqKQoTz7t
+          Kdhoey2PTJOCuhr51RChP8Uuu2R7M+IHJZ6UprI/eJVkPqLrRH3CMr8peHnqRjR9DiFsOjw+mJMG
+          G49fiSv8+qeP1r+iUQq3NTquy4kKS6vWP+fuO9f/YoOFW3esxhYtS1CH0SeOJlf8G3wdUOrYtOlL
+          GZp2+LKwQTNe4RVbvVHTWaIBwlkS5v3N0CAJYQx2VL/JD9+yLF+68LP/lnYeUMO2KYVHXRU0MLRl
+          2527adZTh4l5aaV4TKZWDYbx2JFd8fnkU78L7BXs246pxnP0eiOY8EbLWoeZp17yumnf+SiSp/fs
+          D+J2HMsGg/6Sr3jFb2YrTeKmBB55FttxJW4nIqIGucHbwouj/86n+t6HMJ83zN8vMeJCQm8oYE3K
+          3CHz9cndvTIItLVHSE5Evf3hg+V6oTEMw1DxLO8M9MyXT2IJQsKnkNoCwsi6MnJb9i0t28hHDT/m
+          uM+uH51V0p4i/shcps95xTT7S/QMzj0dxuVWn/kBw5hRhuVVY+fjZ9cWaAA7ZfG2Ltp+5aw1kDeF
+          y3afw4FPG6eicDqKO7aNUBmNY3m2Ua0LNfNvqdJ2opd/YMZH/H5256gXxklAwf4wUvQ98ajXok8D
+          U6rFzBRE1PLRqidlXO9tFohKlQ/8cM/QjLcEz+eDNdd1DeRcxlTRjbodXVjI6Jr0BsFL84HojIdK
+          cih0tnuGTTSV0w2gu3o75rmrt9cjITZgzlfI1mCsan781sy/5Dnnb62QXDOUHOqYkEZ78uGBt6fN
+          PRBNLFnbCdFZv6M21FLiaGtbXwV+d0JpLzj4JYioar/XooTr02iYv7t0Xr/T/AMwY1cza+9v2yWs
+          HieEuK4xT/ae+qBpagn09WXECj5hO4Hj1LDB1RkLc17B6zG9gHo4JkxVH0bOX4Nj/+Af3sCzn/1M
+          LYBxAIG418cDDZ+lEoIYeinlP/hZaJOi7PU2xctLqKEpUJCNBOfj/eRtaOYrF+J3xbHkvCr+q0dT
+          YX/D6HUkep/J2w/wiByJmp8bb+iaRQGLV5KyQES7ajqmFxUdW8dnznmaIv4a2gPox7dNHPyU0I9/
+          VAT5aDE9X2/zsV9KKtyVwcDNIbJyWt8vGBRbUckOVQrqW7Qp4Zo0fNbz22jlHVoZcNetSP6Thwi6
+          a/2sz2/+ypcKo2BHF5OdFxejXR0/gY+0jxLQzZhgj3+fyxSmXX1l3s09olF2NQuYdjj/5ln8XAYd
+          VL11mvNWVg30WQvKPhrlGd86NDjf9QledrslrtuoHvO9woVIpimGLNx63x/9/5XsExbkvkINp52A
+          5vVnmo0O0VzfB0V51wgPd/U9+9u9oEw7HjJ3tXjordleLQRMvJFtXhnRLz6YdwXwIqp71MnyJEDe
+          Li2mGq8kpxglIaQ9OCysv1TvGjYNSrGSXkSXsqBlQmKkaJEuBhxuLCcfHji7oZ/89jyQvurPQhvC
+          dbqFNL9SG03LR9igr+OfqeCNTzSSSrtsdnW3Zni5a/JxeTRnPffe/+JJkzmTjI7rU0g05YD4eEgf
+          qdLEXGN2t9XypbW1VXDC/kx/ztvy6K0atIoGRi7ZwWm5MZEJ7oGS0uG+9b01/uYqZMWL/+qHXj1/
+          XCSd3h19o0rhQ2y9a6BVp+LV1ThGzaBsVGWAo8PU5bXyJrXdxwiGXYXFqrf0vl8KGvqeXwvmgqnw
+          3/x2APwm/i7fzf4uDDe3RTEwV9awPq72gYS+75VOuaDu9OU2W97QxfU75hSL7+zHrj6yJ4MRB8m8
+          6rrGiMEMdwPeyKUZiXNeCvh25SyQy1c0ie+TDSbFe4x2hz2fx6fQ8CRnmv9o+Xj0Fh+w1t2XyjiD
+          aszljMJP/m0mZuzN+YAAxYrqzHBwWY3JPlFh2jWUqfQQRxNby8OP/6HLU9tXrzdOMZhAz3TtFiYa
+          t7lV/uYp0scBNG6z7oSKc3zF8qrtqg516gQhPx2Y+/LDuf/QFMpVDHxi8SHL2acqtI1yTlYEvyTN
+          G8PncYCZ//D2/llXk1GkT/TMx4hgb3L07pG8Q6Qs5ZAFfeygHlZhitrClud+gx6trqS3wDgIApvz
+          zJxLXYHBF18S2TbLEM340kBsIwcLY+FXfHdTJ0B8F1F+Oq69Sb87cz4ZCYSoaeN1B98QkHGQLgSP
+          5VIfkXmUUbycVkyrN2Xb/uRrXwefiRlcgtkvyzHox++Z2Fpv5pOSGiLM/Qm6NJehLvWL4QCfS9r+
+          8Ls+ncg3/tWvs79qpfSybDa3xXtLDJZdI6l6fgq0Kg2D3GAU+SSVFxna/Vpk5huWFfPO7wZ2dX1k
+          7uON8vEsOC7Ex/Me17FYVb/673v8hMzFh9IbqzM3Nof+QFggCnE0nHvPRgv+aVnU+gdvNHCc/vqV
+          LD2uoqFGRQfr7vie+c9qh/5pSPBR1sac5z/RnEc2sC8OKiEe6PkSFuSArmJ0JbqzS7wpc74igkE/
+          EPcMfjs5VmhtlDNJ8N04HdpBmfYxFN/LggSpPKH+YwcNzPqABYYhePS6sRuYjssH0f3OjYbxxAQ0
+          8z+5wjPg40bWy5/6Z9qcXw7mJg2BWoL4i7dDRkmGND8RiYuHdTtcilCAQJMUogfOpuok4ZSCCPKD
+          2Gf/q/dzPoN++PySsQvn2QVjuHcXxiLH7Krx1m1EZe4PMTtABeLMQxZ63+Oc7ZvlwFkJZx/caz/n
+          Pbaad192+sBP/aeXy6v6vuJ6gBk/iP2UeMu1lYDhvREr4lyzOBoTV/UVNAkjweW+41R8h+7GWjen
+          OS/P0LI8nwDiV5MQ5/Nu29Fd2oBmP0XrZ3n3uqWhaFA+ViYV1u5K72rQJAjT5xJLcz+KHd/gIssf
+          mhnPdK8Xk0HdLAPnRddnnlbToFTCWrLTD9EM2Zzz2MxHcz4480OA3nfHuwAfW8x2lvOsJm8n3H7w
+          gKnr2y76doBrMKm/Z4G63UdTcslLuD3IBYMuNrM/+Io//SqybeRr1SPhYimqZux/zxt7SkiCq3lR
+          2fVWXqM5f5aAa7JG9EkU9em6KQe4acWDaMb6+5tPbfxp+tLVVY/0ITLbFBkPrNGlRDVvCpTGQMEe
+          F8zrFnt91Z0uPtrvhZYYSh3mfRx+RUhG60Lsz3Uf1SMfD2DeNwEhpNp6SwN7B4XyhUHH6Xac37/v
+          wDen869f4KdH9QR9V67wJxCClleS+tkk5epEtv4p4VPZau7mnDgdIdHrW/F3ayo/+RAe7aiomLiu
+          bjD3R/DywoR2iMwsRFZuhyT49r7O+/1Ug2dPDiOlnM15m9+gS3YfCL41bNZzzecnL8SrJN977Sa2
+          LQjY02Ra+JSrrv3a1m++HwXOpqWuNfnwPdIH+eGPjuzLGKw20Ykr3q7e1PhlAT/9C0/vTtGIBE+D
+          7/l+JZqNppxt8oWqRE06EO8DRj6fF4DvsXvgzUF88EmvmQs72yDkR59Pn7Mk/uKv/bM+oXpJobsI
+          MQvG893rFoUzway/MRDt1Y7RUfpsOtQSnB3iph2uD8MGe3JUYlzsUR9emnaCn36qfkdfxKTug8Ew
+          2i8JDC2phnixbcC6mgum35GDlg4kA8hqR5n7cu2Zr58CEO/4oCPN3ei3P/KVrB1Ro9HWpwV8MmSM
+          2ZIORtXx4dwpFqxKN2HWnAcMx2n9hJ989yfPHuxh6QKPtCfxxBqjeT6Dss6FLQViHqLppz8TPoV8
+          9hOralxMvvaDz8yytgc+ftVBAjlED7az3hf9Jw9Gf39uBfznv/78+V8/Nwzqz/X2mi8G9Lex//d/
+          XxX4d3bN/i2K0r+Z9HsTgXZZcfv7z/+5hPD3237qb/+/+8/z9u7+/vNH/r1t8Lf/9Nnr/3n8r/ld
+          //mv/wIAAP//AwBxbwgZ4SAAAA==
+      headers:
+        CF-RAY:
+          - 9472cada7afe7d11-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:20 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=vD2YsEJBR2ebZoWd2D9ZJCHxbtSQae6h0ejt5wU.PO4-1748488160-1.0.1.1-gr1R2weSB3qADCmsvlAWq3J9Dwjp5fGtdJkNOLNThoKEWu7Z1KReV0ImxAfTlUXuijFyn8OXqdTkezkTL7xlKx_YC3JCApMDKGM98BVOr_I;
+            path=/; expires=Thu, 29-May-25 03:39:20 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=ZTMtHj1A.fKEhi2PqrMnVjfeurCsxqnAI7RZskT8dbQ-1748488160511-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-allow-origin:
+          - "*"
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-model:
+          - text-embedding-ada-002-v2
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "51"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        via:
+          - envoy-router-6b84dbcf9f-psv4p
+        x-envoy-upstream-service-time:
+          - "53"
+        x-ratelimit-limit-requests:
+          - "10000"
+        x-ratelimit-limit-tokens:
+          - "10000000"
+        x-ratelimit-remaining-requests:
+          - "9999"
+        x-ratelimit-remaining-tokens:
+          - "9999996"
+        x-ratelimit-reset-requests:
+          - 6ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_eff3daa1a051dfb962face8677567afd
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_embeddings_async.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_embeddings_async.yaml
@@ -1,0 +1,423 @@
+interactions:
+  - request:
+      body: '{"input":"This is a test","model":"text-embedding-ada-002","encoding_format":"base64"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "86"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/embeddings
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAwAAAP//VHrJsrJMt+b8v4o33in1h4hILr8Z0kmbidKoFRUVYIOgqDSZQJ44936C
+          vStOVU0cYBqYzXq6lf/xrz9//n7y6nbp//7z5++r7Pq//2N+ds367O8/f/7nv/78+fPnP34+/7+R
+          tzq/Xa/lu/gZ/vNl+b7exr///BH/+8n/HfTPn7+OejJYQNq87cI9ytaRLMlUKu5TPvjXUwjx+8EZ
+          UZMX6sVE1hSMVJ/lh2tRTWnyEQF3z4QZVbflfXkOAZJyecKEmmM13DL0XAvS0yVGDILXu8vWQJt+
+          N+HpPpJ2DKvuCeW4eDNrlbB2CA/1E4kghiwbzm8+bO3ShU8jceIfvlU+HdPeUFalnbBTUpOq9Q+i
+          ADQ5tUxtcJUPj2CIQVRVkfmvwtRHicgFrKZ7g6Wn2aJp+zpLqNzXW3qR07KiI18foIk/BTPMbx+N
+          7112AcplzrTQ2nqirhuTYlS7gnLH+EQsFn0fnROvI+apcSLuHGWMIvljsrN131Z8/X4KEDVVhYf7
+          ttMH1d4baJlnX2IoH5kz534zkLOIRgzysebjrR2fIL31Cut3wB57SlyEk9PGVAreXT7Qq2Og/RDv
+          iV2Irde/4qQD+qoC5u3Cbz49X+4HXsvLDad8UHK6i/JYCXS9J/YiOXpT1VkZKCtOKfT2W5+Mu3iB
+          42W5IjvLLvIpUM4qoCcX8GP92VbL3XZvgX5szyyIwgF15iY9oIP6TjC/C2nbbZ0khfd2u2NBH5kt
+          XT5OHxQuyZ24HccRFXTNgtrsS+KeNwPqz8LW3WTC8CLWvt1E122OS6X4ZpQZQkC9gextDOfqNBAH
+          1/dofEb2CXr5e2cme66qyQ7cAbVCTZn7GbataErbG5Tj5k2Xjgx8OCrWCZmhORDvdWT6tHFgAvJl
+          O+IPzEBD+1WNzet1Ctjejop2MCXnhtoiyoi513b5ENx3FLbEKJjfO200NX5TwFppgDloRaLhI10y
+          UIc1xbz1J/0trrMTbEG902JcfSt+xYW4eeY8wu24XbcPd1lZINXTnTlf48ZZuPgaaK2MNyoJZY34
+          a4AYNPdkkuiOvnzkFz7AIz0JlNbRMqetj2qoTVYS9a7u0FIxug5QKRFmXOy93h+9RYPOBqzppnZy
+          b5jrFXn24LBb9i6jeT19EJzGI7uFI0aNv30paD7/xDRFD43luVEVZGkTXQqnrppGMT+Btt6puNvl
+          O94tTd1aVGoI+NYDqqblp7+gh4gs4j8Ur1p9X/cLOFpU4tX+/Kn6fvkEiDzxw3bOoEVcG8IUgsc5
+          Yn5fC22fuOcDFKtOZ97h/vXGZ3S+oPM4pcTDchvRx5h1YJvugBfGkebd3uMKnKv0jsuN1PEhuPVP
+          5ITPFfHTLtSpXr9d6NrMI+bl0OZP6DjA4pW/iev2PhpEH0toknKFLqiV8GE92SGcPs6FqU2n8H61
+          D0TIr2dCAnhn7URVeCrHTLaJJ3uGx8uNf0KP9ErwFFZi3u+vLwuNbnOjYxVg3mDRvqGuPXmMqPwa
+          jcmeGrDfKxkeKj2uRtxYGDy3l4mZmKLXySqR0Dw/puVU42Oyv2rANYjIFV4HvZNlRUDVJvLwFDs9
+          7w7G4MIyj09MZ1ip+Iw3IMjVGm9K/dH2y7TF6GrWJXFlQ2qf8/zWFzfBbLvpUzS8tOgCixcWmZpf
+          JMTvTlwgmoQOls/ekw9b5xoDj9QnCUT0bscrv99QVlz3RNvGYtvP9YnUorTJzsVrzi/J8gOUSyWd
+          pDDKafRlohIs6JuYbVFXdM/SEN5774vlgyrp3NvL3U/9seDL4opejbqG/HovmD7jZz2JywKO68uD
+          HapTn7NVH53AhI9NjKqvvcnfXkQwjIuEx3gL+iS+lRAG8N94Mbae3hIrkpR5P5g28wc/PbIC+eZw
+          pmuUFznD5rqDZ756UuhdUo2Ja/uIfNcK8dLHWNFwWYsgLcM383dZ1Y5nAWII7WRktjWmEedrJ0Z+
+          6izYNn91aFTPawzOYj/S44yX7fqdK7CTuIvTy8VsR1iFMbi55DK8tGqv1+ONgNJtRJiWs7c3IF43
+          wAqk01cRc047S1Xgo2wS/F1cnu20/AglWiRuxVy9SKpBEr4ZXF9oxayT1Hn8kjyfSKqlgc14rk9E
+          LJ9AuVjSaSMn+WQUZoluobxjxns4oElJKaDbw1Lwy5TEiJbN2gD/GT5++Yb/4FddZleCoxt49JQK
+          NmJlu6DKTd1UzfqyKkFxDE5MZXDbgV63FtqgWGLuTb1WnSUdCmVXNx9iCO42WjE/8eHrpIhs159H
+          O3XWHuCAhx2L5/3s6JMKqFh/JxJEYcg5PcQdHC8s+eFnb5m45xAWr8gk2/X3xacBWRZYeTgRd2cR
+          bzyZzEB5+4mYyR2f8yseZTius5DpE2domPZPH9YBGoh5CTW+PKTfGGZ+ZcapytEYVssPRJ68xsl2
+          0nNmtQt/3TuiRjDJPH3S79sQYWwEJI6vWjTdV1sbLqt9QDBQW1+9BkiRbZIt0elQ6SMIvQ1TAjoz
+          lLfY9o97eNnM/EMXatroNC5zDe1LM8CDUX6qQZnOMx7mEdseBeZ9uiY5AfkihXi7fVBNnEYy0OQG
+          eAFKg7i4ri6wbHuBbsZj2tYhVQFO0mVkmrF65FwpvhiU9+X8w5/6iBuMFVVTVZIyuufjan+TYVd/
+          PmRneb0+fu33AKq+vuGh6RQ0+NdHDOyQIbwZ0ylqdy+/hHt3Y8xG7FqNr7iekBu8LIxSs2z7qUoy
+          9FGQgefz0Y786oso8hYu2U53FPXR8VKgmc+Yk9BHPnwlqYCjf9tjuMqVPtX31+G3nhfRy2mnb+S7
+          6Aef3C9ee80x1QA9z4JF1FHu+fi2hhSl23yk0h43+hg+74OyuXQ+cxNkR+MrvnaQURoT+7G/5bzQ
+          HhJE3nRk1p7QiNk3Dps3e9+JtlntdX5+QIP82A+ZXj2qfIrLSNvIzIiYl5paNSwNRUVEVi9YkQ2p
+          oo51MqB80IqydZJUQxHvAUDABpWvQZCP7jJT0QCJQ9dnUeGfaieL6M1uG/zS9gudFdppgPXFFemg
+          Pozoc3lLEhKk2qX15fJqJ/1+SGHBS4eoRmlXrDsJMQI9WNIhPzf6UO1kCbY9z/EwygH/mR967DY7
+          otF37/VVZrjQCjefWZeLWQ2J/NFQaF0i5mWWxfnNDg/IzUWXYZK1sx5qKWq3BWaWuXmg8TKuDeAL
+          SSVqWT/yafvaS7962V61frsK/CjdcE3RmPPI5ZYd35UF4VNxmW1xAY1q5h7gK7kntpWMoZ31VwaJ
+          cVhQttw/2/HW5RQub82Z/cCDD9xdl2tdCqZfPdVcN+UEW6ISYq6CK2d3p6/BW71qSqPbxeOb+Oyi
+          Gb9J0EevahDucgfFaoiJLp3MmQ+mEJp4GbHgVoicpldM4QdfbLSvvbHKEh+07JKyHZN9bwyGoFMO
+          N+VLF9Hr206IHFyAbWgRtxMP1QBdoyDc1QmVTnJcTebZmeDotwYF+Wgh5kd3C7bEHomlKE80PLfr
+          GN3hoRKyTte8U21V3cz1xcixuc3+Qp3WVnvUmdHGFWfTQlRhJ40umfmZj/fXQ0PEwwumV1WLuPXc
+          xwjF2YkZKzXlox4/FZiks8Ls51nNJf3uHH78CFXcRtVXg3m+oE1vTmyX5KM37Znpw8uuB7qZ9czv
+          7z9+mLF7mWmIczX1f+qdqeu7V3H0iE9gremXwi2ePB5x7sLMP3S8f9btJJWxAnz8YqoMJ71aDp9p
+          2DDNt8l5ceu95ocvIm84EuNN3Zx/npoLx9ZCTJOwi4ZFcZDgkd4J/nS6yxlZnFQ49GlBJ2PtcA7Z
+          NCBy/kjE+6DCGztxPaCT07+Ydk+Kmc+3tx+8w/LnlrQTWRodnKvHgRmFk+Sc+Vcfgn2iEW176PTO
+          lLYX8E1qE1ziwhsqe6vAtBtDEpQWjjroSgXqeGdjlFaZNwnaWoO2cGXiXE8eGoR3UMAdKpVCdnAq
+          nlCjA108vYhmbxRE15dFgezkLP6el67aDRLij5PLzrhe5P0hVTJoi31Gdk+85UuT7EooXKUmhvKO
+          22lQNhpcX+sVlfaByWkbGJ/NIt0MRA/ZUedX/BGh1e8bWiubsZ3WCRpgxluGYYwR3XaLDhQb9uSm
+          OpU3vvENo/BlbXB5FyEaFgWAMutH9vN/3zP+/ehvzOr7yeOiEtTrVLCBnQ5bJWpCOu9VQUPmDPib
+          T1akHdB7I1VMbdq0Gt2lKmzau2AQU6KlPnpUzqBD39l/7Hz0XR6DFE5H+NJpI/l8vHXaZ/Ojj+Xn
+          uYgoRqsT2CMEuCMG9QboShksX0TM+2aIDzsmK+Cbnc1Mha9yamVYRSfpNuJFfWlz9hqqA/jTZ8fM
+          alXk4yGdTuAGWUTcnenyMVsNNShL4UFHyTp7Az4qihLo2/4Xn6j4ng6w4BQY8TbvdupVJ1OCBcqo
+          pChPPu0p2Gh7LY9Mk4K6GvnVEKE/xS67ZHsz4gclnpSmsj94lWQ+outEfcIyvyl4eepGNH0OIWw6
+          PD6YkwYbj1+JK/z6p4/Wv6JRCrc1Oq7LiQpLq9Y/5+471/9ig4Vbd6zGFi1LUIfRJ44mV/wbfB1Q
+          6ti06UsZmnb4srBBM17hFVu9UdNZogHCWRLm/c3QIAlhDHZUv8kP37IsX7rws/+Wdh5Qw7YphUdd
+          FTQwtGXbnbtp1lOHiXlppXhMplYNhvHYkV3x+eRTvwvsFezbjqnGc/R6I5jwRstah5mnXvK6ad/5
+          KJKn9+wP4nYcywaD/pKveMVvZitN4qYEHnkW23Elbicioga5wdvCi6P/zqf63ocwnzfM3y8x4kJC
+          byhgTcrcIfP1yd29Mgi0tUdITkS9/eGD5XqhMQzDUPEs7wz0zJdPYglCwqeQ2gLCyLoyclv2LS3b
+          yEcNP+a4z64fnVXSniL+yFymz3nFNPtL9AzOPR3G5Vaf+QHDmFGG5VVj5+Nn1xZoADtl8bYu2n7l
+          rDWQN4XLdp/DgU8bp6JwOoo7to1QGY1jebZRrQs182+p0nail39gxkf8fnbnqBfGSUDB/jBS9D3x
+          qNeiTwNTqsXMFETU8tGqJ2Vc720WiEqVD/xwz9CMtwTP54M113UN5FzGVNGNuh1dWMjomvQGwUvz
+          geiMh0pyKHS2e4ZNNJXTDaC7ejvmuau31yMhNmDOV8jWYKxqfvzWzL/kOedvrZBcM5Qc6piQRnvy
+          4YG3p809EE0sWdsJ0Vm/ozbUUuJoa1tfBX53QmkvOPgliKhqv9eihOvTaJi/u3Rev9P8AzBjVzNr
+          72/bJaweJ4S4rjFP9p76oGlqCfT1ZcQKPmE7gePUsMHVGQtzXsHrMb2AejgmTFUfRs5fg2P/4B/e
+          wLOf/UwtgHEAgbjXxwMNn6USghh6KeU/+Flok6Ls9TbFy0uooSlQkI0E5+P95G1o5isX4nfFseS8
+          Kv6rR1Nhf8PodSR6n8nbD/CIHImanxtv6JpFAYtXkrJARLtqOqYXFR1bx2fOeZoi/hraA+jHt00c
+          /JTQj39UBPloMT1fb/OxX0oq3JXBwM0hsnJa3y8YFFtRyQ5VCupbtCnhmjR81vPbaOUdWhlw161I
+          /pOHCLpr/azPb/7KlwqjYEcXk50XF6NdHT+Bj7SPEtDNmGCPf5/LFKZdfWXezT2iUXY1C5h2OP/m
+          WfxcBh1UvXWa81ZWDfRZC8o+GuUZ3zo0ON/1CV52uyWu26ge873ChUimKYYs3HrfH/3/lewTFuS+
+          Qg2nnYDm9WeajQ7RXN8HRXnXCA939T37272gTDseMne1eOit2V4tBEy8kW1eGdEvPph3BfAiqnvU
+          yfIkQN4uLaYarySnGCUhpD04LKy/VO8aNg1KsZJeRJeyoGVCYqRokS4GHG4sJx8eOLuhn/z2PJC+
+          6s9CG8J1uoU0v1IbTctH2KCv45+p4I1PNJJKu2x2dbdmeLlr8nF5NGc9997/4kmTOZOMjutTSDTl
+          gPh4SB+p0sRcY3a31fKltbVVcML+TH/O2/LorRq0igZGLtnBabkxkQnugZLS4b71vTX+5ipkxYv/
+          6odePX9cJJ3eHX2jSuFDbL1roFWn4tXVOEbNoGxUZYCjw9TltfImtd3HCIZdhcWqt/S+Xwoa+p5f
+          C+aCqfDf/HYA/Cb+Lt/N/i4MN7dFMTBX1rA+rvaBhL7vlU65oO705TZb3tDF9TvmFIvv7MeuPrIn
+          gxEHybzqusaIwQx3A97IpRmJc14K+HblLJDLVzSJ75MNJsV7jHaHPZ/Hp9DwJGea/2j5ePQWH7DW
+          3ZfKOINqzOWMwk/+bSZm7M35gADFiurMcHBZjck+UWHaNZSp9BBHE1vLw4//octT21evN04xmEDP
+          dO0WJhq3uVX+5inSxwE0brPuhIpzfMXyqu2qDnXqBCE/HZj78sO5/9AUylUMfGLxIcvZpyq0jXJO
+          VgS/JM0bw+dxgJn/8Pb+WVeTUaRP9MzHiGBvcvTukbxDpCzlkAV97KAeVmGK2sKW536DHq2upLfA
+          OAgCm/PMnEtdgcEXXxLZNssQzfjSQGwjBwtj4Vd8d1MnQHwXUX46rr1JvztzPhkJhKhp43UH3xCQ
+          cZAuBI/lUh+ReZRRvJxWTKs3Zdv+5GtfB5+JGVyC2S/LMejH75nYWm/mk5IaIsz9Cbo0l6Eu9Yvh
+          AJ9L2v7wuz6dyDf+1a+zv2ql9LJsNrfFe0sMll0jqXp+CrQqDYPcYBT5JJUXGdr9WmTmG5YV887v
+          BnZ1fWTu443y8Sw4LsTH8x7XsVhVv/rve/yEzMWH0hurMzc2h/5AWCAKcTSce89GC/5pWdT6B280
+          cJz++pUsPa6ioUZFB+vu+J75z2qH/mlI8FHWxpznP9GcRzawLw4qIR7o+RIW5ICuYnQlurNLvClz
+          viKCQT8Q9wx+OzlWaG2UM0nw3Tgd2kGZ9jEU38uCBKk8of5jBw3M+oAFhiF49LqxG5iOywfR/c6N
+          hvHEBDTzP7nCM+DjRtbLn/pn2pxfDuYmDYFagviLt0NGSYY0PxGJi4d1O1yKUIBAkxSiB86m6iTh
+          lIII8oPYZ/+r93M+g374/JKxC+fZBWO4dxfGIsfsqvHWbURl7g8xO0AF4sxDFnrf45ztm+XAWQln
+          H9xrP+c9tpp3X3b6wE/9p5fLq/q+4nqAGT+I/ZR4y7WVgOG9ESviXLM4GhNX9RU0CSPB5b7jVHyH
+          7sZaN6c5L8/QsjyfAOJXkxDn827b0V3agGY/Retnefe6paFoUD5WJhXW7krvatAkCNPnEktzP4od
+          3+Aiyx+aGc90rxeTQd0sA+dF12eeVtOgVMJastMP0QzZnPPYzEdzPjjzQ4Ded8e7AB9bzHaW86wm
+          byfcfvCAqevbLvp2gGswqb9ngbrdR1NyyUu4PcgFgy42sz/4ij/9KrJt5GvVI+FiKapm7H/PG3tK
+          SIKreVHZ9VZeozl/loBrskb0SRT16bopB7hpxYNoxvr7m09t/Gn60tVVj/QhMtsUGQ+s0aVENW8K
+          lMZAwR4XzOsWe33VnS4+2u+FlhhKHeZ9HH5FSEbrQuzPdR/VIx8PYN43ASGk2npLA3sHhfKFQcfp
+          dpzfv+/AN6fzr1/gp0f1BH1XrvAnEIKWV5L62STl6kS2/inhU9lq7uacOB0h0etb8XdrKj/5EB7t
+          qKiYuK5uMPdH8PLChHaIzCxEVm6HJPj2vs77/VSDZ08OI6WczXmb36BLdh8IvjVs1nPN5ycvxKsk
+          33vtJrYtCNjTZFr4lKuu/drWb74fBc6mpa41+fA90gf54Y+O7MsYrDbRiSvert7U+GUBP/0LT+9O
+          0YgET4Pv+X4lmo2mnG3yhapETToQ7wNGPp8XgO+xe+DNQXzwSa+ZCzvbIORHn0+fsyT+4q/9sz6h
+          ekmhuwgxC8bz3esWhTPBrL8xEO3VjtFR+mw61BKcHeKmHa4PwwZ7clRiXOxRH16adoKffqp+R1/E
+          pO6DwTDaLwkMLamGeLFtwLqaC6bfkYOWDiQDyGpHmfty7ZmvnwIQ7/igI83d6Lc/8pWsHVGj0dan
+          BXwyZIzZkg5G1fHh3CkWrEo3YdacBwzHaf2En3z3J88e7GHpAo+0J/HEGqN5PoOyzoUtBWIeoumn
+          PxM+hXz2E6tqXEy+9oPPzLK2Bz5+1UECOUQPtrPeF/0nD0Z/f24F/Oe//vz5Xz83DOrP9faaLwb0
+          t7H/939fFfh3ds3+LYrSv5n0exOBdllx+/vP/7mE8Pfbfupv/7/7z/P27v7+80f+vW3wt//02ev/
+          efyv+V3/+a//AgAA//8DAHFvCBnhIAAA
+      headers:
+        CF-RAY:
+          - 9472cb0bbc8ff9a9-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:28 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=84OzWlNXgYMGAt5FSILjYkBxQnLfxRM9T6sTPr7E2N0-1748488168-1.0.1.1-TJpRZ290t0Z5Uq9dhD15juux6xjityCLsOqmqy5zY6YxJMmg5ab2pYLgStF8FDqF4rP7Mjaj19wS_rQnFmSjwZzzddTv0dUkyS8jlLNceCY;
+            path=/; expires=Thu, 29-May-25 03:39:28 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=o9N.JCQtfm8gFHjK9_H7B8hekt9k6wXQI4CCCLcBspw-1748488168605-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-allow-origin:
+          - "*"
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-model:
+          - text-embedding-ada-002-v2
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "54"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        via:
+          - envoy-router-568fcbbc46-l4b5w
+        x-envoy-upstream-service-time:
+          - "56"
+        x-ratelimit-limit-requests:
+          - "10000"
+        x-ratelimit-limit-tokens:
+          - "10000000"
+        x-ratelimit-remaining-requests:
+          - "9999"
+        x-ratelimit-remaining-tokens:
+          - "9999996"
+        x-ratelimit-reset-requests:
+          - 6ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_35cb99ebdd92a80fa815ff1c733b51fb
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: '{"input":"This is a test","model":"text-embedding-ada-002","encoding_format":"base64"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "86"
+        content-type:
+          - application/json
+        cookie:
+          - __cf_bm=84OzWlNXgYMGAt5FSILjYkBxQnLfxRM9T6sTPr7E2N0-1748488168-1.0.1.1-TJpRZ290t0Z5Uq9dhD15juux6xjityCLsOqmqy5zY6YxJMmg5ab2pYLgStF8FDqF4rP7Mjaj19wS_rQnFmSjwZzzddTv0dUkyS8jlLNceCY;
+            _cfuvid=o9N.JCQtfm8gFHjK9_H7B8hekt9k6wXQI4CCCLcBspw-1748488168605-0.0.1.1-604800000
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/embeddings
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA1R6ybKyTLfm/L+KN94p9YeISC6/GdJJm4nSqBUVFWCDoKg0mUCeOPd+gr0rTlVN
+          HGAamM16upX/8a8/f/5+8up26f/+8+fvq+z6v/9jfnbN+uzvP3/+57/+/Pnz5z9+Pv+/kbc6v12v
+          5bv4Gf7zZfm+3sa///wR//vJ/x30z5+/jnoyWEDavO3CPcrWkSzJVCruUz7411MI8fvBGVGTF+rF
+          RNYUjFSf5YdrUU1p8hEBd8+EGVW35X15DgGScnnChJpjNdwy9FwL0tMlRgyC17vL1kCbfjfh6T6S
+          dgyr7gnluHgza5WwdggP9ROJIIYsG85vPmzt0oVPI3HiH75VPh3T3lBWpZ2wU1KTqvUPogA0ObVM
+          bXCVD49giEFUVZH5r8LUR4nIBayme4Olp9miafs6S6jc11t6kdOyoiNfH6CJPwUzzG8fje9ddgHK
+          Zc600Np6oq4bk2JUu4Jyx/hELBZ9H50TryPmqXEi7hxljCL5Y7Kzdd9WfP1+ChA1VYWH+7bTB9Xe
+          G2iZZ19iKB+ZM+d+M5CziEYM8rHm460dnyC99Qrrd8Aee0pchJPTxlQK3l0+0KtjoP0Q74ldiK3X
+          v+KkA/qqAubtwm8+PV/uB17Lyw2nfFByuovyWAl0vSf2Ijl6U9VZGSgrTin09lufjLt4geNluSI7
+          yy7yKVDOKqAnF/Bj/dlWy912b4F+bM8siMIBdeYmPaCD+k4wvwtp222dJIX3drtjQR+ZLV0+Th8U
+          LsmduB3HERV0zYLa7EvinjcD6s/C1t1kwvAi1r7dRNdtjkul+GaUGUJAvYHsbQzn6jQQB9f3aHxG
+          9gl6+XtnJnuuqskO3AG1Qk2Z+xm2rWhK2xuU4+ZNl44MfDgq1gmZoTkQ73Vk+rRxYALyZTviD8xA
+          Q/tVjc3rdQrY3o6KdjAl54baIsqIudd2+RDcdxS2xCiY3zttNDV+U8BaaYA5aEWi4SNdMlCHNcW8
+          9Sf9La6zE2xBvdNiXH0rfsWFuHnmPMLtuF23D3dZWSDV0505X+PGWbj4GmitjDcqCWWN+GuAGDT3
+          ZJLojr585Bc+wCM9CZTW0TKnrY9qqE1WEvWu7tBSMboOUCkRZlzsvd4fvUWDzgas6aZ2cm+Y6xV5
+          9uCwW/Yuo3k9fRCcxiO7hSNGjb99KWg+/8Q0RQ+N5blRFWRpE10Kp66aRjE/gbbeqbjb5TveLU3d
+          WlRqCPjWA6qm5ae/oIeILOI/FK9afV/3CzhaVOLV/vyp+n75BIg88cN2zqBFXBvCFILHOWJ+Xwtt
+          n7jnAxSrTmfe4f71xmd0vqDzOKXEw3Ib0ceYdWCb7oAXxpHm3d7jCpyr9I7LjdTxIbj1T+SEzxXx
+          0y7UqV6/XejazCPm5dDmT+g4wOKVv4nr9j4aRB9LaJJyhS6olfBhPdkhnD7OhalNp/B+tQ9EyK9n
+          QgJ4Z+1EVXgqx0y2iSd7hsfLjX9Cj/RK8BRWYt7vry8LjW5zo2MVYN5g0b6hrj15jKj8Go3Jnhqw
+          3ysZHio9rkbcWBg8t5eJmZii18kqkdA8P6blVONjsr9qwDWIyBVeB72TZUVA1Sby8BQ7Pe8OxuDC
+          Mo9PTGdYqfiMNyDI1RpvSv3R9su0xehq1iVxZUNqn/P81hc3wWy76VM0vLToAosXFpmaXyTE705c
+          IJqEDpbP3pMPW+caA4/UJwlE9G7HK7/fUFZc90TbxmLbz/WJ1KK0yc7Fa84vyfIDlEslnaQwymn0
+          ZaISLOibmG1RV3TP0hDee++L5YMq6dzby91P/bHgy+KKXo26hvx6L5g+42c9icsCjuvLgx2qU5+z
+          VR+dwISPTYyqr73J315EMIyLhMd4C/okvpUQBvDfeDG2nt4SK5KUeT+YNvMHPz2yAvnmcKZrlBc5
+          w+a6g2e+elLoXVKNiWv7iHzXCvHSx1jRcFmLIC3DN/N3WdWOZwFiCO1kZLY1phHnaydGfuos2DZ/
+          dWhUz2sMzmI/0uOMl+36nSuwk7iL08vFbEdYhTG4ueQyvLRqr9fjjYDSbUSYlrO3NyBeN8AKpNNX
+          EXNOO0tV4KNsEvxdXJ7ttPwIJVokbsVcvUiqQRK+GVxfaMWsk9R5/JI8n0iqpYHNeK5PRCyfQLlY
+          0mkjJ/lkFGaJbqG8Y8Z7OKBJSSmg28NS8MuUxIiWzdoA/xk+fvmG/+BXXWZXgqMbePSUCjZiZbug
+          yk3dVM36sipBcQxOTGVw24FetxbaoFhi7k29Vp0lHQplVzcfYgjuNloxP/Hh66SIbNefRzt11h7g
+          gIcdi+f97OiTCqhYfycSRGHIOT3EHRwvLPnhZ2+ZuOcQFq/IJNv198WnAVkWWHk4EXdnEW88mcxA
+          efuJmMkdn/MrHmU4rrOQ6RNnaJj2Tx/WARqIeQk1vjyk3xhmfmXGqcrRGFbLD0SevMbJdtJzZrUL
+          f907okYwyTx90u/bEGFsBCSOr1o03VdbGy6rfUAwUFtfvQZIkW2SLdHpUOkjCL0NUwI6M5S32PaP
+          e3jZzPxDF2ra6DQucw3tSzPAg1F+qkGZzjMe5hHbHgXmfbomOQH5IoV4u31QTZxGMtDkBngBSoO4
+          uK4usGx7gW7GY9rWIVUBTtJlZJqxeuRcKb4YlPfl/MOf+ogbjBVVU1WSMrrn42p/k2FXfz5kZ3m9
+          Pn7t9wCqvr7hoekUNPjXRwzskCG8GdMpancvv4R7d2PMRuxaja+4npAbvCyMUrNs+6lKMvRRkIHn
+          89GO/OqLKPIWLtlOdxT10fFSoJnPmJPQRz58JamAo3/bY7jKlT7V99fht54X0ctpp2/ku+gHn9wv
+          XnvNMdUAPc+CRdRR7vn4toYUpdt8pNIeN/oYPu+Dsrl0PnMTZEfjK752kFEaE/uxv+W80B4SRN50
+          ZNae0IjZNw6bN3vfibZZ7XV+fkCD/NgPmV49qnyKy0jbyMyImJeaWjUsDUVFRFYvWJENqaKOdTKg
+          fNCKsnWSVEMR7wFAwAaVr0GQj+4yU9EAiUPXZ1Hhn2oni+jNbhv80vYLnRXaaYD1xRXpoD6M6HN5
+          SxISpNql9eXyaif9fkhhwUuHqEZpV6w7CTECPVjSIT83+lDtZAm2Pc/xMMoB/5kfeuw2O6LRd+/1
+          VWa40Ao3n1mXi1kNifzRUGhdIuZllsX5zQ4PyM1Fl2GStbMeailqtwVmlrl5oPEyrg3gC0klalk/
+          8mn72ku/etletX67Cvwo3XBN0ZjzyOWWHd+VBeFTcZltcQGNauYe4Cu5J7aVjKGd9VcGiXFYULbc
+          P9vx1uUULm/Nmf3Agw/cXZdrXQqmXz3VXDflBFuiEmKugitnd6evwVu9akqj28Xjm/jsohm/SdBH
+          r2oQ7nIHxWqIiS6dzJkPphCaeBmx4FaInKZXTOEHX2y0r72xyhIftOySsh2TfW8MhqBTDjflSxfR
+          69tOiBxcgG1oEbcTD9UAXaMg3NUJlU5yXE3m2Zng6LcGBfloIeZHdwu2xB6JpShPNDy36xjd4aES
+          sk7XvFNtVd3M9cXIsbnN/kKd1lZ71JnRxhVn00JUYSeNLpn5mY/310NDxMMLpldVi7j13McIxdmJ
+          GSs15aMePxWYpLPC7OdZzSX97hx+/AhV3EbVV4N5vqBNb05sl+SjN+2Z6cPLrge6mfXM7+8/fpix
+          e5lpiHM19X/qnanru1dx9IhPYK3pl8Itnjwece7CzD90vH/W7SSVsQJ8/GKqDCe9Wg6fadgwzbfJ
+          eXHrveaHLyJvOBLjTd2cf56aC8fWQkyTsIuGRXGQ4JHeCf50ussZWZxUOPRpQSdj7XAO2TQgcv5I
+          xPugwhs7cT2gk9O/mHZPipnPt7cfvMPy55a0E1kaHZyrx4EZhZPknPlXH4J9ohFte+j0zpS2F/BN
+          ahNc4sIbKnurwLQbQxKUFo466EoF6nhnY5RWmTcJ2lqDtnBl4lxPHhqEd1DAHSqVQnZwKp5QowNd
+          PL2IZm8URNeXRYHs5Cz+npeu2g0S4o+Ty864XuT9IVUyaIt9RnZPvOVLk+xKKFylJobyjttpUDYa
+          XF/rFZX2gclpGxifzSLdDEQP2VHnV/wRodXvG1orm7Gd1gkaYMZbhmGMEd12iw4UG/bkpjqVN77x
+          DaPwZW1weRchGhYFgDLrR/bzf98z/v3ob8zq+8njohLU61SwgZ0OWyVqQjrvVUFD5gz4m09WpB3Q
+          eyNVTG3atBrdpSps2rtgEFOipT56VM6gQ9/Zf+x89F0egxROR/jSaSP5fLx12mfzo4/l57mIKEar
+          E9gjBLgjBvUG6EoZLF9EzPtmiA87Jivgm53NTIWvcmplWEUn6TbiRX1pc/YaqgP402fHzGpV5OMh
+          nU7gBllE3J3p8jFbDTUoS+FBR8k6ewM+KooS6Nv+F5+o+J4OsOAUGPE273bqVSdTggXKqKQoTz7t
+          Kdhoey2PTJOCuhr51RChP8Uuu2R7M+IHJZ6UprI/eJVkPqLrRH3CMr8peHnqRjR9DiFsOjw+mJMG
+          G49fiSv8+qeP1r+iUQq3NTquy4kKS6vWP+fuO9f/YoOFW3esxhYtS1CH0SeOJlf8G3wdUOrYtOlL
+          GZp2+LKwQTNe4RVbvVHTWaIBwlkS5v3N0CAJYQx2VL/JD9+yLF+68LP/lnYeUMO2KYVHXRU0MLRl
+          2527adZTh4l5aaV4TKZWDYbx2JFd8fnkU78L7BXs246pxnP0eiOY8EbLWoeZp17yumnf+SiSp/fs
+          D+J2HMsGg/6Sr3jFb2YrTeKmBB55FttxJW4nIqIGucHbwouj/86n+t6HMJ83zN8vMeJCQm8oYE3K
+          3CHz9cndvTIItLVHSE5Evf3hg+V6oTEMw1DxLO8M9MyXT2IJQsKnkNoCwsi6MnJb9i0t28hHDT/m
+          uM+uH51V0p4i/shcps95xTT7S/QMzj0dxuVWn/kBw5hRhuVVY+fjZ9cWaAA7ZfG2Ltp+5aw1kDeF
+          y3afw4FPG6eicDqKO7aNUBmNY3m2Ua0LNfNvqdJ2opd/YMZH/H5256gXxklAwf4wUvQ98ajXok8D
+          U6rFzBRE1PLRqidlXO9tFohKlQ/8cM/QjLcEz+eDNdd1DeRcxlTRjbodXVjI6Jr0BsFL84HojIdK
+          cih0tnuGTTSV0w2gu3o75rmrt9cjITZgzlfI1mCsan781sy/5Dnnb62QXDOUHOqYkEZ78uGBt6fN
+          PRBNLFnbCdFZv6M21FLiaGtbXwV+d0JpLzj4JYioar/XooTr02iYv7t0Xr/T/AMwY1cza+9v2yWs
+          HieEuK4xT/ae+qBpagn09WXECj5hO4Hj1LDB1RkLc17B6zG9gHo4JkxVH0bOX4Nj/+Af3sCzn/1M
+          LYBxAIG418cDDZ+lEoIYeinlP/hZaJOi7PU2xctLqKEpUJCNBOfj/eRtaOYrF+J3xbHkvCr+q0dT
+          YX/D6HUkep/J2w/wiByJmp8bb+iaRQGLV5KyQES7ajqmFxUdW8dnznmaIv4a2gPox7dNHPyU0I9/
+          VAT5aDE9X2/zsV9KKtyVwcDNIbJyWt8vGBRbUckOVQrqW7Qp4Zo0fNbz22jlHVoZcNetSP6Thwi6
+          a/2sz2/+ypcKo2BHF5OdFxejXR0/gY+0jxLQzZhgj3+fyxSmXX1l3s09olF2NQuYdjj/5ln8XAYd
+          VL11mvNWVg30WQvKPhrlGd86NDjf9QledrslrtuoHvO9woVIpimGLNx63x/9/5XsExbkvkINp52A
+          5vVnmo0O0VzfB0V51wgPd/U9+9u9oEw7HjJ3tXjordleLQRMvJFtXhnRLz6YdwXwIqp71MnyJEDe
+          Li2mGq8kpxglIaQ9OCysv1TvGjYNSrGSXkSXsqBlQmKkaJEuBhxuLCcfHji7oZ/89jyQvurPQhvC
+          dbqFNL9SG03LR9igr+OfqeCNTzSSSrtsdnW3Zni5a/JxeTRnPffe/+JJkzmTjI7rU0g05YD4eEgf
+          qdLEXGN2t9XypbW1VXDC/kx/ztvy6K0atIoGRi7ZwWm5MZEJ7oGS0uG+9b01/uYqZMWL/+qHXj1/
+          XCSd3h19o0rhQ2y9a6BVp+LV1ThGzaBsVGWAo8PU5bXyJrXdxwiGXYXFqrf0vl8KGvqeXwvmgqnw
+          3/x2APwm/i7fzf4uDDe3RTEwV9awPq72gYS+75VOuaDu9OU2W97QxfU75hSL7+zHrj6yJ4MRB8m8
+          6rrGiMEMdwPeyKUZiXNeCvh25SyQy1c0ie+TDSbFe4x2hz2fx6fQ8CRnmv9o+Xj0Fh+w1t2XyjiD
+          aszljMJP/m0mZuzN+YAAxYrqzHBwWY3JPlFh2jWUqfQQRxNby8OP/6HLU9tXrzdOMZhAz3TtFiYa
+          t7lV/uYp0scBNG6z7oSKc3zF8qrtqg516gQhPx2Y+/LDuf/QFMpVDHxi8SHL2acqtI1yTlYEvyTN
+          G8PncYCZ//D2/llXk1GkT/TMx4hgb3L07pG8Q6Qs5ZAFfeygHlZhitrClud+gx6trqS3wDgIApvz
+          zJxLXYHBF18S2TbLEM340kBsIwcLY+FXfHdTJ0B8F1F+Oq69Sb87cz4ZCYSoaeN1B98QkHGQLgSP
+          5VIfkXmUUbycVkyrN2Xb/uRrXwefiRlcgtkvyzHox++Z2Fpv5pOSGiLM/Qm6NJehLvWL4QCfS9r+
+          8Ls+ncg3/tWvs79qpfSybDa3xXtLDJZdI6l6fgq0Kg2D3GAU+SSVFxna/Vpk5huWFfPO7wZ2dX1k
+          7uON8vEsOC7Ex/Me17FYVb/673v8hMzFh9IbqzM3Nof+QFggCnE0nHvPRgv+aVnU+gdvNHCc/vqV
+          LD2uoqFGRQfr7vie+c9qh/5pSPBR1sac5z/RnEc2sC8OKiEe6PkSFuSArmJ0JbqzS7wpc74igkE/
+          EPcMfjs5VmhtlDNJ8N04HdpBmfYxFN/LggSpPKH+YwcNzPqABYYhePS6sRuYjssH0f3OjYbxxAQ0
+          8z+5wjPg40bWy5/6Z9qcXw7mJg2BWoL4i7dDRkmGND8RiYuHdTtcilCAQJMUogfOpuok4ZSCCPKD
+          2Gf/q/dzPoN++PySsQvn2QVjuHcXxiLH7Krx1m1EZe4PMTtABeLMQxZ63+Oc7ZvlwFkJZx/caz/n
+          Pbaad192+sBP/aeXy6v6vuJ6gBk/iP2UeMu1lYDhvREr4lyzOBoTV/UVNAkjweW+41R8h+7GWjen
+          OS/P0LI8nwDiV5MQ5/Nu29Fd2oBmP0XrZ3n3uqWhaFA+ViYV1u5K72rQJAjT5xJLcz+KHd/gIssf
+          mhnPdK8Xk0HdLAPnRddnnlbToFTCWrLTD9EM2Zzz2MxHcz4480OA3nfHuwAfW8x2lvOsJm8n3H7w
+          gKnr2y76doBrMKm/Z4G63UdTcslLuD3IBYMuNrM/+Io//SqybeRr1SPhYimqZux/zxt7SkiCq3lR
+          2fVWXqM5f5aAa7JG9EkU9em6KQe4acWDaMb6+5tPbfxp+tLVVY/0ITLbFBkPrNGlRDVvCpTGQMEe
+          F8zrFnt91Z0uPtrvhZYYSh3mfRx+RUhG60Lsz3Uf1SMfD2DeNwEhpNp6SwN7B4XyhUHH6Xac37/v
+          wDen869f4KdH9QR9V67wJxCClleS+tkk5epEtv4p4VPZau7mnDgdIdHrW/F3ayo/+RAe7aiomLiu
+          bjD3R/DywoR2iMwsRFZuhyT49r7O+/1Ug2dPDiOlnM15m9+gS3YfCL41bNZzzecnL8SrJN977Sa2
+          LQjY02Ra+JSrrv3a1m++HwXOpqWuNfnwPdIH+eGPjuzLGKw20Ykr3q7e1PhlAT/9C0/vTtGIBE+D
+          7/l+JZqNppxt8oWqRE06EO8DRj6fF4DvsXvgzUF88EmvmQs72yDkR59Pn7Mk/uKv/bM+oXpJobsI
+          MQvG893rFoUzway/MRDt1Y7RUfpsOtQSnB3iph2uD8MGe3JUYlzsUR9emnaCn36qfkdfxKTug8Ew
+          2i8JDC2phnixbcC6mgum35GDlg4kA8hqR5n7cu2Zr58CEO/4oCPN3ei3P/KVrB1Ro9HWpwV8MmSM
+          2ZIORtXx4dwpFqxKN2HWnAcMx2n9hJ989yfPHuxh6QKPtCfxxBqjeT6Dss6FLQViHqLppz8TPoV8
+          9hOralxMvvaDz8yytgc+ftVBAjlED7az3hf9Jw9Gf39uBfznv/78+V8/Nwzqz/X2mi8G9Lex//d/
+          XxX4d3bN/i2K0r+Z9HsTgXZZcfv7z/+5hPD3237qb/+/+8/z9u7+/vNH/r1t8Lf/9Nnr/3n8r/ld
+          //mv/wIAAP//AwBxbwgZ4SAAAA==
+      headers:
+        CF-RAY:
+          - 9472cb0e498df9a9-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:28 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-allow-origin:
+          - "*"
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-model:
+          - text-embedding-ada-002-v2
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "53"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        via:
+          - envoy-router-dc9d5f6f7-bfg9n
+        x-envoy-upstream-service-time:
+          - "56"
+        x-ratelimit-limit-requests:
+          - "10000"
+        x-ratelimit-limit-tokens:
+          - "10000000"
+        x-ratelimit-remaining-requests:
+          - "9999"
+        x-ratelimit-remaining-tokens:
+          - "9999996"
+        x-ratelimit-reset-requests:
+          - 6ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_9392a0a1e391f86ea94c557497f4903a
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_not_given_filtering.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_not_given_filtering.yaml
@@ -1,0 +1,108 @@
+interactions:
+  - request:
+      body: '{"messages":[{"role":"user","content":"What''s 12 + 12?"}],"model":"gpt-4o-mini","temperature":0.5}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "98"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - OpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAwAAAP//jFJNj9MwEL3nV1hzpVk12aBNewQkbgiJG2gVTe1p6q1ju/aEZVn1vyM7
+          pcnCInHJYd5H3hvPcyEEaAVbAfKALAdvynfy0+P73dPxw+MG3ekrn35WY/v5qB42Xz5GWCWF2z2Q
+          5N+qG+kGb4i1sxMsAyFTcq3umrZp26pdZ2BwikyS9Z7LxpWDtrqs13VTru/Kqr2oD05LirAV3woh
+          hHjO35TTKvoBW5G98mSgGLEn2F5JQkBwJk0AY9SR0TKsZlA6y2Rz9KoWb0RVCzqNaKKom5slMdB+
+          jJjC2tGYBYDWOsZUNke8vyDnayjjeh/cLv4hhb22Oh66QBidTQEiOw8ZPRdC3Ofy44s+4IMbPHfs
+          jpR/VzWTHcwrn8H2grFjNPO4rlevmHWKGLWJi92BRHkgNSvnReOotFsAxaLy31le855qa9v/j/0M
+          SEmeSXU+kNLyZd+ZFijd479o1xXnwBApfNeSOtYU0jMo2uNopiuB+BSZhm6vbU/BBz2dyt53tw2+
+          bZA2txKKc/ELAAD//wMAaAEkkTgDAAA=
+      headers:
+        CF-RAY:
+          - 9472cb57fe48659d-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:41 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=Yi6aaLaw0NZkdHvrki4WOE5tE6U94TABT1plkmJKfqQ-1748488181-1.0.1.1-LdRP3crB0p5QFhTA5pwITOIrJYA7eAyD9jWRNne6ofo.KlYxvbAHDHsub1yEy5RdsLo_SoAYmKEddFZv2adJjFbeq3.3hc1sdtnjLcs_J.E;
+            path=/; expires=Thu, 29-May-25 03:39:41 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=MoVXRPgslfEHsJs5qWj1Rd2oCC7HIsq2nTprVQqpfSQ-1748488181133-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "543"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "549"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999993"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_5fe641e45a5e8b15e3ad21c8469ecaf5
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_response_streaming_async.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_response_streaming_async.yaml
@@ -1,0 +1,333 @@
+interactions:
+  - request:
+      body: '{"input":"What''s 12 + 12?","model":"gpt-4o-mini","stream":true}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "63"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/responses
+    response:
+      body:
+        string: 'event: response.created
+
+          data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_6837cff103f88198b48d6039e3f856cd039a45d2abd10a91","object":"response","created_at":1748488177,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+          event: response.in_progress
+
+          data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_6837cff103f88198b48d6039e3f856cd039a45d2abd10a91","object":"response","created_at":1748488177,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+          event: response.output_item.added
+
+          data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_6837cff183448198a6b50603bc5bf592039a45d2abd10a91","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+
+
+          event: response.content_part.added
+
+          data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_6837cff183448198a6b50603bc5bf592039a45d2abd10a91","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"text":""}}
+
+
+          event: response.output_text.delta
+
+          data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_6837cff183448198a6b50603bc5bf592039a45d2abd10a91","output_index":0,"content_index":0,"delta":"12"}
+
+
+          event: response.output_text.delta
+
+          data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_6837cff183448198a6b50603bc5bf592039a45d2abd10a91","output_index":0,"content_index":0,"delta":"
+          +"}
+
+
+          event: response.output_text.delta
+
+          data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_6837cff183448198a6b50603bc5bf592039a45d2abd10a91","output_index":0,"content_index":0,"delta":"
+          "}
+
+
+          event: response.output_text.delta
+
+          data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_6837cff183448198a6b50603bc5bf592039a45d2abd10a91","output_index":0,"content_index":0,"delta":"12"}
+
+
+          event: response.output_text.delta
+
+          data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_6837cff183448198a6b50603bc5bf592039a45d2abd10a91","output_index":0,"content_index":0,"delta":"
+          equals"}
+
+
+          event: response.output_text.delta
+
+          data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_6837cff183448198a6b50603bc5bf592039a45d2abd10a91","output_index":0,"content_index":0,"delta":"
+          "}
+
+
+          event: response.output_text.delta
+
+          data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_6837cff183448198a6b50603bc5bf592039a45d2abd10a91","output_index":0,"content_index":0,"delta":"24"}
+
+
+          event: response.output_text.delta
+
+          data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_6837cff183448198a6b50603bc5bf592039a45d2abd10a91","output_index":0,"content_index":0,"delta":"."}
+
+
+          event: response.output_text.done
+
+          data: {"type":"response.output_text.done","sequence_number":12,"item_id":"msg_6837cff183448198a6b50603bc5bf592039a45d2abd10a91","output_index":0,"content_index":0,"text":"12
+          + 12 equals 24."}
+
+
+          event: response.content_part.done
+
+          data: {"type":"response.content_part.done","sequence_number":13,"item_id":"msg_6837cff183448198a6b50603bc5bf592039a45d2abd10a91","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"text":"12
+          + 12 equals 24."}}
+
+
+          event: response.output_item.done
+
+          data: {"type":"response.output_item.done","sequence_number":14,"output_index":0,"item":{"id":"msg_6837cff183448198a6b50603bc5bf592039a45d2abd10a91","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"text":"12
+          + 12 equals 24."}],"role":"assistant"}}
+
+
+          event: response.completed
+
+          data: {"type":"response.completed","sequence_number":15,"response":{"id":"resp_6837cff103f88198b48d6039e3f856cd039a45d2abd10a91","object":"response","created_at":1748488177,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"model":"gpt-4o-mini-2024-07-18","output":[{"id":"msg_6837cff183448198a6b50603bc5bf592039a45d2abd10a91","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"text":"12
+          + 12 equals 24."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":14,"input_tokens_details":{"cached_tokens":0},"output_tokens":9,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":23},"user":null,"metadata":{}}}
+
+
+          '
+      headers:
+        CF-RAY:
+          - 9472cb41d9474364-EWR
+        Connection:
+          - keep-alive
+        Content-Type:
+          - text/event-stream; charset=utf-8
+        Date:
+          - Thu, 29 May 2025 03:09:37 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=xcwO9CpEIfCnqq7YaUa1xTsHb7PHgHBbrqIHapZiPnI-1748488177-1.0.1.1-gVS2m.T1Q0blZ_BZZDE4D_1TrW8eSj1nXNItfEi1nIYd_oeRzmN9JiknKpOnqLM_yGwiCAJeq5MYWkeKI1ukRrb7RpGQBqKCxwPooZdq7hU;
+            path=/; expires=Thu, 29-May-25 03:39:37 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=MvpgtBwiS2QiCi_sFTGCV0l53fKk38I432sxv4RxEsk-1748488177157-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "117"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-request-id:
+          - req_5416e77381569aa7379ad3cd2facfbbd
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: '{"input":"What''s 12 + 12?","model":"gpt-4o-mini","stream":true}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "63"
+        content-type:
+          - application/json
+        cookie:
+          - __cf_bm=xcwO9CpEIfCnqq7YaUa1xTsHb7PHgHBbrqIHapZiPnI-1748488177-1.0.1.1-gVS2m.T1Q0blZ_BZZDE4D_1TrW8eSj1nXNItfEi1nIYd_oeRzmN9JiknKpOnqLM_yGwiCAJeq5MYWkeKI1ukRrb7RpGQBqKCxwPooZdq7hU;
+            _cfuvid=MvpgtBwiS2QiCi_sFTGCV0l53fKk38I432sxv4RxEsk-1748488177157-0.0.1.1-604800000
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/responses
+    response:
+      body:
+        string: 'event: response.created
+
+          data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_6837cff1f4608198b0c7325cd6d7a93d04bf0c0fe023e578","object":"response","created_at":1748488178,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+          event: response.in_progress
+
+          data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_6837cff1f4608198b0c7325cd6d7a93d04bf0c0fe023e578","object":"response","created_at":1748488178,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+          event: response.output_item.added
+
+          data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_6837cff281e08198b93a44b690d1448c04bf0c0fe023e578","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+
+
+          event: response.content_part.added
+
+          data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_6837cff281e08198b93a44b690d1448c04bf0c0fe023e578","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"text":""}}
+
+
+          event: response.output_text.delta
+
+          data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_6837cff281e08198b93a44b690d1448c04bf0c0fe023e578","output_index":0,"content_index":0,"delta":"12"}
+
+
+          event: response.output_text.delta
+
+          data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_6837cff281e08198b93a44b690d1448c04bf0c0fe023e578","output_index":0,"content_index":0,"delta":"
+          +"}
+
+
+          event: response.output_text.delta
+
+          data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_6837cff281e08198b93a44b690d1448c04bf0c0fe023e578","output_index":0,"content_index":0,"delta":"
+          "}
+
+
+          event: response.output_text.delta
+
+          data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_6837cff281e08198b93a44b690d1448c04bf0c0fe023e578","output_index":0,"content_index":0,"delta":"12"}
+
+
+          event: response.output_text.delta
+
+          data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_6837cff281e08198b93a44b690d1448c04bf0c0fe023e578","output_index":0,"content_index":0,"delta":"
+          equals"}
+
+
+          event: response.output_text.delta
+
+          data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_6837cff281e08198b93a44b690d1448c04bf0c0fe023e578","output_index":0,"content_index":0,"delta":"
+          "}
+
+
+          event: response.output_text.delta
+
+          data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_6837cff281e08198b93a44b690d1448c04bf0c0fe023e578","output_index":0,"content_index":0,"delta":"24"}
+
+
+          event: response.output_text.delta
+
+          data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_6837cff281e08198b93a44b690d1448c04bf0c0fe023e578","output_index":0,"content_index":0,"delta":"."}
+
+
+          event: response.output_text.done
+
+          data: {"type":"response.output_text.done","sequence_number":12,"item_id":"msg_6837cff281e08198b93a44b690d1448c04bf0c0fe023e578","output_index":0,"content_index":0,"text":"12
+          + 12 equals 24."}
+
+
+          event: response.content_part.done
+
+          data: {"type":"response.content_part.done","sequence_number":13,"item_id":"msg_6837cff281e08198b93a44b690d1448c04bf0c0fe023e578","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"text":"12
+          + 12 equals 24."}}
+
+
+          event: response.output_item.done
+
+          data: {"type":"response.output_item.done","sequence_number":14,"output_index":0,"item":{"id":"msg_6837cff281e08198b93a44b690d1448c04bf0c0fe023e578","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"text":"12
+          + 12 equals 24."}],"role":"assistant"}}
+
+
+          event: response.completed
+
+          data: {"type":"response.completed","sequence_number":15,"response":{"id":"resp_6837cff1f4608198b0c7325cd6d7a93d04bf0c0fe023e578","object":"response","created_at":1748488178,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"model":"gpt-4o-mini-2024-07-18","output":[{"id":"msg_6837cff281e08198b93a44b690d1448c04bf0c0fe023e578","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"text":"12
+          + 12 equals 24."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":14,"input_tokens_details":{"cached_tokens":0},"output_tokens":9,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":23},"user":null,"metadata":{}}}
+
+
+          '
+      headers:
+        CF-RAY:
+          - 9472cb47bdb94364-EWR
+        Connection:
+          - keep-alive
+        Content-Type:
+          - text/event-stream; charset=utf-8
+        Date:
+          - Thu, 29 May 2025 03:09:38 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "118"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-request-id:
+          - req_4a434e2fa2c1a0df8c7a4e1b99dbd245
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_responses_async.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_responses_async.yaml
@@ -1,0 +1,209 @@
+interactions:
+  - request:
+      body:
+        '{"input":"What''s 12 + 12?","model":"gpt-4o-mini","instructions":"Just
+        the number please"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "89"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/responses
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA3RTW27jMAz8zykEfTcLW3FjO0foFYqFQUt0oq0sGRJVtChy94XlR+zd9idwhuRw
+          OKS+DoxxrfiFcY9haM7VqZQdnts2l1VeV5XKTwrb/FmovD6VmMlzJ7DsSlAnUWTP/GkkcO0flLSQ
+          OBtwwqVHIFQNjLG8LKqiqvLzOcUCAcUw1kjXDwYJ1VTUgny7ehftqKoDEzDB6L3z/MJsNCYB2i6F
+          jUICbcI+GshHSdrZ1OQlBmJ0Q2Zj36Jng0FYZPbw0bhIQ6SG3BvaHVHvFJqR4TrQsXDHXlt9FJko
+          jll5zKvZgFTNL+z1wBhjX+l3dbYP18XY8iTLajS2lrUoatHWVSGKPMu/NTZx0OeAiQVDgCs+Aj85
+          mILSWUL7kLSVtaNdBscPWqtTAljrCBYDX3/vgin9wrgo+Arf5681k3tnUg8IQQcCS1PymJiS+AAe
+          jEHTkHOmkWDSEsnHaeeDx3ftYmiWs2qSoetuPEJwVtsrv8zDcew652mTNBoV+x785wweGLtPF4j+
+          XUtsSON4WFxhB9FMLvBAzuNWC2E/oAeKCc5/ZTOafJibd8738Pi/cTnlrcNP/aeZb07LyaRIjq+B
+          h+ec3NAM254+WpkWk1TrAK1ZHk9MJ7IK0nZ31EI8/Y9vXs8qW4K8oXoUZpP0ufrftyK+w7+jXff1
+          EzM5ArMhLlazYsDd6++RQAHBSH8/3P8CAAD//wMAhQO6aMgEAAA=
+      headers:
+        CF-RAY:
+          - 9472cb019ad9433e-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:27 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=WtTUoE6YrHiOeJzkV_hl69OWeRqm715jPbx69WN57Yw-1748488167-1.0.1.1-utal_YD9oicwIv2autnKRz4TbDXJBFO1KrWjEkd9S0bIFx49vU.ac4e1ypUAklFwsW1Tb6scSBerX8YuWWHuxlTTgI9sMvm9mRLsdPqW9bA;
+            path=/; expires=Thu, 29-May-25 03:39:27 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=mD8lr_Yu2M5EC1wPyAFxVEz648jOHHyWmqRwLqw0XUU-1748488167379-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "627"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999959"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_98e3cefc129761545e956f10ca19b950
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"input":"What''s 12 + 12?","model":"gpt-4o-mini","instructions":"Just
+        the number please"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "89"
+        content-type:
+          - application/json
+        cookie:
+          - __cf_bm=WtTUoE6YrHiOeJzkV_hl69OWeRqm715jPbx69WN57Yw-1748488167-1.0.1.1-utal_YD9oicwIv2autnKRz4TbDXJBFO1KrWjEkd9S0bIFx49vU.ac4e1ypUAklFwsW1Tb6scSBerX8YuWWHuxlTTgI9sMvm9mRLsdPqW9bA;
+            _cfuvid=mD8lr_Yu2M5EC1wPyAFxVEz648jOHHyWmqRwLqw0XUU-1748488167379-0.0.1.1-604800000
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/responses
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA3RTW27jMAz8zykEfTcL21FiO0foFYqFQUt0oq0sGRJVtChy94XlR5zd9CdwhuRw
+          OKS+d4xxrfiZcY9haE7VoZQdlvURsyqvK1DV4VQfCylkVpZFldXy0B2Lrj7WqurEgb+MBK79g5IW
+          EmcDTrj0CISqgTGWl6ISVZWfyhQLBBTDWCNdPxgkVFNRC/L94l20o6oOTMAEo/fO8zOz0ZgEaLsU
+          NgoJtAmP0UA+StLOpiavMRCjKzIb+xY9GwzCIrOHz8ZFGiI15N7RPhD1TqEZGS4D7YXb99rqfZEV
+          Yp+V+7yaDUjV/Mzedowx9p1+V2f7cFmMrfK8FaOxrWoPXXZSohS5FKf2qbGJg74GTCwYAlzwHvjJ
+          wRSUzhLau6StrAfaZXD8pLU6JYC1jmAx8O33QzClnxkvBF/h2/y1ZnLvTOoBIehAYGlKHhNTEh/A
+          gzFoGnLONBJMWiL5OO188PihXQzNclZNMnTdjUcIzmp74ed5OI5d5zxtkkajYt+D/5rBHWO36QLR
+          f2iJDWkcD4sr7CCayQUeyHncaiHsB/RAMcH5r2xGkw9z8875Hu7/Ny6nvHX4qf8089VpOZkUyfE1
+          cPeckxuaYdvTRyvTYpJqHaA1y+OJ6URWQdo+HHVRvPyPb17PKluCvKK6F2aT9Ln637dSPMOf0a77
+          +omZHIHZEIvVrBjw4fX3SKCAYKS/7W5/AQAA//8DADqyKq/IBAAA
+      headers:
+        CF-RAY:
+          - 9472cb06ef9b433e-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:28 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "581"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999959"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_0cb0309b702c5eb0a192dc59212bbae6
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_responses_metrics.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_responses_metrics.yaml
@@ -1,0 +1,212 @@
+interactions:
+  - request:
+      body:
+        '{"input":"What''s 12 + 12?","model":"gpt-4o-mini","instructions":"Just
+        the number please"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "89"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - OpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/responses
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA3RTQW7jMAy85xWCzs3CVpzayRP6hWJh0BKTaCtLhkQVLYr8fWHZVuzd9hI4Q3I4
+          HFJfO8a4VvzMuMcwtM/NoZYXhSVg1ZSnpsHqUEp5PFbHg6wBCnnoFArRiFNz6MqCP40ErvuDkhYS
+          ZwNOuPQIhKqFMVbWVVM1TXlsUiwQUAxjjXT9YJBQTUUdyLerd9GOqi5gAiYYvXeen5mNxiRA26Ww
+          VUigTdhGA/koSTubmrzEQIxuyGzsO/RsMAiLzB4+WhdpiNSSe0O7IeqdQjMyXAfaV27fa6v3ohDV
+          vqj3ZTMbkKr5mb3uGGPsK/1mZ/twzcae6mc5Gtupqi6UKoUSRQOi/tbYxEGfAyYWDAGu+Aj85GAK
+          SmcJ7UPSWtaGdhkcPyhXpwSw1hEsBr7+3gRT+plxUfEM3+evnMm9M6kHhKADgaUpeUxMSXwAD8ag
+          ack500owaYnk47TzweO7djG0y1m1ydC8G48QnNX2ys/zcBwvF+dplTQaFfse/OcM7hi7TxeI/l1L
+          bEnjeFhc4QWimVzggZzHtRbCfkAPFBNc/ipmNPkwN78438Pj/8rllJeHn/pPM9+clpNJkRzPgYfn
+          nNzQDuuePlqZFpNU6wCdWR5PTCeSBWm7OWohnv7HV68ny5Ygb6gehcUkfa7+962I7/DvaPO+fmIm
+          R2BWxFU2KwbcvP4eCRQQjPT33f0vAAAA//8DAPvvH7/IBAAA
+      headers:
+        CF-RAY:
+          - 9472cacbad828c83-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:18 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=mI1hauJmw2.LoIBdsHg_QC7_NHqZdnOMzWVIW8FsTRQ-1748488158-1.0.1.1-PfdMmNepTIKHAoMhhN4llNkTT13MFq_85COUdhxqy3ZRC49jL54D1VIubFkA9P6h7l9xUlSX8At.zsM0DfeQZ2ty5TkOlp7EiC.O7LqtTUI;
+            path=/; expires=Thu, 29-May-25 03:39:18 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=tPn8I_CbxQE_7n7eR0tfI8z79gYpGXIT.dYXd5DQUl4-1748488158744-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "611"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999959"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_ed1e4b8509568a7c5b182e720020214a
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"input":"What''s 12 + 12?","model":"gpt-4o-mini","instructions":"Just
+        the number please"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "89"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - OpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/responses
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA3RT0Y6jMAx871dEed6egNIS+gn7C6sTMsG0uQ0JSpzVrlb99xOhpHDXfano2B6P
+          x873jjGuOn5m3KEfm5M4VLLv+rxGIfJaiF6Iqjwcu1qcslPWZ3krRFYcM6zqAxwEf5kIbPsHJS0k
+          1niccekQCLsGplhelaIUIj/WMeYJKPipRtph1EjYzUUtyPeLs8FMqnrQHiOMzlnHz8wErSOgzFLY
+          dEigtN9GPbkgSVkTm7wGT4yuyEwYWnRs1AiLzAE+GxtoDNSQfUezIRpsh3piuIy0L+1+UEbti6wo
+          91m1zxcDYjU/s7cdY4x9x9/k7OAvydg6O0Vj264vi2MNFYhjW2L+1NjIQV8jRhb0Hi74CPzkYAxK
+          awjNQ9Ja1oZ2GRw/KVXHBDDGEiwGvv3eBGP6mfGi5Am+3b9SJndWxx7gvfIEhubkKTEm8REcaI26
+          IWt1I0HHJZIL885Hhx/KBt8sZ9VEQ9NuHIK3RpkLP9+H49j31tEqaTIqDAO4rzu4Y+w2XyC6DyWx
+          IYXTYfEOewh6doF7sg7XWgiHER1QiHD+K7uj0Yd78966AR7/Vy7HvDT83H+e+WqVnE0KZHkKPDzn
+          ZMdmXPd0wci4mKhaeWj18nhCPJEkSJnNURfFy//46vUk2RLkFbtHYTZLv1f/+1aKZ/gz2rSvn5jJ
+          EugVcZnMCh43r39Agg4IJvrb7vYXAAD//wMA5gltyMgEAAA=
+      headers:
+        CF-RAY:
+          - 9472cad0c942159f-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:19 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=QIXfljmZxZub9UwwuM6OT1N99na9ASw8TDtcrRd6Z8Q-1748488159-1.0.1.1-zbWSSmIJdFD_aTFzj0JP0WZWpbLM0wEDzYNyALtNsO07NwGG62DBhYk_IRdRHZ9Wf2ooX6MZUcYruGgEgAnGeXE7ply4Hwvl3PEANnp5GJk;
+            path=/; expires=Thu, 29-May-25 03:39:19 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=F7Q0gtFcXfGctocXEvQSjRs1S7gyxSThlxKpcdlXKG8-1748488159693-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "558"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999959"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_9593682049a6bc80e64872aee04f3bdf
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_responses_not_given_filtering.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_responses_not_given_filtering.yaml
@@ -1,0 +1,108 @@
+interactions:
+  - request:
+      body:
+        '{"input":"What''s 12 + 12?","model":"gpt-4o-mini","instructions":"Just
+        the number please","temperature":0.5}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "107"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - OpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - "false"
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/responses
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA3RTW27jMAz8zykEfTeFrdixkyPsFYqFwUh0oq0sGRJVtChy94XlR+zd9MewhuRo
+          NCS/d4xxrfiZcY+hb471oZJtWxanOqvzUw3tsbyU2aWSQrUqLzNxUPmpEjliJSpx4i8Dgbv8QUkz
+          ibMBR1x6BELVwBDLq6Iu6jqv8xQLBBTDUCNd1xskVGPRBeT71btoB1UtmIAJRu+d52dmozEJ0HYu
+          bBQSaBO20UA+StLOpkt+xUCMbshs7C7oWW8QZpkdfDYuUh+pIfeOdkPUOYVmYLj2tC/cvtNW70Um
+          in1W7fN6MiBV8zN72zHG2Hf6Ls524boYKxXUg7GnUogcqmNel1gccvXU2MRBXz0mFgwBrvgI/ORg
+          CkpnCe1D0lrWhnZ+OH7SUp0SwFpHMBv49nsTTOlnxkXBF/g+/S2Z3DuT7oAQdCCwNCYPiSmJ9+DB
+          GDQNOWcaCSY1kXwce957/NAuhmYeqyYZuvTGIwRntb3y8/Q4jm3rPK2SBqNi14H/msAdY/dxAtF/
+          aIkNaRwGiytsIZrRBR7IeVxrIex69EAxwdlrOaHJh+ny1vkOHueVyylvefx4//jmm9NyNCmS40vg
+          4Tkn1zf9sECv2Xj20crUmKRaB7iYeXliGpFFkLaboRbi5X98tT2LbAnyhupRmI3Sp+p/d0U8w5/R
+          Lv36iZkcgVkRF4tZMeBm+zskUEAw0N93978AAAD//wMAT6oOaMgEAAA=
+      headers:
+        CF-RAY:
+          - 9472cb5c9a194396-EWR
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 May 2025 03:09:41 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=hky4PzuwZI0YHDeLe3UyB0OkeHxklBi6UeyYqib7OLc-1748488181-1.0.1.1-.8FXGe8MaMHhsboFbj_N_g2.OEI.83OjQL9De3dC2FClH.g2WHfq1pgLdORTu5xsjVMjtC8bkH8EggkP45z2HxbiKAeTLML8I1CsyTnv30s;
+            path=/; expires=Thu, 29-May-25 03:39:41 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=gQ7ZU3ok.ksIvbOQBFTWcOCVWLNwRjYQ.X9DzjPR8XU-1748488181926-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "603"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999959"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_972488ab47f149e1d2791593ecf33dc9
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_streaming_with_break.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_streaming_with_break.yaml
@@ -1,0 +1,136 @@
+interactions:
+  - request:
+      body: '{"messages":[{"role":"user","content":"What''s 12 + 12?"}],"model":"gpt-4o-mini","stream":true}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "94"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.82.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.82.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "600"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.3
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string:
+          'data: {"id":"chatcmpl-BcNw7ndvnSncW8DxhS1idxONpgqxU","object":"chat.completion.chunk","created":1748488175,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}]}
+
+
+          data: {"id":"chatcmpl-BcNw7ndvnSncW8DxhS1idxONpgqxU","object":"chat.completion.chunk","created":1748488175,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"12"},"logprobs":null,"finish_reason":null}]}
+
+
+          data: {"id":"chatcmpl-BcNw7ndvnSncW8DxhS1idxONpgqxU","object":"chat.completion.chunk","created":1748488175,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+          +"},"logprobs":null,"finish_reason":null}]}
+
+
+          data: {"id":"chatcmpl-BcNw7ndvnSncW8DxhS1idxONpgqxU","object":"chat.completion.chunk","created":1748488175,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+          "},"logprobs":null,"finish_reason":null}]}
+
+
+          data: {"id":"chatcmpl-BcNw7ndvnSncW8DxhS1idxONpgqxU","object":"chat.completion.chunk","created":1748488175,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"12"},"logprobs":null,"finish_reason":null}]}
+
+
+          data: {"id":"chatcmpl-BcNw7ndvnSncW8DxhS1idxONpgqxU","object":"chat.completion.chunk","created":1748488175,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+          equals"},"logprobs":null,"finish_reason":null}]}
+
+
+          data: {"id":"chatcmpl-BcNw7ndvnSncW8DxhS1idxONpgqxU","object":"chat.completion.chunk","created":1748488175,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+          "},"logprobs":null,"finish_reason":null}]}
+
+
+          data: {"id":"chatcmpl-BcNw7ndvnSncW8DxhS1idxONpgqxU","object":"chat.completion.chunk","created":1748488175,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"24"},"logprobs":null,"finish_reason":null}]}
+
+
+          data: {"id":"chatcmpl-BcNw7ndvnSncW8DxhS1idxONpgqxU","object":"chat.completion.chunk","created":1748488175,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
+
+
+          data: {"id":"chatcmpl-BcNw7ndvnSncW8DxhS1idxONpgqxU","object":"chat.completion.chunk","created":1748488175,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
+
+
+          data: [DONE]
+
+
+          '
+      headers:
+        CF-RAY:
+          - 9472cb393cde1492-EWR
+        Connection:
+          - keep-alive
+        Content-Type:
+          - text/event-stream; charset=utf-8
+        Date:
+          - Thu, 29 May 2025 03:09:36 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=h1vL7TCxyZQWYLiVATU5khuFWAfl7e7DD1hCduxzE8U-1748488176-1.0.1.1-sJaNE8XFsJQdiSrAjR90nA7rr9yBOdYJcgr.dqonlOei8.cltJKLgEqEf98WWTEAjzZY_3NkDCTKZ6BAoprnwscA9Xg3RSagZKs2syOsiqc;
+            path=/; expires=Thu, 29-May-25 03:39:36 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=SNSxlGXUc7grIzRg7NgjFZuLpm8RWoGQ8CcpSyF99Wo-1748488176143-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - braintrust-data
+        openai-processing-ms:
+          - "462"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "481"
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999993"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_574eb3b1e3585ef7a72808f9c33a6bcb
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/py/src/braintrust/wrappers/test_anthropic.py
+++ b/py/src/braintrust/wrappers/test_anthropic.py
@@ -22,6 +22,16 @@ PROJECT_NAME = "test-anthropic-app"
 MODEL = "claude-3-haiku-20240307"  # use the cheapest model since answers dont matter
 
 
+@pytest.fixture(scope="module")
+def vcr_config():
+    return {
+        "filter_headers": [
+            "authorization",
+            "x-api-key",
+        ]
+    }
+
+
 def _get_client():
     return anthropic.Anthropic()
 
@@ -37,6 +47,7 @@ def memory_logger():
         yield bgl
 
 
+@pytest.mark.vcr
 def test_anthropic_messages_create_stream_true(memory_logger):
     assert not memory_logger.pop()
 
@@ -69,6 +80,7 @@ def test_anthropic_messages_create_stream_true(memory_logger):
     assert "12" in span["output"][0]["text"]
 
 
+@pytest.mark.vcr
 def test_anthropic_messages_model_params_inputs(memory_logger):
     assert not memory_logger.pop()
     client = wrap_anthropic(_get_client())
@@ -105,6 +117,7 @@ def test_anthropic_messages_model_params_inputs(memory_logger):
         assert log["metadata"]["top_p"] == 0.5
 
 
+@pytest.mark.vcr
 def test_anthropic_messages_system_prompt_inputs(memory_logger):
     assert not memory_logger.pop()
 
@@ -143,6 +156,7 @@ def test_anthropic_messages_system_prompt_inputs(memory_logger):
         assert inputs_by_role["user"] == q[0]["content"]
 
 
+@pytest.mark.vcr
 @pytest.mark.asyncio
 async def test_anthropic_messages_create_async(memory_logger):
     assert not memory_logger.pop()
@@ -166,6 +180,7 @@ async def test_anthropic_messages_create_async(memory_logger):
     assert "7" in span["output"][0]["text"]
 
 
+@pytest.mark.vcr
 @pytest.mark.asyncio
 async def test_anthropic_messages_create_async_stream_true(memory_logger):
     assert not memory_logger.pop()
@@ -191,6 +206,7 @@ async def test_anthropic_messages_create_async_stream_true(memory_logger):
     assert "7" in span["output"][0]["text"]
 
 
+@pytest.mark.vcr
 @pytest.mark.asyncio
 async def test_anthropic_messages_streaming_async(memory_logger):
     assert not memory_logger.pop()
@@ -230,6 +246,7 @@ async def test_anthropic_messages_streaming_async(memory_logger):
     assert log["metadata"]["max_tokens"] == 1024
 
 
+@pytest.mark.vcr
 def test_anthropic_client_error(memory_logger):
     assert not memory_logger.pop()
 
@@ -252,6 +269,7 @@ def test_anthropic_client_error(memory_logger):
     assert "404" in log["error"]
 
 
+@pytest.mark.vcr
 def test_anthropic_messages_stream_errors(memory_logger):
     assert not memory_logger.pop()
 
@@ -273,6 +291,7 @@ def test_anthropic_messages_stream_errors(memory_logger):
     assert span["metrics"]["end"] > 0
 
 
+@pytest.mark.vcr
 def test_anthropic_messages_streaming_sync(memory_logger):
     assert not memory_logger.pop()
 
@@ -307,6 +326,7 @@ def test_anthropic_messages_streaming_sync(memory_logger):
     assert log["metrics"]["prompt_cache_creation_tokens"] == usage.cache_creation_input_tokens
 
 
+@pytest.mark.vcr
 def test_anthropic_messages_sync(memory_logger):
     assert not memory_logger.pop()
 

--- a/py/src/braintrust/wrappers/test_anthropic.py
+++ b/py/src/braintrust/wrappers/test_anthropic.py
@@ -364,6 +364,6 @@ def _assert_metrics_are_valid(metrics, start, end):
     assert metrics["prompt_tokens"] > 0
     assert metrics["completion_tokens"] > 0
     if start and end:
-        assert start <= metrics["start"] < metrics["end"] <= end
+        assert start <= metrics["start"] <= metrics["end"] <= end
     else:
-        assert metrics["start"] < metrics["end"]
+        assert metrics["start"] <= metrics["end"]

--- a/py/src/braintrust/wrappers/test_openai.py
+++ b/py/src/braintrust/wrappers/test_openai.py
@@ -647,7 +647,7 @@ async def test_openai_streaming_with_break(memory_logger):
     assert len(spans) == 1
     span = spans[0]
     metrics = span["metrics"]
-    assert metrics["time_to_first_token"] > 0
+    assert metrics["time_to_first_token"] >= 0
 
 
 @pytest.mark.asyncio
@@ -681,7 +681,7 @@ async def test_openai_chat_error_in_async_context(memory_logger):
     span = spans[0]
     # The error field might not be present in newer versions
     # Just check that we got a span with time metrics
-    assert span["metrics"]["time_to_first_token"] > 0
+    assert span["metrics"]["time_to_first_token"] >= 0
 
 
 @pytest.mark.asyncio

--- a/py/src/braintrust/wrappers/test_openai.py
+++ b/py/src/braintrust/wrappers/test_openai.py
@@ -20,6 +20,16 @@ TEST_PROMPT = "What's 12 + 12?"
 TEST_SYSTEM_PROMPT = "You are a helpful assistant that only responds with numbers."
 
 
+@pytest.fixture(scope="module")
+def vcr_config():
+    return {
+        "filter_headers": [
+            "authorization",
+            "openai-organization",
+        ]
+    }
+
+
 @pytest.fixture
 def memory_logger():
     init_test_logger(PROJECT_NAME)
@@ -27,6 +37,7 @@ def memory_logger():
         yield bgl
 
 
+@pytest.mark.vcr
 def test_openai_chat_metrics(memory_logger):
     assert not memory_logger.pop()
 
@@ -62,6 +73,7 @@ def test_openai_chat_metrics(memory_logger):
         assert TEST_PROMPT in str(span["input"])
 
 
+@pytest.mark.vcr
 def test_openai_responses_metrics(memory_logger):
     assert not memory_logger.pop()
 
@@ -114,6 +126,7 @@ def test_openai_responses_metrics(memory_logger):
     assert TEST_PROMPT in str(span["input"])
 
 
+@pytest.mark.vcr
 def test_openai_embeddings(memory_logger):
     assert not memory_logger.pop()
 
@@ -145,6 +158,7 @@ def test_openai_embeddings(memory_logger):
     assert "This is a test" in str(span["input"])
 
 
+@pytest.mark.vcr
 def test_openai_chat_streaming_sync(memory_logger):
     assert not memory_logger.pop()
 
@@ -196,6 +210,7 @@ def test_openai_chat_streaming_sync(memory_logger):
         assert "24" in str(span["output"]) or "twenty-four" in str(span["output"]).lower()
 
 
+@pytest.mark.vcr
 def test_openai_chat_with_system_prompt(memory_logger):
     assert not memory_logger.pop()
 
@@ -227,6 +242,7 @@ def test_openai_chat_with_system_prompt(memory_logger):
         assert inputs[1]["content"] == TEST_PROMPT
 
 
+@pytest.mark.vcr
 def test_openai_client_comparison(memory_logger):
     """Test that wrapped and unwrapped clients produce the same output."""
     assert not memory_logger.pop()
@@ -252,6 +268,7 @@ def test_openai_client_comparison(memory_logger):
         assert len(spans) == 1
 
 
+@pytest.mark.vcr
 def test_openai_client_error(memory_logger):
     assert not memory_logger.pop()
 
@@ -277,6 +294,7 @@ def test_openai_client_error(memory_logger):
     assert fake_model in str(log)
 
 
+@pytest.mark.vcr
 @pytest.mark.asyncio
 async def test_openai_chat_async(memory_logger):
     assert not memory_logger.pop()
@@ -326,6 +344,7 @@ async def test_openai_chat_async(memory_logger):
 
 
 @pytest.mark.asyncio
+@pytest.mark.vcr
 async def test_openai_responses_async(memory_logger):
     assert not memory_logger.pop()
 
@@ -371,6 +390,7 @@ async def test_openai_responses_async(memory_logger):
 
 
 @pytest.mark.asyncio
+@pytest.mark.vcr
 async def test_openai_embeddings_async(memory_logger):
     assert not memory_logger.pop()
 
@@ -402,6 +422,7 @@ async def test_openai_embeddings_async(memory_logger):
 
 
 @pytest.mark.asyncio
+@pytest.mark.vcr
 async def test_openai_chat_streaming_async(memory_logger):
     assert not memory_logger.pop()
 
@@ -454,6 +475,7 @@ async def test_openai_chat_streaming_async(memory_logger):
 
 
 @pytest.mark.asyncio
+@pytest.mark.vcr
 async def test_openai_chat_async_with_system_prompt(memory_logger):
     assert not memory_logger.pop()
 
@@ -486,6 +508,7 @@ async def test_openai_chat_async_with_system_prompt(memory_logger):
 
 
 @pytest.mark.asyncio
+@pytest.mark.vcr
 async def test_openai_client_async_comparison(memory_logger):
     """Test that wrapped and unwrapped async clients produce the same output."""
     assert not memory_logger.pop()
@@ -517,6 +540,7 @@ async def test_openai_client_async_comparison(memory_logger):
 
 
 @pytest.mark.asyncio
+@pytest.mark.vcr
 async def test_openai_client_async_error(memory_logger):
     assert not memory_logger.pop()
 
@@ -543,6 +567,7 @@ async def test_openai_client_async_error(memory_logger):
 
 
 @pytest.mark.asyncio
+@pytest.mark.vcr
 async def test_openai_chat_async_context_manager(memory_logger):
     """Test async context manager behavior for chat completions streams."""
     assert not memory_logger.pop()
@@ -594,6 +619,7 @@ async def test_openai_chat_async_context_manager(memory_logger):
 
 
 @pytest.mark.asyncio
+@pytest.mark.vcr
 async def test_openai_streaming_with_break(memory_logger):
     """Test breaking out of the streaming loop early."""
     assert not memory_logger.pop()
@@ -623,6 +649,7 @@ async def test_openai_streaming_with_break(memory_logger):
 
 
 @pytest.mark.asyncio
+@pytest.mark.vcr
 async def test_openai_chat_error_in_async_context(memory_logger):
     """Test error handling inside the async context manager."""
     assert not memory_logger.pop()
@@ -656,6 +683,7 @@ async def test_openai_chat_error_in_async_context(memory_logger):
 
 
 @pytest.mark.asyncio
+@pytest.mark.vcr
 async def test_openai_response_streaming_async(memory_logger):
     """Test the newer responses API with streaming."""
     assert not memory_logger.pop()
@@ -695,6 +723,7 @@ async def test_openai_response_streaming_async(memory_logger):
 
 
 @pytest.mark.asyncio
+@pytest.mark.vcr
 async def test_openai_async_parallel_requests(memory_logger):
     """Test multiple parallel async requests with the wrapped client."""
     assert not memory_logger.pop()
@@ -730,6 +759,7 @@ async def test_openai_async_parallel_requests(memory_logger):
         assert_metrics_are_valid(span["metrics"])
 
 
+@pytest.mark.vcr
 def test_openai_not_given_filtering(memory_logger):
     """Test that NOT_GIVEN values are filtered out of logged inputs but API call still works."""
     assert not memory_logger.pop()
@@ -775,6 +805,7 @@ def test_openai_not_given_filtering(memory_logger):
         assert k not in meta
 
 
+@pytest.mark.vcr
 def test_openai_responses_not_given_filtering(memory_logger):
     """Test that NOT_GIVEN values are filtered out of logged inputs for responses API."""
     assert not memory_logger.pop()

--- a/py/src/braintrust/wrappers/test_openai.py
+++ b/py/src/braintrust/wrappers/test_openai.py
@@ -632,6 +632,8 @@ async def test_openai_streaming_with_break(memory_logger):
         model=TEST_MODEL, messages=[{"role": "user", "content": TEST_PROMPT}], stream=True
     )
 
+    time.sleep(0.2)  # time to first token sleep
+
     # Only process the first few chunks
     counter = 0
     async for chunk in stream:

--- a/py/src/braintrust/wrappers/test_utils.py
+++ b/py/src/braintrust/wrappers/test_utils.py
@@ -4,8 +4,9 @@ def assert_metrics_are_valid(metrics, start=None, end=None):
     assert 0 < metrics["tokens"]
     assert 0 < metrics["prompt_tokens"]
     assert 0 < metrics["completion_tokens"]
-    # we use <= because windows timestamps are not very precise
+    # we use <= because windows timestamps are not very precise and
+    # we use VCR which skips HTTP requests.
     if start and end:
-        assert start <= metrics["start"] < metrics["end"] <= end
+        assert start <= metrics["start"] <= metrics["end"] <= end
     else:
-        assert metrics["start"] < metrics["end"]
+        assert metrics["start"] <= metrics["end"]


### PR DESCRIPTION
This PR adds `pytest-vcr` to save http requests to openai and anthropic on disk and re-use them in tests, which speeds things up a lot and reduces flakiness. To balance the loss of testing reality, we always call the API once per CI run, but not for every python/os/library version. We can revisit this policy at some point, but i think it's ok for now.

```
pytest src/braintrust/wrappers/test_openai.py  0.87s user 0.14s system 97% cpu 1.032 total
pytest src/braintrust/wrappers/test_openai.py --disable-vcr  1.08s user 0.22s system 5% cpu 23.921 total
```

Installing libraries into `venvs` is the main bottleneck now and `uv` is surprisingly a lot faster. 
```
nox -s test_braintrust_core -db uv  1.18s user 0.58s system 43% cpu 4.042 total
nox -s test_braintrust_core -db venv  3.37s user 1.02s system 57% cpu 7.659 total
```

Before:
```
build (3.9, windows-latest) | 9m 52s
build (3.11, ubuntu-latest) | 6m 11s |  
```

After:

```
build (3.9, windows-latest) |  4m 52s |  
build (3.11, ubuntu-latest) | 2m 55s |  
```