### PR TITLE
Fix improper handling of async generator as execute input

### DIFF
--- a/js/src/wrappers/ai-sdk/ai-sdk.ts
+++ b/js/src/wrappers/ai-sdk/ai-sdk.ts
@@ -796,6 +796,22 @@ const wrapTools = (tools: any) => {
   return wrappedTools;
 };
 
+/**
+ * Checks if a value is an AsyncGenerator.
+ * AsyncGenerators are returned by async generator functions (async function* () {})
+ * and must be iterated to consume their yielded values.
+ */
+const isAsyncGenerator = (value: any): value is AsyncGenerator => {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    typeof value[Symbol.asyncIterator] === "function" &&
+    typeof value.next === "function" &&
+    typeof value.return === "function" &&
+    typeof value.throw === "function"
+  );
+};
+
 const wrapToolExecute = (tool: any, name: string) => {
   // Only wrap tools that have an execute function (created with tool() helper)
   // AI SDK v3-v6: tool({ description, inputSchema/parameters, execute })
@@ -811,13 +827,50 @@ const wrapToolExecute = (tool: any, name: string) => {
     return new Proxy(tool, {
       get(target, prop) {
         if (prop === "execute") {
-          return (...args: any[]) =>
-            traced(
+          // Return a function that handles both regular async functions and async generators
+          const wrappedExecute = (...args: any[]) => {
+            const result = originalExecute.apply(target, args);
+
+            // Check if the result is an async generator (from async function* () {})
+            // AI SDK v5 supports async generator tools that yield intermediate status updates
+            if (isAsyncGenerator(result)) {
+              // Return a wrapper async generator that:
+              // 1. Iterates through the original generator
+              // 2. Yields all intermediate values (so consumers see status updates)
+              // 3. Tracks and logs the final yielded value as the tool output
+              return (async function* () {
+                const span = startSpan({
+                  name,
+                  spanAttributes: {
+                    type: SpanTypeAttribute.TOOL,
+                  },
+                });
+                span.log({ input: args.length === 1 ? args[0] : args });
+
+                try {
+                  let lastValue: any;
+                  for await (const value of result) {
+                    lastValue = value;
+                    yield value;
+                  }
+                  // Log the final yielded value as the output
+                  span.log({ output: lastValue });
+                } catch (error) {
+                  span.log({ error: serializeError(error) });
+                  throw error;
+                } finally {
+                  span.end();
+                }
+              })();
+            }
+
+            // For regular async functions, use traced as before
+            return traced(
               async (span) => {
                 span.log({ input: args.length === 1 ? args[0] : args });
-                const result = await originalExecute.apply(target, args);
-                span.log({ output: result });
-                return result;
+                const awaitedResult = await result;
+                span.log({ output: awaitedResult });
+                return awaitedResult;
               },
               {
                 name,
@@ -826,6 +879,8 @@ const wrapToolExecute = (tool: any, name: string) => {
                 },
               },
             );
+          };
+          return wrappedExecute;
         }
         return target[prop];
       },


### PR DESCRIPTION
## Summary

Async generator tools return empty output when using the Braintrust AI SDK wrapper. (#1134)

### The Problem

AI SDK v5 supports tools with async generator `execute` functions that yield intermediate status updates:

```typescript
const greetingTool = ai.tool({
  description: "A tool that streams a greeting",
  inputSchema: z.object({ name: z.string() }),
  execute: async function* ({ name }) {
    yield { status: "starting", message: "Preparing..." };
    yield { status: "processing", message: `Looking up ${name}...` };
    yield { status: "done", greeting: `Hello, ${name}!` };
  },
});
```

When wrapped with Braintrust's `wrapAISDK()`, the tool result was logged as `{}` instead of the final yielded value `{"status":"done","greeting":"Hello, World!"}`.

### Root Cause

The wrapper was using `await` on the result of calling the execute function:

```typescript
const result = await originalExecute.apply(target, args);
span.log({ output: result });
```

When `originalExecute` is an async generator function, calling it returns an `AsyncGenerator` object immediately—**the generator code doesn't run yet**. You must iterate through the generator to execute its code and get the yielded values.

`await`-ing an AsyncGenerator just returns the generator object itself (not the values). When serialized to JSON, this becomes `{}`.

### Solution

Detect when the execute function returns an AsyncGenerator and handle it specially:

1. Check if the result has async iterator protocol methods (`Symbol.asyncIterator`, `next`, `return`, `throw`)
2. If so, return a wrapper async generator that:
   - Iterates through the original generator
   - Yields all intermediate values (preserving streaming behavior)
   - Captures the final yielded value
   - Logs that final value as the tool output
3. If not an async generator, handle as before with simple `await`

### Test Plan

- [x] Added unit test for async generator tool execution
- [x] Verified test fails without fix
- [x] Verified test passes with fix
- [x] All existing tool tests pass (no regressions)
- [x] Full ai-sdk test suite passes
