### PR TITLE
Trace with_raw_response.create() calls in Python wrap_openai

### DIFF
--- a/py/src/braintrust/wrappers/cassettes/test_openai_responses_with_raw_response.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_responses_with_raw_response.yaml
@@ -1,0 +1,111 @@
+interactions:
+- request:
+    body: '{"input":"What''s 12 + 12?","instructions":"Just the number please","model":"gpt-4o-mini"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '89'
+      Content-Type:
+      - application/json
+      Host:
+      - api.openai.com
+      User-Agent:
+      - OpenAI/Python 2.9.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.9.0
+      X-Stainless-Raw-Response:
+      - 'true'
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.11.13
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3xU0W7bMAx8z1cIem4GR3GdNJ+wXygGg5bpVKssChIVNCjy74Pl2LG3dm8xjzyR
+        d2Q+N0JI08qTkAGjrwu1V9W+bVEXrS4qXRTVy74qO1UWOyyPuxdoNB6Lg3oGpZTal0f5NFBQ8xs1
+        TzTkIo5xHRAY2xoGbHeonndVdTyWGYsMnOJQo6n3FhnbsagB/X4OlNzQVwc24hg21hp3lifxuRFC
+        COnhimGob/GCljwGuRHilpMxBBowl6zNAeOmV+oWGYyNazRySJoNudzRzxRZ8BsKl/oGg/AWYZqp
+        h4+aEvvENdM7uhXRADKRrTXY9RM9tWgH7rPnbUnb3jizVYUqt8Vhu5t0zLzyJF7ziOOgs0V9PP/H
+        oVapYnAIDsdSdc9dceiqQ4mQmTMLXz1mHowRzvgAvrMig5oco3s0tWxsRTuJgh88V+cEcI4YJnFf
+        f61AS2cfqPkCyUQnIVUp5/Dt/mvOlIFsfh1iNJHB8Zg8JOYk6SGAtWjXvnBI41r5gBdDKdbT5tZZ
+        7Nk3H6j3XGvQb1i/4/VbLOAgkyG3zAgIkdxqbbHrKPAiaTAg9T2EiXve4ggd8rU27UDcGVxtdMRw
+        MRprNtMVdJDsKL2MTAGXYzL2HgNwyuHdj+IezRLfO+so9PD4Xlib80Zd7x1fMDQUDV/HhWpN6h/X
+        Nyr9RkaP1iQmOQMPpyWTrxf+F3PQL3sMyWm4CytbE6Gx019Fyns8D2Dc6iqVevo3vjj/ecxsYPso
+        LFaj/n3s6qv4V7Sz+d8xMzHYBXE5K5ji2uweGVpgGOhvm9sfAAAA//8DAD6Hmzu4BQAA
+    headers:
+      CF-RAY:
+      - 9aa9663d8c54cb73-PDX
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 08 Dec 2025 04:08:06 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=Vmb_xImKA3vcktQZDmvrtx3KeYLC58yPUKZMtNqocSA-1765166886-1.0.1.1-sxBXY70ng4iATtk5ekYKwc1Al0Fzc96oQ_YK4vD641oHGz6npDR5Tg3lhhjQRO1vDWdEbiRgtplPHjKg3dkidEy1ecvWf9TwLKP6MO5ldvU;
+        path=/; expires=Mon, 08-Dec-25 04:38:06 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=Owou.npLEpK.c8eABsWye5n3kfDYPRLJeLTJJZV85Lw-1765166886292-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - user-bkcsfvrp2vh67rqzpgtsbnle
+      openai-processing-ms:
+      - '2289'
+      openai-project:
+      - proj_IG1Ou5SIiy81s3W66WZ5dtN6
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '2293'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999959'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_db952f90e31b49ec8f025c020fdacf37
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_responses_with_raw_response_async.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_responses_with_raw_response_async.yaml
@@ -1,0 +1,111 @@
+interactions:
+- request:
+    body: '{"input":"What''s 12 + 12?","instructions":"Just the number please","model":"gpt-4o-mini"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '89'
+      Content-Type:
+      - application/json
+      Host:
+      - api.openai.com
+      User-Agent:
+      - AsyncOpenAI/Python 2.9.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - async:asyncio
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.9.0
+      X-Stainless-Raw-Response:
+      - 'true'
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.11.13
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3RU0Y6jMAx871dEed6egLKF9hPuF1YnZILp5jbEUeJUW5367ydCoXC3+1Y89sSe
+        sftnJ4TUnTwL6TG4JuuyrDqU5UEdTpBDnmXH0+FY9kVVKszq/NS22B5VXWbH1z7Dqszly0hB7W9U
+        PNOQDTjFlUdg7BoYsbw6vubHY11XCQsMHMNYo2hwBhm7qagF9XHxFO3YVw8m4BTWxmh7kWfxZyeE
+        ENLBDf1Y3+EVDTn0cifEPSWj9zRiNhqTAtrOrzQdMmgTtmhgHxVrsqmjnzGw4HcUNg4teuEMwjzT
+        AJ8NRXaRG6YPtBuiEWQi0ygw2ycG6tCM3BfH+5L2g7Z6X2RFuc+qfV4/dEy88ize0ojToItFQ7h8
+        71B9qqAeHaoLVfTda9lWqijrqkjMiYVvDhMPhgAXfALfWZFARZbRPptaN7ahnUXBT16qUwJYSwyz
+        uG+/NqChi/PUfoEkorOQRSmX8P3xa8mUnkx6HULQgcHylDwmpiTpwIMxaLa+sI/TWjmPV00xNPPm
+        NknsxTfnaXDcKFDv2Hzg7VvM4yiTJrvO8AiB7GZtse/J8yppNCAOA/iZe9niAD3yrdHdSNxr3Gx0
+        QH/VChvW8xX0EM0kvQxMHtdjMg4OPXBM4fxH9ogmiR+d9eQHeH6vrE15k66Pjq/oWwqab9NCdToO
+        z+ublH4nrSZrIpNcgKfTksk1K/+zJejWPfpoFTyElZ0O0Jr5ryKmPV4G0HZzlUXx8n98df7LmMnA
+        7lmYbUb999iLr+Jf0S7mf8fMxGBWxOWiYAxbswdk6IBhpL/v7n8BAAD//wMAUbWMVbgFAAA=
+    headers:
+      CF-RAY:
+      - 9aa9664fe955fc83-PDX
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 08 Dec 2025 04:08:09 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=PYWIA_OZV_XpYHOVP5CjU03HZmpmVV4EBBa3WT1tCaY-1765166889-1.0.1.1-B7DAvTRV7NbH0xRoOYhQ.TI0cs8vH6V3RIVaVvR68bulXIze10DejdncTfTPXDLg_DsYe82lWc7MRJsAbYMOl9xU0QKVs6Zm2dQkNd8nzQw;
+        path=/; expires=Mon, 08-Dec-25 04:38:09 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=OxBAQjyaSN7VVtX9nS.5cVkOTZRSaRzOjezXdCCTm_A-1765166889464-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - user-bkcsfvrp2vh67rqzpgtsbnle
+      openai-processing-ms:
+      - '2163'
+      openai-project:
+      - proj_IG1Ou5SIiy81s3W66WZ5dtN6
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '2167'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999959'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_7efae712197340ab939fb85a186697cd
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_responses_with_raw_response_streaming.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_responses_with_raw_response_streaming.yaml
@@ -1,0 +1,134 @@
+interactions:
+- request:
+    body: '{"input":"What''s 12 + 12?","instructions":"Just the number please","model":"gpt-4o-mini","stream":true}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '103'
+      Content-Type:
+      - application/json
+      Host:
+      - api.openai.com
+      User-Agent:
+      - OpenAI/Python 2.9.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.9.0
+      X-Stainless-Raw-Response:
+      - 'true'
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.11.13
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: 'event: response.created
+
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_059cd711785b7c65006936548826d8819b8e094c2b8cf1b382","object":"response","created_at":1765168264,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":"Just
+        the number please","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.in_progress
+
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_059cd711785b7c65006936548826d8819b8e094c2b8cf1b382","object":"response","created_at":1765168264,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":"Just
+        the number please","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_059cd711785b7c650069365488c2b0819ba49a54343b1270bd","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+
+
+        event: response.content_part.added
+
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_059cd711785b7c650069365488c2b0819ba49a54343b1270bd","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_059cd711785b7c650069365488c2b0819ba49a54343b1270bd","output_index":0,"content_index":0,"delta":"24","logprobs":[],"obfuscation":"Wvlnrnqds5qfrP"}
+
+
+        event: response.output_text.done
+
+        data: {"type":"response.output_text.done","sequence_number":5,"item_id":"msg_059cd711785b7c650069365488c2b0819ba49a54343b1270bd","output_index":0,"content_index":0,"text":"24","logprobs":[]}
+
+
+        event: response.content_part.done
+
+        data: {"type":"response.content_part.done","sequence_number":6,"item_id":"msg_059cd711785b7c650069365488c2b0819ba49a54343b1270bd","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"24"}}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","sequence_number":7,"output_index":0,"item":{"id":"msg_059cd711785b7c650069365488c2b0819ba49a54343b1270bd","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"24"}],"role":"assistant"}}
+
+
+        event: response.completed
+
+        data: {"type":"response.completed","sequence_number":8,"response":{"id":"resp_059cd711785b7c65006936548826d8819b8e094c2b8cf1b382","object":"response","created_at":1765168264,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":"Just
+        the number please","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[{"id":"msg_059cd711785b7c650069365488c2b0819ba49a54343b1270bd","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"24"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":22,"input_tokens_details":{"cached_tokens":0},"output_tokens":2,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":24},"user":null,"metadata":{}}}
+
+
+        '
+    headers:
+      CF-RAY:
+      - 9aa987f2a86aff13-PDX
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Mon, 08 Dec 2025 04:31:04 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=4seYPgO51B4D5ykA4je8GvK_2_4jVKUAxusjiEeIVYY-1765168264-1.0.1.1-_QfKY0QNCqgRnN3HddfNkguNvCZFsMyuU89frXmyhSv59xVZ2tHADe0GtfzjwL3J7tZs66txc_rSqVdARNSEqn.lYi17w8wQS_exhQhCGAQ;
+        path=/; expires=Mon, 08-Dec-25 05:01:04 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=TQtRdLT3mrDKg95_wmsmeRLbV8CCEkS9jPQRPoWWLuM-1765168264211-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - user-bkcsfvrp2vh67rqzpgtsbnle
+      openai-processing-ms:
+      - '59'
+      openai-project:
+      - proj_IG1Ou5SIiy81s3W66WZ5dtN6
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '62'
+      x-request-id:
+      - req_8adcfe4c32c64c729b871ccb946741f2
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_responses_with_raw_response_streaming_async.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_responses_with_raw_response_streaming_async.yaml
@@ -1,0 +1,134 @@
+interactions:
+- request:
+    body: '{"input":"What''s 12 + 12?","instructions":"Just the number please","model":"gpt-4o-mini","stream":true}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '103'
+      Content-Type:
+      - application/json
+      Host:
+      - api.openai.com
+      User-Agent:
+      - AsyncOpenAI/Python 2.9.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - async:asyncio
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.9.0
+      X-Stainless-Raw-Response:
+      - 'true'
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.11.13
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: 'event: response.created
+
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0802de25a77e8156006936548a8560819ba1c779292954ea54","object":"response","created_at":1765168266,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":"Just
+        the number please","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.in_progress
+
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0802de25a77e8156006936548a8560819ba1c779292954ea54","object":"response","created_at":1765168266,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":"Just
+        the number please","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0802de25a77e8156006936548b5d84819bb334e45b0badeaac","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+
+
+        event: response.content_part.added
+
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0802de25a77e8156006936548b5d84819bb334e45b0badeaac","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0802de25a77e8156006936548b5d84819bb334e45b0badeaac","output_index":0,"content_index":0,"delta":"24","logprobs":[],"obfuscation":"tDlJAwL4dyxR7e"}
+
+
+        event: response.output_text.done
+
+        data: {"type":"response.output_text.done","sequence_number":5,"item_id":"msg_0802de25a77e8156006936548b5d84819bb334e45b0badeaac","output_index":0,"content_index":0,"text":"24","logprobs":[]}
+
+
+        event: response.content_part.done
+
+        data: {"type":"response.content_part.done","sequence_number":6,"item_id":"msg_0802de25a77e8156006936548b5d84819bb334e45b0badeaac","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"24"}}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","sequence_number":7,"output_index":0,"item":{"id":"msg_0802de25a77e8156006936548b5d84819bb334e45b0badeaac","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"24"}],"role":"assistant"}}
+
+
+        event: response.completed
+
+        data: {"type":"response.completed","sequence_number":8,"response":{"id":"resp_0802de25a77e8156006936548a8560819ba1c779292954ea54","object":"response","created_at":1765168266,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":"Just
+        the number please","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[{"id":"msg_0802de25a77e8156006936548b5d84819bb334e45b0badeaac","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"24"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":22,"input_tokens_details":{"cached_tokens":0},"output_tokens":2,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":24},"user":null,"metadata":{}}}
+
+
+        '
+    headers:
+      CF-RAY:
+      - 9aa988015f235eea-PDX
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Mon, 08 Dec 2025 04:31:06 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=UjLuYFFK.OKZ8I3uZeNoDLOVC.P1wDVS9IhPn_QuxmI-1765168266-1.0.1.1-z5syVEBj7ML2KL9LXb6pJ9hIW7jilkYcUEZYQm.cdblw0hUCD1N5YSX.9TAVWNyjTBPdSJ_NMXJikLSaEMHYhzsDFzK6gvHupaFCTtvy63s;
+        path=/; expires=Mon, 08-Dec-25 05:01:06 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=7vX8if14Ag2uCoYv5ADzxiCXmdDINynZ7mDVMm0GxUs-1765168266580-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - user-bkcsfvrp2vh67rqzpgtsbnle
+      openai-processing-ms:
+      - '67'
+      openai-project:
+      - proj_IG1Ou5SIiy81s3W66WZ5dtN6
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '74'
+      x-request-id:
+      - req_1b6d11ae39b842ffa29ed7783187ed0e
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
### Context <!-- Help the reviewer understand the why you are doing this -->

The Python SDK's `wrap_openai()` function doesn't trace calls made via `client.responses.with_raw_response.create()`. 
This is intended to be the Python equivalent of the JS SDK issue fixed in PR #1145.

When users access `.with_raw_response`, the `__getattr__` method in the wrapper class delegates to the unwrapped OpenAI client, completely bypassing the tracing logic. This means users who need access to HTTP response metadata (status codes, headers) lose all observability.

### Description <!-- Help the reviewer understand what you changed and what the expected behavior is now -->

Added support for tracing `with_raw_response.create()` calls on the responses API while preserving the raw response interface.

**Changes:**
- Added `WithRawResponseResponsesWrapper` and `AsyncWithRawResponseResponsesWrapper` classes that intercept `with_raw_response.create()` calls and add tracing
- Added `StreamingRawResponseWrapper` and `AsyncStreamingRawResponseWrapper` classes that preserve raw response properties (`status_code`, `headers`) while returning a traced stream from `.parse()`
- Added `with_raw_response` property to `ResponsesV1Wrapper` and `AsyncResponsesV1Wrapper` that returns the wrapped version

**Behavior:**
- `client.responses.with_raw_response.create()` now logs a span AND returns the raw response object with `status_code`, `headers`, and `.parse()`
- Supports both streaming (`stream=True`) and non-streaming modes
- Supports both sync and async clients

### Testing <!-- Describe how and what you tested. Include screenshots or videos as needed -->

Added 4 new tests covering all combinations:
- `test_openai_responses_with_raw_response` - sync, non-streaming
- `test_openai_responses_with_raw_response_async` - async, non-streaming
- `test_openai_responses_with_raw_response_streaming` - sync, streaming
- `test_openai_responses_with_raw_response_streaming_async` - async, streaming

Each test verifies:
1. A span is logged with correct name and type
2. Raw response properties are accessible (`status_code`, `headers`)
3. Response can be parsed via `.parse()`
4. Metrics are valid

Verified tests fail without the fix and pass with it using `nox -s test_openai`.