### PR TITLE
allow release tags to be deleted / re-applied

### DIFF
--- a/py/scripts/validate-release-tag.sh
+++ b/py/scripts/validate-release-tag.sh
@@ -15,7 +15,7 @@ fi
 ROOT_DIR=$(git rev-parse --show-toplevel)
 
 # Fetch the latest tags to ensure we're up to date
-git fetch --tags --prune
+git fetch --tags --prune --force
 
 TAG=$1
 


### PR DESCRIPTION
A release tag can be deleted and re-applied and sometimes cached on github actions. 