### PR TITLE
Fix typing of BraintrustExporter

### DIFF
--- a/integrations/otel-js/src/otel.ts
+++ b/integrations/otel-js/src/otel.ts
@@ -17,6 +17,11 @@ import {
 } from "@opentelemetry/sdk-trace-base";
 import { IDGenerator, type Span as BraintrustSpan } from "braintrust";
 
+interface ExportResult {
+  code: number;
+  error?: Error;
+}
+
 const FILTER_PREFIXES = [
   "gen_ai.",
   "braintrust.",
@@ -629,7 +634,7 @@ export class BraintrustExporter {
    */
   export(
     spans: ReadableSpan[],
-    resultCallback: (result: { code: number; error?: unknown }) => void,
+    resultCallback: (result: ExportResult) => void,
   ): void {
     try {
       // Process each span through the processor
@@ -644,10 +649,14 @@ export class BraintrustExporter {
           resultCallback({ code: 0 }); // SUCCESS
         })
         .catch((error) => {
-          resultCallback({ code: 1, error }); // FAILURE
+          const errorObj =
+            error instanceof Error ? error : new Error(String(error));
+          resultCallback({ code: 1, error: errorObj }); // FAILURE
         });
     } catch (error) {
-      resultCallback({ code: 1, error }); // FAILURE
+      const errorObj =
+        error instanceof Error ? error : new Error(String(error));
+      resultCallback({ code: 1, error: errorObj }); // FAILURE
     }
   }
 


### PR DESCRIPTION
ExportResult comes from opentelemetry/core so I shallow copied it to avoid the direct dependency to the core library. 

I build and packed the braintrust-otel package and I was able to remove the `as unknown as SpanExporter` from the exporter_example.ts.

Will update the test on next braintrust/otel release
<img width="800" height="417" alt="Screenshot 2025-12-02 at 10 43 31 AM" src="https://github.com/user-attachments/assets/cc4ae89d-37f9-4e8f-bf6f-90a991d11feb" />
<img width="443" height="175" alt="Screenshot 2025-12-02 at 10 50 49 AM" src="https://github.com/user-attachments/assets/137f2782-8890-4fdd-b962-e07a848cbeb6" />
