### PR TITLE
feat: make Eval() compatible with edge/browser environments

### DIFF
--- a/js/src/exports-browser.ts
+++ b/js/src/exports-browser.ts
@@ -4,7 +4,6 @@ export * from "./functions/invoke";
 export * from "./functions/stream";
 export * from "./wrappers/oai";
 export * from "./exports-types";
-// Now that Eval() has conditional CLI dependencies, it works in edge environments!
 export {
   Eval,
   EvalResult,

--- a/js/src/isomorph.ts
+++ b/js/src/isomorph.ts
@@ -11,6 +11,19 @@ export interface CallerLocation {
   caller_lineno: number;
 }
 
+export interface ProgressReporter {
+  start: (name: string, total: number) => void;
+  stop: () => void;
+  increment: (name: string) => void;
+}
+
+export interface ChalkInstance {
+  bold: {
+    red: (s: string) => string;
+  };
+  hex: (color: string) => (s: string) => string;
+}
+
 export interface IsoAsyncLocalStorage<T> {
   enterWith(store: T): void;
   run<R>(store: T | undefined, callback: () => R): R;
@@ -61,6 +74,17 @@ export interface Common {
   // zlib (promisified and type-erased).
   gunzip?: (data: any) => Promise<any>;
   gzip?: (data: any) => Promise<any>;
+
+  chalk: ChalkInstance;
+  newProgressReporter: () => ProgressReporter;
+}
+
+class SimpleProgressReporter implements ProgressReporter {
+  public start(name: string, _total: number) {
+    console.log(`Running evaluator ${name}`);
+  }
+  public stop() {}
+  public increment(_name: string) {}
 }
 
 const iso: Common = {
@@ -70,5 +94,12 @@ const iso: Common = {
   getCallerLocation: () => undefined,
   newAsyncLocalStorage: <T>() => new DefaultAsyncLocalStorage<T>(),
   processOn: (_0, _1) => {},
+  chalk: {
+    bold: {
+      red: (s: string) => s,
+    },
+    hex: () => (s: string) => s,
+  },
+  newProgressReporter: () => new SimpleProgressReporter(),
 };
 export default iso;

--- a/js/src/node.ts
+++ b/js/src/node.ts
@@ -4,11 +4,13 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as fsSync from "node:fs";
 import * as crypto from "node:crypto";
+import chalk from "chalk";
 
 import iso from "./isomorph";
 import { getRepoInfo, getPastNAncestors } from "./gitutil";
 import { getCallerLocation } from "./stackutil";
 import { _internalSetInitialState } from "./logger";
+import { BarProgressReporter } from "./progress";
 import { promisify } from "util";
 import * as zlib from "zlib";
 
@@ -35,6 +37,8 @@ export function configureNode() {
   iso.gzip = promisify(zlib.gzip);
   iso.gunzip = promisify(zlib.gunzip);
   iso.hash = (data) => crypto.createHash("sha256").update(data).digest("hex");
+  iso.chalk = chalk;
+  iso.newProgressReporter = () => new BarProgressReporter();
 
   _internalSetInitialState();
 }

--- a/js/src/progress.ts
+++ b/js/src/progress.ts
@@ -1,12 +1,4 @@
-// Conditional import for cli-progress (Node.js-only)
-let cliProgress: any;
-try {
-  cliProgress = require("cli-progress");
-} catch {
-  // In edge/browser environments, cli-progress is not available
-  // BarProgressReporter should not be used in these environments
-  cliProgress = null;
-}
+import * as cliProgress from "cli-progress";
 
 const MAX_NAME_LENGTH = 40;
 
@@ -33,16 +25,10 @@ export class SimpleProgressReporter implements ProgressReporter {
 }
 
 export class BarProgressReporter implements ProgressReporter {
-  private multiBar: any; // cliProgress.MultiBar (typed as any for conditional import)
-  private bars: Record<string, any> = {}; // Record<string, cliProgress.SingleBar>
+  private multiBar: cliProgress.MultiBar;
+  private bars: Record<string, cliProgress.SingleBar> = {};
 
   constructor() {
-    if (!cliProgress) {
-      throw new Error(
-        "BarProgressReporter requires cli-progress which is only available in Node.js environments. " +
-          "Use SimpleProgressReporter in edge/browser environments instead.",
-      );
-    }
     this.multiBar = new cliProgress.MultiBar(
       {
         clearOnComplete: false,


### PR DESCRIPTION
  Makes Eval() compatible with edge/browser environments by removing hard dependencies on Node.js-only packages (chalk, cli-progress).

  Platform-specific code is now abstracted through the isomorph pattern: browser-safe defaults are provided in isomorph.ts, and Node.js implementations are
  configured in node.ts. Application code remains platform-agnostic by calling iso.chalk and iso.newProgressReporter() instead of importing packages directly.

  This follows the existing pattern used for hash, filesystem operations, and other platform-specific functionality.