### PR TITLE
Fix for Issue 584: LanguageModelV1#supportsUrl is a function, not a property 

### DIFF
--- a/js/src/wrappers/ai-sdk-v1.test.ts
+++ b/js/src/wrappers/ai-sdk-v1.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { describe, it, expect, vi } from "vitest";
 import {
   wrapAISDKModel,

--- a/js/src/wrappers/ai-sdk-v1.ts
+++ b/js/src/wrappers/ai-sdk-v1.ts
@@ -77,8 +77,8 @@ class BraintrustLanguageModelWrapper implements LanguageModelV1 {
     return this.model.supportsStructuredOutputs;
   }
 
-  get supportsUrl(): ((url: URL) => boolean) | undefined {
-    return this.model.supportsUrl;
+  supportsUrl(url: URL): boolean {
+    return this.model.supportsUrl?.(url) ?? false;
   }
 
   // For the first cut, do not support custom span_info arguments. We can


### PR DESCRIPTION
Here's a fix for https://github.com/braintrustdata/braintrust-sdk/issues/583

The issue here is that `supportsUrl` is a **function** in LanguageModelV1. We were implementing it as though it were a property in our subclass and thus client calls to `supportsUrl` were failing as the reference to `this` was incorrect.

I was able to verify the fix with the following script:

```
import { initLogger, wrapAISDKModel } from "braintrust";
import { generateText } from "ai";
import { createVertex } from "@ai-sdk/google-vertex/edge";

import * as dotenv from "dotenv";
dotenv.config();

initLogger({
  projectName: "vertex-bug",
  apiKey: process.env.BRAINTRUST_API_KEY,
});

const vertex = createVertex({
  project: process.env.GOOGLE_PROJECT_ID,
  location: process.env.GOOGLE_VERTEX_LOCATION,
  googleCredentials: {
    clientEmail: process.env.GOOGLE_CLIENT_EMAIL!,
    privateKey: process.env.GOOGLE_PRIVATE_KEY!,
    privateKeyId: process.env.GOOGLE_PRIVATE_KEY_ID,
  },
});

const model = wrapAISDKModel(vertex.languageModel("gemini-2.0-flash"));

async function main() {
  generateText({
    model,
    messages: [
      {
        role: "user",
        content: [
          {
            type: "text",
            text: "What is this video about?",
          },
          {
            type: "file",
            data: "https://<google cloud storage url to a public video>",
            mimeType: "video/mp4",
          },
        ],
      },
    ],
  }).then(({ text }) => {
    console.log(text);
  });
}

main().catch(console.error);
```

Dependency Versions:
```
braintrust: 0.3.8
ai: 4.3.19
@ai-sdk/google-vertex: 2.2.27
```