### PR TITLE
Fix when prettier not found

### DIFF
--- a/js/src/cli-util/pull.ts
+++ b/js/src/cli-util/pull.ts
@@ -182,9 +182,9 @@ ${functionDefinitions.join("\n")}
           `Failed to format with prettier (${error instanceof Error ? error.message : error}). Using unformatted output.`,
         ),
       );
-      return fileDef;
     }
   }
+  return fileDef;
 }
 
 function makeFunctionDefinition({


### PR DESCRIPTION
If the prettier module isn't found, we should return `fileDef` (we were only doing so when it failed to run).