### PR TITLE
Fix langchain-js to require min ^0.3.7

### DIFF
--- a/integrations/langchain-js/package.json
+++ b/integrations/langchain-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@braintrust/langchain-js",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "SDK for integrating Braintrust with LangChain.js",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -35,7 +35,7 @@
     "zod-to-json-schema": "^3.22.5"
   },
   "dependencies": {
-    "braintrust": "workspace:^"
+    "braintrust": "^0.3.7"
   },
   "peerDependencies": {
     "@langchain/core": "^0.3.42"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
   integrations/langchain-js:
     dependencies:
       braintrust:
-        specifier: workspace:^
+        specifier: ^0.3.7
         version: link:../../js
     devDependencies:
       '@langchain/core':


### PR DESCRIPTION
This was very subtle. When we published 0.0.6 langchain-js integration the existing braintrust version was 0.0.160 (as [seen in npmjs](https://www.npmjs.com/package/@braintrust/langchain-js?activeTab=code)). When we moved from 0.0.x to 0.x.y (actual SEMVER) we neglected to publish a new langchain-js that had the latest minor version. This is important since we had shipped various fixes to tracing context propagation.