### PR TITLE
fix: fix try dict method to handle pydantic classes

### DIFF
--- a/integrations/adk-py/src/braintrust_adk/__init__.py
+++ b/integrations/adk-py/src/braintrust_adk/__init__.py
@@ -3,6 +3,7 @@ import time
 from contextlib import AbstractAsyncContextManager
 from typing import Any, AsyncGenerator, Dict, Iterable, Optional, TypeVar, Union, cast
 
+from pydantic import BaseModel
 from wrapt import wrap_function_wrapper
 
 from braintrust.logger import NOOP_SPAN, Attachment, current_span, init_logger, start_span
@@ -515,6 +516,10 @@ def _serialize_part(part: Any) -> Any:
 
 
 def _try_dict(obj: Any) -> Union[Iterable[Any], Dict[str, Any]]:
+    # Handle Pydantic CLASSES (not instances)
+    if isinstance(obj, type) and issubclass(obj, BaseModel):
+        return obj.model_fields
+
     if hasattr(obj, "model_dump"):
         try:
             obj = obj.model_dump(exclude_none=True)


### PR DESCRIPTION
## Summary
  Fixes a `TypeError` in the `_try_dict` serialization helper where `model_dump()` was being called on Pydantic model classes instead of instances. This occurred when using Google ADK's LLM agent schema definitions, which accept Pydantic model classes for`output_schema` parameters.

## Problem
  Google ADK's LLM agents accept Pydantic model **classes** (not instances) for defining output schemas ([see docs](https://google.github.io/adk-docs/agents/llm-agents/#structuring-data-input_schema-output_schema-output_key)). When the braintrust-adk tracing wrapper attempted to serialize these agent configurations, it passed these Pydantic classes to `_try_dict`, which incorrectly tried to call `model_dump()` on them.

  Since `model_dump()` is an instance method requiring `self`, calling it on a class resulted in:

  TypeError: BaseModel.model_dump() missing 1 required positional argument: 'self'
    File ".../braintrust_adk/init.py", line 522, in _try_dict
      obj = obj.model_dump(exclude_none=True)

## Solution
  Added a check to distinguish between Pydantic model classes and instances:
  - **For Pydantic model classes**: Return `model_fields` to serialize the schema definition
  - **For instances**: Continue using `model_dump()` to serialize the data

  This properly handles both use cases: schema definitions (Pydantic model classes) and actual data (instances).

## Changes
  - Added type check: `isinstance(obj, type) and issubclass(obj, BaseModel)`
  - Returns `model_fields` for Pydantic classes to capture the schema structure
  - Added `BaseModel` import from pydantic