### PR TITLE
[WIP] Return the original message structure from the anthropic wrapper in TS.

### DIFF
--- a/js/src/wrappers/anthropic.ts
+++ b/js/src/wrappers/anthropic.ts
@@ -324,7 +324,9 @@ type MetricsOrUndefined = Metrics | undefined;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function parseEventFromMessage(message: any) {
   // FIXME[matt] the whole content or just the text?
-  const output = message?.content || null;
+  const output = message
+    ? { role: message.role, content: message.content }
+    : null;
   const metrics = parseMetricsFromUsage(message?.usage);
   const metas = ["stop_reason", "stop_sequence"];
   const metadata: Record<string, unknown> = {};


### PR DESCRIPTION
Right now this returns different shapes for input and output and that's kind of messy. 