### PR TITLE
externalize opentelemetry to avoid bundling with esbuild

### DIFF
--- a/js/tsup.config.ts
+++ b/js/tsup.config.ts
@@ -5,7 +5,17 @@ export default defineConfig([
     entry: ["src/index.ts"],
     format: ["cjs", "esm"],
     outDir: "dist",
-    external: ["zod"],
+    // Mark OpenTelemetry packages as external to prevent bundling.
+    // This allows users to install their own version of OpenTelemetry
+    // and ensures version compatibility with their applications.
+    external: [
+      "zod",
+      "@opentelemetry/api",
+      "@opentelemetry/sdk-trace-base",
+      "@opentelemetry/exporter-trace-otlp-http",
+      "@opentelemetry/resources",
+      "@opentelemetry/semantic-conventions",
+    ],
     dts: {
       // Split DTS generation to reduce memory usage
       compilerOptions: {
@@ -19,6 +29,14 @@ export default defineConfig([
     entry: ["src/browser.ts"],
     format: ["cjs", "esm"],
     outDir: "dist",
+    // OpenTelemetry packages marked as external (though not used in browser build)
+    external: [
+      "@opentelemetry/api",
+      "@opentelemetry/sdk-trace-base",
+      "@opentelemetry/exporter-trace-otlp-http",
+      "@opentelemetry/resources",
+      "@opentelemetry/semantic-conventions",
+    ],
     dts: {
       // Split DTS generation to reduce memory usage
       compilerOptions: {
@@ -32,7 +50,16 @@ export default defineConfig([
     entry: ["src/cli.ts"],
     format: ["cjs"],
     outDir: "dist",
-    external: ["esbuild", "prettier", "typescript"],
+    external: [
+      "esbuild",
+      "prettier",
+      "typescript",
+      "@opentelemetry/api",
+      "@opentelemetry/sdk-trace-base",
+      "@opentelemetry/exporter-trace-otlp-http",
+      "@opentelemetry/resources",
+      "@opentelemetry/semantic-conventions",
+    ],
     // CLI doesn't need DTS
     dts: false,
     clean: false,
@@ -41,7 +68,16 @@ export default defineConfig([
     entry: ["dev/index.ts"],
     format: ["cjs", "esm"],
     outDir: "dev/dist",
-    external: ["esbuild", "prettier", "typescript"],
+    external: [
+      "esbuild",
+      "prettier",
+      "typescript",
+      "@opentelemetry/api",
+      "@opentelemetry/sdk-trace-base",
+      "@opentelemetry/exporter-trace-otlp-http",
+      "@opentelemetry/resources",
+      "@opentelemetry/semantic-conventions",
+    ],
     dts: {
       // Split DTS generation to reduce memory usage
       compilerOptions: {


### PR DESCRIPTION
competing with #864 