### PR TITLE
fix(python): add org_id to prompt cache key for cross-org isolation

### DIFF
--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -1678,13 +1678,14 @@ def load_prompt(
             eprint(f"Failed to load prompt, attempting to fall back to cache: {server_error}")
             try:
                 if id:
-                    return _state._prompt_cache.get(id=id)
+                    return _state._prompt_cache.get(id=id, org_id=_state.org_id)
                 else:
                     return _state._prompt_cache.get(
                         slug,
                         version=str(version) if version else "latest",
                         project_id=project_id,
                         project_name=project,
+                        org_id=_state.org_id,
                     )
             except Exception as cache_error:
                 if id:
@@ -1714,6 +1715,7 @@ def load_prompt(
                 _state._prompt_cache.set(
                     prompt,
                     id=id,
+                    org_id=_state.org_id,
                 )
             elif slug:
                 _state._prompt_cache.set(
@@ -1722,6 +1724,7 @@ def load_prompt(
                     version=str(version) if version else "latest",
                     project_id=project_id,
                     project_name=project,
+                    org_id=_state.org_id,
                 )
         except Exception as e:
             eprint(f"Failed to store prompt in cache: {e}")


### PR DESCRIPTION
- Adds `org_id` to cache key format for proper organization isolation
- Adds tests for cross-org cache behavior

The prompt cache was using a key format of `{project_name}:{slug}:{version}` which did not include the organization ID. This caused a cross-org cache collision bug where two organizations with the same project name and prompt slug could retrieve each other's cached prompts.

## Test plan

- [x] Added `test_handle_different_orgs_with_same_project_and_slug` - verifies prompts from different orgs with same project/slug are isolated
- [x] Added `test_org_id_isolation_with_disk_cache` - verifies isolation works after memory eviction (via disk cache)
- [x] All 15 prompt cache tests pass



