### PR TITLE
Forward claude-agent-sdk Query properties (like interrupt) through wrapped generator

### DIFF
--- a/js/Makefile
+++ b/js/Makefile
@@ -59,7 +59,6 @@ test-ai-sdk:
 # -------------------------------------------------------------------------------------------------
 
 test-claude-agent-sdk:
-	@command -v claude >/dev/null 2>&1 || curl -fsSL https://claude.ai/install.sh | bash
 	cd src/wrappers/claude-agent-sdk && pnpm install && pnpm test
 
 

--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -58,7 +58,8 @@ ANTHROPIC_VERSIONS = (LATEST, "0.50.0", "0.49.0", "0.48.0")
 OPENAI_VERSIONS = (LATEST, "1.77.0", "1.71", "1.91", "1.92")
 # litellm latest requires Python >= 3.10
 LITELLM_VERSIONS = (LATEST, "1.74.0")
-CLAUDE_AGENT_SDK_VERSIONS = (LATEST, "0.1.0")
+# CLI bundling started in 0.1.10 - older versions require external Claude Code installation
+CLAUDE_AGENT_SDK_VERSIONS = (LATEST, "0.1.10")
 AGNO_VERSIONS = (LATEST, "2.1.0")
 # pydantic_ai 1.x requires Python >= 3.10
 # Two test suites with different version requirements:
@@ -111,18 +112,6 @@ def test_pydantic_ai_integration(session, version):
 def test_claude_agent_sdk(session, version):
     # claude_agent_sdk requires Python >= 3.10
     _install_test_deps(session)
-    # Install Claude Code CLI using native installer (no nodeenv needed)
-    if sys.platform == "win32":
-        # Windows: use CMD installer (more compatible than PowerShell)
-        session.run(
-            "cmd",
-            "/c",
-            "curl -fsSL https://claude.ai/install.cmd -o install.cmd && install.cmd && del install.cmd",
-            external=True,
-        )
-    else:
-        # macOS/Linux: use bash installer
-        session.run("bash", "-c", "curl -fsSL https://claude.ai/install.sh | bash", external=True)
     _install(session, "claude_agent_sdk", version)
     _run_tests(session, f"{WRAPPER_DIR}/claude_agent_sdk/test_wrapper.py")
     _run_core_tests(session)

--- a/scripts/claude-docker.sh
+++ b/scripts/claude-docker.sh
@@ -52,9 +52,9 @@ EOF
 # Clear any existing Claude auth to avoid conflicts with ANTHROPIC_API_KEY
 claude /logout > /dev/null 2>&1 || true
 
-# Install Claude Code CLI using native installer
-echo "Installing Claude Code..."
-curl -fsSL https://claude.ai/install.sh | bash
+# Update Claude to latest version
+echo "Updating Claude..."
+sudo npm install -g @anthropic-ai/claude-code@latest
 
 # Add Braintrust MCP server
 echo "Adding Braintrust MCP server..."


### PR DESCRIPTION
forked from from https://github.com/braintrustdata/braintrust-sdk/pull/1181

drive-by: use claude code bundled build for python