### PR TITLE
remove the pretty terminal link

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -128,7 +128,6 @@
     "simple-git": "^3.21.0",
     "slugify": "^1.6.6",
     "source-map": "^0.7.4",
-    "terminal-link": "^5.0.0",
     "uuid": "^9.0.1",
     "zod": "^3.25.34",
     "zod-to-json-schema": "^3.22.5"

--- a/js/src/cli.ts
+++ b/js/src/cli.ts
@@ -24,7 +24,6 @@ import {
   ProgressReporter,
 } from "./progress";
 import chalk from "chalk";
-import terminalLink from "terminal-link";
 
 // Re-use the module resolution logic from Jest
 import {
@@ -131,11 +130,7 @@ async function initExperiment(
     setCurrent: false,
   });
   const info = await logger.summarize({ summarizeScores: false });
-  const linkText = info.experimentUrl
-    ? terminalLink(info.experimentUrl, info.experimentUrl, {
-        fallback: () => info.experimentUrl!,
-      })
-    : "locally";
+  const linkText = info.experimentUrl || "locally";
   console.error(
     chalk.cyan("▶") +
       ` Experiment ${chalk.bold(info.experimentName)} is running at ${linkText}`,

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -9,7 +9,6 @@ import { queue } from "async";
 
 import chalk from "chalk";
 import boxen from "boxen";
-import terminalLink from "terminal-link";
 import pluralize from "pluralize";
 import Table from "cli-table3";
 import { GenericFunction } from "./framework-types";
@@ -1608,11 +1607,7 @@ export function formatExperimentSummary(summary: ExperimentSummary) {
   const content = [comparisonLine, ...tableParts].filter(Boolean).join("\n");
 
   const footer = summary.experimentUrl
-    ? terminalLink(
-        `View results for ${summary.experimentName}`,
-        summary.experimentUrl,
-        { fallback: () => `See results at ${summary.experimentUrl}` },
-      )
+    ? `See results at ${summary.experimentUrl}`
     : "";
 
   const boxContent = [content, footer].filter(Boolean).join("\n\n");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,9 +223,6 @@ importers:
       source-map:
         specifier: ^0.7.4
         version: 0.7.4
-      terminal-link:
-        specifier: ^5.0.0
-        version: 5.0.0
       uuid:
         specifier: ^9.0.1
         version: 9.0.1
@@ -4228,13 +4225,6 @@ packages:
       type-fest: 0.21.3
     dev: true
 
-  /ansi-escapes@7.2.0:
-    resolution: {integrity: sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==}
-    engines: {node: '>=18'}
-    dependencies:
-      environment: 1.1.0
-    dev: false
-
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -5151,11 +5141,6 @@ packages:
     engines: {node: '>=0.12'}
     dev: false
 
-  /environment@1.1.0:
-    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
-    engines: {node: '>=18'}
-    dev: false
-
   /error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
     dependencies:
@@ -6042,11 +6027,6 @@ packages:
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-
-  /has-flag@5.0.1:
-    resolution: {integrity: sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==}
-    engines: {node: '>=12'}
-    dev: false
 
   /has-property-descriptors@1.0.1:
     resolution: {integrity: sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==}
@@ -8627,11 +8607,6 @@ packages:
       ts-interface-checker: 0.1.13
     dev: true
 
-  /supports-color@10.2.2:
-    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
-    engines: {node: '>=18'}
-    dev: false
-
   /supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -8651,14 +8626,6 @@ packages:
     dependencies:
       has-flag: 4.0.0
     dev: true
-
-  /supports-hyperlinks@4.3.0:
-    resolution: {integrity: sha512-i6sWEzuwadSlcr2mOnb0ktlIl+K5FVxsPXmoPfknDd2gyw4ZBIAZ5coc0NQzYqDdEYXMHy8NaY9rWwa1Q1myiQ==}
-    engines: {node: '>=20'}
-    dependencies:
-      has-flag: 5.0.1
-      supports-color: 10.2.2
-    dev: false
 
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -8722,14 +8689,6 @@ packages:
       tslib: 2.8.1
       typescript: 4.9.5
     dev: true
-
-  /terminal-link@5.0.0:
-    resolution: {integrity: sha512-qFAy10MTMwjzjU8U16YS4YoZD+NQLHzLssFMNqgravjbvIPNiqkGFR4yjhJfmY9R5OFU7+yHxc6y+uGHkKwLRA==}
-    engines: {node: '>=20'}
-    dependencies:
-      ansi-escapes: 7.2.0
-      supports-hyperlinks: 4.3.0
-    dev: false
 
   /test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}


### PR DESCRIPTION
terminal link pulls in supports hyperlink which has a hard dependency on support-color

The browser version of supports-color doesn't have the method that supports-hyperlink uses causing failures in cloudflare environments

<img width="1229" height="294" alt="Screenshot 2025-12-04 at 12 21 08 PM" src="https://github.com/user-attachments/assets/01e4b973-5fbf-4dd3-8d90-8bf41f064249" />


Cloudflare error

`  ✘ [ERROR] No matching export in
  "../../node_modules/.pnpm/supports-color@10.2.2/node_modules/supports-color/browser.js" for import
  "createSupportsColor"
  
  
  ../../node_modules/.pnpm/supports-hyperlinks@4.3.0/node_modules/supports-hyperlinks/index.js:2:8:
        2 │ import {createSupportsColor} from 'supports-color';
          ╵         ~~~~~~~~~~~~~~~~~~~
`
