### PR TITLE
keep traceloop.* spans

### DIFF
--- a/js/examples/otel/custom_otel_example.ts
+++ b/js/examples/otel/custom_otel_example.ts
@@ -70,7 +70,7 @@ async function runExample() {
     "\nSpans sent to Braintrust! Check your dashboard at https://braintrust.dev",
   );
   console.log(
-    "Note: Only root spans and spans with gen_ai.*, braintrust.*, llm.*, or ai.* prefixes were sent to Braintrust",
+    "Note: Only root spans and spans with gen_ai.*, braintrust.*, llm.*, ai.*, or traceloop.* prefixes were sent to Braintrust",
   );
   await provider.shutdown();
 }

--- a/js/src/otel.test.ts
+++ b/js/src/otel.test.ts
@@ -62,12 +62,18 @@ describe("AISpanProcessor", () => {
     );
     const llmSpan = tracer.startSpan("llm.generate", {}, parentContext);
     const aiSpan = tracer.startSpan("ai.model_call", {}, parentContext);
+    const traceloopSpan = tracer.startSpan(
+      "traceloop.agent",
+      {},
+      parentContext,
+    );
     const regularSpan = tracer.startSpan("database_query", {}, parentContext);
 
     genAiSpan.end();
     braintrustSpan.end();
     llmSpan.end();
     aiSpan.end();
+    traceloopSpan.end();
     regularSpan.end();
     rootSpan.end();
 
@@ -82,6 +88,7 @@ describe("AISpanProcessor", () => {
     expect(spanNames).toContain("braintrust.eval");
     expect(spanNames).toContain("llm.generate");
     expect(spanNames).toContain("ai.model_call");
+    expect(spanNames).toContain("traceloop.agent");
     // database_query should be filtered out as it doesn't match filtered prefixes
     expect(spanNames).not.toContain("database_query");
   });
@@ -117,6 +124,13 @@ describe("AISpanProcessor", () => {
     const aiAttrSpan = tracer.startSpan("ai_attr_operation", {}, parentContext);
     aiAttrSpan.setAttributes({ "ai.temperature": 0.7 });
 
+    const traceloopAttrSpan = tracer.startSpan(
+      "traceloop_attr_operation",
+      {},
+      parentContext,
+    );
+    traceloopAttrSpan.setAttributes({ "traceloop.agent_id": "agent-123" });
+
     const regularSpan = tracer.startSpan(
       "regular_operation",
       {},
@@ -128,6 +142,7 @@ describe("AISpanProcessor", () => {
     braintrustAttrSpan.end();
     llmAttrSpan.end();
     aiAttrSpan.end();
+    traceloopAttrSpan.end();
     regularSpan.end();
     rootSpan.end();
 
@@ -142,6 +157,7 @@ describe("AISpanProcessor", () => {
     expect(spanNames).toContain("braintrust_attr_operation");
     expect(spanNames).toContain("llm_attr_operation");
     expect(spanNames).toContain("ai_attr_operation");
+    expect(spanNames).toContain("traceloop_attr_operation");
     expect(spanNames).not.toContain("regular_operation");
   });
 

--- a/js/src/otel.ts
+++ b/js/src/otel.ts
@@ -40,7 +40,13 @@ interface Span extends ReadableSpan {
   setStatus(status: { code: number; message?: string }): void;
 }
 
-const FILTER_PREFIXES = ["gen_ai.", "braintrust.", "llm.", "ai."] as const;
+const FILTER_PREFIXES = [
+  "gen_ai.",
+  "braintrust.",
+  "llm.",
+  "ai.",
+  "traceloop.",
+] as const;
 
 /**
  * Custom filter function type for span filtering.
@@ -127,7 +133,7 @@ export class AISpanProcessor {
    * Keep spans if:
    * 1. It's a root span (no parent)
    * 2. Custom filter returns true/false (if provided)
-   * 3. Span name starts with 'gen_ai.', 'braintrust.', 'llm.', or 'ai.'
+   * 3. Span name starts with 'gen_ai.', 'braintrust.', 'llm.', 'ai.', or 'traceloop.'
    * 4. Any attribute name starts with those prefixes
    */
   private shouldKeepFilteredSpan(span: ReadableSpan): boolean {

--- a/py/src/braintrust/otel.py
+++ b/py/src/braintrust/otel.py
@@ -44,7 +44,7 @@ except ImportError:
     OTEL_AVAILABLE = False
 
 
-FILTER_PREFIXES = ("gen_ai.", "braintrust.", "llm.", "ai.")
+FILTER_PREFIXES = ("gen_ai.", "braintrust.", "llm.", "ai.", "traceloop.")
 
 
 class AISpanProcessor:
@@ -96,7 +96,7 @@ class AISpanProcessor:
         Keep spans if:
         1. It's a root span (no parent)
         2. Custom filter returns True/False (if provided)
-        3. Span name starts with 'gen_ai.', 'braintrust.', 'llm.', or 'ai.'
+        3. Span name starts with 'gen_ai.', 'braintrust.', 'llm.', 'ai.', or 'traceloop.'
         4. Any attribute name starts with those prefixes
         """
         if not span:


### PR DESCRIPTION
there are some `traceloop.*` spans we want to keep for context in our AI Span Processor. 