### PR TITLE
Temporary test suite solve for litellem dependency problems

### DIFF
--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -93,6 +93,9 @@ def test_openai(session, version):
 @nox.parametrize("version", LITELLM_VERSIONS, ids=LITELLM_VERSIONS)
 def test_litellm(session, version):
     _install_test_deps(session)
+    # Install a compatible version of openai (1.99.9 or lower) to avoid the ResponseTextConfig removal in 1.100.0
+    # https://github.com/BerriAI/litellm/issues/13711
+    session.install("openai<=1.99.9", "--force-reinstall")
     _install(session, "litellm", version)
     _run_tests(session, f"{WRAPPER_DIR}/test_litellm.py")
     _run_core_tests(session)


### PR DESCRIPTION
The latest version of LIteLLM has a dependency problem with version `1.100.0` of `openai`.
https://github.com/BerriAI/litellm/issues/13711

Here's the summary:

```
OpenAI just released v1.100.0. LiteLLM allows for openAI package to be any version >= >=1.99.5, including v1.100.0.

However, v1.100.0 removes ResponseTextConfig, which breaks litellm upon import.
```

This breaks our test suite when running our LiteLLM tests. This change installs version `1.99.9` of `openai` to work around the versioning bug in LiteLLM. We can remove this conditional once LiteLLM fixes their versioning specifications.