### PR TITLE
[JS SDK] Pin npm cli version to `11.6.2` for release automation

### DIFF
--- a/.github/workflows/publish-js-sdk.yaml
+++ b/.github/workflows/publish-js-sdk.yaml
@@ -82,6 +82,8 @@ jobs:
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
+      - name: Install npm 11.6.2
+        run: npm install -g npm@11.6.2
 
       # Regular release path (tag-based)
       - name: Publish to npm (regular release)


### PR DESCRIPTION
You need >11.5 to use OIDC 
https://docs.npmjs.com/trusted-publishers

my github workflow passed after making this change - see:
https://github.com/braintrustdata/braintrust-sdk/actions/workflows/publish-js-sdk.yaml

pre-release version:
https://www.npmjs.com/package/braintrust/v/0.4.4-alpha.1?activeTab=versions