### PR TITLE
make the queue non-blocking by default 

### DIFF
--- a/js/Makefile
+++ b/js/Makefile
@@ -38,7 +38,7 @@ test-openai-%:
 # common things
 # -------------------------------------------------------------------------------------------------
 
-.PHONY: test-pnpm test test-latest prune installing-optional-deps docs build verify-ci
+.PHONY: test-pnpm test test-latest prune installing-optional-deps docs build verify-ci bench
 
 install-optional-deps:
 	npm_config_save=false npm_config_lockfile=false pnpm add "openai" "@anthropic-ai/sdk"
@@ -63,6 +63,9 @@ docs:
 
 build:
 	pnpm run build
+
+bench:
+	npx tsx src/queue.bench.ts
 
 
 # note: we don't use the docs in ci, but this makes sure they keep building

--- a/js/Makefile
+++ b/js/Makefile
@@ -1,4 +1,20 @@
-.PHONY: prune test-anthropic test-anthropic-@0.39.0 test-anthropic-@0.38.0 test-anthropic-latest test
+# Default target
+help:
+	@echo "Braintrust JS SDK Makefile"
+	@echo ""
+	@echo "Available commands:"
+	@echo "  make help                - Show this help message"
+	@echo "  make build              - Build the SDK"
+	@echo "  make clean              - Clean build artifacts"
+	@echo "  make install-optional-deps - Install optional dependencies"
+	@echo "  make test               - Run all tests (core + wrappers)"
+	@echo "  make test-core          - Run core tests only"
+	@echo "  make test-openai        - Run OpenAI wrapper tests"
+	@echo "  make test-anthropic     - Run Anthropic wrapper tests"
+	@echo "  make bench              - Run queue performance benchmarks"
+	@echo "  make test-latest        - Run core + latest versions of wrappers"
+
+.PHONY: help bench build clean test test-core test-openai test-anthropic test-latest install-optional-deps
 
 # -------------------------------------------------------------------------------------------------	#
 # Anthropic testing
@@ -45,15 +61,15 @@ install-optional-deps:
 
 
 # Test everything but the wrappers.
-test-pnpm:
+test-core:
 	pnpm prune
 	pnpm test
 
 # Test everything
-test: test-pnpm test-openai test-anthropic
+test: test-core test-openai test-anthropic
 
 # Test the core and the latest versions of wrappers.
-test-latest: test-pnpm test-anthropic-latest test-openai-latest
+test-latest: test-core test-anthropic-latest test-openai-latest
 
 prune:
 	pnpm prune
@@ -81,3 +97,6 @@ define pnpm_install_no_save
 	@echo "No save installing "$(1)""
 	npm_config_save=false npm_config_lockfile=false pnpm add "$(1)"
 endef
+
+clean:
+	npm run clean

--- a/js/package.json
+++ b/js/package.json
@@ -75,6 +75,7 @@
     "autoevals": "^0.0.69",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.5.3",
+    "tinybench": "^4.0.1",
     "ts-jest": "^29.1.4",
     "tsup": "^8.3.5",
     "typedoc": "^0.28.5",

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -2,6 +2,7 @@
 
 import { v4 as uuidv4 } from "uuid";
 
