### PR TITLE
Add Docker environment for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ dist
 .aider*
 !.aiderignore
 
+docker-compose.override.yml
+Dockerfile.local
+
 **/.claude/settings.local.json
 CLAUDE.local.md
 .zed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# Development container for braintrust-sdk-ruby
+FROM debian:trixie-slim
+
+# Set UTF-8 locale
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
+# Configure UV to use copy mode (expected in Docker with different filesystems)
+ENV UV_LINK_MODE=copy
+
+# Install curl, ca-certificates, and git first (needed for install-deps.sh and mise)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    ca-certificates \
+    git \
+    openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user with configurable UID/GID
+ARG UID=1000
+ARG GID=1000
+RUN groupadd -g $GID dev && useradd -m -u $UID -g $GID dev
+
+# Create directories for mise and bundle cache
+RUN mkdir -p /home/dev/.local/share/mise /home/dev/.local/bin \
+    && chown -R dev:dev /home/dev
+
+# Switch to non-root user
+USER dev
+ENV HOME=/home/dev
+ENV PATH="/home/dev/.local/bin:$PATH"
+
+# Install mise as the dev user
+RUN curl https://mise.run | sh
+
+# Configure git safe.directory for mounted volumes
+RUN git config --global --add safe.directory /app
+
+# Activate mise in bash
+RUN echo 'eval "$(mise activate bash)"' >> ~/.bashrc
+
+WORKDIR /app
+
+CMD ["bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  dev:
+    build: .
+    volumes:
+      - .:/app
+      - dev-home:/home/dev/
+    working_dir: /app
+    env_file: .env
+    environment:
+      - MISE_TRUSTED_CONFIG_PATHS=/app
+
+volumes:
+  dev-home:


### PR DESCRIPTION
This is a QoL improvement for developers and contributors: it allows them to do development work within a Docker container. This is helpful for (1) making environment setup (because the Docker image contains all the dependencies needed) and (2) isolates tools from the host machine to prevent conflicts or spillage into other parts of the dev's system.

Let me know if this is something that would be considered!