### PR TITLE
Switch responses wrapper for js to not do transforms (similar to the agents wrapper)

### DIFF
--- a/js/src/wrappers/oai.test.ts
+++ b/js/src/wrappers/oai.test.ts
@@ -322,7 +322,9 @@ describe("openai client unit tests", TEST_SUITE_OPTIONS, () => {
     assert.equal(span.input, "What is 6x6?");
     assert.ok(span.metadata.model.startsWith(TEST_MODEL));
     assert.equal(span.metadata.provider, "openai");
-    expect(span.output).toContain("36");
+    // Check if output contains "36" either in the structure or stringified
+    const outputStr = JSON.stringify(span.output);
+    expect(outputStr).toContain("36");
 
     const m = span.metrics;
     assert.isTrue(start <= m.start && m.start < m.end && m.end <= end);
@@ -371,12 +373,9 @@ describe("openai client unit tests", TEST_SUITE_OPTIONS, () => {
       "the whole poem, strip punctuation",
     );
     assert.equal(span.metadata.temperature, 0.5);
-    // This line takes the output text, converts it to lowercase, and removes all characters
-    // except letters, numbers and whitespace using a regex
-    assert.isString(span.output);
-    const output = span.output.toLowerCase().replace(/[^\w\s]/g, "");
-
-    expect(output).toContain("shall i compare thee");
+    // Check if output contains the expected text either in the structure or stringified
+    const outputStr = JSON.stringify(span.output).toLowerCase();
+    expect(outputStr).toContain("shall i compare thee");
     const m = span.metrics;
     assert.isTrue(m.tokens > 0);
     assert.isTrue(m.prompt_tokens > 0);
@@ -410,7 +409,9 @@ describe("openai client unit tests", TEST_SUITE_OPTIONS, () => {
     assert.equal(span.input, "What is the capital of France?");
     assert.ok(span.metadata.model.startsWith(TEST_MODEL));
     assert.equal(span.metadata.provider, "openai");
-    expect(span.output).toContain("Paris");
+    // Check if output contains "Paris" either in the structure or stringified
+    const outputStr = JSON.stringify(span.output);
+    expect(outputStr).toContain("Paris");
     const m = span.metrics;
     assert.isTrue(m.tokens > 0);
     assert.isTrue(m.prompt_tokens > 0);
@@ -492,8 +493,10 @@ describe("openai client unit tests", TEST_SUITE_OPTIONS, () => {
     assert.ok(span.metadata.model.startsWith(TEST_MODEL));
     assert.equal(span.metadata.provider, "openai");
     assert.ok(span.metadata.text);
-    assert.equal(span.output.value, 24);
-    assert.equal(span.output.reasoning, output_parsed.reasoning);
+    // For parse operations, check if the parsed data is in the output structure
+    const outputStr = JSON.stringify(span.output);
+    expect(outputStr).toContain("24");
+    expect(span.output).toBeDefined();
     const m = span.metrics;
     assert.isTrue(start <= m.start && m.start < m.end && m.end <= end);
     assert.isTrue(m.tokens > 0);

--- a/js/src/wrappers/oai.test.ts
+++ b/js/src/wrappers/oai.test.ts
@@ -126,7 +126,7 @@ describe("openai client unit tests", TEST_SUITE_OPTIONS, () => {
     const span = spans[0] as any;
     assert.ok(span);
     assert.equal(span.span_attributes.type, "llm");
-    assert.equal(span.metadata.model, TEST_MODEL);
+    assert.ok(span.metadata.model.startsWith(TEST_MODEL));
     assert.equal(span.metadata.provider, "openai");
     const m = span.metrics;
     assert.isTrue(start <= m.start && m.start < m.end && m.end <= end);
@@ -319,8 +319,8 @@ describe("openai client unit tests", TEST_SUITE_OPTIONS, () => {
     const span = spans[0] as any;
     assert.equal(span.span_attributes.name, "openai.responses.create");
     assert.equal(span.span_attributes.type, "llm");
-    assert.equal(span.input[0].content, "What is 6x6?");
-    assert.equal(span.metadata.model, TEST_MODEL);
+    assert.equal(span.input, "What is 6x6?");
+    assert.ok(span.metadata.model.startsWith(TEST_MODEL));
     assert.equal(span.metadata.provider, "openai");
     expect(span.output).toContain("36");
 
@@ -363,15 +363,13 @@ describe("openai client unit tests", TEST_SUITE_OPTIONS, () => {
     const span = spans[0] as any;
     assert.equal(span.span_attributes.name, "openai.responses.create");
     assert.equal(span.span_attributes.type, "llm");
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any
-    const input = span.input as any[];
-    assert.lengthOf(input, 2);
-    assert.equal(input[0].content, "Read me a few lines of Sonnet 18");
-    assert.equal(input[0].role, "user");
-    assert.equal(input[1].content, "the whole poem, strip punctuation");
-    assert.equal(input[1].role, "system");
-    assert.equal(span.metadata.model, TEST_MODEL);
+    assert.equal(span.input, "Read me a few lines of Sonnet 18");
+    assert.ok(span.metadata.model.startsWith(TEST_MODEL));
     assert.equal(span.metadata.provider, "openai");
+    assert.equal(
+      span.metadata.instructions,
+      "the whole poem, strip punctuation",
+    );
     assert.equal(span.metadata.temperature, 0.5);
     // This line takes the output text, converts it to lowercase, and removes all characters
     // except letters, numbers and whitespace using a regex
@@ -409,8 +407,8 @@ describe("openai client unit tests", TEST_SUITE_OPTIONS, () => {
     const span = spans[0] as any;
     assert.equal(span.span_attributes.name, "openai.responses.create");
     assert.equal(span.span_attributes.type, "llm");
-    assert.equal(span.input[0].content, "What is the capital of France?");
-    assert.equal(span.metadata.model, TEST_MODEL);
+    assert.equal(span.input, "What is the capital of France?");
+    assert.ok(span.metadata.model.startsWith(TEST_MODEL));
     assert.equal(span.metadata.provider, "openai");
     expect(span.output).toContain("Paris");
     const m = span.metrics;
@@ -490,8 +488,8 @@ describe("openai client unit tests", TEST_SUITE_OPTIONS, () => {
     const span = spans[0] as any;
     assert.equal(span.span_attributes.name, "openai.responses.parse");
     assert.equal(span.span_attributes.type, "llm");
-    assert.equal(span.input[0].content, "What is 20 + 4?");
-    assert.equal(span.metadata.model, TEST_MODEL);
+    assert.equal(span.input, "What is 20 + 4?");
+    assert.ok(span.metadata.model.startsWith(TEST_MODEL));
     assert.equal(span.metadata.provider, "openai");
     assert.ok(span.metadata.text);
     assert.equal(span.output.value, 24);
@@ -544,7 +542,7 @@ describe("openai client unit tests", TEST_SUITE_OPTIONS, () => {
     const span = spans[0] as any;
     assert.equal(span.span_attributes.name, "Chat Completion");
     assert.equal(span.span_attributes.type, "llm");
-    assert.equal(span.metadata.model, TEST_MODEL);
+    assert.ok(span.metadata.model.startsWith(TEST_MODEL));
     assert.equal(span.metadata.provider, "openai");
     const m = span.metrics;
     assert.isTrue(start <= m.start && m.start < m.end && m.end <= end);

--- a/js/src/wrappers/oai_responses.ts
+++ b/js/src/wrappers/oai_responses.ts
@@ -59,16 +59,14 @@ function parseSpanFromResponseCreateParams(params: any): TimedSpan {
 function parseEventFromResponseCreateResult(result: any) {
   const data: Record<string, any> = {};
 
-  // Extract output - prioritize output_text but preserve full output structure
-  if (result?.output_text) {
-    data.output = result.output_text;
-  } else if (result?.output) {
+  // Extract output
+  if (result?.output !== undefined) {
     data.output = result.output;
   }
 
-  // Extract metadata - preserve all response fields except output_text and usage
+  // Extract metadata - preserve all response fields except output and usage
   if (result) {
-    const { output_text, usage, ...metadata } = result;
+    const { output, usage, ...metadata } = result;
     if (Object.keys(metadata).length > 0) {
       data.metadata = metadata;
     }
@@ -106,18 +104,14 @@ function parseSpanFromResponseParseParams(params: any): TimedSpan {
 function parseEventFromResponseParseResult(result: any) {
   const data: Record<string, any> = {};
 
-  // Extract output - prioritize output_parsed, then output_text, then full output structure
-  if (result?.output_parsed) {
-    data.output = result.output_parsed;
-  } else if (result?.output_text) {
-    data.output = result.output_text;
-  } else if (result?.output) {
+  // Extract output
+  if (result?.output !== undefined) {
     data.output = result.output;
   }
 
-  // Extract metadata - preserve all response fields except output fields and usage
+  // Extract metadata - preserve all response fields except output and usage
   if (result) {
-    const { output_parsed, output_text, output, usage, ...metadata } = result;
+    const { output, usage, ...metadata } = result;
     if (Object.keys(metadata).length > 0) {
       data.metadata = metadata;
     }
@@ -171,16 +165,10 @@ function parseLogFromItem(item: any): {} {
     case "response.completed":
       const data: Record<string, any> = {};
 
-      // Extract output text - collect all output_text content
-      const texts = [];
-      for (const output of response?.output || []) {
-        for (const content of output?.content || []) {
-          if (content?.type === "output_text") {
-            texts.push(content.text);
-          }
-        }
+      // Extract output
+      if (response?.output !== undefined) {
+        data.output = response.output;
       }
-      data.output = texts.join("");
 
       // Extract metadata - preserve response fields except usage and output
       if (response) {


### PR DESCRIPTION
This looks worse until we clean it up in the UI but is strictly better due to not hiding any data. 

## Before
<img width="1071" height="1149" alt="image" src="https://github.com/user-attachments/assets/57c5ee7f-e780-419b-ab59-e7c9e5b3c333" />


## After
<img width="1115" height="1119" alt="image" src="https://github.com/user-attachments/assets/e0320b91-1108-4bd4-8d5f-92ac3bfe668f" />
