### PR TITLE
fix: await processOutput in wrapGenerateObject

### DIFF
--- a/js/src/wrappers/ai-sdk/ai-sdk.ts
+++ b/js/src/wrappers/ai-sdk/ai-sdk.ts
@@ -121,7 +121,7 @@ const wrapGenerateObject = (
         });
 
         span.log({
-          output: processOutput(result, options.denyOutputPaths),
+          output: await processOutput(result, options.denyOutputPaths),
           metrics: extractTokenMetrics(result),
         });
 


### PR DESCRIPTION
## Problem

When using `wrapAISDK` with `generateObject`, the output logged to Braintrust shows as an empty object `{}` instead of the actual structured output.

Fixes #1148

## Root Cause

The `processOutput` function is async, but in `wrapGenerateObject` (line 124) it wasn't being awaited:

```typescript
span.log({
  output: processOutput(result, options.denyOutputPaths),  // Missing await!
  metrics: extractTokenMetrics(result),
});
```

This causes a Promise to be logged, which serializes as `{}`.

## Fix

Added `await` before `processOutput()` call, consistent with `wrapGenerateText` which correctly awaits on line 196:

```typescript
span.log({
  output: await processOutput(result, options.denyOutputPaths),
  metrics: extractTokenMetrics(result),
});
```

## Testing

Before fix: Braintrust console shows `Output: {}` for `generateObject` calls
After fix: Braintrust console shows actual structured output