### PR TITLE
fix: support OpenAI SDK v5 parse method in wrapper

### DIFF
--- a/js/src/wrappers/oai.test.ts
+++ b/js/src/wrappers/oai.test.ts
@@ -418,6 +418,55 @@ describe("openai client unit tests", TEST_SUITE_OPTIONS, () => {
     assert.isTrue(m.prompt_tokens > 0);
     assert.isTrue(start <= m.start && m.start < m.end && m.end <= end);
   });
+
+  test("openai.chat.completions.parse (v5 GA method)", async () => {
+    // Test that the parse method is properly wrapped in the GA namespace (v5)
+    if (!oai.chat?.completions?.parse) {
+      // Skip if parse method not available (older SDK version)
+      return;
+    }
+
+    assert.lengthOf(await backgroundLogger.drain(), 0);
+
+    // Use a simple schema for testing
+    const schema = {
+      type: "object",
+      properties: {
+        answer: { type: "number" },
+      },
+      required: ["answer"],
+    };
+
+    const start = getCurrentUnixTimestamp();
+    const result = await client.chat.completions.parse({
+      messages: [{ role: "user", content: "What is 2 + 2?" }],
+      model: TEST_MODEL,
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "math_response",
+          schema: schema,
+        },
+      },
+    });
+    const end = getCurrentUnixTimestamp();
+
+    assert.ok(result);
+
+    const spans = await backgroundLogger.drain();
+    assert.lengthOf(spans, 1);
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any
+    const span = spans[0] as any;
+    assert.equal(span.span_attributes.name, "Chat Completion");
+    assert.equal(span.span_attributes.type, "llm");
+    assert.equal(span.metadata.model, TEST_MODEL);
+    assert.equal(span.metadata.provider, "openai");
+    const m = span.metrics;
+    assert.isTrue(start <= m.start && m.start < m.end && m.end <= end);
+    assert.isTrue(m.tokens > 0);
+    assert.isTrue(m.prompt_tokens > 0);
+    assert.isTrue(m.time_to_first_token > 0);
+  });
 });
 
 test("parseMetricsFromUsage", () => {


### PR DESCRIPTION
## Summary
- Adds support for the OpenAI SDK v5 `parse` method in the chat completions wrapper
- Updates `wrapOpenAIv4` to proxy both `create` and `parse` methods for v4 and v5 compatibility
- Adds a new unit test to verify the `parse` method wrapping and tracing functionality

## Changes

### Core Functionality
- Modified `wrapOpenAIv4` to use a Proxy for `openai.chat.completions` that wraps both `create` and `parse` methods
- Updated documentation to reflect support for both v4 and v5 OpenAI APIs

### Testing
- Added a new test case in `oai.test.ts` to:
  - Check if the `parse` method exists on the client
  - Validate the parsing of a simple JSON schema response
  - Assert tracing spans and metrics are correctly recorded

## Test plan
- [x] Run existing and new unit tests to ensure no regressions
- [x] Verify the new `parse` method test passes when using OpenAI SDK v5
- [x] Confirm tracing spans are generated with correct attributes and metrics

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a0e78d51-d7c6-4449-83e9-b2cdf725277e