### PR TITLE
Fixes linting issue with @traced when used without parenthis

### DIFF
--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -1623,6 +1623,16 @@ def _try_log_output(span, output):
 F = TypeVar("F", bound=Callable[..., Any])
 
 
+@overload
+def traced(f: F) -> F:
+    """Decorator to trace the wrapped function when used without parentheses."""
+
+
+@overload
+def traced(*span_args: Any, **span_kwargs: Any) -> Callable[[F], F]:
+    """Decorator to trace the wrapped function when used with arguments."""
+
+
 def traced(*span_args: Any, **span_kwargs: Any) -> Callable[[F], F]:
     """Decorator to trace the wrapped function. Can either be applied bare (`@traced`) or by providing arguments (`@traced(*span_args, **span_kwargs)`), which will be forwarded to the created span. See `Span.start_span` for full details on the span arguments.
 

--- a/py/src/braintrust/test_logger.py
+++ b/py/src/braintrust/test_logger.py
@@ -592,6 +592,76 @@ async def test_traced_async_function(with_memory_logger):
         },
     )
 
+    @logger.traced()
+    async def async_multiply(x: int, y: int) -> int:
+        """An async function that multiplies two numbers."""
+        await asyncio.sleep(0.001)  # Small delay to simulate async work
+        result = x * y
+        logger.current_span().log(metadata={"operation": "multiply"})
+        return result
+
+    start_time = time.time()
+    result = await async_multiply(3, 4)
+    end_time = time.time()
+
+    assert result == 12
+
+    logs = with_memory_logger.pop()
+    assert len(logs) == 1
+    log = logs[0]
+
+    assert_dict_matches(
+        log,
+        {
+            "input": {"x": 3, "y": 4},
+            "output": 12,
+            "metadata": {"operation": "multiply"},
+            "metrics": {
+                "start": lambda x: start_time <= x <= end_time,
+                "end": lambda x: start_time <= x <= end_time,
+            },
+            "span_attributes": {
+                "name": "async_multiply",
+                "type": "function",
+            },
+        },
+    )
+
+    @logger.traced(name="async_multiply_with_name")
+    async def async_multiply(x: int, y: int) -> int:
+        """An async function that multiplies two numbers."""
+        await asyncio.sleep(0.001)  # Small delay to simulate async work
+        result = x * y
+        logger.current_span().log(metadata={"operation": "multiply"})
+        return result
+
+    start_time = time.time()
+    result = await async_multiply(3, 4)
+    end_time = time.time()
+
+    assert result == 12
+
+    logs = with_memory_logger.pop()
+    assert len(logs) == 1
+    log = logs[0]
+
+    assert_dict_matches(
+        log,
+        {
+            "input": {"x": 3, "y": 4},
+            "output": 12,
+            "metadata": {"operation": "multiply"},
+            "metrics": {
+                "start": lambda x: start_time <= x <= end_time,
+                "end": lambda x: start_time <= x <= end_time,
+            },
+            "span_attributes": {
+                "name": "async_multiply_with_name",
+                "type": "function",
+            },
+        },
+    )
+
 
 def test_traced_sync_function(with_memory_logger):
     """Test tracing synchronous functions."""

--- a/py/src/braintrust/test_logger.py
+++ b/py/src/braintrust/test_logger.py
@@ -593,7 +593,7 @@ async def test_traced_async_function(with_memory_logger):
     )
 
     @logger.traced()
-    async def async_multiply(x: int, y: int) -> int:
+    async def async_multiply(x: int, y: int) -> int:  # pylint: disable=function-redefined
         """An async function that multiplies two numbers."""
         await asyncio.sleep(0.001)  # Small delay to simulate async work
         result = x * y
@@ -628,7 +628,7 @@ async def test_traced_async_function(with_memory_logger):
     )
 
     @logger.traced(name="async_multiply_with_name")
-    async def async_multiply(x: int, y: int) -> int:
+    async def async_multiply(x: int, y: int) -> int:  # pylint: disable=function-redefined
         """An async function that multiplies two numbers."""
         await asyncio.sleep(0.001)  # Small delay to simulate async work
         result = x * y


### PR DESCRIPTION
See this issue here: https://discord.com/channels/1146930518722609238/1389049635515011082/1389049635515011082

If using `@traced` without parenthesis you get the linting error below.  This PR fixes it.

<img width="893" alt="Screenshot 2025-06-30 at 1 09 27 PM" src="https://github.com/user-attachments/assets/e4753a86-a078-4a89-9f93-830551565bde" />
