### PR TITLE
Run only core tests before Python releases

### DIFF
--- a/py/Makefile
+++ b/py/Makefile
@@ -15,7 +15,12 @@ test:
 	nox -x
 
 test-wheel: build
-	nox -x -- --wheel
+	# This target runs a small set of sanity checks before we release our
+	# build artifact to pypi. We skip running the full test suite because
+	# (a) theoretically it should have been run before (b) it has
+	# integration tests and we don't want to block the release because
+	# some service is down, etc. This decision could be revisited anytime.
+	nox -s test_core -- --wheel
 
 test-core:
 	nox -s test_core


### PR DESCRIPTION

- Modified the `test-wheel` target in py/Makefile to run only core tests (`test_core`) instead of the full test suite before releasing to PyPI.
- The full test suite can fail for a variety of reasons (providers down, etc) and it was already passed, so this is a fine smoke test. 
