### PR TITLE
Update OpenAI parsing of arguments for some models

### DIFF
--- a/py/src/braintrust/oai.py
+++ b/py/src/braintrust/oai.py
@@ -312,19 +312,25 @@ class ChatCompletionWrapper:
 
                 # pylint: disable=unsubscriptable-object
                 if not tool_calls or (tool_delta.get("id") and tool_calls[-1]["id"] != tool_delta.get("id")):
+                    function_arg = tool_delta.get("function", {})
                     tool_calls = (tool_calls or []) + [
                         {
-                            "id": delta["tool_calls"][0]["id"],
-                            "type": delta["tool_calls"][0]["type"],
+                            "id": tool_delta.get("id"),
+                            "type": tool_delta.get("type"),
                             "function": {
-                                "name": delta["tool_calls"][0]["function"]["name"],
-                                "arguments": delta["tool_calls"][0]["function"]["arguments"] or "",
+                                "name": function_arg.get("name"),
+                                "arguments": function_arg.get("arguments") or "",
                             },
                         }
                     ]
                 else:
                     # pylint: disable=unsubscriptable-object
-                    tool_calls[-1]["function"]["arguments"] += delta["tool_calls"][0]["function"]["arguments"] or ""
+                    # append to existing tool call
+                    function_arg = tool_delta.get("function", {})
+                    args = function_arg.get("arguments") or ""
+                    if isinstance(args, str):
+                        # pylint: disable=unsubscriptable-object
+                        tool_calls[-1]["function"]["arguments"] += args
 
         return {
             "metrics": metrics,

--- a/py/src/braintrust/wrappers/test_openai.py
+++ b/py/src/braintrust/wrappers/test_openai.py
@@ -378,201 +378,6 @@ def test_openai_responses_sparse_indices(memory_logger):
     # No spans should be generated from this unit test
     assert not memory_logger.pop()
 
-
-def test_chat_completion_streaming_none_arguments(memory_logger):
-    """Test that ChatCompletionWrapper handles None arguments in tool calls (e.g., GLM-4.6 behavior)."""
-    assert not memory_logger.pop()
-
-    # Simulate streaming results with None arguments in tool calls
-    # This mimics the behavior of GLM-4.6 which returns {'arguments': None, 'name': 'weather'}
-    all_results = [
-        # First chunk: initial tool call with None arguments
-        {
-            "choices": [
-                {
-                    "delta": {
-                        "role": "assistant",
-                        "tool_calls": [
-                            {
-                                "id": "call_123",
-                                "type": "function",
-                                "function": {
-                                    "name": "get_weather",
-                                    "arguments": None,  # GLM-4.6 returns None here
-                                },
-                            }
-                        ],
-                    },
-                    "finish_reason": None,
-                }
-            ],
-        },
-        # Second chunk: subsequent tool call arguments (also None)
-        {
-            "choices": [
-                {
-                    "delta": {
-                        "tool_calls": [
-                            {
-                                "function": {
-                                    "arguments": None,  # Subsequent chunks can also have None
-                                }
-                            }
-                        ],
-                    },
-                    "finish_reason": None,
-                }
-            ],
-        },
-        # Third chunk: actual arguments
-        {
-            "choices": [
-                {
-                    "delta": {
-                        "tool_calls": [
-                            {
-                                "function": {
-                                    "arguments": '{"city": "New York"}',
-                                }
-                            }
-                        ],
-                    },
-                    "finish_reason": None,
-                }
-            ],
-        },
-        # Final chunk
-        {
-            "choices": [
-                {
-                    "delta": {},
-                    "finish_reason": "tool_calls",
-                }
-            ],
-        },
-    ]
-
-    # Process the results
-    wrapper = ChatCompletionWrapper(None, None)
-    result = wrapper._postprocess_streaming_results(all_results)
-
-    # Verify the output was built correctly
-    assert "output" in result
-    assert len(result["output"]) == 1
-    message = result["output"][0]["message"]
-    assert message["role"] == "assistant"
-    assert message["tool_calls"] is not None
-    assert len(message["tool_calls"]) == 1
-
-    # Verify the tool call was assembled correctly despite None arguments
-    tool_call = message["tool_calls"][0]
-    assert tool_call["id"] == "call_123"
-    assert tool_call["type"] == "function"
-    assert tool_call["function"]["name"] == "get_weather"
-    # The arguments should be the concatenation: "" + "" + '{"city": "New York"}'
-    assert tool_call["function"]["arguments"] == '{"city": "New York"}'
-
-    # No spans should be generated from this unit test
-    assert not memory_logger.pop()
-
-
-def test_chat_completion_streaming_none_arguments(memory_logger):
-    """Test that ChatCompletionWrapper handles None arguments in tool calls (e.g., GLM-4.6 behavior)."""
-    assert not memory_logger.pop()
-
-    # Simulate streaming results with None arguments in tool calls
-    # This mimics the behavior of GLM-4.6 which returns {'arguments': None, 'name': 'weather'}
-    all_results = [
-        # First chunk: initial tool call with None arguments
-        {
-            "choices": [
-                {
-                    "delta": {
-                        "role": "assistant",
-                        "tool_calls": [
-                            {
-                                "id": "call_123",
-                                "type": "function",
-                                "function": {
-                                    "name": "get_weather",
-                                    "arguments": None,  # GLM-4.6 returns None here
-                                },
-                            }
-                        ],
-                    },
-                    "finish_reason": None,
-                }
-            ],
-        },
-        # Second chunk: subsequent tool call arguments (also None)
-        {
-            "choices": [
-                {
-                    "delta": {
-                        "tool_calls": [
-                            {
-                                "function": {
-                                    "arguments": None,  # Subsequent chunks can also have None
-                                }
-                            }
-                        ],
-                    },
-                    "finish_reason": None,
-                }
-            ],
-        },
-        # Third chunk: actual arguments
-        {
-            "choices": [
-                {
-                    "delta": {
-                        "tool_calls": [
-                            {
-                                "function": {
-                                    "arguments": '{"city": "New York"}',
-                                }
-                            }
-                        ],
-                    },
-                    "finish_reason": None,
-                }
-            ],
-        },
-        # Final chunk
-        {
-            "choices": [
-                {
-                    "delta": {},
-                    "finish_reason": "tool_calls",
-                }
-            ],
-        },
-    ]
-
-    # Process the results
-    wrapper = ChatCompletionWrapper(None, None)
-    result = wrapper._postprocess_streaming_results(all_results)
-
-    # Verify the output was built correctly
-    assert "output" in result
-    assert len(result["output"]) == 1
-    message = result["output"][0]["message"]
-    assert message["role"] == "assistant"
-    assert message["tool_calls"] is not None
-    assert len(message["tool_calls"]) == 1
-
-    # Verify the tool call was assembled correctly despite None arguments
-    tool_call = message["tool_calls"][0]
-    assert tool_call["id"] == "call_123"
-    assert tool_call["type"] == "function"
-    assert tool_call["function"]["name"] == "get_weather"
-    # The arguments should be the concatenation: "" + "" + '{"city": "New York"}'
-    assert tool_call["function"]["arguments"] == '{"city": "New York"}'
-
-    # No spans should be generated from this unit test
-    assert not memory_logger.pop()
-
-
 @pytest.mark.vcr
 def test_openai_embeddings(memory_logger):
     assert not memory_logger.pop()
@@ -2128,3 +1933,102 @@ class TestAutoInstrumentOpenAI:
     def test_auto_instrument_openai(self):
         """Test auto_instrument patches OpenAI, creates spans, and uninstrument works."""
         verify_autoinstrument_script("test_auto_openai.py")
+
+class TestZAICompatibleOpenAI:
+    """Tests for validating some ZAI compatibility with OpenAI wrapper."""
+
+    def test_chat_completion_streaming_none_arguments(self, memory_logger):
+        """Test that ChatCompletionWrapper handles None arguments in tool calls (e.g., GLM-4.6 behavior)."""
+        assert not memory_logger.pop()
+
+        # Simulate streaming results with None arguments in tool calls
+        # This mimics the behavior of GLM-4.6 which returns {'arguments': None, 'name': 'weather'}
+        all_results = [
+            # First chunk: initial tool call with None arguments
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "role": "assistant",
+                            "tool_calls": [
+                                {
+                                    "id": "call_123",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "get_weather",
+                                        "arguments": None,  # GLM-4.6 returns None here
+                                    },
+                                }
+                            ],
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            # Second chunk: subsequent tool call arguments (also None)
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "function": {
+                                        "arguments": None,  # Subsequent chunks can also have None
+                                    }
+                                }
+                            ],
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            # Third chunk: actual arguments
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "function": {
+                                        "arguments": '{"city": "New York"}',
+                                    }
+                                }
+                            ],
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            # Final chunk
+            {
+                "choices": [
+                    {
+                        "delta": {},
+                        "finish_reason": "tool_calls",
+                    }
+                ],
+            },
+        ]
+
+        # Process the results
+        wrapper = ChatCompletionWrapper(None, None)
+        result = wrapper._postprocess_streaming_results(all_results)
+
+        # Verify the output was built correctly
+        assert "output" in result
+        assert len(result["output"]) == 1
+        message = result["output"][0]["message"]
+        assert message["role"] == "assistant"
+        assert message["tool_calls"] is not None
+        assert len(message["tool_calls"]) == 1
+
+        # Verify the tool call was assembled correctly despite None arguments
+        tool_call = message["tool_calls"][0]
+        assert tool_call["id"] == "call_123"
+        assert tool_call["type"] == "function"
+        assert tool_call["function"]["name"] == "get_weather"
+        # The arguments should be the concatenation: "" + "" + '{"city": "New York"}'
+        assert tool_call["function"]["arguments"] == '{"city": "New York"}'
+
+        # No spans should be generated from this unit test
+        assert not memory_logger.pop()


### PR DESCRIPTION
Some models parse arguments as `None` when providing tool calls. Eg. GLM-4.6

```
{'id': 'call_xAFPJJaHlZWWgG52ScgnehqR', 'type': 'function', 'function': {'arguments': None, 'name': 'weather'}}
```

The proposed code fixes the concatenation by parsing `None` arguments to empty string.