### PR TITLE
[AI SDK]: Set 'model' from wrapGenerate callback if it cannot be found in the result

### DIFF
--- a/js/src/wrappers/ai-sdk-shared.test.ts
+++ b/js/src/wrappers/ai-sdk-shared.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import {
   detectProviderFromResult,
   extractModelFromResult,
+  extractModelFromWrapGenerateCallback,
   camelToSnake,
   extractModelParameters,
   getNumberProperty,
@@ -53,6 +54,22 @@ describe("ai-sdk-shared utilities", () => {
 
     it("should return undefined if no model found", () => {
       expect(extractModelFromResult({})).toBeUndefined();
+    });
+  });
+
+  describe("extractModelFromWrapGenerateCallback", () => {
+    it("should extract model from wrapGenerate callback", () => {
+      expect(
+        extractModelFromWrapGenerateCallback({
+          modelId: "us.anthropic.claude-sonnet-4-20250514-v1:0",
+          config: {
+            headers: {},
+          },
+          specificationVersion: "v2",
+          provider: "amazon-bedrock",
+          supportedUrls: {},
+        }),
+      ).toBe("us.anthropic.claude-sonnet-4-20250514-v1:0");
     });
   });
 

--- a/js/src/wrappers/ai-sdk-shared.ts
+++ b/js/src/wrappers/ai-sdk-shared.ts
@@ -34,6 +34,16 @@ export function extractModelFromResult(result: {
   return undefined;
 }
 
+export function extractModelFromWrapGenerateCallback(model: {
+  modelId?: string;
+  config?: Record<string, unknown>;
+  specificationVersion?: string;
+  provider?: string;
+  supportedUrls?: Record<string, unknown>;
+}): string | undefined {
+  return model?.modelId;
+}
+
 export function camelToSnake(str: string): string {
   return str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
 }


### PR DESCRIPTION
As discussed [here](https://github.com/vercel/ai/issues/8563), sometimes the provider model id is not returned from the result of a call from `wrapGenerate`. However, `wrapGenerate` passes `model` as an argument to its callback. In the event that we cannot find the model in the result, we'll fall-back to looking it up from the callback model.