### PR TITLE
validate file readability when creating attachments

### DIFF
--- a/js/src/isomorph.ts
+++ b/js/src/isomorph.ts
@@ -55,6 +55,7 @@ export interface Common {
   utimes?: (path: string, atime: Date, mtime: Date) => Promise<void>;
   unlink?: (path: string) => Promise<void>;
   stat?: (path: string) => Promise<any>; // type-erased
+  statSync?: (path: string) => any; // type-erased
   homedir?: () => string;
 
   // zlib (promisified and type-erased).

--- a/js/src/logger.test.ts
+++ b/js/src/logger.test.ts
@@ -741,15 +741,21 @@ describe("wrapTraced generator support", () => {
   });
 });
 
-test("attachment with unreadable path throws", () => {
-  expect(
-    () =>
-      new Attachment({
-        data: "unreadable.txt",
-        filename: "unreadable.txt",
-        contentType: "text/plain",
-      }),
-  ).toThrow(/Failed to read file:/);
+test("attachment with unreadable path logs warning", () => {
+  const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+  new Attachment({
+    data: "unreadable.txt",
+    filename: "unreadable.txt",
+    contentType: "text/plain",
+  });
+
+  expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+  expect(consoleWarnSpy).toHaveBeenCalledWith(
+    "Failed to read file: Error: ENOENT: no such file or directory, stat 'unreadable.txt'",
+  );
+
+  consoleWarnSpy.mockRestore();
 });
 
 test("attachment with readable path returns data", async () => {

--- a/js/src/logger.test.ts
+++ b/js/src/logger.test.ts
@@ -8,6 +8,7 @@ import {
   BraintrustState,
   wrapTraced,
   currentSpan,
+  Attachment,
 } from "./logger";
 import { LazyValue } from "./util";
 import { configureNode } from "./node";
@@ -735,4 +736,15 @@ describe("wrapTraced generator support", () => {
     expect(log.span_attributes?.name).toBe("main");
     expect(log.metadata).toEqual({ a: "b", total: 6 });
   });
+});
+
+test("attachment with unreadable path throws", () => {
+  expect(
+    () =>
+      new Attachment({
+        data: "unreadable.txt",
+        filename: "unreadable.txt",
+        contentType: "text/plain",
+      }),
+  ).toThrow(/Failed to read file:/);
 });

--- a/js/src/logger.test.ts
+++ b/js/src/logger.test.ts
@@ -752,7 +752,7 @@ test("attachment with unreadable path logs warning", () => {
 
   expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
   expect(consoleWarnSpy).toHaveBeenCalledWith(
-    "Failed to read file: Error: ENOENT: no such file or directory, stat 'unreadable.txt'",
+    expect.stringMatching(/Failed to read file:/),
   );
 
   consoleWarnSpy.mockRestore();

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -1119,7 +1119,7 @@ with a Blob/ArrayBuffer, or run the program on Node.js.`,
     try {
       statSync(data);
     } catch (e) {
-      throw new Error(`Failed to read file: ${String(e)}`);
+      throw new Error(`Failed to read file: ${e}`);
     }
   }
 }

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -1119,7 +1119,7 @@ with a Blob/ArrayBuffer, or run the program on Node.js.`,
     try {
       statSync(data);
     } catch (e) {
-      throw new Error(`Failed to read file: ${e}`);
+      console.warn(`Failed to read file: ${e}`);
     }
   }
 }

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -1091,6 +1091,8 @@ export class Attachment extends BaseAttachment {
 
   private initData(data: string | Blob | ArrayBuffer): LazyValue<Blob> {
     if (typeof data === "string") {
+      this.ensureFileReadable(data);
+
       const readFile = iso.readFile;
       if (!readFile) {
         throw new Error(
@@ -1102,6 +1104,22 @@ with a Blob/ArrayBuffer, or run the program on Node.js.`,
       return new LazyValue(async () => new Blob([await readFile(data)]));
     } else {
       return new LazyValue(async () => new Blob([data]));
+    }
+  }
+
+  private ensureFileReadable(data: string) {
+    const statSync = iso.statSync;
+    if (!statSync) {
+      throw new Error(
+        `This platform does not support reading the filesystem. Construct the Attachment
+with a Blob/ArrayBuffer, or run the program on Node.js.`,
+      );
+    }
+
+    try {
+      statSync(data);
+    } catch (e) {
+      throw new Error(`Failed to read file: ${String(e)}`);
     }
   }
 }

--- a/js/src/node.ts
+++ b/js/src/node.ts
@@ -2,6 +2,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import * as path from "node:path";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
+import * as fsSync from "node:fs";
 import * as crypto from "node:crypto";
 
 import iso from "./isomorph";
@@ -27,6 +28,7 @@ export function configureNode() {
   iso.readFile = fs.readFile;
   iso.readdir = fs.readdir;
   iso.stat = fs.stat;
+  iso.statSync = fsSync.statSync;
   iso.utimes = fs.utimes;
   iso.unlink = fs.unlink;
   iso.homedir = os.homedir;

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -2466,6 +2466,7 @@ class Attachment(BaseAttachment):
 
     def _init_data(self, data: Union[str, bytes, bytearray]) -> LazyValue[bytes]:
         if isinstance(data, str):
+            self._ensure_file_readable(data)
 
             def read_file() -> bytes:
                 with open(data, "rb") as f:
@@ -2474,6 +2475,13 @@ class Attachment(BaseAttachment):
             return LazyValue(read_file, use_mutex=True)
         else:
             return LazyValue(lambda: bytes(data), use_mutex=False)
+
+    def _ensure_file_readable(self, data: str) -> None:
+        try:
+            with open(data, "rb"):
+                pass
+        except Exception as e:
+            raise IOError(f"Failed to read file: {e}") from e
 
 
 class ExternalAttachment(BaseAttachment):

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -2478,8 +2478,7 @@ class Attachment(BaseAttachment):
 
     def _ensure_file_readable(self, data: str) -> None:
         try:
-            with open(data, "rb"):
-                pass
+            os.stat(data)
         except Exception as e:
             raise IOError(f"Failed to read file: {e}") from e
 

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -2480,7 +2480,7 @@ class Attachment(BaseAttachment):
         try:
             os.stat(data)
         except Exception as e:
-            raise IOError(f"Failed to read file: {e}") from e
+            _logger.warning(f"Failed to read file: {e}")
 
 
 class ExternalAttachment(BaseAttachment):

--- a/py/src/braintrust/test_logger.py
+++ b/py/src/braintrust/test_logger.py
@@ -1132,13 +1132,17 @@ async def test_traced_async_generator_unlimited_with_minus_one(with_memory_logge
 
 
 
-def test_attachment_unreadable_path_raises_ioerror():
-    with pytest.raises(IOError, match="Failed to read file:"):
+def test_attachment_unreadable_path_logs_warning(caplog):
+    with caplog.at_level(logging.WARNING, logger="braintrust"):
         Attachment(
             data="unreadable.txt",
             filename="unreadable.txt",
             content_type="text/plain",
         )
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == "WARNING"
+    assert caplog.records[0].message == "Failed to read file: [Errno 2] No such file or directory: 'unreadable.txt'"
 
 
 def test_attachment_readable_path_returns_data(tmp_path):

--- a/py/src/braintrust/test_logger.py
+++ b/py/src/braintrust/test_logger.py
@@ -1142,7 +1142,7 @@ def test_attachment_unreadable_path_logs_warning(caplog):
 
     assert len(caplog.records) == 1
     assert caplog.records[0].levelname == "WARNING"
-    assert caplog.records[0].message == "Failed to read file: [Errno 2] No such file or directory: 'unreadable.txt'"
+    assert "Failed to read file" in caplog.records[0].message
 
 
 def test_attachment_readable_path_returns_data(tmp_path):

--- a/py/src/braintrust/test_logger.py
+++ b/py/src/braintrust/test_logger.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import os
-import tempfile
 import time
 from typing import AsyncGenerator, List
 from unittest import TestCase
@@ -1142,16 +1141,10 @@ def test_attachment_unreadable_path_raises_ioerror():
         )
 
 
-def test_attachment_readable_path_returns_data():
-    with tempfile.NamedTemporaryFile(mode="wb", delete=False) as tmp:
-        tmp.write(b"hello world")
-        tmp_path = tmp.name
-    try:
-        a = Attachment(
-            data=tmp_path,
-            filename="file.txt",
-            content_type="text/plain",
-        )
-        assert a.data == b"hello world"
-    finally:
-        os.unlink(tmp_path)
+def test_attachment_readable_path_returns_data(tmp_path):
+    file_path = tmp_path / "attachments" / "hello.txt"
+    file_path.parent.mkdir(parents=True)
+    file_path.write_bytes(b"hello world")
+
+    a = Attachment(data=str(file_path), filename="hello.txt", content_type="text/plain")
+    assert a.data == b"hello world"

--- a/py/src/braintrust/test_logger.py
+++ b/py/src/braintrust/test_logger.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import tempfile
 import time
 from typing import AsyncGenerator, List
 from unittest import TestCase
@@ -1139,3 +1140,18 @@ def test_attachment_unreadable_path_raises_ioerror():
             filename="unreadable.txt",
             content_type="text/plain",
         )
+
+
+def test_attachment_readable_path_returns_data():
+    with tempfile.NamedTemporaryFile(mode="wb", delete=False) as tmp:
+        tmp.write(b"hello world")
+        tmp_path = tmp.name
+    try:
+        a = Attachment(
+            data=tmp_path,
+            filename="file.txt",
+            content_type="text/plain",
+        )
+        assert a.data == b"hello world"
+    finally:
+        os.unlink(tmp_path)

--- a/py/src/braintrust/test_logger.py
+++ b/py/src/braintrust/test_logger.py
@@ -1129,3 +1129,13 @@ async def test_traced_async_generator_unlimited_with_minus_one(with_memory_logge
         os.environ.pop("BRAINTRUST_MAX_GENERATOR_ITEMS", None)
         if original:
             os.environ["BRAINTRUST_MAX_GENERATOR_ITEMS"] = original
+
+
+
+def test_attachment_unreadable_path_raises_ioerror():
+    with pytest.raises(IOError, match="Failed to read file:"):
+        Attachment(
+            data="unreadable.txt",
+            filename="unreadable.txt",
+            content_type="text/plain",
+        )


### PR DESCRIPTION
Previously, filepath-based attachments weren't validated until the logger was flushed, which caused missing or unreadable files to fail silently. 

This PR introduces a synchronous check upon attachment creation to raise non-existent file issues earlier.