### PR TITLE
Add expect test for Zod v4 schema serialization (BRA-3619)

### DIFF
--- a/js/dev/server.ts
+++ b/js/dev/server.ts
@@ -389,7 +389,7 @@ function makeScorer(
   return ret;
 }
 
-function makeEvalParametersSchema(
+export function makeEvalParametersSchema(
   parameters: EvalParameters,
 ): z.infer<typeof evalParametersSerializedSchema> {
   return Object.fromEntries(

--- a/js/src/zod-serialization.test.ts
+++ b/js/src/zod-serialization.test.ts
@@ -1,0 +1,47 @@
+import { expect, test, describe } from "vitest";
+import { z as zv3 } from "zod/v3";
+import { z as zv4 } from "zod/v4";
+import { makeEvalParametersSchema } from "../dev/server";
+
+describe("makeEvalParametersSchema", () => {
+  test("Zod v3 string schema serializes correctly", () => {
+    const parameters = {
+      instructions: zv3
+        .string()
+        .describe("The instructions for the agent")
+        .default("You are a helpful assistant."),
+    };
+
+    const result = makeEvalParametersSchema(parameters);
+
+    expect(result.instructions.schema).toMatchInlineSnapshot(`
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "default": "You are a helpful assistant.",
+        "description": "The instructions for the agent",
+        "type": "string",
+      }
+    `);
+  });
+
+  test("Zod v4 string schema serializes correctly (BRA-3619)", () => {
+    // This reproduces the bug reported in BRA-3619:
+    // When a user defines parameters with Zod v4, the schema doesn't
+    // serialize correctly, causing the playground UI to show JSON/YAML
+    // instead of the "Text" input option.
+    const parameters = {
+      instructions: zv4
+        .string()
+        .describe("The instructions for the agent")
+        .default("You are a helpful assistant."),
+    };
+
+    const result = makeEvalParametersSchema(parameters);
+
+    expect(result.instructions.schema).toMatchInlineSnapshot(`
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+      }
+    `);
+  });
+});


### PR DESCRIPTION
### Context <!-- Help the reviewer understand the why you are doing this -->

Olmo requested an expect test in https://github.com/braintrustdata/braintrust/pull/9205 to demonstrate the Zod v4 serialization issue.

This test shows that `zodToJsonSchema()` doesn't understand Zod v4's schema structure, causing string parameters to serialize without a type field.

Also see: https://linear.app/braintrustdata/issue/BRA-3619/support-zod-v4-for-remote-eval-parameters

### Description <!-- Help the reviewer understand what you changed and what the expected behavior is now -->

- Exported `makeEvalParametersSchema()` from `dev/server.ts` so it can be tested directly
- Added `src/zod-serialization.test.ts` with inline snapshots showing:
 - Zod v3: Serializes correctly with `type: "string"`
 - Zod v4: Missing type field entirely

This demonstrates why the playground UI falls back to JSON/YAML instead of showing the "Text" input option for Zod v4 users.

### Testing <!-- Describe how and what you tested. Include screenshots or videos as needed -->

```
pnpm vitest run src/zod-serialization.test.ts
```

Both tests pass. The snapshots capture the current (broken) behavior for Zod v4, so when a fix is implemented, updating the snapshots will show the before/after difference.