### PR TITLE
Fix _internal_btql.limit being silently overwritten by DEFAULT_FETCH_BATCH_SIZE

### DIFF
--- a/js/CHANGELOG.md
+++ b/js/CHANGELOG.md
@@ -1,3 +1,9 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Fixed dataset `_internal_btql` parameter to properly override default BTQL settings (e.g., custom limit values). Previously, when passing `_internal_btql: { limit: 1 }` to `initDataset()`, the SDK would overwrite the custom limit with `DEFAULT_FETCH_BATCH_SIZE` (1000).
+
 Release notes can be found [here](https://www.braintrust.dev/docs/reference/release-notes).

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -5484,7 +5484,6 @@ export class ObjectFetcher<RecordType>
         `btql`,
         {
           query: {
-            ...this._internal_btql,
             select: [
               {
                 op: "star",
@@ -5505,6 +5504,7 @@ export class ObjectFetcher<RecordType>
             },
             cursor,
             limit,
+            ...(this._internal_btql ?? {}),
           },
           use_columnstore: false,
           brainstore_realtime: true,


### PR DESCRIPTION
Fix _internal_btql.limit being silently overwritten by DEFAULT_FETCH_BATCH_SIZE in the JS/TS SDK's ObjectFetcher.fetchRecordsFromApi(). Mirrors Python SDK fix shipped in v0.3.6.