### PR TITLE
Get rid of peer dependencies that we don't need. 

### DIFF
--- a/integrations/openai-agents-js/package.json
+++ b/integrations/openai-agents-js/package.json
@@ -33,9 +33,5 @@
   },
   "dependencies": {
     "braintrust": "workspace:^"
-  },
-  "peerDependencies": {
-    "@openai/agents": ">=0.0.14 <1.0.0",
-    "@openai/agents-core": ">=0.0.14 <1.0.0"
   }
 }

--- a/integrations/openai-agents-js/src/openai-agents-types.ts
+++ b/integrations/openai-agents-js/src/openai-agents-types.ts
@@ -1,0 +1,150 @@
+/**
+ * Type definitions copied from @openai/agents-core.
+ *
+ * Original source: https://github.com/openai/openai-agents-js
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 OpenAI
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+type SpanDataBase = {
+  type: string;
+};
+
+export type AgentSpanData = SpanDataBase & {
+  type: "agent";
+  name: string;
+  handoffs?: string[];
+  tools?: string[];
+  output_type?: string;
+};
+
+export type FunctionSpanData = SpanDataBase & {
+  type: "function";
+  name: string;
+  input: string;
+  output: string;
+  mcp_data?: string;
+};
+
+export type GenerationSpanData = SpanDataBase & {
+  type: "generation";
+  input?: Array<Record<string, any>>;
+  output?: Array<Record<string, any>>;
+  model?: string;
+  model_config?: Record<string, any>;
+  usage?: Record<string, any>;
+};
+
+export type ResponseSpanData = SpanDataBase & {
+  type: "response";
+  response_id?: string;
+  /**
+   * Not used by the OpenAI tracing provider but helpful for other tracing providers.
+   */
+  _input?: string | Record<string, any>[];
+  _response?: Record<string, any>;
+};
+
+export type HandoffSpanData = SpanDataBase & {
+  type: "handoff";
+  from_agent?: string;
+  to_agent?: string;
+};
+
+export type CustomSpanData = SpanDataBase & {
+  type: "custom";
+  name: string;
+  data: Record<string, any>;
+};
+
+export type GuardrailSpanData = SpanDataBase & {
+  type: "guardrail";
+  name: string;
+  triggered: boolean;
+};
+
+export type TranscriptionSpanData = SpanDataBase & {
+  type: "transcription";
+  input: {
+    data: string;
+    format: "pcm" | string;
+  };
+  output?: string;
+  model?: string;
+  model_config?: Record<string, any>;
+};
+
+export type SpeechSpanData = SpanDataBase & {
+  type: "speech";
+  input?: string;
+  output: {
+    data: string;
+    format: "pcm" | string;
+  };
+  model?: string;
+  model_config?: Record<string, any>;
+};
+
+export type SpeechGroupSpanData = SpanDataBase & {
+  type: "speech_group";
+  input?: string;
+};
+
+export type MCPListToolsSpanData = SpanDataBase & {
+  type: "mcp_tools";
+  server?: string;
+  result?: string[];
+};
+
+export type SpanData =
+  | AgentSpanData
+  | FunctionSpanData
+  | GenerationSpanData
+  | ResponseSpanData
+  | HandoffSpanData
+  | CustomSpanData
+  | GuardrailSpanData
+  | TranscriptionSpanData
+  | SpeechSpanData
+  | SpeechGroupSpanData
+  | MCPListToolsSpanData;
+
+// Simplified versions of Trace and Span types - only including what we actually use
+export type Trace = {
+  type: "trace";
+  traceId: string;
+  name: string;
+  groupId: string | null;
+  metadata?: Record<string, any>;
+};
+
+export type Span<TData extends SpanData = SpanData> = {
+  type: "trace.span";
+  traceId: string;
+  spanData: TData;
+  spanId: string;
+  parentId: string | null;
+  startedAt: string | null;
+  endedAt: string | null;
+  error: { message: string; data?: Record<string, any> } | null;
+};

