### PR TITLE
Improve support for zod v4

### DIFF
--- a/core/js/src/generated_types.ts
+++ b/core/js/src/generated_types.ts
@@ -1,6 +1,6 @@
 // Auto-generated file (internal git SHA 10d02c4e14f09ae288e6bd5af3cebe98cf1dbf83) -- do not modify
 
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const AclObjectType = z.union([
   z.enum([

--- a/core/js/src/object.ts
+++ b/core/js/src/object.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import {
   AsyncScoringControlType as AsyncScoringControl,
   ObjectReference as objectReferenceSchema,

--- a/core/js/src/span_identifier_v1.ts
+++ b/core/js/src/span_identifier_v1.ts
@@ -2,7 +2,7 @@
 
 import * as uuid from "uuid";
 import { ParentExperimentIds, ParentProjectLogIds } from "./object";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 function tryMakeUuid(s: string): { bytes: Buffer; isUUID: boolean } {
   try {

--- a/core/js/src/span_identifier_v2.ts
+++ b/core/js/src/span_identifier_v2.ts
@@ -3,7 +3,7 @@
 import * as uuid from "uuid";
 import { ParentExperimentIds, ParentProjectLogIds } from "./object";
 import { SpanComponentsV1 } from "./span_identifier_v1";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 function tryMakeUuid(s: string): { bytes: Buffer; isUUID: boolean } {
   try {

--- a/core/js/src/span_identifier_v3.ts
+++ b/core/js/src/span_identifier_v3.ts
@@ -7,7 +7,7 @@ import {
   ParentPlaygroundLogIds,
 } from "./object";
 import { SpanComponentsV2 } from "./span_identifier_v2";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { InvokeFunctionType as InvokeFunctionRequest } from "./generated_types";
 import {
   base64ToUint8Array,

--- a/core/js/src/zod_util.test.ts
+++ b/core/js/src/zod_util.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
 import { objectNullish, parseNoStrip } from "./zod_util";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 const testSchema = z.object({
   a: z.string(),

--- a/core/js/src/zod_util.ts
+++ b/core/js/src/zod_util.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { forEachMissingKey } from "./object_util";
 
 export class ExtraFieldsError extends Error {

--- a/integrations/langchain-js/package.json
+++ b/integrations/langchain-js/package.json
@@ -31,7 +31,7 @@
     "tsup": "^8.3.5",
     "typescript": "^5.3.3",
     "vitest": "^2.1.9",
-    "zod": "^3.22.4",
+    "zod": "^3.25.34",
     "zod-to-json-schema": "^3.22.5"
   },
   "dependencies": {

--- a/integrations/langchain-js/src/BraintrustCallbackHandler.test.ts
+++ b/integrations/langchain-js/src/BraintrustCallbackHandler.test.ts
@@ -7,7 +7,7 @@ import { flush, initLogger, NOOP_SPAN } from "braintrust";
 import { http, HttpResponse } from "msw";
 import { ReadableStream } from "stream/web";
 import { describe, expect, it } from "vitest";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { BraintrustCallbackHandler } from "./BraintrustCallbackHandler";
 import {

--- a/integrations/openai-agents-js/src/openai-agents-integration.test.ts
+++ b/integrations/openai-agents-js/src/openai-agents-integration.test.ts
@@ -7,7 +7,7 @@ import {
   describe,
 } from "vitest";
 import { OpenAIAgentsTraceProcessor } from "./index";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 // Import necessary types and functions from braintrust
 import {

--- a/integrations/val.town/src/commands/update.ts
+++ b/integrations/val.town/src/commands/update.ts
@@ -1,7 +1,7 @@
 import { Command } from "@cliffy/command";
 import { colors } from "@cliffy/ansi/colors";
 import { expandGlob } from "@std/fs";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { join } from "@std/path";
 
 const configSchema = z.object({

--- a/js/btql/ast.ts
+++ b/js/btql/ast.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const posSchema = z.strictObject({
   line: z.number(),

--- a/js/dev/errorHandler.ts
+++ b/js/dev/errorHandler.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { Request, Response, ErrorRequestHandler, NextFunction } from "express";
 import { HttpError } from "http-errors";
 

--- a/js/dev/server.ts
+++ b/js/dev/server.ts
@@ -46,7 +46,7 @@ import {
   evalParametersSerializedSchema,
 } from "./types";
 import { EvalParameters, validateParameters } from "../src/eval-parameters";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { promptDefinitionToPromptData } from "../src/framework2";
 import zodToJsonSchema from "zod-to-json-schema";
 export interface DevServerOpts {

--- a/js/dev/types.ts
+++ b/js/dev/types.ts
@@ -4,7 +4,7 @@ import {
   RunEval as runEvalSchema,
   PromptData as promptDataSchema,
 } from "../src/generated_types";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { EvaluatorDef } from "../src/framework";
 import { BaseMetadata } from "../src/logger";
 

--- a/js/examples/dev-server.ts
+++ b/js/examples/dev-server.ts
@@ -1,5 +1,5 @@
 import { EvaluatorDef, login } from "braintrust";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { runDevServer } from "../dev/server";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/js/examples/otel/aisdk_example.ts
+++ b/js/examples/otel/aisdk_example.ts
@@ -1,7 +1,7 @@
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { generateText, tool } from "ai";
 import { openai } from "@ai-sdk/openai";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { BraintrustSpanProcessor } from "braintrust";
 
 const sdk = new NodeSDK({

--- a/js/examples/otel/package-lock.json
+++ b/js/examples/otel/package-lock.json
@@ -2820,7 +2820,7 @@
       },
       "peerDependencies": {
         "ws": "^8.18.0",
-        "zod": "^3.23.8"
+        "zod": "^3.25.34"
       },
       "peerDependenciesMeta": {
         "ws": {

--- a/js/examples/wrappers/ai-sdk-v1.ts
+++ b/js/examples/wrappers/ai-sdk-v1.ts
@@ -1,7 +1,7 @@
 import { openai } from "@ai-sdk/openai";
 import { generateText } from "ai";
 import { wrapAISDKModel, initLogger, traced } from "../../dist/index.js";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 initLogger({
   projectName: "AI SDK Tool Calls Demo",

--- a/js/scripts/openapi_zod_client_output_template.hbs
+++ b/js/scripts/openapi_zod_client_output_template.hbs
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 {{#each schemas}}
 export const {{@key}} = {{{this}}};

--- a/js/src/cli-util/pull.ts
+++ b/js/src/cli-util/pull.ts
@@ -10,7 +10,7 @@ import { _internalGetGlobalState } from "../logger";
 import { loadCLIEnv } from "./bundle";
 import { PullArgs } from "./types";
 import { warning } from "../framework";
-import { z } from "zod";
+import { z } from "zod/v3";
 import fs from "fs/promises";
 import util from "util";
 import slugify from "slugify";

--- a/js/src/eval-parameters.ts
+++ b/js/src/eval-parameters.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { Prompt } from "./logger";
 import {
   promptDefinitionWithToolsSchema,

--- a/js/src/framework-types.ts
+++ b/js/src/framework-types.ts
@@ -1,5 +1,5 @@
 import { type IfExistsType as IfExists } from "./generated_types";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 // Type to accept both regular Zod schemas and OpenAPI-extended ones
 type ZodSchema<T = any> =

--- a/js/src/framework2.ts
+++ b/js/src/framework2.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import slugifyLib from "slugify";
 import { _initializeSpanContext } from "./framework";
-import { z } from "zod";
+import { z } from "zod/v3";
 import {
   type FunctionTypeEnumType as FunctionType,
   IfExists as IfExistsSchema,

--- a/js/src/functions/invoke.ts
+++ b/js/src/functions/invoke.ts
@@ -15,7 +15,7 @@ import {
   getSpanParentObject,
 } from "../logger";
 import { BraintrustStream } from "./stream";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 /**
  * Arguments for the `invoke` function.

--- a/js/src/functions/stream.ts
+++ b/js/src/functions/stream.ts
@@ -11,7 +11,7 @@ import {
   ParsedEvent,
   ReconnectInterval,
 } from "eventsource-parser";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const braintrustStreamChunkSchema = z.union([
   z.object({

--- a/js/src/functions/upload.ts
+++ b/js/src/functions/upload.ts
@@ -18,7 +18,7 @@ import fs from "fs";
 import path from "path";
 import { createGzip } from "zlib";
 import { addAzureBlobHeaders, isEmpty } from "../util";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { capitalize } from "@braintrust/core";
 import { findCodeDefinition, makeSourceMapContext } from "./infer-source";
 import slugifyLib from "slugify";

--- a/js/src/generated_types.ts
+++ b/js/src/generated_types.ts
@@ -1,6 +1,6 @@
 // Auto-generated file (internal git SHA 10d02c4e14f09ae288e6bd5af3cebe98cf1dbf83) -- do not modify
 
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const AclObjectType = z.union([
   z.enum([

--- a/js/src/parameters.test.ts
+++ b/js/src/parameters.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, beforeAll } from "vitest";
 import { runEvaluator } from "./framework";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { type ProgressReporter } from "./progress";
 import { configureNode } from "./node";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,11 +80,11 @@ importers:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@20.10.5)(msw@2.6.6)
       zod:
-        specifier: ^3.22.4
-        version: 3.24.0
+        specifier: ^3.25.34
+        version: 3.25.76
       zod-to-json-schema:
         specifier: ^3.22.5
-        version: 3.22.5(zod@3.24.0)
+        version: 3.22.5(zod@3.25.76)
 
   integrations/openai-agents-js:
     dependencies:
@@ -2490,8 +2490,8 @@ packages:
       p-queue: 6.6.2
       p-retry: 4.6.2
       uuid: 10.0.0
-      zod: 3.25.34
-      zod-to-json-schema: 3.22.5(zod@3.25.34)
+      zod: 3.25.76
+      zod-to-json-schema: 3.22.5(zod@3.25.76)
     transitivePeerDependencies:
       - openai
     dev: true
@@ -2525,7 +2525,7 @@ packages:
       '@langchain/langgraph-checkpoint': 0.0.13(@langchain/core@0.3.42)
       '@langchain/langgraph-sdk': 0.0.31
       uuid: 10.0.0
-      zod: 3.25.34
+      zod: 3.25.76
     dev: true
 
   /@langchain/openai@0.3.17(@langchain/core@0.3.42):
@@ -2536,9 +2536,9 @@ packages:
     dependencies:
       '@langchain/core': 0.3.42
       js-tiktoken: 1.0.21
-      openai: 4.104.0(zod@3.24.0)
-      zod: 3.24.0
-      zod-to-json-schema: 3.22.5(zod@3.24.0)
+      openai: 4.104.0(zod@3.25.76)
+      zod: 3.25.76
+      zod-to-json-schema: 3.22.5(zod@3.25.76)
     transitivePeerDependencies:
       - encoding
       - ws
@@ -6535,30 +6535,6 @@ packages:
       mimic-fn: 2.1.0
     dev: true
 
-  /openai@4.104.0(zod@3.24.0):
-    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
-    hasBin: true
-    peerDependencies:
-      ws: ^8.18.0
-      zod: ^3.23.8
-    peerDependenciesMeta:
-      ws:
-        optional: true
-      zod:
-        optional: true
-    dependencies:
-      '@types/node': 18.19.123
-      '@types/node-fetch': 2.6.13
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0
-      zod: 3.24.0
-    transitivePeerDependencies:
-      - encoding
-    dev: true
-
   /openai@4.104.0(zod@3.25.76):
     resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
     hasBin: true
@@ -8786,20 +8762,13 @@ packages:
     resolution: {integrity: sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==}
     dev: false
 
-  /zod-to-json-schema@3.22.5(zod@3.24.0):
-    resolution: {integrity: sha512-+akaPo6a0zpVCCseDed504KBJUQpEW5QZw7RMneNmKw+fGaML1Z9tUNLnHHAC8x6dzVRO1eB2oEMyZRnuBZg7Q==}
-    peerDependencies:
-      zod: ^3.22.4
-    dependencies:
-      zod: 3.24.0
-    dev: true
-
   /zod-to-json-schema@3.22.5(zod@3.25.34):
     resolution: {integrity: sha512-+akaPo6a0zpVCCseDed504KBJUQpEW5QZw7RMneNmKw+fGaML1Z9tUNLnHHAC8x6dzVRO1eB2oEMyZRnuBZg7Q==}
     peerDependencies:
       zod: ^3.22.4
     dependencies:
       zod: 3.25.34
+    dev: false
 
   /zod-to-json-schema@3.22.5(zod@3.25.76):
     resolution: {integrity: sha512-+akaPo6a0zpVCCseDed504KBJUQpEW5QZw7RMneNmKw+fGaML1Z9tUNLnHHAC8x6dzVRO1eB2oEMyZRnuBZg7Q==}
@@ -8807,7 +8776,6 @@ packages:
       zod: ^3.22.4
     dependencies:
       zod: 3.25.76
-    dev: false
 
   /zod-to-json-schema@3.24.6(zod@3.25.34):
     resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
@@ -8823,10 +8791,6 @@ packages:
       zod: ^3.24.1
     dependencies:
       zod: 3.25.76
-
-  /zod@3.24.0:
-    resolution: {integrity: sha512-Hz+wiY8yD0VLA2k/+nsg2Abez674dDGTai33SwNvMPuf9uIrBC9eFgIMQxBBbHFxVXi8W+5nX9DcAh9YNSQm/w==}
-    dev: true
 
   /zod@3.25.34:
     resolution: {integrity: sha512-lZHvSc2PpWdcfpHlyB33HA9nqP16GpC9IpiG4lYq9jZCJVLZNnWd6Y1cj79bcLSBKTkxepfpjckPv5Y5VOPlwA==}


### PR DESCRIPTION
This change updates the imports for zod from `import { z } from "zod";` to `import { z } from "zod/v3";` to improve support for zod v4 in the SDK.

### The problem
My application is using zod v4 (`^4.0.15` specifically) which causes issues when building a prompt via the Braintrust SDK. In my code, I load a prompt and then attempt to build it:

```ts
const prompt = await loadPrompt({ projectId: "my-project-id", slug: "my-prompt-slug" });
const built = prompt.build({ some: "params" });
```

This results in an error on the `prompt.build` line:

```
TypeError: Cannot read properties of undefined (reading '_zod')
    at t._zod.parse (/my-code/index.js:3671:6503)
    at /my-code/index.js:3654:655
    at t.safeParse (/my-code/index.js:3673:4749)
    at Fen.runBuild (/my-code/index.js:3763:12868)
    at Fen.build (/my-code/index.js:3763:11985)
```

### The solution

Starting with zod v3.25.0 (which is already used in most places throughout the SDK), the zod package includes both v3 and v4 of the package available by either import from `"zod/v3"` or `"zod/v4/core"`. Importing directly from `"zod"` will import v3 when a v3.* version is installed and v4 when a v4.* version is installed. Since the v3 and v4 types are incompatible, this is causing issues when a user of the SDK (me) has v4 installed but the SDK is expecting v3.

To fix this, I've updated all imports in the JS SDK to import from `"zod/v3"` instead of `"zod"` directly, [as suggested by the zod docs](https://zod.dev/library-authors?id=how-to-support-zod-4).

### Testing

I tried to test this change locally by pointing my application to a local version of the repo (updating `package.json` to use `"braintrust": "/path/to/code/braintrust-sdk/js"`), but that caused some other issues when building since the `core` package couldn't be found.

Instead, I manually updated the SDK in my `node_modules` (specifically `node_modules/braintrust/dist/index.mjs`) to import from "zod/v3" everywhere instead of "zod" and verified that calling `prompt.build()` in my application code succeeded 🎉 .