### PR TITLE
feat: Enable passing additional metadata to AI SDK spans

### DIFF
--- a/js/src/wrappers/ai-sdk-v2.ts
+++ b/js/src/wrappers/ai-sdk-v2.ts
@@ -55,6 +55,8 @@ export interface MiddlewareConfig {
   debug?: boolean;
   /** Name identifier for the middleware instance */
   name?: string;
+  /** Additional metadata to add to the span */
+  additionalMetadata?: Record<string, any>;
 }
 
 // V2-specific exclude keys for extractModelParameters
@@ -104,6 +106,7 @@ export function BraintrustMiddleware(
           input: params.prompt,
           metadata: {
             ...extractModelParameters(params, V2_EXCLUDE_KEYS),
+            ...(config.additionalMetadata || {}),
           },
         },
       };
@@ -113,7 +116,7 @@ export function BraintrustMiddleware(
       try {
         const result = await doGenerate();
 
-        const metadata: Record<string, unknown> = {};
+        const metadata: Record<string, unknown> = config.additionalMetadata || {};
 
         const provider = detectProviderFromResult(result);
         if (provider !== undefined) {
@@ -175,6 +178,7 @@ export function BraintrustMiddleware(
           input: params.prompt,
           metadata: {
             ...extractModelParameters(params, V2_EXCLUDE_KEYS),
+            ...(config.additionalMetadata || {}),
           },
         },
       };
@@ -238,7 +242,7 @@ export function BraintrustMiddleware(
                 finishReason: finalFinishReason,
               };
 
-              const metadata: Record<string, unknown> = {};
+              const metadata: Record<string, unknown> = config.additionalMetadata || {};
 
               const provider = detectProviderFromResult(resultForDetection);
               if (provider !== undefined) {

--- a/js/src/wrappers/ai-sdk-v3.ts
+++ b/js/src/wrappers/ai-sdk-v3.ts
@@ -35,6 +35,10 @@ const V3_EXCLUDE_KEYS = new Set([
   "tools", // Already captured in metadata.tools
 ]);
 
+interface WrapAISDKOptions {
+  additionalMetadata?: Record<string, any>;
+}
+
 /**
  * Wraps Vercel AI SDK methods with Braintrust tracing. Returns wrapped versions
  * of generateText, streamText, generateObject, and streamObject that automatically
@@ -58,6 +62,7 @@ const V3_EXCLUDE_KEYS = new Set([
  */
 export function wrapAISDK<T extends AISDKMethods>(
   ai: T,
+  { additionalMetadata = {} }: WrapAISDKOptions = {}
 ): {
   generateText: T["generateText"];
   streamText: T["streamText"];
@@ -97,6 +102,7 @@ export function wrapAISDK<T extends AISDKMethods>(
             ...(provider ? { provider } : {}),
             ...(model ? { model } : {}),
             ...(finishReason ? { finish_reason: finishReason } : {}),
+            ...additionalMetadata,
           },
         });
 
@@ -133,6 +139,7 @@ export function wrapAISDK<T extends AISDKMethods>(
             ...(provider ? { provider } : {}),
             ...(model ? { model } : {}),
             ...(finishReason ? { finish_reason: finishReason } : {}),
+            ...additionalMetadata,
           },
         });
 
@@ -149,7 +156,10 @@ export function wrapAISDK<T extends AISDKMethods>(
       name: "ai-sdk.streamText",
       event: {
         input: extractInput(params),
-        metadata: extractModelParameters(params, V3_EXCLUDE_KEYS),
+        metadata: {
+          ...extractModelParameters(params, V3_EXCLUDE_KEYS),
+          ...additionalMetadata,
+        },
       },
     });
 
@@ -198,6 +208,7 @@ export function wrapAISDK<T extends AISDKMethods>(
                 ...(provider ? { provider } : {}),
                 ...(model ? { model } : {}),
                 ...(finishReason ? { finish_reason: finishReason } : {}),
+                ...additionalMetadata,
               },
             });
             span.end();
@@ -229,7 +240,10 @@ export function wrapAISDK<T extends AISDKMethods>(
       name: "ai-sdk.streamObject",
       event: {
         input: extractInput(params),
-        metadata: extractModelParameters(params, V3_EXCLUDE_KEYS),
+        metadata: {
+          ...extractModelParameters(params, V3_EXCLUDE_KEYS),
+          ...additionalMetadata,
+        },
       },
     });
 
@@ -261,6 +275,7 @@ export function wrapAISDK<T extends AISDKMethods>(
                 ...(provider ? { provider } : {}),
                 ...(model ? { model } : {}),
                 ...(finishReason ? { finish_reason: finishReason } : {}),
+                ...additionalMetadata,
               },
             });
             span.end();


### PR DESCRIPTION
Non-breaking mechanism that enables supplying additional metadata to be logged on spans for a wrapped AI SDK. Supports both V2 and V3 wrapping mechanism. The primary use case is to enable more granular BTQL filtering of ai-sdk spans within a braintrust project.