### PR TITLE
Fix formatting of pip install command in README

### DIFF
--- a/py/examples/temporal/README.md
+++ b/py/examples/temporal/README.md
@@ -7,7 +7,7 @@ This example demonstrates distributed tracing for Temporal workflows using Brain
 1. Install Braintrust with Temporal support:
 
    ```bash
-   pip install braintrust[temporal]
+   pip install "braintrust[temporal]"
    ```
 
    Or if using mise:


### PR DESCRIPTION
zsh (and i believe fish) needs this to be quoted or you get a `zsh: no matches found: braintrust[temporal]`. 

Quotes should be benign for bash.

cc @clutchski