### PR TITLE
Add changelog automation to python/js sdk release

### DIFF
--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Script to generate release notes filtered by path
+# Usage: generate-release-notes.sh <current-tag> <path-filter>
+# Example: generate-release-notes.sh js-sdk-v0.4.6 js/
+
+set -e
+
+if [ $# -lt 2 ]; then
+  echo "ERROR: Required arguments not provided"
+  echo "Usage: $0 <current-tag> <path-filter>"
+  exit 1
+fi
+
+CURRENT_TAG=$1
+PATH_FILTER=$2
+
+# Extract the SDK prefix (js-sdk or py-sdk)
+SDK_PREFIX=$(echo "$CURRENT_TAG" | sed -E 's/^([^-]+-[^-]+)-.*/\1/')
+
+# Find the previous tag for this SDK
+PREVIOUS_TAG=$(git tag --list "${SDK_PREFIX}-v*" --sort=-v:refname | grep -v "^${CURRENT_TAG}$" | head -1)
+
+if [ -z "$PREVIOUS_TAG" ]; then
+  echo "No previous tag found for ${SDK_PREFIX}, generating notes from all history"
+  PREVIOUS_TAG=$(git rev-list --max-parents=0 HEAD)
+fi
+
+echo "Generating release notes for ${CURRENT_TAG}"
+echo "Previous version: ${PREVIOUS_TAG}"
+echo "Path filter: ${PATH_FILTER}"
+echo ""
+
+# Generate the changelog
+CHANGELOG=$(git log ${PREVIOUS_TAG}..${CURRENT_TAG} --oneline --no-merges -- ${PATH_FILTER})
+
+if [ -z "$CHANGELOG" ]; then
+  echo "## What's Changed"
+  echo ""
+  echo "No changes found in ${PATH_FILTER} since ${PREVIOUS_TAG}"
+else
+  echo "## What's Changed"
+  echo ""
+
+  # Format each commit as a markdown list item with PR link
+  while IFS= read -r line; do
+    # Extract commit hash and message
+    COMMIT_HASH=$(echo "$line" | awk '{print $1}')
+    COMMIT_MSG=$(echo "$line" | cut -d' ' -f2-)
+
+    # Extract PR number if present (match the last occurrence)
+    if [[ $COMMIT_MSG =~ \(#([0-9]+)\)[[:space:]]*$ ]]; then
+      PR_NUM="${BASH_REMATCH[1]}"
+      # Remove PR number from message (only the last occurrence)
+      CLEAN_MSG=$(echo "$COMMIT_MSG" | sed -E 's/[[:space:]]*\(#[0-9]+\)[[:space:]]*$//')
+      echo "* ${CLEAN_MSG} (#${PR_NUM})"
+    else
+      echo "* ${COMMIT_MSG}"
+    fi
+  done <<< "$CHANGELOG"
+fi
+
+echo ""
+echo "**Full Changelog**: https://github.com/\${GITHUB_REPOSITORY}/compare/${PREVIOUS_TAG}...${CURRENT_TAG}"

--- a/.github/workflows/publish-js-sdk.yaml
+++ b/.github/workflows/publish-js-sdk.yaml
@@ -69,7 +69,7 @@ jobs:
       (needs.validate.result == 'success' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
 
     env:
@@ -77,6 +77,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history for changelog generation
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -105,3 +107,30 @@ jobs:
           name: javascript-sdk-${{ github.event_name == 'workflow_dispatch' && 'prerelease' || 'release' }}-dist
           path: js/dist/
           retention-days: 5
+
+      # Create GitHub Release (only for regular releases)
+      - name: Generate release notes
+        if: github.event_name == 'push'
+        id: release_notes
+        run: |
+          RELEASE_NOTES=$(.github/scripts/generate-release-notes.sh "${{ env.RELEASE_TAG }}" "js/")
+          echo "notes<<EOF" >> $GITHUB_OUTPUT
+          echo "$RELEASE_NOTES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        if: github.event_name == 'push'
+        uses: actions/github-script@v7
+        env:
+          RELEASE_NOTES: ${{ steps.release_notes.outputs.notes }}
+        with:
+          script: |
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: process.env.RELEASE_TAG,
+              name: process.env.RELEASE_TAG,
+              body: process.env.RELEASE_NOTES,
+              draft: false,
+              prerelease: false
+            });

--- a/.github/workflows/publish-py-sdk.yaml
+++ b/.github/workflows/publish-py-sdk.yaml
@@ -33,6 +33,8 @@ jobs:
   build-and-publish:
     needs: validate
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -44,6 +46,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history for changelog generation
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -63,3 +67,28 @@ jobs:
         working-directory: py
         run: |
           make publish-to-pypi
+
+      # Create GitHub Release
+      - name: Generate release notes
+        id: release_notes
+        run: |
+          RELEASE_NOTES=$(.github/scripts/generate-release-notes.sh "${{ env.RELEASE_TAG }}" "py/")
+          echo "notes<<EOF" >> $GITHUB_OUTPUT
+          echo "$RELEASE_NOTES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: actions/github-script@v7
+        env:
+          RELEASE_NOTES: ${{ steps.release_notes.outputs.notes }}
+        with:
+          script: |
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: process.env.RELEASE_TAG,
+              name: process.env.RELEASE_TAG,
+              body: process.env.RELEASE_NOTES,
+              draft: false,
+              prerelease: false
+            });


### PR DESCRIPTION
tested js:
```
export GITHUB_REPOSITORY="braintrustdata/braintrust-sdk"
LATEST_JS_TAG=$(git tag --list "js-sdk-v*" --sort=-v:refname | head -1)
.github/scripts/generate-release-notes.sh "$LATEST_JS_TAG" js/
Generating release notes for js-sdk-v0.4.6
Previous version: js-sdk-v0.4.5
Path filter: js/

## What's Changed

* add @google/genai wrapper (#1003)
* Merge dicts - ignore undefined (#1004)
* [AI SDK] Fix load prompt (#1000)
* fix remote evals with users with multiple orgs (#1002)
* Properly handle attachments so we don't try to load base64 files in json (#998)
* Pass version into dataset fetch query (#997)
* rename `BraintrustMiddleware` spans from `ai-sdk.generate*` to `ai-sdk.do*` (#996)

**Full Changelog**: https://github.com/${GITHUB_REPOSITORY}/compare/js-sdk-v0.4.5...js-sdk-v0.4.6
```

tested python:
```
export GITHUB_REPOSITORY="braintrustdata/braintrust-sdk"
LATEST_PY_TAG=$(git tag --list "py-sdk-v*" --sort=-v:refname | head -1)
.github/scripts/generate-release-notes.sh "$LATEST_PY_TAG" py/
Generating release notes for py-sdk-v0.3.4
Previous version: py-sdk-v0.3.3
Path filter: py/

## What's Changed

* add gemini env var (#1005)

**Full Changelog**: https://github.com/${GITHUB_REPOSITORY}/compare/py-sdk-v0.3.3...py-sdk-v0.3.4
```