### PR TITLE
Fix UTF-8 encoding for non-ASCII log data with orjson + urllib3 1.x

### DIFF
--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -1104,7 +1104,7 @@ class _HTTPBackgroundLogger:
             _HTTPBackgroundLogger._write_payload_to_dir(payload_dir=self.all_publish_payloads_dir, payload=dataStr)
         for i in range(self.num_tries):
             start_time = time.time()
-            resp = conn.post("/logs3", data=dataStr)
+            resp = conn.post("/logs3", data=dataStr.encode("utf-8"))
             if resp.ok:
                 return
             resp_errmsg = f"{resp.status_code}: {resp.text}"


### PR DESCRIPTION
### Context <!-- Help the reviewer understand the why you are doing this -->

Fixes BRA-3739 (https://linear.app/braintrustdata/issue/BRA-3739/python-sdk-unicodeencodeerror-with-urllib3-1x-orjson)

Customer reported (Pylon #9837, https://app.usepylon.com/issues?conversationID=c890a2ca-fc55-4a71-af6d-e01a731e301d) that SDK 0.3.13+ fails with `UnicodeEncodeError` when logging data containing non-ASCII characters. They have blocked SDK versions 0.3.13+ until fixed.

The issue occurs when users have:
- `urllib3` 1.x (often pinned by enterprise environments)
- `orjson` installed (added in 0.3.13 for performance)
- Non-ASCII characters in their data (e.g., `→`, `—`, emoji)

### Description <!-- Help the reviewer understand what you changed and what the expected behavior is now -->

**Root cause:** `orjson.dumps().decode("utf-8")` returns actual Unicode characters (e.g., `→`), while `json.dumps()` escapes them as `\uXXXX`. When the JSON string is passed to `requests.post(data=str)`, urllib3 1.x passes it to `http.client` which tries to encode it as latin-1, failing for characters outside 0-255. urllib3 2.x handles this correctly by encoding strings as UTF-8.

**Fix:** Encode the POST body as UTF-8 bytes before sending:
```python
# Before
resp = conn.post("/logs3", data=dataStr)

# After
resp = conn.post("/logs3", data=dataStr.encode("utf-8"))
```
This is the correct HTTP practice (bodies should be bytes) and works regardless of urllib3 version or orjson presence.

### Testing <!-- Describe how and what you tested. Include screenshots or videos as needed -->

Reproduced and verified fix with:

```
pip install braintrust urllib3==1.26.20 orjson
```

```python
from braintrust import Eval

Eval(
  "test-project",
  data=[{"input": "→ arrow here"}],
  task=lambda x: "result",
  scores=[lambda: 1],
)
```

- Before fix: UnicodeEncodeError: 'latin-1' codec can't encode character '\u2192'
- After fix: Eval completes successfully

**Verified fix doesn't break non-orjson path:**

```
$ git -C sdk log --oneline -1
91b2fffd Fix UTF-8 encoding for non-ASCII log data with orjson + urllib3 1.x

$ pip uninstall orjson -y
Successfully uninstalled orjson-3.11.4

$ python -c "from expect_tests.eval_unicode_logging import *"
=========================SUMMARY=========================
100.00% 'simple_score' score
0 errors
```