### PR TITLE
Pass version into dataset fetch query

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "braintrust",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "SDK for integrating Braintrust",
   "repository": {
     "type": "git",

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -4816,6 +4816,11 @@ class ObjectFetcher<RecordType>
             },
             use_columnstore: false,
             brainstore_realtime: true,
+            ...(this.pinnedVersion !== undefined
+              ? {
+                  version: this.pinnedVersion,
+                }
+              : {}),
           },
           { headers: { "Accept-Encoding": "gzip" } },
         );

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -2583,6 +2583,7 @@ class ObjectFetcher(ABC, Generic[TMapping]):
                         },
                         "use_columnstore": False,
                         "brainstore_realtime": True,
+                        **({"version": self._pinned_version} if self._pinned_version is not None else {}),
                     },
                     headers={
                         "Accept-Encoding": "gzip",

--- a/py/src/braintrust/version.py
+++ b/py/src/braintrust/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.3.2"
+VERSION = "0.3.3"
 
 # this will be templated during the build
 GIT_COMMIT = "__GIT_COMMIT__"


### PR DESCRIPTION
Before this, when you initialized a dataset with a version specifier, we wouldn't pass that into the query, so you'd just get the latest version of the dataset. After this, we actually use the version specifier.