### PR TITLE
update ast with MatchingSpansFilter

### DIFF
--- a/js/btql/ast.ts
+++ b/js/btql/ast.ts
@@ -268,6 +268,18 @@ export const singleSpanFilterSchema: z.ZodType<SingleSpanFilter> =
     loc,
   });
 
+export type MatchingSpansFilter = {
+  op: "matchingspansfilter";
+  expr: Expr;
+  loc?: NullableLoc;
+};
+export const matchingSpansFilterSchema: z.ZodType<MatchingSpansFilter> =
+  z.strictObject({
+    op: z.literal("matchingspansfilter"),
+    expr: z.lazy(() => exprSchema),
+    loc,
+  });
+
 export type Expr =
   | Literal
   | Interval
@@ -282,7 +294,8 @@ export type Expr =
   | UnaryExpr
   | ArithmeticExpr
   | BtqlSnippet
-  | SingleSpanFilter;
+  | SingleSpanFilter
+  | MatchingSpansFilter;
 
 export const exprSchema: z.ZodType<Expr> = z.union([
   literalSchema,
@@ -299,6 +312,7 @@ export const exprSchema: z.ZodType<Expr> = z.union([
   arithmeticExprSchema,
   btqlSnippetSchema,
   singleSpanFilterSchema,
+  matchingSpansFilterSchema,
 ]);
 
 export const aliasExpr = z.strictObject({


### PR DESCRIPTION
This is a sister-PR to implementing MatchingSpansFilter in brainstore, which requires an AST update.