+import { Queue } from "./queue";
 import {
   _urljoin,
   AnyDatasetRecord,
@@ -1933,7 +1934,7 @@ const BACKGROUND_LOGGER_BASE_SLEEP_TIME_S = 1.0;
 // the backend in a deterministic order.
 class HTTPBackgroundLogger implements BackgroundLogger {
   private apiConn: LazyValue<HTTPConnection>;
-  private items: LazyValue<BackgroundLogEvent>[] = [];
+  private queue: Queue<LazyValue<BackgroundLogEvent>>;
   private activeFlush: Promise<void> = Promise.resolve();
   private activeFlushResolved = true;
   private activeFlushError: unknown = undefined;
@@ -1944,7 +1945,7 @@ class HTTPBackgroundLogger implements BackgroundLogger {
   public maxRequestSize: number = 6 * 1024 * 1024;
   public defaultBatchSize: number = 100;
   public numTries: number = 3;
-  public queueDropExceedingMaxsize: number | undefined = undefined;
+  public queueDropExceedingMaxsize: number = 1000;
   public queueDropLoggingPeriod: number = 60;
   public failedPublishPayloadsDir: string | undefined = undefined;
   public allPublishPayloadsDir: string | undefined = undefined;
@@ -1988,6 +1989,8 @@ class HTTPBackgroundLogger implements BackgroundLogger {
     if (!isNaN(queueDropExceedingMaxsizeEnv)) {
       this.queueDropExceedingMaxsize = queueDropExceedingMaxsizeEnv;
     }
+    
+    this.queue = new Queue(this.queueDropExceedingMaxsize);
 
     const queueDropLoggingPeriodEnv = Number(
       iso.getEnv("BRAINTRUST_QUEUE_DROP_LOGGING_PERIOD"),
@@ -2026,17 +2029,8 @@ class HTTPBackgroundLogger implements BackgroundLogger {
       return;
     }
 
-    const [addedItems, droppedItems] = (() => {
-      if (this.queueDropExceedingMaxsize === undefined) {
-        return [items, []];
-      }
-      const numElementsToAdd = Math.min(
-        Math.max(this.queueDropExceedingMaxsize - this.items.length, 0),
-        items.length,
-      );
-      return [items.slice(0, numElementsToAdd), items.slice(numElementsToAdd)];
-    })();
-    this.items.push(...addedItems);
+    const droppedItems = this.queue.push(...items);
+    
     if (!this.syncFlush) {
       this.triggerActiveFlush();
     }
@@ -2065,15 +2059,14 @@ class HTTPBackgroundLogger implements BackgroundLogger {
 
   private async flushOnce(args?: { batchSize?: number }): Promise<void> {
     if (this._disabled) {
-      this.items = [];
+      this.queue.clear();
       return;
     }
 
     const batchSize = args?.batchSize ?? this.defaultBatchSize;
 
     // Drain the queue.
-    const wrappedItems = this.items;
-    this.items = [];
+    const wrappedItems = this.queue.drain();
 
     const [allItems, attachments] = await this.unwrapLazyValues(wrappedItems);
     if (allItems.length === 0) {
@@ -2135,7 +2128,7 @@ class HTTPBackgroundLogger implements BackgroundLogger {
     }
 
     // If more items were added while we were flushing, flush again
-    if (this.items.length > 0) {
+    if (this.queue.length() > 0) {
       await this.flushOnce(args);
     }
   }

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -1934,7 +1934,7 @@ const BACKGROUND_LOGGER_BASE_SLEEP_TIME_S = 1.0;
 // the backend in a deterministic order.
 class HTTPBackgroundLogger implements BackgroundLogger {
   private apiConn: LazyValue<HTTPConnection>;
-  private queue: Deque<LazyValue<BackgroundLogEvent>>;
+  private queue: Queue<LazyValue<BackgroundLogEvent>>;
   private activeFlush: Promise<void> = Promise.resolve();
   private activeFlushResolved = true;
   private activeFlushError: unknown = undefined;

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -2,7 +2,7 @@
 
 import { v4 as uuidv4 } from "uuid";
 
-import { Queue } from "./queue";
+import { Deque } from "./queue";
 import {
   _urljoin,
   AnyDatasetRecord,
@@ -1934,7 +1934,7 @@ const BACKGROUND_LOGGER_BASE_SLEEP_TIME_S = 1.0;
 // the backend in a deterministic order.
 class HTTPBackgroundLogger implements BackgroundLogger {
   private apiConn: LazyValue<HTTPConnection>;
-  private queue: Queue<LazyValue<BackgroundLogEvent>>;
+  private queue: Deque<LazyValue<BackgroundLogEvent>>;
   private activeFlush: Promise<void> = Promise.resolve();
   private activeFlushResolved = true;
   private activeFlushError: unknown = undefined;
@@ -1990,7 +1990,7 @@ class HTTPBackgroundLogger implements BackgroundLogger {
       this.queueDropExceedingMaxsize = queueDropExceedingMaxsizeEnv;
     }
 
-    this.queue = new Queue(this.queueDropExceedingMaxsize);
+    this.queue = new Deque(this.queueDropExceedingMaxsize);
 
     const queueDropLoggingPeriodEnv = Number(
       iso.getEnv("BRAINTRUST_QUEUE_DROP_LOGGING_PERIOD"),

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -2,7 +2,7 @@
 
 import { v4 as uuidv4 } from "uuid";
 
-import { Deque } from "./queue";
+import { Queue } from "./queue";
 import {
   _urljoin,
   AnyDatasetRecord,
@@ -1990,7 +1990,7 @@ class HTTPBackgroundLogger implements BackgroundLogger {
       this.queueDropExceedingMaxsize = queueDropExceedingMaxsizeEnv;
     }
 
-    this.queue = new Deque(this.queueDropExceedingMaxsize);
+    this.queue = new Queue(this.queueDropExceedingMaxsize);
 
     const queueDropLoggingPeriodEnv = Number(
       iso.getEnv("BRAINTRUST_QUEUE_DROP_LOGGING_PERIOD"),

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -1945,7 +1945,7 @@ class HTTPBackgroundLogger implements BackgroundLogger {
   public maxRequestSize: number = 6 * 1024 * 1024;
   public defaultBatchSize: number = 100;
   public numTries: number = 3;
-  public queueDropExceedingMaxsize: number = 1000;
+  public queueDropExceedingMaxsize: number = 5000;
   public queueDropLoggingPeriod: number = 60;
   public failedPublishPayloadsDir: string | undefined = undefined;
   public allPublishPayloadsDir: string | undefined = undefined;

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -1989,7 +1989,7 @@ class HTTPBackgroundLogger implements BackgroundLogger {
     if (!isNaN(queueDropExceedingMaxsizeEnv)) {
       this.queueDropExceedingMaxsize = queueDropExceedingMaxsizeEnv;
     }
-    
+
     this.queue = new Queue(this.queueDropExceedingMaxsize);
 
     const queueDropLoggingPeriodEnv = Number(
@@ -2030,7 +2030,7 @@ class HTTPBackgroundLogger implements BackgroundLogger {
     }
 
     const droppedItems = this.queue.push(...items);
-    
+
     if (!this.syncFlush) {
       this.triggerActiveFlush();
     }

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -2,7 +2,7 @@
 
 import { v4 as uuidv4 } from "uuid";
 
-import { Queue } from "./queue";
+import { Queue, DEFAULT_QUEUE_SIZE } from "./queue";
 import {
   _urljoin,
   AnyDatasetRecord,
@@ -1945,7 +1945,7 @@ class HTTPBackgroundLogger implements BackgroundLogger {
   public maxRequestSize: number = 6 * 1024 * 1024;
   public defaultBatchSize: number = 100;
   public numTries: number = 3;
-  public queueDropExceedingMaxsize: number = 5000;
+  public queueDropExceedingMaxsize: number = DEFAULT_QUEUE_SIZE;
   public queueDropLoggingPeriod: number = 60;
   public failedPublishPayloadsDir: string | undefined = undefined;
   public allPublishPayloadsDir: string | undefined = undefined;

--- a/js/src/queue.bench.ts
+++ b/js/src/queue.bench.ts
@@ -1,0 +1,40 @@
+import { Bench } from "tinybench";
+import { Queue } from "./queue";
+
+const bench = new Bench({ name: "Queue Performance", time: 1000 });
+
+const testData = Array.from({ length: 1000 }, (_, i) => i);
+const smallData = Array.from({ length: 10 }, (_, i) => i);
+
+bench
+  .add("fill no overflow", () => {
+    const q = new Queue<number>(2000);
+    q.push(...testData);
+    q.drain();
+  })
+  .add("fill with overflow", () => {
+    const q = new Queue<number>(100);
+    q.push(...testData);
+    q.drain();
+  })
+  .add("single items", () => {
+    const q = new Queue<number>(500);
+    for (let i = 0; i < 1000; i++) {
+      q.push(i);
+    }
+    q.drain();
+  })
+  .add("small batches", () => {
+    const q = new Queue<number>(50);
+    for (let i = 0; i < 100; i++) {
+      q.push(...smallData);
+      if (i % 10 === 0) q.drain();
+    }
+    q.drain();
+  });
+
+(async () => {
+  await bench.run();
+  console.log(bench.name);
+  console.table(bench.table());
+})();

--- a/js/src/queue.bench.ts
+++ b/js/src/queue.bench.ts
@@ -5,6 +5,13 @@ const bench = new Bench({ name: "Queue Performance", time: 1000 });
 
 const testData = Array.from({ length: 1000 }, (_, i) => i);
 const smallData = Array.from({ length: 10 }, (_, i) => i);
+const partialData = Array.from({ length: 100 }, (_, i) => i);
+
+// Initialize queues once
+const fullQueue = new Queue<number>(1000);
+const wrappedQueue = new Queue<number>(1000);
+const smallQueue = new Queue<number>(50);
+const partialQueue = new Queue<number>(1000);
 
 bench
   .add("fill no overflow", () => {
@@ -31,6 +38,22 @@ bench
       if (i % 10 === 0) q.drain();
     }
     q.drain();
+  })
+  // New benchmarks comparing drain vs drain2 with pre-initialized queues
+  .add("drain - full queue", () => {
+    fullQueue.push(...testData);
+    fullQueue.drain();
+  })
+  .add("drain - wrapped", () => {
+    wrappedQueue.push(...testData);
+    wrappedQueue.drain();
+    wrappedQueue.push(...testData.slice(0, 500));
+    wrappedQueue.drain();
+  })
+  // New benchmarks for partially filled queue
+  .add("drain - partial queue", () => {
+    partialQueue.push(...partialData);
+    partialQueue.drain();
   });
 
 (async () => {

--- a/js/src/queue.test.ts
+++ b/js/src/queue.test.ts
@@ -1,0 +1,82 @@
+import { expect, test } from "vitest";
+import { Queue } from "./queue";
+
+test("Queue basic operations - push, drain, length", () => {
+  const queue = new Queue<number>(0);
+  
+  expect(queue.length()).toBe(0);
+  
+  queue.push(1, 2, 3);
+  expect(queue.length()).toBe(3);
+  
+  const drained = queue.drain();
+  expect(drained).toEqual([1, 2, 3]);
+  expect(queue.length()).toBe(0);
+});
+
+test("Queue clear operation", () => {
+  const queue = new Queue<string>(0);
+  
+  queue.push("a", "b", "c");
+  expect(queue.length()).toBe(3);
+  
+  queue.clear();
+  expect(queue.length()).toBe(0);
+  
+  const drained = queue.drain();
+  expect(drained).toEqual([]);
+});
+
+test("Queue with maxSize less than 1 should accept unlimited items", () => {
+  const q1 = new Queue<number>(0);
+  
+  for (let i = 0; i < 10; i++) {
+    const dropped = q1.push(i);
+    expect(dropped).toEqual([]);
+  }
+  expect(q1.length()).toBe(10);
+});
+
+test("Queue with maxSize should drop excess items from the front", () => {
+  const q = new Queue<number>(2);
+ 
+  const d0 = q.push(1);
+  expect(d0).toEqual([]);
+  expect(q.length()).toBe(1);
+
+  const d1 = q.push(2);
+  expect(d1).toEqual([]);
+  expect(q.length()).toBe(2);
+
+  const d2 = q.push(3, 4, 5);
+  expect(d2).toEqual([1, 2, 3]);
+  expect(q.length()).toBe(2);
+
+  const d3 = q.push(6, 7, 8);
+  expect(d3).toEqual([4, 5, 6]);
+  expect(q.length()).toBe(2);
+
+  const d4 = q.drain()
+  expect(d4).toEqual([7, 8])
+  expect(q.length()).toBe(0);
+
+  const d5 = q.push(1);
+  expect(d5).toEqual([]);
+  expect(q.length()).toBe(1);
+});
+
+test("Queue should maintain order with mixed operations", () => {
+  const queue = new Queue<number>(4);
+  
+  queue.push(1, 2);
+  queue.push(3);
+  
+  let drained = queue.drain();
+  expect(drained).toEqual([1, 2, 3]);
+  
+  queue.push(4, 5, 6, 7);
+  expect(queue.length()).toBe(4);
+  
+  drained = queue.drain();
+  expect(drained).toEqual([4, 5, 6, 7]);
+});

--- a/js/src/queue.test.ts
+++ b/js/src/queue.test.ts
@@ -1,406 +1,56 @@
 import { expect, test } from "vitest";
 import { Queue } from "./queue";
 
-test("Queue basic operations - push, drain, length", () => {
-  const queue = new Queue<number>(0);
-
-  expect(queue.length()).toBe(0);
-
-  queue.push(1, 2, 3);
-  expect(queue.length()).toBe(3);
-
-  const drained = queue.drain();
-  expect(drained).toEqual([1, 2, 3]);
-  expect(queue.length()).toBe(0);
-});
-
-test("Queue clear operation", () => {
-  const queue = new Queue<string>(0);
-
-  queue.push("a", "b", "c");
-  expect(queue.length()).toBe(3);
-
-  queue.clear();
-  expect(queue.length()).toBe(0);
-
-  const drained = queue.drain();
-  expect(drained).toEqual([]);
-});
-
-test("Queue with maxSize less than 1 should accept unlimited items", () => {
-  const q1 = new Queue<number>(0);
-
-  for (let i = 0; i < 10; i++) {
-    const dropped = q1.push(i);
-    expect(dropped).toEqual([]);
-  }
-  expect(q1.length()).toBe(10);
-});
-
-test("Queue with maxSize should drop excess items from the front", () => {
-  const q = new Queue<number>(2);
-
-  const d0 = q.push(1);
-  expect(d0).toEqual([]);
-  expect(q.length()).toBe(1);
-
-  const d1 = q.push(2);
-  expect(d1).toEqual([]);
-  expect(q.length()).toBe(2);
-
-  const d2 = q.push(3, 4, 5);
-  expect(d2).toEqual([1, 2, 3]);
-  expect(q.length()).toBe(2);
-
-  const d3 = q.push(6, 7, 8);
-  expect(d3).toEqual([4, 5, 6]);
-  expect(q.length()).toBe(2);
-
-  const d4 = q.drain();
-  expect(d4).toEqual([7, 8]);
-  expect(q.length()).toBe(0);
-
-  const d5 = q.push(1);
-  expect(d5).toEqual([]);
-  expect(q.length()).toBe(1);
-});
-
-test("Queue should maintain order with mixed operations", () => {
-  const queue = new Queue<number>(4);
-
-  queue.push(1, 2);
-  queue.push(3);
-
-  let drained = queue.drain();
-  expect(drained).toEqual([1, 2, 3]);
-
-  queue.push(4, 5, 6, 7);
-  expect(queue.length()).toBe(4);
-
-  drained = queue.drain();
-  expect(drained).toEqual([4, 5, 6, 7]);
-});
-
-test("Queue basic operations - push and drain", () => {
-  const queue = new Queue<number>(5);
-
-  expect(queue.length()).toBe(0);
-
-  const dropped1 = queue.push(1, 2, 3);
-  expect(dropped1).toEqual([]);
-
-  expect(queue.length()).toBe(3);
-
-  const drained = queue.drain();
-  expect(drained).toEqual([1, 2, 3]);
-
-  expect(queue.length()).toBe(0);
-
-  const emptyDrain = queue.drain();
-  expect(emptyDrain).toEqual([]);
-});
-
-test("Queue with maxSize should overwrite oldest items", () => {
+test("Queue basic operations", () => {
   const queue = new Queue<number>(3);
 
+  // Empty queue
+  expect(queue.length()).toBe(0);
+  expect(queue.peek()).toBe(undefined);
+  expect(queue.drain()).toEqual([]);
+
+  // Fill without overflow
   const dropped1 = queue.push(1, 2, 3);
   expect(dropped1).toEqual([]);
   expect(queue.length()).toBe(3);
+  expect(queue.peek()).toBe(1);
 
+  // Overflow behavior - drops oldest
   const dropped2 = queue.push(4);
   expect(dropped2).toEqual([1]);
   expect(queue.length()).toBe(3);
+  expect(queue.peek()).toBe(2);
 
+  // Drain maintains FIFO order
   const drained = queue.drain();
   expect(drained).toEqual([2, 3, 4]);
-});
-
-test("Queue edge case - capacity 1", () => {
-  const queue = new Queue<number>(1);
-
-  const dropped1 = queue.push(1);
-  expect(dropped1).toEqual([]);
-  expect(queue.length()).toBe(1);
-
-  const dropped2 = queue.push(2);
-  expect(dropped2).toEqual([1]);
-  expect(queue.length()).toBe(1);
-
-  const drained = queue.drain();
-  expect(drained).toEqual([2]);
-
-  expect(queue.length()).toBe(0);
-  const emptyDrain = queue.drain();
-  expect(emptyDrain).toEqual([]);
-});
-
-test("Queue circular buffer wrapping", () => {
-  const queue = new Queue<number>(3);
-
-  // Fill completely
-  queue.push(1, 2, 3);
-  expect(queue.length()).toBe(3);
-
-  // Test overflow behavior - should drop oldest items
-  const dropped = queue.push(4, 5);
-  expect(dropped).toEqual([1, 2]);
-  expect(queue.length()).toBe(3);
-
-  // Verify remaining items in correct order
-  const drained = queue.drain();
-  expect(drained).toEqual([3, 4, 5]);
-});
-
-test("Queue peek method returns next item without removing it", () => {
-  const queue = new Queue<number>(3);
-
-  expect(queue.peek()).toBe(undefined);
-
-  queue.push(1, 2);
-
-  expect(queue.peek()).toBe(1);
-  expect(queue.length()).toBe(2);
-
-  // Note: We removed popLeft method, so this test now uses drain to verify peek
-  const firstItem = queue.peek();
-  expect(firstItem).toBe(1);
-
-  const drained = queue.drain();
-  expect(drained).toEqual([1, 2]);
-  expect(queue.peek()).toBe(undefined);
-});
-
-test("Queue clears items from memory", () => {
-  const queue = new Queue<{ value: number }>(2);
-
-  const obj1 = { value: 1 };
-  const obj2 = { value: 2 };
-  const obj3 = { value: 3 };
-
-  queue.push(obj1, obj2);
-
-  // Fill to capacity to trigger overwrite
-  queue.push(obj3);
-
-  // Verify buffer handles overwrites correctly
-  expect(queue.length()).toBe(2);
-  expect(queue.peek()).toBe(obj2);
-});
-
-test("Queue drain returns all items and clears queue", () => {
-  const queue = new Queue<number>(5);
-
-  expect(queue.drain()).toEqual([]);
-
-  queue.push(1, 2, 3);
-
-  const drained = queue.drain();
-  expect(drained).toEqual([1, 2, 3]);
   expect(queue.length()).toBe(0);
   expect(queue.peek()).toBe(undefined);
-
-  // Verify we can use it again after drain
-  queue.push(4);
-  expect(queue.peek()).toBe(4);
 });
 
-test("Queue clear method empties queue", () => {
-  const queue = new Queue<number>(5);
+test("Queue edge cases", () => {
+  // Capacity 1
+  const q1 = new Queue<number>(1);
+  q1.push(1);
+  const dropped = q1.push(2);
+  expect(dropped).toEqual([1]);
+  expect(q1.drain()).toEqual([2]);
 
+  // Negative maxSize defaults to 5000
+  const q2 = new Queue<number>(-1);
+  const items = Array.from({ length: 100 }, (_, i) => i);
+  const droppedItems = q2.push(...items);
+  expect(droppedItems).toEqual([]);
+  expect(q2.length()).toBe(100);
+});
+
+test("Queue clear operation", () => {
+  const queue = new Queue<number>(5);
   queue.push(1, 2, 3);
   expect(queue.length()).toBe(3);
 
   queue.clear();
   expect(queue.length()).toBe(0);
   expect(queue.peek()).toBe(undefined);
-});
-
-test("Queue handles maxSize < 1 by using 5000", () => {
-  const queue = new Queue<number>(-1);
-
-  // Should be able to add many items without dropping any
-  const items = Array.from({ length: 100 }, (_, i) => i);
-  const dropped = queue.push(...items);
-
-  expect(dropped).toEqual([]);
-  expect(queue.length()).toBe(100);
-});
-
-test("Performance: Queue comparison", () => {
-  function runTest<
-    T extends {
-      push(...items: number[]): number[];
-      drain(): number[];
-      length(): number;
-      clear(): void;
-    },
-  >(queueType: new (maxSize: number) => T, name: string, size: number) {
-    const q = new queueType(size);
-    const start = performance.now();
-
-    // Phase 1: Fill without overflowing (10 times)
-    for (let run = 0; run < 10; run++) {
-      for (let i = 0; i < size; i++) {
-        q.push(i);
-      }
-      q.drain();
-    }
-
-    // Phase 2: Fill with overflow (10 times)
-    for (let run = 0; run < 10; run++) {
-      for (let i = 0; i < size * 2; i++) {
-        q.push(i);
-      }
-      q.drain();
-    }
-
-    // Phase 3: Multiple drain/fill cycles (10 times)
-    for (let run = 0; run < 10; run++) {
-      for (let cycle = 0; cycle < 10; cycle++) {
-        for (let i = 0; i < size; i++) {
-          q.push(i);
-        }
-        q.drain();
-      }
-    }
-
-    const elapsed = performance.now() - start;
-    console.log(`${name} (size ${size}): ${elapsed.toFixed(2)}ms`);
-    return elapsed;
-  }
-
-  function runFillNoOverflow<
-    T extends {
-      push(...items: number[]): number[];
-      drain(): number[];
-      length(): number;
-      clear(): void;
-    },
-  >(
-    queueType: new (maxSize: number) => T,
-    size: number,
-    iterations: number = 10,
-  ) {
-    const q = new queueType(size);
-    const start = performance.now();
-
-    for (let run = 0; run < iterations; run++) {
-      for (let i = 0; i < size; i++) {
-        q.push(i);
-      }
-      q.drain();
-    }
-
-    return performance.now() - start;
-  }
-
-  function runFillWithOverflow<
-    T extends {
-      push(...items: number[]): number[];
-      drain(): number[];
-      length(): number;
-      clear(): void;
-    },
-  >(
-    queueType: new (maxSize: number) => T,
-    size: number,
-    iterations: number = 10,
-  ) {
-    const q = new queueType(size);
-    const start = performance.now();
-
-    for (let run = 0; run < iterations; run++) {
-      for (let i = 0; i < size * 2; i++) {
-        q.push(i);
-      }
-      q.drain();
-    }
-
-    return performance.now() - start;
-  }
-
-  function runSmallFillDrain<
-    T extends {
-      push(...items: number[]): number[];
-      drain(): number[];
-      length(): number;
-      clear(): void;
-    },
-  >(
-    queueType: new (maxSize: number) => T,
-    size: number,
-    iterations: number = 100,
-  ) {
-    const q = new queueType(size);
-    const start = performance.now();
-
-    const itemsToAdd = Math.floor(size / 10); // 1/10th full
-    for (let run = 0; run < iterations; run++) {
-      for (let i = 0; i < itemsToAdd; i++) {
-        q.push(i);
-      }
-      q.drain();
-    }
-
-    return performance.now() - start;
-  }
-
-  function runCycleOperations<
-    T extends {
-      push(...items: number[]): number[];
-      drain(): number[];
-      length(): number;
-      clear(): void;
-    },
-  >(
-    queueType: new (maxSize: number) => T,
-    size: number,
-    iterations: number = 10,
-  ) {
-    const q = new queueType(size);
-    const start = performance.now();
-
-    for (let run = 0; run < iterations; run++) {
-      for (let cycle = 0; cycle < 10; cycle++) {
-        for (let i = 0; i < size; i++) {
-          q.push(i);
-        }
-        q.drain();
-      }
-    }
-
-    return performance.now() - start;
-  }
-
-  console.log("\nPerformance Test Results:");
-  console.log("=========================");
-
-  for (const size of [1000, 5000]) {
-    // Test 1: Fill without overflow
-    const queueFillNoOverflow = runFillNoOverflow(Queue, size);
-    console.log(
-      `Queue (size ${size}) - Fill (no overflow): ${queueFillNoOverflow.toFixed(2)}ms`,
-    );
-
-    // Test 2: Fill with overflow
-    const queueFillOverflow = runFillWithOverflow(Queue, size);
-    console.log(
-      `Queue (size ${size}) - Fill (with overflow): ${queueFillOverflow.toFixed(2)}ms`,
-    );
-
-    // Test 3: Small fill/drain cycles
-    const queueSmall = runSmallFillDrain(Queue, size);
-    console.log(
-      `Queue (size ${size}) - Small fill/drain: ${queueSmall.toFixed(2)}ms`,
-    );
-
-    // Test 4: Cycle operations
-    const queueCycle = runCycleOperations(Queue, size);
-    console.log(
-      `Queue (size ${size}) - Cycle operations: ${queueCycle.toFixed(2)}ms`,
-    );
-
-    // Verify tests completed
-    expect(queueFillNoOverflow).toBeGreaterThan(0);
-  }
+  expect(queue.drain()).toEqual([]);
 });

--- a/js/src/queue.test.ts
+++ b/js/src/queue.test.ts
@@ -3,12 +3,12 @@ import { Queue } from "./queue";
 
 test("Queue basic operations - push, drain, length", () => {
   const queue = new Queue<number>(0);
-  
+
   expect(queue.length()).toBe(0);
-  
+
   queue.push(1, 2, 3);
   expect(queue.length()).toBe(3);
-  
+
   const drained = queue.drain();
   expect(drained).toEqual([1, 2, 3]);
   expect(queue.length()).toBe(0);
@@ -16,20 +16,20 @@ test("Queue basic operations - push, drain, length", () => {
 
 test("Queue clear operation", () => {
   const queue = new Queue<string>(0);
-  
+
   queue.push("a", "b", "c");
   expect(queue.length()).toBe(3);
-  
+
   queue.clear();
   expect(queue.length()).toBe(0);
-  
+
   const drained = queue.drain();
   expect(drained).toEqual([]);
 });
 
 test("Queue with maxSize less than 1 should accept unlimited items", () => {
   const q1 = new Queue<number>(0);
-  
+
   for (let i = 0; i < 10; i++) {
     const dropped = q1.push(i);
     expect(dropped).toEqual([]);
@@ -39,7 +39,7 @@ test("Queue with maxSize less than 1 should accept unlimited items", () => {
 
 test("Queue with maxSize should drop excess items from the front", () => {
   const q = new Queue<number>(2);
- 
+
   const d0 = q.push(1);
   expect(d0).toEqual([]);
   expect(q.length()).toBe(1);
@@ -56,8 +56,8 @@ test("Queue with maxSize should drop excess items from the front", () => {
   expect(d3).toEqual([4, 5, 6]);
   expect(q.length()).toBe(2);
 
-  const d4 = q.drain()
-  expect(d4).toEqual([7, 8])
+  const d4 = q.drain();
+  expect(d4).toEqual([7, 8]);
   expect(q.length()).toBe(0);
 
   const d5 = q.push(1);
@@ -67,16 +67,16 @@ test("Queue with maxSize should drop excess items from the front", () => {
 
 test("Queue should maintain order with mixed operations", () => {
   const queue = new Queue<number>(4);
-  
+
   queue.push(1, 2);
   queue.push(3);
-  
+
   let drained = queue.drain();
   expect(drained).toEqual([1, 2, 3]);
-  
+
   queue.push(4, 5, 6, 7);
   expect(queue.length()).toBe(4);
-  
+
   drained = queue.drain();
   expect(drained).toEqual([4, 5, 6, 7]);
 });

--- a/js/src/queue.test.ts
+++ b/js/src/queue.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { Queue } from "./queue";
+import { Queue, Deque } from "./queue";
 
 test("Queue basic operations - push, drain, length", () => {
   const queue = new Queue<number>(0);
@@ -79,4 +79,355 @@ test("Queue should maintain order with mixed operations", () => {
 
   drained = queue.drain();
   expect(drained).toEqual([4, 5, 6, 7]);
+});
+
+test("Deque basic operations - push and drain", () => {
+  const deque = new Deque<number>(5);
+
+  expect(deque.length()).toBe(0);
+
+  const dropped1 = deque.push(1, 2, 3);
+  expect(dropped1).toEqual([]);
+
+  expect(deque.length()).toBe(3);
+
+  const drained = deque.drain();
+  expect(drained).toEqual([1, 2, 3]);
+
+  expect(deque.length()).toBe(0);
+
+  const emptyDrain = deque.drain();
+  expect(emptyDrain).toEqual([]);
+});
+
+test("Deque with maxSize should overwrite oldest items", () => {
+  const deque = new Deque<number>(3);
+
+  const dropped1 = deque.push(1, 2, 3);
+  expect(dropped1).toEqual([]);
+  expect(deque.length()).toBe(3);
+
+  const dropped2 = deque.push(4);
+  expect(dropped2).toEqual([1]);
+  expect(deque.length()).toBe(3);
+
+  const drained = deque.drain();
+  expect(drained).toEqual([2, 3, 4]);
+});
+
+test("Deque edge case - capacity 1", () => {
+  const deque = new Deque<number>(1);
+
+  const dropped1 = deque.push(1);
+  expect(dropped1).toEqual([]);
+  expect(deque.length()).toBe(1);
+
+  const dropped2 = deque.push(2);
+  expect(dropped2).toEqual([1]);
+  expect(deque.length()).toBe(1);
+
+  const drained = deque.drain();
+  expect(drained).toEqual([2]);
+
+  expect(deque.length()).toBe(0);
+  const emptyDrain = deque.drain();
+  expect(emptyDrain).toEqual([]);
+});
+
+test("Deque circular buffer wrapping", () => {
+  const deque = new Deque<number>(3);
+
+  // Fill completely
+  deque.push(1, 2, 3);
+  expect(deque.length()).toBe(3);
+
+  // Test overflow behavior - should drop oldest items
+  const dropped = deque.push(4, 5);
+  expect(dropped).toEqual([1, 2]);
+  expect(deque.length()).toBe(3);
+
+  // Verify remaining items in correct order
+  const drained = deque.drain();
+  expect(drained).toEqual([3, 4, 5]);
+});
+
+test("Deque peek method returns next item without removing it", () => {
+  const deque = new Deque<number>(3);
+
+  expect(deque.peek()).toBe(undefined);
+
+  deque.push(1, 2);
+
+  expect(deque.peek()).toBe(1);
+  expect(deque.length()).toBe(2);
+
+  expect(deque.popLeft()).toBe(1);
+  expect(deque.peek()).toBe(2);
+
+  expect(deque.popLeft()).toBe(2);
+  expect(deque.peek()).toBe(undefined);
+});
+
+test("Deque clears popped items from memory", () => {
+  const deque = new Deque<{ value: number }>(2);
+
+  const obj1 = { value: 1 };
+  const obj2 = { value: 2 };
+  const obj3 = { value: 3 };
+
+  deque.push(obj1, obj2);
+
+  // Pop item and verify it's cleared from internal buffer
+  const popped = deque.popLeft();
+  expect(popped).toBe(obj1);
+
+  // Verify buffer slot is cleared (peek at internal state via any casting for test)
+  const buffer = (deque as any).buffer;
+  const head = (deque as any).head;
+  expect(buffer[(head - 1 + buffer.length) % buffer.length]).toBe(undefined);
+
+  // Fill to capacity to trigger overwrite
+  deque.push(obj3);
+
+  // The slot where obj2 was should still contain obj2 since it hasn't been popped
+  expect(deque.peek()).toBe(obj2);
+});
+
+test("Deque drain returns all items and clears deque", () => {
+  const deque = new Deque<number>(5);
+
+  expect(deque.drain()).toEqual([]);
+
+  deque.push(1, 2, 3);
+
+  const drained = deque.drain();
+  expect(drained).toEqual([1, 2, 3]);
+  expect(deque.length()).toBe(0);
+  expect(deque.peek()).toBe(undefined);
+
+  // Verify we can use it again after drain
+  deque.push(4);
+  expect(deque.peek()).toBe(4);
+});
+
+test("Deque clear method empties deque", () => {
+  const deque = new Deque<number>(5);
+
+  deque.push(1, 2, 3);
+  expect(deque.length()).toBe(3);
+
+  deque.clear();
+  expect(deque.length()).toBe(0);
+  expect(deque.peek()).toBe(undefined);
+  expect(deque.popLeft()).toBe(undefined);
+});
+
+test("Deque handles maxSize < 1 by using 5000", () => {
+  const deque = new Deque<number>(-1);
+
+  // Should be able to add many items without dropping any
+  const items = Array.from({ length: 100 }, (_, i) => i);
+  const dropped = deque.push(...items);
+
+  expect(dropped).toEqual([]);
+  expect(deque.length()).toBe(100);
+});
+
+test("Performance: Queue vs Deque comparison", () => {
+  function runTest<
+    T extends {
+      push(...items: number[]): number[];
+      drain(): number[];
+      length(): number;
+      clear(): void;
+    },
+  >(queueType: new (maxSize: number) => T, name: string, size: number) {
+    const q = new queueType(size);
+    const start = performance.now();
+
+    // Phase 1: Fill without overflowing (10 times)
+    for (let run = 0; run < 10; run++) {
+      for (let i = 0; i < size; i++) {
+        q.push(i);
+      }
+      q.drain();
+    }
+
+    // Phase 2: Fill with overflow (10 times)
+    for (let run = 0; run < 10; run++) {
+      for (let i = 0; i < size * 2; i++) {
+        q.push(i);
+      }
+      q.drain();
+    }
+
+    // Phase 3: Multiple drain/fill cycles (10 times)
+    for (let run = 0; run < 10; run++) {
+      for (let cycle = 0; cycle < 10; cycle++) {
+        for (let i = 0; i < size; i++) {
+          q.push(i);
+        }
+        q.drain();
+      }
+    }
+
+    const elapsed = performance.now() - start;
+    console.log(`${name} (size ${size}): ${elapsed.toFixed(2)}ms`);
+    return elapsed;
+  }
+
+  function runFillNoOverflow<
+    T extends {
+      push(...items: number[]): number[];
+      drain(): number[];
+      length(): number;
+      clear(): void;
+    },
+  >(
+    queueType: new (maxSize: number) => T,
+    size: number,
+    iterations: number = 10,
+  ) {
+    const q = new queueType(size);
+    const start = performance.now();
+
+    for (let run = 0; run < iterations; run++) {
+      for (let i = 0; i < size; i++) {
+        q.push(i);
+      }
+      q.drain();
+    }
+
+    return performance.now() - start;
+  }
+
+  function runFillWithOverflow<
+    T extends {
+      push(...items: number[]): number[];
+      drain(): number[];
+      length(): number;
+      clear(): void;
+    },
+  >(
+    queueType: new (maxSize: number) => T,
+    size: number,
+    iterations: number = 10,
+  ) {
+    const q = new queueType(size);
+    const start = performance.now();
+
+    for (let run = 0; run < iterations; run++) {
+      for (let i = 0; i < size * 2; i++) {
+        q.push(i);
+      }
+      q.drain();
+    }
+
+    return performance.now() - start;
+  }
+
+  function runSmallFillDrain<
+    T extends {
+      push(...items: number[]): number[];
+      drain(): number[];
+      length(): number;
+      clear(): void;
+    },
+  >(
+    queueType: new (maxSize: number) => T,
+    size: number,
+    iterations: number = 100,
+  ) {
+    const q = new queueType(size);
+    const start = performance.now();
+
+    const itemsToAdd = Math.floor(size / 10); // 1/10th full
+    for (let run = 0; run < iterations; run++) {
+      for (let i = 0; i < itemsToAdd; i++) {
+        q.push(i);
+      }
+      q.drain();
+    }
+
+    return performance.now() - start;
+  }
+
+  function runCycleOperations<
+    T extends {
+      push(...items: number[]): number[];
+      drain(): number[];
+      length(): number;
+      clear(): void;
+    },
+  >(
+    queueType: new (maxSize: number) => T,
+    size: number,
+    iterations: number = 10,
+  ) {
+    const q = new queueType(size);
+    const start = performance.now();
+
+    for (let run = 0; run < iterations; run++) {
+      for (let cycle = 0; cycle < 10; cycle++) {
+        for (let i = 0; i < size; i++) {
+          q.push(i);
+        }
+        q.drain();
+      }
+    }
+
+    return performance.now() - start;
+  }
+
+  console.log("\nPerformance Comparison Table:");
+  console.log("=====================================");
+  console.log(
+    "Size   | Test Type           | Queue (ms) | Deque (ms) | Speedup",
+  );
+  console.log(
+    "-------|---------------------|------------|------------|--------",
+  );
+
+  for (const size of [1000, 5000, 10000]) {
+    // Test 1: Fill without overflow
+    const queueFillNoOverflow = runFillNoOverflow(Queue, size);
+    const dequeFillNoOverflow = runFillNoOverflow(Deque, size);
+    const speedup1 = (queueFillNoOverflow / dequeFillNoOverflow).toFixed(1);
+    console.log(
+      `${size.toString().padStart(6)} | Fill (no overflow)  | ${queueFillNoOverflow.toFixed(2).padStart(10)} | ${dequeFillNoOverflow.toFixed(2).padStart(10)} | ${speedup1}x`,
+    );
+
+    // Test 2: Fill with overflow
+    const queueFillOverflow = runFillWithOverflow(Queue, size);
+    const dequeFillOverflow = runFillWithOverflow(Deque, size);
+    const speedup2 = (queueFillOverflow / dequeFillOverflow).toFixed(1);
+    console.log(
+      `${size.toString().padStart(6)} | Fill (with overflow)| ${queueFillOverflow.toFixed(2).padStart(10)} | ${dequeFillOverflow.toFixed(2).padStart(10)} | ${speedup2}x`,
+    );
+
+    // Test 3: Small fill/drain cycles
+    const queueSmall = runSmallFillDrain(Queue, size);
+    const dequeSmall = runSmallFillDrain(Deque, size);
+    const speedup3 = (queueSmall / dequeSmall).toFixed(1);
+    console.log(
+      `${size.toString().padStart(6)} | Small fill/drain    | ${queueSmall.toFixed(2).padStart(10)} | ${dequeSmall.toFixed(2).padStart(10)} | ${speedup3}x`,
+    );
+
+    // Test 4: Cycle operations
+    const queueCycle = runCycleOperations(Queue, size);
+    const dequeCycle = runCycleOperations(Deque, size);
+    const speedup4 = (queueCycle / dequeCycle).toFixed(1);
+    console.log(
+      `${size.toString().padStart(6)} | Cycle operations    | ${queueCycle.toFixed(2).padStart(10)} | ${dequeCycle.toFixed(2).padStart(10)} | ${speedup4}x`,
+    );
+
+    if (size < 10000)
+      console.log(
+        "-------|---------------------|------------|------------|--------",
+      );
+
+    // Verify tests completed
+    expect(queueFillNoOverflow).toBeGreaterThan(0);
+    expect(dequeFillNoOverflow).toBeGreaterThan(0);
+  }
 });

--- a/js/src/queue.ts
+++ b/js/src/queue.ts
@@ -1,3 +1,5 @@
+const DEFAULT_QUEUE_SIZE = 5000;
+
 // A simple queue that drops oldest items when full. It uses a circular
 // buffer to store items so that dropping oldest things in the queue
 // is O(1) time.
@@ -11,9 +13,9 @@ export class Queue<T> {
   constructor(maxSize: number) {
     if (maxSize < 1) {
       console.warn(
-        `Queue maxSize ${maxSize} is invalid, using default size 5000`,
+        `maxSize ${maxSize} is <1, using default ${DEFAULT_QUEUE_SIZE}`,
       );
-      maxSize = 5000;
+      maxSize = DEFAULT_QUEUE_SIZE;
     }
     this.capacity = maxSize;
     this.buffer = new Array(this.capacity);

--- a/js/src/queue.ts
+++ b/js/src/queue.ts
@@ -1,9 +1,12 @@
-export class Deque<T> {
+// A simple queue that drops oldest items when full. It uses a circular
+// buffer to store items so that dropping oldest things in the queue
+// is O(1) time.
+export class Queue<T> {
   private buffer: Array<T | undefined>;
-  private head: number = 0;
-  private tail: number = 0;
-  private size: number = 0;
-  private capacity: number;
+  private head: number = 0; // the index of the first item in the queue
+  private tail: number = 0; // the index of the next item to be added
+  private size: number = 0; // the number of items in the queue
+  private capacity: number; // the maximum number of items the queue can hold
 
   constructor(maxSize: number) {
     this.capacity = maxSize < 1 ? 5000 : maxSize;
@@ -40,6 +43,9 @@ export class Deque<T> {
 
   drain(): T[] {
     const items: T[] = [];
+
+    // FIXME: if it's full maybe just return this.buffer and create a new
+    // one.
 
     let current = this.head;
     while (current !== this.tail) {

--- a/js/src/queue.ts
+++ b/js/src/queue.ts
@@ -2,7 +2,7 @@
 // buffer to store items so that dropping oldest things in the queue
 // is O(1) time.
 export class Queue<T> {
-  private buffer: Array<T | undefined>;
+  private buffer: Array<T>;
   private head: number = 0; // the index of the first item in the queue
   private tail: number = 0; // the index of the next item to be added
   private size: number = 0; // the number of items in the queue
@@ -10,7 +10,7 @@ export class Queue<T> {
 
   constructor(maxSize: number) {
     this.capacity = maxSize < 1 ? 5000 : maxSize;
-    this.buffer = new Array(this.capacity);
+    this.clear();
   }
 
   push(...items: T[]): T[] {
@@ -44,22 +44,23 @@ export class Queue<T> {
   drain(): T[] {
     const items: T[] = [];
 
-    // FIXME: if it's full maybe just return this.buffer and create a new
-    // one.
+    if (this.size === 0) {
+      return items;
+    }
 
     let current = this.head;
-    while (current !== this.tail) {
+    while (this.size > 0) {
       const item = this.buffer[current];
       if (item !== undefined) {
         items.push(item);
       }
       this.buffer[current] = undefined;
       current = (current + 1) % this.capacity;
+      this.size--;
     }
 
     this.head = 0;
     this.tail = 0;
-    this.size = 0;
 
     return items;
   }

--- a/js/src/queue.ts
+++ b/js/src/queue.ts
@@ -48,6 +48,9 @@ export class Queue<T> {
       return items;
     }
 
+    // FIXME[matt] we could short circuit if the buffer is full
+    // and just return buffer and create a new one.
+
     let current = this.head;
     while (this.size > 0) {
       const item = this.buffer[current];

--- a/js/src/queue.ts
+++ b/js/src/queue.ts
@@ -2,7 +2,7 @@
 // buffer to store items so that dropping oldest things in the queue
 // is O(1) time.
 export class Queue<T> {
-  private buffer: Array<T>;
+  private buffer: Array<T | undefined>;
   private head: number = 0; // the index of the first item in the queue
   private tail: number = 0; // the index of the next item to be added
   private size: number = 0; // the number of items in the queue
@@ -10,7 +10,7 @@ export class Queue<T> {
 
   constructor(maxSize: number) {
     this.capacity = maxSize < 1 ? 5000 : maxSize;
-    this.clear();
+    this.buffer = new Array(this.capacity);
   }
 
   push(...items: T[]): T[] {

--- a/js/src/queue.ts
+++ b/js/src/queue.ts
@@ -2,7 +2,7 @@
 // buffer to store items so that dropping oldest things in the queue
 // is O(1) time.
 export class Queue<T> {
-  private buffer: Array<T | undefined>;
+  private buffer: Array<T>;
   private head: number = 0; // the index of the first item in the queue
   private tail: number = 0; // the index of the next item to be added
   private size: number = 0; // the number of items in the queue
@@ -49,33 +49,28 @@ export class Queue<T> {
 
   drain(): T[] {
     const items: T[] = [];
-
     if (this.size === 0) {
       return items;
     }
 
-    // FIXME[matt] we could short circuit if the buffer is full
-    // and just return buffer and create a new one.
-
-    let current = this.head;
-    while (this.size > 0) {
-      const item = this.buffer[current];
-      if (item !== undefined) {
-        items.push(item);
-      }
-      this.buffer[current] = undefined;
-      current = (current + 1) % this.capacity;
-      this.size--;
+    if (this.head < this.tail) {
+      items.push(...this.buffer.slice(this.head, this.tail));
+      this.buffer.fill(undefined as T, this.head, this.tail);
+    } else {
+      items.push(...this.buffer.slice(this.head));
+      items.push(...this.buffer.slice(0, this.tail));
+      this.buffer.fill(undefined as T, this.head, this.capacity);
+      this.buffer.fill(undefined as T, 0, this.tail);
     }
 
     this.head = 0;
     this.tail = 0;
-
+    this.size = 0;
     return items;
   }
 
   clear(): void {
-    this.buffer = new Array(this.capacity);
+    this.buffer.fill(undefined as T);
     this.head = 0;
     this.tail = 0;
     this.size = 0;

--- a/js/src/queue.ts
+++ b/js/src/queue.ts
@@ -1,0 +1,41 @@
+export class Queue<T> {
+  private items: T[] = [];
+  private maxSize: number;
+
+  constructor(maxSize: number) {
+    this.maxSize = maxSize;
+  }
+
+  push(...items: T[]): T[] {
+    if (this.maxSize < 1) {
+      this.items.push(...items);
+      return [];
+    }
+
+    // Add all new items to the queue
+    this.items.push(...items);
+    
+    // If we exceed maxSize, drop oldest items
+    if (this.items.length > this.maxSize) {
+      const numToDrop = this.items.length - this.maxSize;
+      const dropped = this.items.splice(0, numToDrop);
+      return dropped;
+    }
+    
+    return [];
+  }
+
+  drain(): T[] {
+    const items = this.items;
+    this.items = [];
+    return items;
+  }
+
+  length(): number {
+    return this.items.length;
+  }
+
+  clear(): void {
+    this.items = [];
+  }
+}

--- a/js/src/queue.ts
+++ b/js/src/queue.ts
@@ -9,7 +9,13 @@ export class Queue<T> {
   private capacity: number; // the maximum number of items the queue can hold
 
   constructor(maxSize: number) {
-    this.capacity = maxSize < 1 ? 5000 : maxSize;
+    if (maxSize < 1) {
+      console.warn(
+        `Queue maxSize ${maxSize} is invalid, using default size 5000`,
+      );
+      maxSize = 5000;
+    }
+    this.capacity = maxSize;
     this.buffer = new Array(this.capacity);
   }
 

--- a/js/src/queue.ts
+++ b/js/src/queue.ts
@@ -14,14 +14,14 @@ export class Queue<T> {
 
     // Add all new items to the queue
     this.items.push(...items);
-    
+
     // If we exceed maxSize, drop oldest items
     if (this.items.length > this.maxSize) {
       const numToDrop = this.items.length - this.maxSize;
       const dropped = this.items.splice(0, numToDrop);
       return dropped;
     }
-    
+
     return [];
   }
 

--- a/js/src/queue.ts
+++ b/js/src/queue.ts
@@ -1,4 +1,4 @@
-const DEFAULT_QUEUE_SIZE = 5000;
+export const DEFAULT_QUEUE_SIZE = 5000;
 
 // A simple queue that drops oldest items when full. It uses a circular
 // buffer to store items so that dropping oldest things in the queue

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,9 @@ importers:
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
+      tinybench:
+        specifier: ^4.0.1
+        version: 4.0.1
       ts-jest:
         specifier: ^29.1.4
         version: 29.1.4(@babel/core@7.24.7)(esbuild@0.25.5)(jest@29.7.0)(typescript@5.4.4)
@@ -6938,6 +6941,11 @@ packages:
 
   /tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+    dev: true
+
+  /tinybench@4.0.1:
+    resolution: {integrity: sha512-Nb1srn7dvzkVx0J5h1vq8f48e3TIcbrS7e/UfAI/cDSef/n8yLh4zsAEsFkfpw6auTY+ZaspEvam/xs8nMnotQ==}
+    engines: {node: '>=18.0.0'}
     dev: true
 
   /tinyexec@0.3.2:

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -71,6 +71,7 @@ from .prompt import BRAINTRUST_PARAMS, ImagePart, PromptBlockData, PromptMessage
 from .prompt_cache.disk_cache import DiskCache
 from .prompt_cache.lru_cache import LRUCache
 from .prompt_cache.prompt_cache import PromptCache
+from .queue import LogQueue
 from .serializable_data_class import SerializableDataClass
 from .span_identifier_v3 import SpanComponentsV3, SpanObjectTypeV3
 from .span_types import SpanTypeAttribute
@@ -712,10 +713,9 @@ class _HTTPBackgroundLogger:
         self.started = False
 
         self.logger = logging.getLogger("braintrust")
-        self.queue: "queue.Queue[LazyValue[Dict[str, Any]]]" = queue.Queue(maxsize=self.queue_maxsize)
-        # Each time we put items in the queue, we increment a semaphore to
-        # indicate to any consumer thread that it should attempt a flush.
-        self.queue_filled_semaphore = threading.Semaphore(value=0)
+        self.queue: "LogQueue[LazyValue[Dict[str, Any]]]" = LogQueue(
+            maxsize=self.queue_maxsize, drop_when_full=self.queue_drop_when_full
+        )
 
         atexit.register(self._finalize)
 
@@ -723,16 +723,8 @@ class _HTTPBackgroundLogger:
         self._start()
         dropped_items = []
         for event in args:
-            try:
-                self.queue.put_nowait(event)
-            except queue.Full:
-                # Notify consumers to start draining the queue.
-                self.queue_filled_semaphore.release()
-                if self.queue_drop_when_full:
-                    dropped_items.append(event)
-                else:
-                    self.queue.put(event)
-        self.queue_filled_semaphore.release()
+            dropped = self.queue.put(event)
+            dropped_items.extend(dropped)
 
         if dropped_items:
             self._register_dropped_item_count(len(dropped_items))
@@ -757,7 +749,7 @@ class _HTTPBackgroundLogger:
     def _publisher(self):
         while True:
             # Wait for some data on the queue before trying to flush.
-            self.queue_filled_semaphore.acquire()
+            self.queue.wait_for_items()
 
             while self.sync_flush:
                 time.sleep(0.1)
@@ -775,12 +767,7 @@ class _HTTPBackgroundLogger:
         # order of published elements would be undefined.
         with self.flush_lock:
             # Drain the queue.
-            wrapped_items = []
-            try:
-                for _ in range(self.queue.qsize()):
-                    wrapped_items.append(self.queue.get_nowait())
-            except queue.Empty:
-                pass
+            wrapped_items = self.queue.drain_all()
 
             all_items, attachments = self._unwrap_lazy_values(wrapped_items)
             if len(all_items) == 0:

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -8,7 +8,6 @@ import inspect
 import json
 import logging
 import os
-import queue
 import sys
 import textwrap
 import threading
@@ -71,7 +70,7 @@ from .prompt import BRAINTRUST_PARAMS, ImagePart, PromptBlockData, PromptMessage
 from .prompt_cache.disk_cache import DiskCache
 from .prompt_cache.lru_cache import LRUCache
 from .prompt_cache.prompt_cache import PromptCache
-from .queue import LogQueue
+from .queue import DEFAULT_QUEUE_SIZE, LogQueue
 from .serializable_data_class import SerializableDataClass
 from .span_identifier_v3 import SpanComponentsV3, SpanObjectTypeV3
 from .span_types import SpanTypeAttribute
@@ -679,7 +678,7 @@ class _HTTPBackgroundLogger:
         try:
             self.queue_maxsize = int(os.environ["BRAINTRUST_QUEUE_SIZE"])
         except:
-            self.queue_maxsize = 5000
+            self.queue_maxsize = DEFAULT_QUEUE_SIZE
 
         try:
             self.queue_drop_logging_period = float(os.environ["BRAINTRUST_QUEUE_DROP_LOGGING_PERIOD"])

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -681,10 +681,6 @@ class _HTTPBackgroundLogger:
         except:
             self.queue_maxsize = 1000
 
-        try:
-            self.queue_drop_when_full = bool(int(os.environ["BRAINTRUST_QUEUE_DROP_WHEN_FULL"]))
-        except:
-            self.queue_drop_when_full = False
 
         try:
             self.queue_drop_logging_period = float(os.environ["BRAINTRUST_QUEUE_DROP_LOGGING_PERIOD"])
@@ -703,10 +699,6 @@ class _HTTPBackgroundLogger:
         except:
             self.all_publish_payloads_dir = None
 
-        # Don't limit the queue size if we're in 'sync_flush' mode and are not
-        # dropping when full, otherwise logging could block indefinitely.
-        if self.sync_flush and not self.queue_drop_when_full:
-            self.queue_maxsize = 0
 
         self.start_thread_lock = threading.RLock()
         self.thread = threading.Thread(target=self._publisher, daemon=True)
@@ -714,7 +706,7 @@ class _HTTPBackgroundLogger:
 
         self.logger = logging.getLogger("braintrust")
         self.queue: "LogQueue[LazyValue[Dict[str, Any]]]" = LogQueue(
-            maxsize=self.queue_maxsize, drop_when_full=self.queue_drop_when_full
+            maxsize=self.queue_maxsize
         )
 
         atexit.register(self._finalize)

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -681,7 +681,6 @@ class _HTTPBackgroundLogger:
         except:
             self.queue_maxsize = 1000
 
-
         try:
             self.queue_drop_logging_period = float(os.environ["BRAINTRUST_QUEUE_DROP_LOGGING_PERIOD"])
         except:
@@ -699,15 +698,12 @@ class _HTTPBackgroundLogger:
         except:
             self.all_publish_payloads_dir = None
 
-
         self.start_thread_lock = threading.RLock()
         self.thread = threading.Thread(target=self._publisher, daemon=True)
         self.started = False
 
         self.logger = logging.getLogger("braintrust")
-        self.queue: "LogQueue[LazyValue[Dict[str, Any]]]" = LogQueue(
-            maxsize=self.queue_maxsize
-        )
+        self.queue: "LogQueue[LazyValue[Dict[str, Any]]]" = LogQueue(maxsize=self.queue_maxsize)
 
         atexit.register(self._finalize)
 

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -679,7 +679,7 @@ class _HTTPBackgroundLogger:
         try:
             self.queue_maxsize = int(os.environ["BRAINTRUST_QUEUE_SIZE"])
         except:
-            self.queue_maxsize = 1000
+            self.queue_maxsize = 5000
 
         try:
             self.queue_drop_logging_period = float(os.environ["BRAINTRUST_QUEUE_DROP_LOGGING_PERIOD"])

--- a/py/src/braintrust/queue.py
+++ b/py/src/braintrust/queue.py
@@ -2,6 +2,8 @@ import threading
 from collections import deque
 from typing import Any, List, Optional, TypeVar
 
+from .util import eprint
+
 T = TypeVar("T")
 
 
@@ -13,10 +15,14 @@ class LogQueue:
         Initialize the LogQueue.
 
         Args:
-            maxsize: Maximum size of the queue. 0 or less than 1 means unlimited.
+            maxsize: Maximum size of the queue. If 0 or negative, defaults to 5000.
         """
+        if maxsize < 1:
+            eprint(f"Queue maxsize {maxsize} is invalid, using default size 5000")
+            maxsize = 5000
+
         self.maxsize = maxsize
-        self._maxlen = None if maxsize < 1 else maxsize
+        self._maxlen = maxsize
         self._mutex = threading.Lock()
         self._queue: deque[T] = deque(maxlen=self._maxlen)
         self._semaphore = threading.Semaphore(value=0)
@@ -36,7 +42,7 @@ class LogQueue:
             dropped = []
 
             # If queue is at max capacity, popleft before appending
-            if self._maxlen is not None and len(self._queue) == self._maxlen:
+            if len(self._queue) == self._maxlen:
                 dropped_item = self._queue.popleft()
                 dropped.append(dropped_item)
                 self._total_dropped += 1

--- a/py/src/braintrust/queue.py
+++ b/py/src/braintrust/queue.py
@@ -6,7 +6,7 @@ T = TypeVar("T")
 
 
 class LogQueue:
-    """A queue that drops oldest items when full."""
+    """A thread-safe queue that drops oldest items when full."""
 
     def __init__(self, maxsize: int = 0):
         """
@@ -75,7 +75,8 @@ class LogQueue:
 
     def wait_for_items(self, timeout: Optional[float] = None) -> bool:
         """
-        Wait for items to be available in the queue.
+        Will block until the queue has at least one item in it. Might be empty by the time
+        you read though.
 
         Args:
             timeout: Maximum time to wait in seconds. None means wait forever.

--- a/py/src/braintrust/queue.py
+++ b/py/src/braintrust/queue.py
@@ -34,13 +34,13 @@ class LogQueue:
         """
         with self._mutex:
             dropped = []
-            
+
             # If queue is at max capacity, popleft before appending
             if self._maxlen is not None and len(self._queue) == self._maxlen:
                 dropped_item = self._queue.popleft()
                 dropped.append(dropped_item)
                 self._total_dropped += 1
-            
+
             self._queue.append(item)
 
         # Signal that items are available
@@ -58,7 +58,7 @@ class LogQueue:
         with self._mutex:
             if len(self._queue) == 0:
                 return []
-    
+
             old_queue = self._queue
             self._queue = deque(maxlen=self._maxlen)
 

--- a/py/src/braintrust/queue.py
+++ b/py/src/braintrust/queue.py
@@ -1,10 +1,12 @@
 import threading
 from collections import deque
-from typing import Any, List, Optional, TypeVar
+from typing import List, Optional, TypeVar
 
 from .util import eprint
 
 T = TypeVar("T")
+
+DEFAULT_QUEUE_SIZE = 5000
 
 
 class LogQueue:
@@ -18,8 +20,8 @@ class LogQueue:
             maxsize: Maximum size of the queue. If 0 or negative, defaults to 5000.
         """
         if maxsize < 1:
-            eprint(f"Queue maxsize {maxsize} is invalid, using default size 5000")
-            maxsize = 5000
+            eprint(f"Queue maxsize {maxsize} is invalid, using default size {DEFAULT_QUEUESIZE}")
+            maxsize = DEFAULT_QUEUESIZE
 
         self.maxsize = maxsize
         self._maxlen = maxsize

--- a/py/src/braintrust/queue.py
+++ b/py/src/braintrust/queue.py
@@ -17,7 +17,7 @@ class LogQueue:
         Initialize the LogQueue.
 
         Args:
-            maxsize: Maximum size of the queue. If 0 or negative, defaults to 5000.
+            maxsize: Maximum size of the queue. If 0 or negative, defaults to DEFAULT_QUEUE_SIZE.
         """
         if maxsize < 1:
             eprint(f"Queue maxsize {maxsize} is invalid, using default size {DEFAULT_QUEUE_SIZE}")

--- a/py/src/braintrust/queue.py
+++ b/py/src/braintrust/queue.py
@@ -20,8 +20,8 @@ class LogQueue:
             maxsize: Maximum size of the queue. If 0 or negative, defaults to 5000.
         """
         if maxsize < 1:
-            eprint(f"Queue maxsize {maxsize} is invalid, using default size {DEFAULT_QUEUESIZE}")
-            maxsize = DEFAULT_QUEUESIZE
+            eprint(f"Queue maxsize {maxsize} is invalid, using default size {DEFAULT_QUEUE_SIZE}")
+            maxsize = DEFAULT_QUEUE_SIZE
 
         self.maxsize = maxsize
         self._maxlen = maxsize

--- a/py/src/braintrust/queue.py
+++ b/py/src/braintrust/queue.py
@@ -6,7 +6,7 @@ from .util import eprint
 
 T = TypeVar("T")
 
-DEFAULT_QUEUE_SIZE = 5000
+DEFAULT_QUEUE_SIZE = 25000
 
 
 class LogQueue:

--- a/py/src/braintrust/queue.py
+++ b/py/src/braintrust/queue.py
@@ -1,0 +1,94 @@
+import queue
+import threading
+from typing import Any, List, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+class LogQueue:
+    """A queue that can drop oldest items when full, with semaphore signaling."""
+
+    def __init__(self, maxsize: int = 0, drop_when_full: bool = False):
+        """
+        Initialize the LogQueue.
+
+        Args:
+            maxsize: Maximum size of the queue. 0 means unlimited.
+            drop_when_full: If True, drop oldest items when queue is full.
+                           If False, block on put when queue is full.
+        """
+        self.maxsize = maxsize
+        self.drop_when_full = drop_when_full
+        self._queue: "queue.Queue[T]" = queue.Queue(maxsize=maxsize)
+        self._semaphore = threading.Semaphore(value=0)
+        self._total_dropped = 0
+
+    def put(self, item: T) -> List[T]:
+        """
+        Put an item in the queue.
+
+        Args:
+            item: The item to add to the queue.
+
+        Returns:
+            List of items that were dropped (empty if no items were dropped).
+        """
+        dropped = []
+        if not self.drop_when_full:
+            self._queue.put(item)
+            self._semaphore.release()
+            return dropped
+
+        try:
+            self._queue.put_nowait(item)
+        except queue.Full:
+            # Drop the oldest item and add the new one
+            try:
+                dropped_item = self._queue.get_nowait()
+                dropped.append(dropped_item)
+                self._total_dropped += 1
+                self._queue.put_nowait(item)
+            except queue.Empty:
+                # Queue became empty somehow, just add the item
+                self._queue.put_nowait(item)
+
+        # Signal that items are available
+        self._semaphore.release()
+        return dropped
+
+    def drain_all(self) -> List[T]:
+        """
+        Drain all items from the queue.
+
+        Returns:
+            List of all items that were in the queue.
+        """
+        items = []
+        try:
+            while True:
+                items.append(self._queue.get_nowait())
+        except queue.Empty:
+            pass
+
+        return items
+
+    def size(self) -> int:
+        """
+        Get the current size of the queue.
+
+        Returns:
+            Number of items currently in the queue.
+        """
+        return self._queue.qsize()
+
+    def wait_for_items(self, timeout: Optional[float] = None) -> bool:
+        """
+        Wait for items to be available in the queue.
+
+        Args:
+            timeout: Maximum time to wait in seconds. None means wait forever.
+
+        Returns:
+            True if items became available, False if timeout occurred.
+        """
+        return self._semaphore.acquire(timeout=timeout)

--- a/py/src/braintrust/queue.py
+++ b/py/src/braintrust/queue.py
@@ -1,25 +1,24 @@
-import queue
 import threading
+from collections import deque
 from typing import Any, List, Optional, TypeVar
 
 T = TypeVar("T")
 
 
 class LogQueue:
-    """A queue that can drop oldest items when full, with semaphore signaling."""
+    """A queue that drops oldest items when full."""
 
-    def __init__(self, maxsize: int = 0, drop_when_full: bool = False):
+    def __init__(self, maxsize: int = 0):
         """
         Initialize the LogQueue.
 
         Args:
-            maxsize: Maximum size of the queue. 0 means unlimited.
-            drop_when_full: If True, drop oldest items when queue is full.
-                           If False, block on put when queue is full.
+            maxsize: Maximum size of the queue. 0 or less than 1 means unlimited.
         """
         self.maxsize = maxsize
-        self.drop_when_full = drop_when_full
-        self._queue: "queue.Queue[T]" = queue.Queue(maxsize=maxsize)
+        self._maxlen = None if maxsize < 1 else maxsize
+        self._mutex = threading.Lock()
+        self._queue: deque[T] = deque(maxlen=self._maxlen)
         self._semaphore = threading.Semaphore(value=0)
         self._total_dropped = 0
 
@@ -33,24 +32,16 @@ class LogQueue:
         Returns:
             List of items that were dropped (empty if no items were dropped).
         """
-        dropped = []
-        if not self.drop_when_full:
-            self._queue.put(item)
-            self._semaphore.release()
-            return dropped
-
-        try:
-            self._queue.put_nowait(item)
-        except queue.Full:
-            # Drop the oldest item and add the new one
-            try:
-                dropped_item = self._queue.get_nowait()
+        with self._mutex:
+            dropped = []
+            
+            # If queue is at max capacity, popleft before appending
+            if self._maxlen is not None and len(self._queue) == self._maxlen:
+                dropped_item = self._queue.popleft()
                 dropped.append(dropped_item)
                 self._total_dropped += 1
-                self._queue.put_nowait(item)
-            except queue.Empty:
-                # Queue became empty somehow, just add the item
-                self._queue.put_nowait(item)
+            
+            self._queue.append(item)
 
         # Signal that items are available
         self._semaphore.release()
@@ -63,14 +54,15 @@ class LogQueue:
         Returns:
             List of all items that were in the queue.
         """
-        items = []
-        try:
-            while True:
-                items.append(self._queue.get_nowait())
-        except queue.Empty:
-            pass
+        old_queue = None
+        with self._mutex:
+            if len(self._queue) == 0:
+                return []
+    
+            old_queue = self._queue
+            self._queue = deque(maxlen=self._maxlen)
 
-        return items
+        return list(old_queue) if old_queue else []
 
     def size(self) -> int:
         """
@@ -79,7 +71,7 @@ class LogQueue:
         Returns:
             Number of items currently in the queue.
         """
-        return self._queue.qsize()
+        return len(self._queue)
 
     def wait_for_items(self, timeout: Optional[float] = None) -> bool:
         """

--- a/py/src/braintrust/test_queue.py
+++ b/py/src/braintrust/test_queue.py
@@ -103,15 +103,16 @@ def test_log_queue_semaphore_signaling():
     queue.drain_all()
 
 
-def test_log_queue_unlimited_size():
-    """Test queue with unlimited capacity (maxsize=0 or negative)"""
-    # Test maxsize=0 (unlimited)
+def test_log_queue_default_size():
+    """Test queue with invalid maxsize defaults to 5000"""
+    # Test maxsize=0 defaults to 5000
     queue = LogQueue(maxsize=0)
+    assert queue.maxsize == 5000
 
-    # Should be able to add many items without drops
+    # Should be able to add many items without drops (up to 5000)
     for i in range(100):
         dropped = queue.put(f"item{i}")
-        assert dropped == []  # No drops in unlimited queue
+        assert dropped == []  # No drops when under capacity
 
     # All items should be there
     items = queue.drain_all()
@@ -119,10 +120,11 @@ def test_log_queue_unlimited_size():
     assert items[0] == "item0"
     assert items[99] == "item99"
 
-    # Test negative maxsize should also be unlimited
+    # Test negative maxsize also defaults to 5000
     queue_neg = LogQueue(maxsize=-5)
+    assert queue_neg.maxsize == 5000
 
-    # Should be able to add items without drops
+    # Should be able to add items without drops (when under capacity)
     for i in range(10):
         dropped = queue_neg.put(f"item{i}")
         assert dropped == []

--- a/py/src/braintrust/test_queue.py
+++ b/py/src/braintrust/test_queue.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from braintrust.queue import LogQueue
+from braintrust.queue import DEFAULT_QUEUE_SIZE, LogQueue
 
 
 def test_log_queue_basic_operations():
@@ -109,10 +109,8 @@ def test_log_queue_wait_for_items_semaphore_reset():
 
 
 def test_log_queue_default_size():
-    """Test queue with invalid maxsize defaults to 5000"""
-    # Test maxsize=0 defaults to 5000
     queue = LogQueue(maxsize=0)
-    assert queue.maxsize == 5000
+    assert queue.maxsize == DEFAULT_QUEUE_SIZE
 
     # Should be able to add many items without drops (up to 5000)
     for i in range(100):
@@ -125,9 +123,9 @@ def test_log_queue_default_size():
     assert items[0] == "item0"
     assert items[99] == "item99"
 
-    # Test negative maxsize also defaults to 5000
+    # Test negative maxsize also defaults
     queue_neg = LogQueue(maxsize=-5)
-    assert queue_neg.maxsize == 5000
+    assert queue_neg.maxsize == DEFAULT_QUEUE_SIZE
 
     # Should be able to add items without drops (when under capacity)
     for i in range(10):

--- a/py/src/braintrust/test_queue.py
+++ b/py/src/braintrust/test_queue.py
@@ -88,8 +88,6 @@ def test_log_queue_drop_behavior():
     assert items == ["item3", "item4"]
 
 
-
-
 def test_log_queue_semaphore_signaling():
     """Test that semaphore is properly signaled when items are added"""
     queue = LogQueue(maxsize=5)
@@ -103,10 +101,6 @@ def test_log_queue_semaphore_signaling():
 
     # After draining, should signal again if there were items
     queue.drain_all()
-
-
-
-
 
 
 def test_log_queue_unlimited_size():
@@ -134,11 +128,9 @@ def test_log_queue_unlimited_size():
         assert dropped == []
 
     assert queue_neg.size() == 10
-    
+
     items = queue_neg.drain_all()
     assert len(items) == 10
-
-
 
 
 @pytest.mark.asyncio
@@ -158,7 +150,7 @@ async def test_queue_never_blocks_event_loop():
 
     # Start queue operation and flag setter concurrently
     flag_task = asyncio.create_task(set_flag())
-    
+
     # This should not block since we drop when full
     dropped = queue.put("item2")
     assert dropped == ["item1"]
@@ -216,13 +208,13 @@ def test_log_queue_thread_safety():
     """Test that queue operations are thread-safe under concurrent access"""
     import threading
     import time
-    
+
     queue = LogQueue(maxsize=5)
     total_added = 0
     total_dropped = 0
     total_drained = 0
     errors = []
-    
+
     def producer(thread_id):
         nonlocal total_added, total_dropped
         try:
@@ -234,7 +226,7 @@ def test_log_queue_thread_safety():
                 time.sleep(0.001)  # Small delay to encourage interleaving
         except Exception as e:
             errors.append(f"Producer {thread_id}: {e}")
-    
+
     def consumer():
         nonlocal total_drained
         try:
@@ -245,34 +237,34 @@ def test_log_queue_thread_safety():
                     total_drained += len(items)
         except Exception as e:
             errors.append(f"Consumer: {e}")
-    
+
     # Start multiple producer threads and one consumer
     threads = []
     for i in range(3):
         t = threading.Thread(target=producer, args=(i,))
         threads.append(t)
         t.start()
-    
+
     consumer_thread = threading.Thread(target=consumer)
     threads.append(consumer_thread)
     consumer_thread.start()
-    
+
     # Wait for all threads to complete
     for t in threads:
         t.join()
-    
+
     # Final drain to get any remaining items
     final_items = queue.drain_all()
     total_drained += len(final_items)
-    
+
     # Check for errors
     assert not errors, f"Thread safety errors: {errors}"
-    
+
     # Verify conservation of items
     assert total_added == 60  # 3 threads * 20 items each
     assert total_dropped >= 0
     assert total_drained >= 0
     assert total_drained + total_dropped == total_added
-    
+
     # Verify queue is in a consistent state
     assert queue.size() == 0  # Should be empty after final drain

--- a/py/src/braintrust/test_queue.py
+++ b/py/src/braintrust/test_queue.py
@@ -206,8 +206,6 @@ async def test_queue_concurrent_drops_and_drains():
 
 def test_log_queue_thread_safety():
     """Test that queue operations are thread-safe under concurrent access"""
-    import threading
-    import time
 
     queue = LogQueue(maxsize=5)
     total_added = 0


### PR DESCRIPTION
Change our SDK queue behaviour such that:

- by default we drop logs if our size is > X 
- the current default is 5000, which is up for discussion. 
- by default we drop oldest logs if it's full
- this means in python we drop the `BRAINTRUST_QUEUE_DROP_WHEN_FULL` env variable, since it will always do this.
- also splits the queue up so we can unit test easier
- uses deques for efficient dropping when full 
- don't allow unlimited queue sizes anymore 

The user impact is that (a) we coarsely bound our memory use ... albeit without a ton of control (b) we never block application threads when full. I think both of these are good traits and users will understand them

JS and Python have diff env variables for the queue size (`BRAINTRUST_QUEUE_SIZE`, `BRAINTRUST_QUEUE_DROP_EXCEEDING_MAXSIZE`) . We could also consolidate on one reasonably safely, because I think the most important part is whether we block or not. I haven't done this yet.

also added `tinybench` as a dev dependency to make benchmarking easier. 