### PR TITLE
await logger flush in processor hooks

### DIFF
--- a/integrations/openai-agents-js/src/index.ts
+++ b/integrations/openai-agents-js/src/index.ts
@@ -647,17 +647,15 @@ export class OpenAIAgentsTraceProcessor {
     return Promise.resolve();
   }
 
-  shutdown(): Promise<void> {
+  async shutdown(): Promise<void> {
     if (this.logger && typeof this.logger.flush === "function") {
-      this.logger.flush();
+      await this.logger.flush();
     }
-    return Promise.resolve();
   }
 
-  forceFlush(): Promise<void> {
+  async forceFlush(): Promise<void> {
     if (this.logger && typeof this.logger.flush === "function") {
-      this.logger.flush();
+      await this.logger.flush();
     }
-    return Promise.resolve();
   }
 }

--- a/integrations/openai-agents-js/src/openai-agents-trace-processor.test.ts
+++ b/integrations/openai-agents-js/src/openai-agents-trace-processor.test.ts
@@ -1,0 +1,94 @@
+import { assert, describe, test } from "vitest";
+import { OpenAIAgentsTraceProcessor } from "./index";
+
+function createDeferredPromise(): {
+  promise: Promise<void>;
+  resolve: () => void;
+} {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+describe("OpenAIAgentsTraceProcessor flush behavior", () => {
+  test("forceFlush waits for logger.flush to complete", async () => {
+    let flushCalls = 0;
+    const deferred = createDeferredPromise();
+
+    const processor = new OpenAIAgentsTraceProcessor({
+      logger: {
+        flush: () => {
+          flushCalls += 1;
+          return deferred.promise;
+        },
+      } as any,
+    });
+
+    let forceFlushResolved = false;
+    const forceFlushPromise = processor.forceFlush().then(() => {
+      forceFlushResolved = true;
+    });
+
+    await Promise.resolve();
+
+    assert.equal(
+      flushCalls,
+      1,
+      "forceFlush should call logger.flush exactly once",
+    );
+    assert.isFalse(
+      forceFlushResolved,
+      "forceFlush should not resolve before logger.flush resolves",
+    );
+
+    deferred.resolve();
+    await forceFlushPromise;
+
+    assert.isTrue(
+      forceFlushResolved,
+      "forceFlush should resolve after logger.flush",
+    );
+  });
+
+  test("shutdown waits for logger.flush to complete", async () => {
+    let flushCalls = 0;
+    const deferred = createDeferredPromise();
+
+    const processor = new OpenAIAgentsTraceProcessor({
+      logger: {
+        flush: () => {
+          flushCalls += 1;
+          return deferred.promise;
+        },
+      } as any,
+    });
+
+    let shutdownResolved = false;
+    const shutdownPromise = processor.shutdown().then(() => {
+      shutdownResolved = true;
+    });
+
+    await Promise.resolve();
+
+    assert.equal(
+      flushCalls,
+      1,
+      "shutdown should call logger.flush exactly once",
+    );
+    assert.isFalse(
+      shutdownResolved,
+      "shutdown should not resolve before logger.flush resolves",
+    );
+
+    deferred.resolve();
+    await shutdownPromise;
+
+    assert.isTrue(
+      shutdownResolved,
+      "shutdown should resolve after logger.flush",
+    );
+  });
+});


### PR DESCRIPTION
Attempt to fix an issue with Agent SDK traces where creating spans via withGenerationSpan and exporting them using OpenAIAgentsTraceProcessor from braintrust/openai-agents causes the trace to not be marked as completed.  