### PR TITLE
Fix withResponse() on wrapped OpenAI responses API

### DIFF
--- a/js/src/wrappers/oai_responses.ts
+++ b/js/src/wrappers/oai_responses.ts
@@ -400,6 +400,13 @@ function apiPromiseProxy(
           );
         };
       }
+      // Handle withResponse() - must call on original target to access private #client field
+      if (name === "withResponse") {
+        return async () => {
+          const { data, response } = await target.withResponse();
+          return { data: onThen(data), response };
+        };
+      }
       return Reflect.get(target, name, receiver);
     },
   });


### PR DESCRIPTION
### Context <!-- Help the reviewer understand the why you are doing this -->

A customer reported that calling `.withResponse()` on a wrapped OpenAI client's `responses.create()` fails with:

```
TypeError: Cannot read private member from an object whose class did not declare it
```

This happens because the OpenAI SDK's `withResponse()` method accesses a private class field (`#client`), which fails when called through `wrapOpenAI`'s internal JavaScript Proxy wrapper since private fields are bound to the original class instance, not the proxy object.

source support case:
https://app.usepylon.com/issues?conversationID=1a7c9159-6789-4511-a698-657359d2532a

### Description <!-- Help the reviewer understand what you changed and what the expected behavior is now -->

Added explicit handling for `withResponse` in `apiPromiseProxy` (`oai_responses.ts`). Instead of letting the call fall through to `Reflect.get()` (which returns a function bound to the proxy), we
now intercept it and call `withResponse()` directly on the original target object.

The `onThen` processing is still applied to the data before returning, so span logging continues to work correctly.

### Testing <!-- Describe how and what you tested. Include screenshots or videos as needed -->

- Added live test `"openai.responses.create withResponse"` in `oai.test.ts`
- Verified test fails without fix (reproduces the exact error)
- Verified test passes with fix

Log generated without the fix:
https://www.braintrust.dev/app/braintrustdata.com/p/mgallegos_case_8915/logs?r=a49bbc50-7804-41dd-b9ca-33a480ed50ff&s=a49bbc50-7804-41dd-b9ca-33a480ed50ff

Log generated with the fix:
https://www.braintrust.dev/app/braintrustdata.com/p/mgallegos_case_8915/logs?r=b1a22bdd-d3c7-4bf7-8946-d0698e28c2d1&s=b1a22bdd-d3c7-4bf7-8946-d0698e28c2d1