### PR TITLE
Add experiment context propagation to evaluation hooks

### DIFF
--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -26,6 +26,7 @@ import {
   Span,
   StartSpanArgs,
   init as _initExperiment,
+  currentExperiment,
   currentSpan,
   flush,
   logError as logSpanError,
@@ -130,6 +131,10 @@ export interface EvalHooks<
    * The task's span.
    */
   span: Span;
+  /**
+   * The experiment under which the task is run. Also accessible via currentExperiment()
+   */
+  experiment: Experiment | undefined;
   /**
    * The current parameters being used for this specific task execution.
    * Array parameters are converted to single values.
@@ -905,6 +910,7 @@ async function runEvaluatorInternal(
                 metadata,
                 expected,
                 span,
+                experiment: experiment || currentExperiment(),
                 parameters: parameters ?? {},
                 reportProgress: (event: TaskProgressEvent) => {
                   stream?.({


### PR DESCRIPTION
## Summary
- Introduces experiment context propagation in evaluation hooks for both JS and Python SDKs
- Adds `experiment` property to `EvalHooks` interface and `DictEvalHooks` class
- Passes current experiment context to task evaluation hooks to enable experiment-aware task execution

## Changes

### JavaScript SDK
- Added `currentExperiment` import and usage in `runEvaluatorInternal` to propagate experiment context
- Extended `EvalHooks` interface with optional `experiment` property

### Python SDK
- Added abstract `experiment` property to `EvalHooks` base class
- Updated `DictEvalHooks` to accept and store an optional `experiment` instance
- Modified `_run_evaluator_internal` to pass experiment context when creating `DictEvalHooks`

## Test plan
- Verified that experiment context is accessible within evaluation hooks during task execution
- Ensured no regressions in existing evaluation flow
- Confirmed compatibility with current experiment tracking mechanisms

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9a5faa59-22ed-4638-84cf-8ebce7435cba