### PR TITLE
Add support for tags when using eval hooks

### DIFF
--- a/js/src/framework.test.ts
+++ b/js/src/framework.test.ts
@@ -627,7 +627,7 @@ test("tags can be set to a list", async () => {
   const logs = await memoryLogger.drain();
   const rootSpans = logs.filter((l: any) => !l["span_parents"]);
   expect(rootSpans).toHaveLength(1);
-  expect((rootSpans[0] as any).tags ?? []).toEqual(expectedTags);
+  expect((rootSpans[0] as any).tags).toEqual(expectedTags);
 });
 
 test("empty list returns undefined for tags", async () => {
@@ -660,5 +660,5 @@ test("empty list returns undefined for tags", async () => {
   const logs = await memoryLogger.drain();
   const rootSpans = logs.filter((l: any) => !l["span_parents"]);
   expect(rootSpans).toHaveLength(1);
-  expect((rootSpans[0] as any).tags ?? []).toEqual([]);
+  expect((rootSpans[0] as any).tags).toEqual(undefined);
 });

--- a/js/src/framework.test.ts
+++ b/js/src/framework.test.ts
@@ -571,7 +571,7 @@ test("hooks.tags can be appended and logged to root span", async () => {
     "strawberry",
   ];
 
-  await runEvaluator(
+  const result = await runEvaluator(
     experiment,
     {
       projectName: "proj",
@@ -588,6 +588,7 @@ test("hooks.tags can be appended and logged to root span", async () => {
     [],
     undefined,
   );
+  expect(result.results[0].tags).toEqual(expectedTags);
 
   await memoryLogger.flush();
   const logs = await memoryLogger.drain();
@@ -604,7 +605,7 @@ test.each<[string[]]>([[[]], [["chocolate", "vanilla", "strawberry"]]])(
     const experiment =
       _exportsForTestingOnly.initTestExperiment("js-tags-list");
 
-    await runEvaluator(
+    const result = await runEvaluator(
       experiment,
       {
         projectName: "proj",
@@ -621,6 +622,7 @@ test.each<[string[]]>([[[]], [["chocolate", "vanilla", "strawberry"]]])(
       [],
       undefined,
     );
+    expect(result.results[0].tags).toEqual(tags);
 
     await memoryLogger.flush();
     const logs = await memoryLogger.drain();

--- a/js/src/framework.test.ts
+++ b/js/src/framework.test.ts
@@ -599,6 +599,11 @@ test("tags can be appended and logged to root span", async () => {
 
 test.each([
   {
+    title: "undefined list returns undefined for tags",
+    providedTags: undefined,
+    expectedTags: undefined,
+  },
+  {
     title: "empty list returns undefined for tags",
     providedTags: [],
     expectedTags: undefined,

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -968,7 +968,11 @@ async function runEvaluatorInternal(
               event: { input: datum.input },
             },
           );
-          rootSpan.log({ output, metadata, expected, tags });
+          if (tags.length) {
+            rootSpan.log({ output, metadata, expected, tags });
+          } else {
+            rootSpan.log({ output, metadata, expected });
+          }
 
           const scoringArgs = {
             input: datum.input,
@@ -1110,7 +1114,7 @@ async function runEvaluatorInternal(
           input: datum.input,
           ...("expected" in datum ? { expected: datum.expected } : {}),
           output,
-          tags,
+          tags: tags.length ? tags : undefined,
           metadata,
           scores: {
             ...(evaluator.errorScoreHandler && unhandledScores

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -150,7 +150,7 @@ export interface EvalHooks<
   /**
    * The tags for the current evaluation.
    */
-  tags: string[];
+  tags: string[] | undefined;
 }
 
 // This happens to be compatible with ScorerArgs defined in @braintrust/core.
@@ -959,7 +959,8 @@ async function runEvaluatorInternal(
                 output = outputResult;
               }
 
-              tags = hooksForTask.tags;
+              tags = hooksForTask.tags ?? [];
+
               span.log({ output });
             },
             {

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -644,6 +644,26 @@ function clearTestBackgroundLogger() {
   _internalGetGlobalState()?.setOverrideBgLogger(null);
 }
 
+// Initialize a test Experiment without making network calls by injecting fake metadata.
+// Useful for unit tests that need an Experiment instance.
+function initTestExperiment(
+  experimentName: string,
+  projectName?: string,
+): Experiment {
+  setInitialTestState();
+  const state = _internalGetGlobalState();
+  const project = projectName ?? experimentName;
+
+  const lazyMetadata: LazyValue<ProjectExperimentMetadata> = new LazyValue(
+    async () => ({
+      project: { id: project, name: project, fullInfo: {} },
+      experiment: { id: experimentName, name: experimentName, fullInfo: {} },
+    }),
+  );
+
+  return new Experiment(state, lazyMetadata);
+}
+
 /**
  * This function should be invoked exactly once after configuring the `iso`
  * object based on the platform. See js/src/node.ts for an example.
@@ -6259,6 +6279,7 @@ export const _exportsForTestingOnly = {
   simulateLoginForTests,
   simulateLogoutForTests,
   setInitialTestState,
+  initTestExperiment,
   isGeneratorFunction,
   isAsyncGeneratorFunction,
 };

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -1317,7 +1317,7 @@ async def _run_evaluator_internal(experiment, evaluator: Evaluator, position: Op
             input=datum.input,
             expected=datum.expected,
             metadata=metadata,
-            tags=tags,
+            tags=tags if tags else None,
             output=output,
             scores={
                 **(

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -1069,8 +1069,8 @@ class DictEvalHooks(Dict[str, Any]):
         return self["tags"]
 
     @tags.setter
-    def tags(self, tags: Sequence[str]) -> None:
-        self["tags"] = tags
+    def tags(self, tags: Optional[Sequence[str]]) -> None:
+        self["tags"] =  [] if tags is None else list(tags)
 
     def meta(self, **info: Any):
         warnings.warn(

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -1259,7 +1259,7 @@ async def _run_evaluator_internal(experiment, evaluator: Evaluator, position: Op
                     output = await await_or_run(event_loop, evaluator.task, *task_args)
                     span.log(input=task_args[0], output=output)
                 tags = hooks.tags
-                root_span.log(output=output, metadata=metadata, tags=tags)
+                root_span.log(output=output, metadata=metadata, tags=tags if tags else None)
 
                 score_promises = [
                     asyncio.create_task(

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -1258,8 +1258,8 @@ async def _run_evaluator_internal(experiment, evaluator: Evaluator, position: Op
                     hooks.set_span(span)
                     output = await await_or_run(event_loop, evaluator.task, *task_args)
                     span.log(input=task_args[0], output=output)
-                tags = hooks.tags
-                root_span.log(output=output, metadata=metadata, tags=tags if tags else None)
+                tags = hooks.tags if hooks.tags else None
+                root_span.log(output=output, metadata=metadata, tags=tags)
 
                 score_promises = [
                     asyncio.create_task(
@@ -1296,7 +1296,7 @@ async def _run_evaluator_internal(experiment, evaluator: Evaluator, position: Op
                         scorer_name: exc_info for scorer_name, _, exc_info in failing_scorers_and_exceptions
                     }
                     metadata["scorer_errors"] = scorer_errors
-                    root_span.log(metadata=metadata, tags=hooks.tags)
+                    root_span.log(metadata=metadata, tags=tags)
                     names = ", ".join(scorer_errors.keys())
                     exceptions = [x[1] for x in failing_scorers_and_exceptions]
                     unhandled_scores = list(scorer_errors.keys())
@@ -1317,7 +1317,7 @@ async def _run_evaluator_internal(experiment, evaluator: Evaluator, position: Op
             input=datum.input,
             expected=datum.expected,
             metadata=metadata,
-            tags=tags if tags else None,
+            tags=tags,
             output=output,
             scores={
                 **(

--- a/py/src/braintrust/test_framework.py
+++ b/py/src/braintrust/test_framework.py
@@ -358,7 +358,7 @@ async def test_hooks_tags_list(with_memory_logger, with_simulate_login):
 
 @pytest.mark.asyncio
 async def test_hooks_tags_empty_list(with_memory_logger, with_simulate_login):
-    """ Test that hooks.tags can be set to a list. """
+    """ Test that hooks.tags can be set to an empty list. """
 
     expected_tags = []
 
@@ -389,4 +389,4 @@ async def test_hooks_tags_empty_list(with_memory_logger, with_simulate_login):
     # assert root span contains tags
     root_span = [log for log in logs if not log["span_parents"]]
     assert len(root_span) == 1
-    assert root_span[0].get("tags") == expected_tags
+    assert root_span[0].get("tags") == None

--- a/py/src/braintrust/test_framework.py
+++ b/py/src/braintrust/test_framework.py
@@ -286,10 +286,12 @@ async def test_eval_no_send_logs_true(with_memory_logger):
 async def test_hooks_tags_append(with_memory_logger, with_simulate_login):
     """ Test that hooks.tags can be appended to and logged. """
 
-    expected_tags = ["chocolate", "vanilla", "strawberry"]
+    initial_tags = ["cookies n cream"]
+    appended_tags = ["chocolate", "vanilla", "strawberry"]
+    expected_tags = ["cookies n cream", "chocolate", "vanilla", "strawberry"]
 
     def task_with_hooks(input, hooks):
-        for x in expected_tags:
+        for x in appended_tags:
             hooks.tags.append(x)
         return input
 
@@ -299,7 +301,7 @@ async def test_hooks_tags_append(with_memory_logger, with_simulate_login):
     evaluator = Evaluator(
         project_name=__name__,
         eval_name=__name__,
-        data=[EvalCase(input="hello", expected="hello world")],
+        data=[EvalCase(input="hello", expected="hello world", tags=initial_tags)],
         task=task_with_hooks,
         scores=[simple_scorer],
         experiment_name=__name__,
@@ -324,8 +326,7 @@ async def test_hooks_tags_list(with_memory_logger, with_simulate_login, expected
     """ Test that hooks.tags can be set to a list. """
 
     def task_with_hooks(input, hooks):
-        for x in expected_tags:
-            hooks.tags.append(x)
+        hooks.tags = expected_tags
         return input
 
     def simple_scorer(input, output, expected):

--- a/py/src/braintrust/test_framework.py
+++ b/py/src/braintrust/test_framework.py
@@ -321,7 +321,7 @@ async def test_hooks_tags_append(with_memory_logger, with_simulate_login, simple
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(("tags", "expected_tags"), [([], None), (["chocolate", "vanilla", "strawberry"], ["chocolate", "vanilla", "strawberry"])])
+@pytest.mark.parametrize(("tags", "expected_tags"), [(None, None),([], None), (["chocolate", "vanilla", "strawberry"], ["chocolate", "vanilla", "strawberry"])])
 async def test_hooks_tags_list(with_memory_logger, with_simulate_login, simple_scorer, tags, expected_tags):
     """ Test that hooks.tags can be set to a list. """
 
@@ -385,3 +385,24 @@ async def test_hooks_tags_with_failing_scorer(with_memory_logger, with_simulate_
     root_span = [log for log in logs if not log["span_parents"]]
     assert len(root_span) == 1
     assert root_span[0].get("tags") == expected_tags
+
+@pytest.mark.asyncio
+async def test_hooks_tags_with_invalid_type(with_memory_logger, with_simulate_login, simple_scorer):
+    """ Test that hooks.tags can be set to a list. """
+    def task_with_hooks(input, hooks):
+        hooks.tags = 123
+        return input
+
+    evaluator = Evaluator(
+        project_name=__name__,
+        eval_name=__name__,
+        data=[EvalCase(input="hello", expected="hello world")],
+        task=task_with_hooks,
+        scores=[simple_scorer],
+        experiment_name=__name__,
+        metadata=None,
+        summarize_scores=False,
+    )
+    exp = init_test_exp(__name__)
+    result = await run_evaluator(experiment=exp, evaluator=evaluator, position=None, filters=[])
+    assert isinstance(result.results[0].error, TypeError)

--- a/py/src/braintrust/test_framework.py
+++ b/py/src/braintrust/test_framework.py
@@ -388,7 +388,7 @@ async def test_hooks_tags_with_failing_scorer(with_memory_logger, with_simulate_
 
 @pytest.mark.asyncio
 async def test_hooks_tags_with_invalid_type(with_memory_logger, with_simulate_login, simple_scorer):
-    """ Test that hooks.tags can be set to a list. """
+    """ Test that result contains an error for cases where hooks.tags is set to an invalid type. """
     def task_with_hooks(input, hooks):
         hooks.tags = 123
         return input
@@ -405,4 +405,5 @@ async def test_hooks_tags_with_invalid_type(with_memory_logger, with_simulate_lo
     )
     exp = init_test_exp(__name__)
     result = await run_evaluator(experiment=exp, evaluator=evaluator, position=None, filters=[])
+    assert len(result.results) == 1
     assert isinstance(result.results[0].error, TypeError)

--- a/py/src/braintrust/test_framework.py
+++ b/py/src/braintrust/test_framework.py
@@ -309,7 +309,8 @@ async def test_hooks_tags_append(with_memory_logger, with_simulate_login):
         summarize_scores=False,
     )
     exp = init_test_exp(__name__)
-    await run_evaluator(experiment=exp, evaluator=evaluator, position=None, filters=[])
+    result = await run_evaluator(experiment=exp, evaluator=evaluator, position=None, filters=[])
+    assert result.results[0].tags == expected_tags
 
     logs = with_memory_logger.pop()
     assert len(logs) == 3
@@ -343,7 +344,8 @@ async def test_hooks_tags_list(with_memory_logger, with_simulate_login, expected
         summarize_scores=False,
     )
     exp = init_test_exp(__name__)
-    await run_evaluator(experiment=exp, evaluator=evaluator, position=None, filters=[])
+    result = await run_evaluator(experiment=exp, evaluator=evaluator, position=None, filters=[])
+    assert result.results[0].tags == expected_tags
 
     logs = with_memory_logger.pop()
     assert len(logs) == 3

--- a/py/src/braintrust/test_helpers.py
+++ b/py/src/braintrust/test_helpers.py
@@ -1,7 +1,7 @@
 import pytest
 
 from braintrust import logger
-from braintrust.logger import ObjectMetadata, OrgProjectMetadata
+from braintrust.logger import ObjectMetadata, OrgProjectMetadata, ProjectExperimentMetadata
 from braintrust.util import LazyValue
 
 # Fake API key for testing only - this will not work with actual API calls
@@ -71,6 +71,31 @@ def init_test_logger(project_name: str):
     l = logger.init_logger(project=project_name)
     l._lazy_metadata = lazy_metadata  # Skip actual login by setting fake metadata directly
     return l
+
+def init_test_exp(experiment_name: str, project_name: str = None):
+    """
+    Initialize an experiment for testing with fake project and experiment metadata.
+
+    This sets up an experiment with fake metadata to avoid requiring actual
+    API calls. This is useful for testing experiment validation behavior.
+
+    Args:
+        experiment_name: The name to use for the test experiment.
+        project_name: The name to use for the test project. Defaults to experiment_name.
+    """
+    if project_name is None:
+        project_name = experiment_name
+
+    import braintrust
+
+    project_metadata = ObjectMetadata(id=project_name, name=project_name, full_info=dict())
+    experiment_metadata = ObjectMetadata(id=experiment_name, name=experiment_name, full_info=dict())
+    metadata = ProjectExperimentMetadata(project=project_metadata, experiment=experiment_metadata)
+    lazy_metadata = LazyValue(lambda: metadata, use_mutex=False)
+
+    exp = braintrust.init(project=project_name, experiment=experiment_name)
+    exp._lazy_metadata = lazy_metadata  # Skip actual login by setting fake metadata directly
+    return exp
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
adding support for tags allows filtering eval logs by an array of strings

ref: https://www.braintrust.dev/docs/reference/libs/python#evalhooks-objects