### PR TITLE
Fix CI: propagate bg logger across threads for openai-agents >= 0.8

### DIFF
--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -61,6 +61,7 @@ LITELLM_VERSIONS = (LATEST, "1.74.0")
 # CLI bundling started in 0.1.10 - older versions require external Claude Code installation
 CLAUDE_AGENT_SDK_VERSIONS = (LATEST, "0.1.10")
 AGNO_VERSIONS = (LATEST, "2.1.0")
+OPENAI_AGENTS_VERSIONS = (LATEST, "0.8.0", "0.7.0")
 # pydantic_ai 1.x requires Python >= 3.10
 # Two test suites with different version requirements:
 # 1. wrap_openai approach: works with older versions (0.1.9+)
@@ -152,6 +153,16 @@ def test_openai(session, version):
     _install(session, "openai", version)
     # openai-agents requires Python >= 3.10
     _install(session, "openai-agents")
+    _run_tests(session, f"{WRAPPER_DIR}/test_openai.py")
+    _run_core_tests(session)
+
+
+@nox.session()
+@nox.parametrize("version", OPENAI_AGENTS_VERSIONS, ids=OPENAI_AGENTS_VERSIONS)
+def test_openai_agents(session, version):
+    _install_test_deps(session)
+    _install(session, "openai")
+    _install(session, "openai-agents", version)
     _run_tests(session, f"{WRAPPER_DIR}/test_openai.py")
     _run_core_tests(session)
 

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -407,10 +407,12 @@ class BraintrustState:
         self._id_generator = None
 
         # For unit-testing, tests may wish to temporarily override the global
-        # logger with a custom one. We allow this but keep the override variable
-        # thread-local to prevent the possibility that tests running on
-        # different threads unintentionally use the same override.
-        self._override_bg_logger = threading.local()
+        # logger with a custom one. We use a ContextVar so that the override
+        # propagates across thread boundaries (e.g. asyncio.to_thread) while
+        # still being isolated per-context (preventing test cross-talk).
+        self._override_bg_logger: contextvars.ContextVar[_BackgroundLogger | None] = contextvars.ContextVar(
+            "_override_bg_logger", default=None
+        )
 
         self.reset_login_info()
 
@@ -587,7 +589,7 @@ class BraintrustState:
         return self._user_info
 
     def global_bg_logger(self) -> "_BackgroundLogger":
-        return getattr(self._override_bg_logger, "logger", None) or self._global_bg_logger.get()
+        return self._override_bg_logger.get() or self._global_bg_logger.get()
 
     # Should only be called by the login function.
     def login_replace_api_conn(self, api_conn: "HTTPConnection"):
@@ -1436,21 +1438,21 @@ _logger = logging.getLogger("braintrust")
 @contextlib.contextmanager
 def _internal_with_custom_background_logger():
     custom_logger = _HTTPBackgroundLogger(LazyValue(lambda: _state.api_conn(), use_mutex=True))
-    _state._override_bg_logger.logger = custom_logger
+    token = _state._override_bg_logger.set(custom_logger)
     try:
         yield custom_logger
     finally:
-        _state._override_bg_logger.logger = None
+        _state._override_bg_logger.reset(token)
 
 
 @contextlib.contextmanager
 def _internal_with_memory_background_logger():
     memory_logger = _MemoryBackgroundLogger()
-    _state._override_bg_logger.logger = memory_logger
+    token = _state._override_bg_logger.set(memory_logger)
     try:
         yield memory_logger
     finally:
-        _state._override_bg_logger.logger = None
+        _state._override_bg_logger.reset(token)
 
 
 @dataclasses.dataclass

--- a/py/src/braintrust/wrappers/openai.py
+++ b/py/src/braintrust/wrappers/openai.py
@@ -8,6 +8,7 @@ from typing import Any
 import braintrust
 from agents import tracing
 from braintrust.logger import NOOP_SPAN
+from braintrust.wrappers.threads import setup_threads
 
 
 def _span_type(span: tracing.Span[Any]) -> braintrust.SpanTypeAttribute:
@@ -62,6 +63,7 @@ class BraintrustTracingProcessor(tracing.TracingProcessor):
     """
 
     def __init__(self, logger: braintrust.Span | braintrust.Experiment | braintrust.Logger | None = None):
+        setup_threads()  # Propagate ContextVars across worker threads (agents SDK >= 0.8)
         self._logger = logger
         self._spans: dict[str, braintrust.Span] = {}
         self._first_input: dict[str, Any] = {}


### PR DESCRIPTION
## Summary

- **Root cause**: `_override_bg_logger` was `threading.local()`, which doesn't propagate to child threads. `openai-agents` 0.8.0 runs sync `@function_tool` functions via `asyncio.to_thread()`, so spans created in tool worker threads logged to the wrong (real HTTP) logger instead of the test memory logger.
- Changed `_override_bg_logger` from `threading.local()` to `ContextVar` so it propagates via `asyncio.to_thread()` while remaining isolated per-context
- Added `setup_threads()` call in `BraintrustTracingProcessor.__init__()` to propagate `ContextVar` context across `ThreadPoolExecutor` worker threads
- Added `test_openai_agents` nox session with version matrix (latest, 0.8.0, 0.7.0) for independent agents SDK version testing

## Test plan

- [x] `test_agents_tool_openai_nested_spans` passes (was failing)
- [x] All 41 OpenAI wrapper tests pass
- [x] All 104 logger tests pass
- [x] Core tests pass (343 passed, pre-existing teardown issues excluded)
- [ ] CI runs `test_openai_agents(latest)`, `test_openai_agents(0.8.0)`, `test_openai_agents(0.7.0)` sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)