### PR TITLE
Allow links to be clicked in supported terminals

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -128,6 +128,7 @@
     "simple-git": "^3.21.0",
     "slugify": "^1.6.6",
     "source-map": "^0.7.4",
+    "termi-link": "^1.0.1",
     "uuid": "^9.0.1",
     "zod": "^3.25.34",
     "zod-to-json-schema": "^3.22.5"

--- a/js/src/cli.ts
+++ b/js/src/cli.ts
@@ -24,6 +24,7 @@ import {
   ProgressReporter,
 } from "./progress";
 import chalk from "chalk";
+import { terminalLink } from "termi-link";
 
 // Re-use the module resolution logic from Jest
 import {
@@ -130,7 +131,11 @@ async function initExperiment(
     setCurrent: false,
   });
   const info = await logger.summarize({ summarizeScores: false });
-  const linkText = info.experimentUrl || "locally";
+  const linkText = info.experimentUrl
+    ? terminalLink(info.experimentUrl, info.experimentUrl, {
+        fallback: (_text: string, url: string) => url,
+      })
+    : "locally";
   console.error(
     chalk.cyan("▶") +
       ` Experiment ${chalk.bold(info.experimentName)} is running at ${linkText}`,

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -8,6 +8,7 @@ import {
 import { queue } from "async";
 
 import chalk from "chalk";
+import { terminalLink } from "termi-link";
 import boxen from "boxen";
 import pluralize from "pluralize";
 import Table from "cli-table3";
@@ -1607,7 +1608,11 @@ export function formatExperimentSummary(summary: ExperimentSummary) {
   const content = [comparisonLine, ...tableParts].filter(Boolean).join("\n");
 
   const footer = summary.experimentUrl
-    ? `See results at ${summary.experimentUrl}`
+    ? terminalLink(
+        `View results for ${summary.experimentName}`,
+        summary.experimentUrl,
+        { fallback: () => `See results at ${summary.experimentUrl}` },
+      )
     : "";
 
   const boxContent = [content, footer].filter(Boolean).join("\n\n");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,9 @@ importers:
       source-map:
         specifier: ^0.7.4
         version: 0.7.4
+      termi-link:
+        specifier: ^1.0.1
+        version: 1.1.0
       uuid:
         specifier: ^9.0.1
         version: 9.0.1
@@ -8689,6 +8692,11 @@ packages:
       tslib: 2.8.1
       typescript: 4.9.5
     dev: true
+
+  /termi-link@1.1.0:
+    resolution: {integrity: sha512-2qSN6TnomHgVLtk+htSWbaYs4Rd2MH/RU7VpHTy6MBstyNyWbM4yKd1DCYpE3fDg8dmGWojXCngNi/MHCzGuAA==}
+    engines: {node: '>=12'}
+    dev: false
 
   /test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}


### PR DESCRIPTION
Found a termi-link package based on terminal link with a small fix to windows that also includes less dependencies. 

Less overall downloads but more streamlined package for exactly what we want for our use case.

In fancy terminal
<img width="607" height="219" alt="Screenshot 2025-12-04 at 2 28 52 PM" src="https://github.com/user-attachments/assets/6c683eaa-8af1-4ef8-8d10-f773a77818bd" />
In fallback terminal
<img width="1229" height="294" alt="Screenshot 2025-12-04 at 12 21 08 PM" src="https://github.com/user-attachments/assets/471eaf10-bc2f-4943-9624-04242d82d915" />
