### PR TITLE
OTel exporter

### DIFF
--- a/js/src/exports-node.ts
+++ b/js/src/exports-node.ts
@@ -27,4 +27,8 @@ export { LazyValue } from "./util";
 export * from "./wrappers/oai";
 export { wrapAISDKModel } from "./wrappers/ai-sdk";
 export { wrapAnthropic } from "./wrappers/anthropic";
-export { AISpanProcessor, BraintrustSpanProcessor } from "./otel";
+export {
+  AISpanProcessor,
+  BraintrustSpanProcessor,
+  BraintrustExporter,
+} from "./otel";

--- a/js/src/otel.ts
+++ b/js/src/otel.ts
@@ -344,3 +344,107 @@ export class BraintrustSpanProcessor {
     return this.aiSpanProcessor.forceFlush();
   }
 }
+
+/**
+ * A trace exporter that sends OpenTelemetry spans to Braintrust.
+ *
+ * This exporter wraps the standard OTLP trace exporter and can be used with
+ * any OpenTelemetry setup, including @vercel/otel's registerOTel function,
+ * NodeSDK, or custom tracer providers. It can optionally filter spans to
+ * only send AI-related telemetry.
+ *
+ * Environment Variables:
+ * - BRAINTRUST_API_KEY: Your Braintrust API key
+ * - BRAINTRUST_PARENT: Parent identifier (e.g., "project_name:test")
+ * - BRAINTRUST_API_URL: Base URL for Braintrust API (defaults to https://api.braintrust.dev)
+ *
+ * @example With @vercel/otel:
+ * ```typescript
+ * import { registerOTel } from '@vercel/otel';
+ * import { BraintrustExporter } from 'braintrust';
+ *
+ * export function register() {
+ *   registerOTel({
+ *     serviceName: 'my-app',
+ *     traceExporter: new BraintrustExporter({
+ *       filterAISpans: true,
+ *     }),
+ *   });
+ * }
+ * ```
+ *
+ * @example With NodeSDK:
+ * ```typescript
+ * import { NodeSDK } from '@opentelemetry/sdk-node';
+ * import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+ * import { BraintrustExporter } from 'braintrust';
+ *
+ * const sdk = new NodeSDK({
+ *   spanProcessors: [
+ *     new BatchSpanProcessor(new BraintrustExporter({
+ *       apiKey: 'your-api-key',
+ *       parent: 'project_name:test'
+ *     }))
+ *   ]
+ * });
+ * ```
+ */
+export class BraintrustExporter {
+  private static checkOtelAvailable(): void {
+    if (!OTEL_AVAILABLE) {
+      throw new Error(
+        "OpenTelemetry packages are not installed. " +
+          "Install them with: npm install @opentelemetry/api @opentelemetry/sdk-trace-base @opentelemetry/exporter-trace-otlp-http @opentelemetry/resources @opentelemetry/semantic-conventions",
+      );
+    }
+  }
+
+  private readonly processor: BraintrustSpanProcessor;
+  private readonly spans: ReadableSpan[] = [];
+  private readonly callbacks: Array<(result: any) => void> = [];
+
+  constructor(options: BraintrustSpanProcessorOptions = {}) {
+    BraintrustExporter.checkOtelAvailable();
+
+    // Use BraintrustSpanProcessor under the hood
+    this.processor = new BraintrustSpanProcessor(options);
+  }
+
+  /**
+   * Export spans to Braintrust by simulating span processor behavior.
+   */
+  export(spans: ReadableSpan[], resultCallback: (result: any) => void): void {
+    try {
+      // Process each span through the processor
+      spans.forEach((span) => {
+        this.processor.onEnd(span);
+      });
+
+      // Force flush to ensure spans are sent
+      this.processor
+        .forceFlush()
+        .then(() => {
+          resultCallback({ code: 0 }); // SUCCESS
+        })
+        .catch((error) => {
+          resultCallback({ code: 1, error }); // FAILURE
+        });
+    } catch (error) {
+      resultCallback({ code: 1, error }); // FAILURE
+    }
+  }
+
+  /**
+   * Shutdown the exporter.
+   */
+  shutdown(): Promise<void> {
+    return this.processor.shutdown();
+  }
+
+  /**
+   * Force flush the exporter.
+   */
+  forceFlush(): Promise<void> {
+    return this.processor.forceFlush();
+  }
+}


### PR DESCRIPTION
Add an exporter, which is just a wrapper around the span processor. This will let us easily plug into spots that want an exporter, rather than a processor.