### PR TITLE
fix remote evals with users with multiple orgs

### DIFF
--- a/js/dev/authorize.ts
+++ b/js/dev/authorize.ts
@@ -70,9 +70,20 @@ export function makeCheckAuthorized(allowedOrgName: string | undefined) {
     }
 
     try {
+      const orgName = parseHeader(req.headers, "x-bt-org-name");
+
+      if (!orgName) {
+        return next(createError(400, "Missing x-bt-org-name header"));
+      }
+
+      if (allowedOrgName && allowedOrgName !== orgName) {
+        const errorMessage = `Org '${orgName}' is not allowed. Only org '${allowedOrgName}' is allowed.`;
+        return next(createError(403, errorMessage));
+      }
+
       const state = await cachedLogin({
         apiKey: req.ctx?.token,
-        orgName: allowedOrgName,
+        orgName: orgName,
       });
       req.ctx.state = state;
       next();

--- a/py/examples/evals/example.eval.py
+++ b/py/examples/evals/example.eval.py
@@ -1,0 +1,43 @@
+from braintrust import Eval
+
+NUM_EXAMPLES = 10
+
+
+def exact_match_scorer(input, output, expected):
+    if expected is None:
+        return 0.0
+    return 1.0 if output == expected else 0.0
+
+
+def data_fn():
+    data = []
+    for i in range(NUM_EXAMPLES):
+        names = [
+            "Foo",
+            "Bar",
+            "Alice",
+            "Bob",
+            "Charlie",
+            "Diana",
+            "Eve",
+            "Frank",
+        ]
+        greetings = ["Hi", "Hello", "Hey", "Greetings"]
+
+        name = names[i % len(names)]
+        greeting = greetings[i % len(greetings)]
+
+        data.append({"input": name, "expected": f"{greeting} {name}"})
+    return data
+
+
+def task_fn(input, hooks=None):
+    return f"Hi {input}"
+
+
+Eval(
+    "queue-test",
+    data=data_fn,
+    task=task_fn,
+    scores=[exact_match_scorer],
+)

--- a/py/src/braintrust/devserver/server.py
+++ b/py/src/braintrust/devserver/server.py
@@ -54,10 +54,19 @@ class CheckAuthorizedMiddleware(BaseHTTPMiddleware):
                 return JSONResponse({"error": "Unauthorized"}, status_code=401)
 
             try:
+                org_name = ctx.org_name
+
+                if not org_name:
+                    return JSONResponse({"error": "Missing x-bt-org-name header"}, status_code=400)
+
+                if self.allowed_org_name and self.allowed_org_name != org_name:
+                    error_message = f"Org '{org_name}' is not allowed. Only org '{self.allowed_org_name}' is allowed."
+                    return JSONResponse({"error": error_message}, status_code=403)
+
                 state = await cached_login(
                     api_key=ctx.token,
                     app_url=ctx.app_origin,
-                    org_name=self.allowed_org_name,
+                    org_name=org_name,
                 )
                 ctx.state = state
             except Exception as e:


### PR DESCRIPTION
if you had many orgs, it could default to the wrong org and you'd make API requests that would fail in confusing ways.