### PR TITLE
add root_span_id and span_id to the updateSpan log if they were exported

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -1778,12 +1778,16 @@ function updateSpanImpl({
   parentObjectType,
   parentObjectId,
   id,
+  root_span_id,
+  span_id,
   event,
 }: {
   state: BraintrustState;
   parentObjectType: SpanObjectTypeV3;
   parentObjectId: LazyValue<string>;
   id: string;
+  root_span_id?: string;
+  span_id?: string;
   event: Omit<Partial<ExperimentEvent>, "id">;
 }): void {
   const updateEvent = deepCopyEvent(
@@ -1801,6 +1805,8 @@ function updateSpanImpl({
 
   const record = new LazyValue(async () => ({
     id,
+    root_span_id,
+    span_id,
     ...updateEvent,
     ...(await parentIds()),
     [IS_MERGE_FIELD]: true,
@@ -1837,6 +1843,8 @@ export function updateSpan({
       spanComponentsToObjectIdLambda(resolvedState, components),
     ),
     id: components.data.row_id,
+    root_span_id: components.data.root_span_id,
+    span_id: components.data.span_id,
     event,
   });
 }

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -3269,6 +3269,8 @@ def _update_span_impl(
     parent_object_type: SpanObjectTypeV3,
     parent_object_id: LazyValue[str],
     id: str,
+    root_span_id: str | None = None,
+    span_id: str | None = None,
     **event: Any,
 ):
     update_event = _validate_and_sanitize_experiment_log_partial_args(
@@ -3287,6 +3289,8 @@ def _update_span_impl(
     def compute_record():
         return dict(
             id=id,
+            root_span_id=root_span_id,
+            span_id=span_id,
             **update_event,
             **parent_ids(),
             **{
@@ -3318,6 +3322,8 @@ def update_span(exported: str, **event: Any) -> None:
         parent_object_type=components.object_type,
         parent_object_id=LazyValue(_span_components_to_object_id_lambda(components), use_mutex=False),
         id=components.row_id,
+        root_span_id=components.root_span_id,
+        span_id=components.span_id,
         **event,
     )
 


### PR DESCRIPTION
I believe these don't get used to actually update the span since the id is provided, but it helps our realtime events in the UI