### PR TITLE
use uv in langchain tests

### DIFF
--- a/integrations/langchain-py/noxfile.py
+++ b/integrations/langchain-py/noxfile.py
@@ -7,6 +7,8 @@ import nox
 
 LATEST = "__latest__"
 
+nox.options.default_venv_backend = "uv"
+
 
 LANGGRAPH_VERSIONS = ("0.3.21", "0.3.22", LATEST)
 
@@ -23,4 +25,4 @@ def _install(session, package, version=LATEST):
     cmd = f"{package}=={version}"
     if version == LATEST or not version:
         cmd = package
-    session.run("pip", "install", cmd)
+    session.install(cmd)

--- a/py/Makefile
+++ b/py/Makefile
@@ -29,7 +29,6 @@ verify: lint test
 
 install-build-deps:
 	# Ensure pip is at a known version first for reproducible builds
-	python -m pip install pip==25.1.1
 	python -m pip install uv==0.7.8
 	# Use 'python -m pip' to ensure we're using python's pip
 	# https://pip.pypa.io/en/latest/user_guide/


### PR DESCRIPTION
speeds up our windows CI (which is the blocker) by about 25% .

    build (3.13, windows-latest)  before:6m 7s  -> 4m 27s  
    build (3.13, ubuntu-latest)   before:3m 1s  -> 2m 30s 