--- a/integrations/openai-agents-js/src/types.ts
+++ b/integrations/openai-agents-js/src/types.ts
@@ -8,9 +8,9 @@ import type {
   HandoffSpanData,
   CustomSpanData,
   GuardrailSpanData,
-} from "@openai/agents-core/dist/tracing/spans";
-
-import type { Trace, Span } from "@openai/agents";
+  Trace,
+  Span,
+} from "./openai-agents-types";
 
 export enum SpanType {
   AGENT = "agent",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,9 +54,6 @@ importers:
 
   integrations/openai-agents-js:
     dependencies:
-      '@openai/agents-core':
-        specifier: '>=0.0.14 <1.0.0'
-        version: 0.0.15(ws@8.18.3)(zod@3.25.67)
       braintrust:
         specifier: workspace:^
         version: link:../../js
@@ -2533,6 +2530,7 @@ packages:
       zod-to-json-schema: 3.24.6(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
+    dev: true
     optional: true
 
   /@mswjs/interceptors@0.37.3:
@@ -2623,6 +2621,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - ws
+    dev: true
 
   /@openai/agents-openai@0.0.14(zod@3.25.67):
     resolution: {integrity: sha512-qSGBictwfJ3dMhC3QvqOLMm8RVZ/eIYNcFNLHps7hWeB1xeDGJFDZ/X7dDicejOeEXbi/nGe1ry6LbXDYSo3uQ==}
@@ -3366,6 +3365,7 @@ packages:
     dependencies:
       mime-types: 3.0.1
       negotiator: 1.0.0
+    dev: true
     optional: true
 
   /acorn@8.15.0:
@@ -3460,6 +3460,7 @@ packages:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+    dev: true
     optional: true
 
   /ajv@8.17.1:
@@ -3752,6 +3753,7 @@ packages:
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
     optional: true
 
   /brace-expansion@1.1.11:
@@ -4065,6 +4067,7 @@ packages:
     requiresBuild: true
     dependencies:
       safe-buffer: 5.2.1
+    dev: true
     optional: true
 
   /content-type@1.0.5:
@@ -4083,6 +4086,7 @@ packages:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
     requiresBuild: true
+    dev: true
     optional: true
 
   /cookie@0.7.1:
@@ -4093,6 +4097,7 @@ packages:
   /cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+    dev: true
 
   /cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
@@ -4146,6 +4151,7 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+    dev: true
 
   /csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -4622,6 +4628,7 @@ packages:
     resolution: {integrity: sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==}
     engines: {node: '>=20.0.0'}
     requiresBuild: true
+    dev: true
     optional: true
 
   /eventsource@3.0.7:
@@ -4630,6 +4637,7 @@ packages:
     requiresBuild: true
     dependencies:
       eventsource-parser: 3.0.3
+    dev: true
     optional: true
 
   /execa@5.1.1:
@@ -4676,6 +4684,7 @@ packages:
       express: '>= 4.11'
     dependencies:
       express: 5.1.0
+    dev: true
     optional: true
 
   /express@4.21.2:
@@ -4751,13 +4760,16 @@ packages:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
     optional: true
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    dev: true
 
   /fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+    dev: true
 
   /fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
@@ -4832,6 +4844,7 @@ packages:
       statuses: 2.0.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
     optional: true
 
   /find-up@4.1.0:
@@ -4902,6 +4915,7 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
     requiresBuild: true
+    dev: true
     optional: true
 
   /fs-extra@10.1.0:
@@ -5184,6 +5198,7 @@ packages:
     requiresBuild: true
     dependencies:
       safer-buffer: 2.1.2
+    dev: true
     optional: true
 
   /import-local@3.2.0:
@@ -5316,6 +5331,7 @@ packages:
   /is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
     requiresBuild: true
+    dev: true
     optional: true
 
   /is-reference@3.0.3:
@@ -5376,6 +5392,7 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    dev: true
 
   /istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -5951,6 +5968,7 @@ packages:
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
     requiresBuild: true
+    dev: true
     optional: true
 
   /json-schema-traverse@1.0.0:
@@ -6160,6 +6178,7 @@ packages:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
     requiresBuild: true
+    dev: true
     optional: true
 
   /memorystream@0.3.1:
@@ -6175,6 +6194,7 @@ packages:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
     requiresBuild: true
+    dev: true
     optional: true
 
   /merge-stream@2.0.0:
@@ -6210,6 +6230,7 @@ packages:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
     requiresBuild: true
+    dev: true
     optional: true
 
   /mime-types@2.1.35:
@@ -6224,6 +6245,7 @@ packages:
     requiresBuild: true
     dependencies:
       mime-db: 1.54.0
+    dev: true
     optional: true
 
   /mime@1.6.0:
@@ -6399,6 +6421,7 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
     requiresBuild: true
+    dev: true
     optional: true
 
   /neo-async@2.6.2:
@@ -6512,6 +6535,7 @@ packages:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
+    dev: true
 
   /onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -6558,6 +6582,7 @@ packages:
     dependencies:
       ws: 8.18.3
       zod: 3.25.67
+    dev: true
 
   /openai@5.11.0(zod@3.25.34):
     resolution: {integrity: sha512-+AuTc5pVjlnTuA9zvn8rA/k+1RluPIx9AD4eDcnutv6JNwHHZxIhkFy+tmMKCvmMFDQzfA/r1ujvPWB19DQkYg==}
@@ -6746,6 +6771,7 @@ packages:
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+    dev: true
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -6771,6 +6797,7 @@ packages:
     resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
     engines: {node: '>=16'}
     requiresBuild: true
+    dev: true
     optional: true
 
   /path-type@3.0.0:
@@ -6822,6 +6849,7 @@ packages:
     resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
     engines: {node: '>=16.20.0'}
     requiresBuild: true
+    dev: true
     optional: true
 
   /pkg-dir@4.2.0:
@@ -6930,6 +6958,7 @@ packages:
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+    dev: true
 
   /pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
@@ -6956,6 +6985,7 @@ packages:
     requiresBuild: true
     dependencies:
       side-channel: 1.1.0
+    dev: true
     optional: true
 
   /querystringify@2.2.0:
@@ -6989,6 +7019,7 @@ packages:
       http-errors: 2.0.0
       iconv-lite: 0.6.3
       unpipe: 1.0.0
+    dev: true
     optional: true
 
   /react-is@18.3.1:
@@ -7135,6 +7166,7 @@ packages:
       path-to-regexp: 8.2.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
     optional: true
 
   /run-parallel@1.2.0:
@@ -7231,6 +7263,7 @@ packages:
       statuses: 2.0.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
     optional: true
 
   /serve-static@1.16.2:
@@ -7256,6 +7289,7 @@ packages:
       send: 1.2.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
     optional: true
 
   /set-function-length@1.1.1:
@@ -7292,6 +7326,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       shebang-regex: 3.0.0
+    dev: true
 
   /shebang-regex@1.0.0:
     resolution: {integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==}
@@ -7301,6 +7336,7 @@ packages:
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+    dev: true
 
   /shell-quote@1.8.1:
     resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
@@ -8041,6 +8077,7 @@ packages:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.1
+    dev: true
     optional: true
 
   /typed-array-buffer@1.0.0:
@@ -8192,6 +8229,7 @@ packages:
     requiresBuild: true
     dependencies:
       punycode: 2.3.1
+    dev: true
     optional: true
 
   /url-parse@1.5.10:
@@ -8663,6 +8701,7 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
+    dev: true
 
   /why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -8706,6 +8745,7 @@ packages:
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    dev: true
 
   /write-file-atomic@4.0.2:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
@@ -8726,6 +8766,7 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+    dev: true
 
   /y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -8803,12 +8844,14 @@ packages:
       zod: ^3.24.1
     dependencies:
       zod: 3.25.76
+    dev: true
 
   /zod@3.25.34:
     resolution: {integrity: sha512-lZHvSc2PpWdcfpHlyB33HA9nqP16GpC9IpiG4lYq9jZCJVLZNnWd6Y1cj79bcLSBKTkxepfpjckPv5Y5VOPlwA==}
 
   /zod@3.25.67:
     resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
+    dev: true
 
   /zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}


### PR DESCRIPTION
I don't think these were actually doing anything and us depending on these libraries would cause them to go out of sync sometimes (since they also depend on each other) and cause lots of issues. This is much easier. 

Tested locally with npm link.