### PR TITLE
Test out paths-ignore github setting

### DIFF
--- a/.github/workflows/test-js-trigger.yaml
+++ b/.github/workflows/test-js-trigger.yaml
@@ -4,8 +4,8 @@ on:
   pull_request:
     paths-ignore:
       - "py/**"
-      - "integrations/langchain-py/**"
-      - "integrations/adk-py/**"
+      - "integrations/*-py/**"
+
   push:
     branches: [main]
 

--- a/.github/workflows/test-py-trigger.yaml
+++ b/.github/workflows/test-py-trigger.yaml
@@ -4,9 +4,9 @@ on:
   pull_request:
     paths-ignore:
       - "js/**"
-      - "integrations/langchain-js/**"
+      - "integrations/*-js/**"
       - "integrations/vercel-ai-sdk/**"
-      - "integrations/openai-agents-js/**"
+
   push:
     branches: [main]
 


### PR DESCRIPTION
### Background

It was bugging me all week that when I was making just js sdk changes all the python builds would build.

### Changes
Add and test out the paths ignore github setting.

There is no great way I have thought of to test workflow changes like this locally since once you make the change to the workflow yaml those workflow jobs will always run. 

I could put the filter changes directly into the js.yaml and py.yaml builds but I figured it might be nice to try out the filter settings in a separate job, watch when the two trigger jobs run during some PRs and then add the changes to the real jy.yaml and py.yaml jobs.