### PR TITLE
Bump versions braintrust (py) v0.2.3 and openai-agents (js) v0.0.2

### DIFF
--- a/integrations/openai-agents-js/package.json
+++ b/integrations/openai-agents-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@braintrust/openai-agents",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "SDK for integrating Braintrust with OpenAI Agents",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/py/src/braintrust/version.py
+++ b/py/src/braintrust/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.2.2"
+VERSION = "0.2.3"
 
 # this will be templated during the build
 GIT_COMMIT = "__GIT_COMMIT__"


### PR DESCRIPTION
This fixes an openai-agents bug where the tracing context didn't get inherited. 