### PR TITLE
Add maxCount to getPastNAncestors

### DIFF
--- a/js/src/gitutil.ts
+++ b/js/src/gitutil.ts
@@ -121,7 +121,7 @@ export async function getPastNAncestors(
   if (!ancestor) {
     return [];
   }
-  const commits = await git.log({ from: ancestor, to: "HEAD" });
+  const commits = await git.log({ from: ancestor, to: "HEAD", maxCount: n });
   return commits.all.map((c) => c.hash);
 }
 


### PR DESCRIPTION
From [this Discord chat](https://discord.com/channels/1146930518722609238/1397661870479114380):

We just started getting this error when doing the following with the JS SDK:

```
const experiment = initExperiment({ ... });
const experimentId = await experiment.id;
```

The second line throws `413: Request Entity Too Large (Body exceeded 1mb limit)`. We're not passing anything large to `initExperiment`. The issue appears to be `ancestor_commits` is a huge array of hashes, resulting in a 1049329 byte POST to https://www.braintrust.dev/api/experiment/register. We recently had to rewrite some commit history to remove some sensitive data committed to our repo.