### PR TITLE
Add groupBy field to monitor view options schema

### DIFF
--- a/core/js/typespecs/view.ts
+++ b/core/js/typespecs/view.ts
@@ -59,6 +59,7 @@ export const monitorViewOptionsSchema = z
     chartVisibility: z.record(z.boolean()).nullish(),
     projectId: z.string().nullish(),
     type: z.enum(["project", "experiment"]).nullish(),
+    groupBy: z.string().nullish(),
   })
   .strip();
 

--- a/core/js/typespecs/view.ts
+++ b/core/js/typespecs/view.ts
@@ -63,6 +63,8 @@ export const monitorViewOptionsSchema = z
   })
   .strip();
 
+export type MonitorViewOptions = z.infer<typeof monitorViewOptionsSchema>;
+
 export const viewOptionsSchema = z
   .union([
     // Monitor view with explicit type


### PR DESCRIPTION
- Add groupBy as optional string field to monitorViewOptionsSchema
- Enables saving and loading groupBy selections with monitor views