### PR TITLE
Extend JSON log validation to enforce 10MB size limit

### DIFF
--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -598,7 +598,13 @@ def construct_logs3_data(items: Sequence[str]):
 
 def _check_json_serializable(event):
     try:
-        return bt_dumps(event)
+        json_str = bt_dumps(event)
+        # Check if the JSON string exceeds 10MB (10 * 1024 * 1024 bytes)
+        size_bytes = len(json_str.encode('utf-8'))
+        size_limit = 10 * 1024 * 1024  # 10MB
+        if size_bytes > size_limit:
+            raise Exception(f"Log record size ({size_bytes} bytes) exceeds the 10MB limit")
+        return json_str
     except TypeError as e:
         raise Exception(f"All logged values must be JSON-serializable: {event}") from e
 

--- a/py/src/braintrust/test_logger.py
+++ b/py/src/braintrust/test_logger.py
@@ -699,3 +699,35 @@ def test_traced_sync_function(with_memory_logger):
             },
         },
     )
+
+
+def test_log_size_limit(with_simulate_login):
+    """Test that log records exceeding 10MB are rejected."""
+    experiment = braintrust.init(project="test_project", experiment="test_log_size")
+    
+    # Create a large string that will exceed 10MB when serialized
+    # 10MB = 10 * 1024 * 1024 = 10485760 bytes
+    # Create a string slightly larger than 10MB
+    large_data = "x" * (11 * 1024 * 1024)  # 11MB of 'x' characters
+    
+    # Test that logging large data raises an exception
+    with pytest.raises(Exception) as exc_info:
+        experiment.log(
+            input="test input",
+            output=large_data,
+            metadata={"test": "size limit"}
+        )
+    
+    assert "Log record size" in str(exc_info.value)
+    assert "exceeds the 10MB limit" in str(exc_info.value)
+    
+    # Test that data just under the limit works fine
+    small_data = "x" * (9 * 1024 * 1024)  # 9MB of 'x' characters
+    # This should not raise an exception
+    experiment.log(
+        input="test input",
+        output=small_data,
+        metadata={"test": "under size limit"}
+    )
+    
+    experiment.close()


### PR DESCRIPTION
## Summary
- Adds a size check to JSON log serialization to reject logs exceeding 10MB
- Enhances robustness by preventing excessively large log records from being processed
- Includes comprehensive tests to verify size limit enforcement and acceptance of smaller logs

## Changes

### Logger Enhancements
- Modified `_check_json_serializable` function to:
  - Serialize event to JSON string
  - Calculate byte size of JSON string
  - Raise an exception if size exceeds 10MB (10 * 1024 * 1024 bytes)

### Tests
- Added `test_log_size_limit` to:
  - Confirm that logging data larger than 10MB raises an exception
  - Verify that data just under the 10MB limit logs successfully without errors

## Test plan
- Run `test_log_size_limit` to ensure:
  - Large log entries are rejected with appropriate error message
  - Smaller log entries are accepted and logged correctly
- Existing tests remain unaffected and pass successfully

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/fdb3f518-7b16-46ae-a6ba-e675da2e032a