### PR TITLE
Increase get_past_n_ancestors default to 1000

### DIFF
--- a/js/src/gitutil.ts
+++ b/js/src/gitutil.ts
@@ -101,7 +101,7 @@ async function getBaseBranchAncestor(remote: string | undefined = undefined) {
 }
 
 export async function getPastNAncestors(
-  n: number = 10,
+  n: number = 1000,
   remote: string | undefined = undefined,
 ) {
   const git = await currentRepo();

--- a/py/src/braintrust/gitutil.py
+++ b/py/src/braintrust/gitutil.py
@@ -78,7 +78,7 @@ def _get_base_branch_ancestor(remote=None):
         return None
 
 
-def get_past_n_ancestors(n=200, remote=None):
+def get_past_n_ancestors(n=1000, remote=None):
     with _gitlock:
         repo = _current_repo()
         if repo is None:

--- a/py/src/braintrust/gitutil.py
+++ b/py/src/braintrust/gitutil.py
@@ -78,7 +78,7 @@ def _get_base_branch_ancestor(remote=None):
         return None
 
 
-def get_past_n_ancestors(n=10, remote=None):
+def get_past_n_ancestors(n=200, remote=None):
     with _gitlock:
         repo = _current_repo()
         if repo is None:


### PR DESCRIPTION
Per chat with @ankrgyl, increasing `get_past_n_ancestors()`'s default `n` value. This helps when you don't run evals on every commit on the baseline branch (master), but only some of them, which may be more than 10 commits in the past. This is what we do, as only some commits to PostHog touch AI features. In that case currently the comparison just gets borked.

This is a major increase on the limit, by a factor of 100 – however from quick performance testing, there is zero meaningful performance difference. Git seems incredibly fast at this. The test:

```python
import timeit
execution_time = timeit.timeit('get_past_n_ancestors(n=1000)', globals=globals(), number=1000)
print(f"Average execution time over 1000 runs: {execution_time:.6f} seconds")
```

The output:

```
Average execution time over 1000 runs: 0.000079 seconds
```