### PR TITLE
Error handling in claude agent sdk wrapper class by re-raising  exceptions during tracing

### DIFF
--- a/py/src/braintrust/wrappers/claude_agent_sdk/_wrapper.py
+++ b/py/src/braintrust/wrappers/claude_agent_sdk/_wrapper.py
@@ -255,6 +255,7 @@ def _create_client_wrapper_class(original_client_class: Any) -> Any:
                     span.log(output=final_results[-1] if final_results else None)
                 except Exception as e:
                     log.warning("Error in tracing code", exc_info=e)
+                    raise
                 finally:
                     llm_tracker.cleanup()
                     if hasattr(_thread_local, 'parent_span_export'):


### PR DESCRIPTION
In the claude agent sdk, I couldn't handle error cases because it outputs errors to stdout.