### PR TITLE
[ai-sdk]: Preserve result object when returning from wrappedStreamObject

### DIFF
--- a/js/src/wrappers/ai-sdk-v3.test.ts
+++ b/js/src/wrappers/ai-sdk-v3.test.ts
@@ -273,6 +273,10 @@ describe("ai-sdk v3 wrapper", TEST_SUITE_OPTIONS, () => {
       wrapperSpan.metrics ?? { start: start / 1000, end: end / 1000 },
     );
 
+    expect(typeof streamRes.toTextStreamResponse).toBe("function");
+    const textStreamResponse = streamRes.toTextStreamResponse();
+    expect(textStreamResponse).toBeDefined();
+
     expect(wrapperSpan).toEqual(
       expect.objectContaining({
         span_attributes: expect.objectContaining({

--- a/js/src/wrappers/ai-sdk-v3.ts
+++ b/js/src/wrappers/ai-sdk-v3.ts
@@ -285,10 +285,13 @@ export function wrapAISDK<T extends AISDKMethods>(
         });
       });
 
-      return {
-        ...result,
-        partialObjectStream: wrapStream,
-      };
+      Object.defineProperty(result, "partialObjectStream", {
+        value: wrapStream,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+      return result;
     } catch (error) {
       span.log({
         error: error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
A potential fix for https://github.com/braintrustdata/braintrust-sdk/issues/966

The problem with returning `{...result}` from the `wrappedStreamObject` is that the spread operator will not included properties from the object's prototype chain. In this case, that means removing things like [toTextStreamResponse](https://ai-sdk.dev/cookbook/next/stream-object#server).

Returning the object directly and using `Object.defineProperty` to override `partialObjectStream` appears to solve the issue.