### PR TITLE
add with_raw_response to responses.parse for OpenAI and AsyncOpenAI

### DIFF
--- a/py/src/braintrust/oai.py
+++ b/py/src/braintrust/oai.py
@@ -795,7 +795,7 @@ class ResponsesV1Wrapper(NamedWrapper):
         return ResponseWrapper(self.__responses.with_raw_response.create, None).create(*args, **kwargs)
 
     def parse(self, *args: Any, **kwargs: Any) -> Any:
-        return ResponseWrapper(self.__responses.parse, None, "openai.responses.parse").create(*args, **kwargs)
+        return ResponseWrapper(self.__responses.with_raw_response.parse, None, "openai.responses.parse").create(*args, **kwargs)
 
 
 class AsyncResponsesV1Wrapper(NamedWrapper):
@@ -808,7 +808,7 @@ class AsyncResponsesV1Wrapper(NamedWrapper):
         return AsyncResponseWrapper(response)
 
     async def parse(self, *args: Any, **kwargs: Any) -> Any:
-        response = await ResponseWrapper(None, self.__responses.parse, "openai.responses.parse").acreate(*args, **kwargs)
+        response = await ResponseWrapper(None, self.__responses.with_raw_response.parse, "openai.responses.parse").acreate(*args, **kwargs)
         return AsyncResponseWrapper(response)
 
 


### PR DESCRIPTION
### Context
If you use client.responses.parse through the AI Proxy and include the `x-bt-use-cache` header it's supposed to add a metric called cached that indicates the request was either a HIT or MISS. `client.responses.create` does this because it includes the raw response headers but client.responses.parse does not.

### Description
Copied the pattern already present for create and added `with_raw_response`.

Steps to Reproduce:

1. Run the following code:
```
init_logger(project="barrett-onboarding")

client = wrap_openai(
    AsyncOpenAI(
        base_url="https://staging-api.braintrust.dev/v1/proxy",
        api_key=os.getenv("BRAINTRUST_API_KEY"),
        default_headers={"x-bt-use-cache": "always"},
    )
)


async def main():
    resp = await client.responses.parse(
        model="gpt-5-mini-2025-08-07",
        instructions="you're a storyteller",
        input="tell me a story",
        prompt_cache_key="user",
    )


if __name__ == "__main__":
    asyncio.run(main())
```
2. Navigate to the named project.
3. Open the Logs.
4. Open the trace that was sent.

### Testing
Tested the change locally with the above repro script.