### PR TITLE
Fix prerelease workflow to publish packages with appropriate suffix

### DIFF
--- a/.github/workflows/publish-js-sdk.yaml
+++ b/.github/workflows/publish-js-sdk.yaml
@@ -9,9 +9,8 @@
 #
 # 2. PRE-RELEASE (manual, workflow_dispatch):
 #    - Manually triggered via GitHub Actions UI
-#    - Choose pre-release type (beta/alpha/rc)
-#    - Automatically appends "rc{run_number}" to current package.json version
-#    - Publishes with appropriate dist-tag (beta/alpha/next)
+#    - Automatically appends "rc.{run_number}" to current package.json version
+#    - Publishes with "rc" dist-tag
 #    - Does NOT require updating package.json in the repository
 #
 
@@ -21,16 +20,7 @@ on:
   push:
     tags:
       - "js-sdk-v*.*.*" # Trigger on version tags like js-sdk-v0.1.0, js-sdk-v1.2.3, etc.
-  workflow_dispatch:
-    inputs:
-      prerelease_type:
-        description: "Pre-release type (determines npm dist-tag)"
-        required: true
-        type: choice
-        options:
-          - beta
-          - alpha
-          - rc
+  workflow_dispatch: # Trigger pre-release manually
 
 jobs:
   validate:
@@ -97,8 +87,8 @@ jobs:
         run: |
           # Read current version from package.json and append run number
           CURRENT_VERSION=$(node -p "require('./package.json').version")
-          NEW_VERSION="${CURRENT_VERSION}-${{ github.event.inputs.prerelease_type }}.${GITHUB_RUN_NUMBER}"
-          ./scripts/publish-prerelease.sh "${{ github.event.inputs.prerelease_type }}" "$NEW_VERSION"
+          NEW_VERSION="${CURRENT_VERSION}-rc.${GITHUB_RUN_NUMBER}"
+          ./scripts/publish-prerelease.sh "rc" "$NEW_VERSION"
 
       # Upload artifacts for both paths
       - name: Upload build artifacts

--- a/js/scripts/publish-prerelease.sh
+++ b/js/scripts/publish-prerelease.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 # Can be used both locally and in CI/CD
 #
 # Usage: ./publish-prerelease.sh <type> <version>
-#   type: beta, alpha, or rc
-#   version: explicit version to publish, e.g., 1.2.3-beta.1
+#   type: rc
+#   version: explicit version to publish, e.g., 1.2.3-rc.1
 
 # Get directories
 ROOT_DIR=$(git rev-parse --show-toplevel)
@@ -17,12 +17,10 @@ if [ $# -lt 2 ]; then
   echo "Usage: $0 <type> <version>"
   echo ""
   echo "Arguments:"
-  echo "  type: beta, alpha, or rc"
+  echo "  type: rc"
   echo "  version: explicit version to publish"
   echo ""
-  echo "Examples:"
-  echo "  $0 beta 1.2.3-beta.1"
-  echo "  $0 alpha 1.2.3-alpha.5"
+  echo "Example:"
   echo "  $0 rc 1.2.3-rc.1"
   exit 1
 fi
@@ -31,15 +29,11 @@ PRERELEASE_TYPE="$1"
 VERSION="$2"
 
 # Validate prerelease type
-case "$PRERELEASE_TYPE" in
-  beta|alpha|rc)
-    ;;
-  *)
-    echo "ERROR: Invalid prerelease type: $PRERELEASE_TYPE"
-    echo "Must be one of: beta, alpha, rc"
-    exit 1
-    ;;
-esac
+if [ "$PRERELEASE_TYPE" != "rc" ]; then
+  echo "ERROR: Invalid prerelease type: $PRERELEASE_TYPE"
+  echo "Must be: rc"
+  exit 1
+fi
 
 # Validate version format
 if [ -z "$VERSION" ]; then
@@ -48,24 +42,13 @@ if [ -z "$VERSION" ]; then
 fi
 
 # Validate that version contains the correct prerelease suffix
-if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-($PRERELEASE_TYPE)(\.[0-9]+)?$ ]]; then
-  echo "ERROR: Version '$VERSION' must include the prerelease type '$PRERELEASE_TYPE'"
-  echo "Expected format: X.Y.Z-$PRERELEASE_TYPE.N (e.g., 1.2.3-$PRERELEASE_TYPE.1)"
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$ ]]; then
+  echo "ERROR: Version '$VERSION' must include the prerelease type 'rc'"
+  echo "Expected format: X.Y.Z-rc.N (e.g., 1.2.3-rc.1)"
   exit 1
 fi
 
-# Map prerelease type to npm dist-tag
-case "$PRERELEASE_TYPE" in
-  beta)
-    DIST_TAG="beta"
-    ;;
-  alpha)
-    DIST_TAG="alpha"
-    ;;
-  rc)
-    DIST_TAG="next"
-    ;;
-esac
+DIST_TAG="rc"
 
 echo "================================================"
 echo " Publishing Pre-release"


### PR DESCRIPTION
I tried prereleasing https://github.com/braintrustdata/braintrust-sdk/pull/1011 but didn't specify a prerelease suffix so ended up releasing `0.4.7` on beta tag 🤦  https://www.npmjs.com/package/braintrust/v/0.4.6?activeTab=versions

new github flow:
<img width="1160" height="1000" alt="image" src="https://github.com/user-attachments/assets/c0a13f61-35e8-4c1d-ad86-48471dd268fb" />


new package release (github run number used for uniqueness):
`0.4.7-rc.8`
https://www.npmjs.com/package/braintrust/v/0.4.7-rc.8



