### PR TITLE
Add cache write token metric for OpenAI Agents responses.

### DIFF
--- a/integrations/openai-agents-js/src/index.ts
+++ b/integrations/openai-agents-js/src/index.ts
@@ -409,6 +409,9 @@ export class OpenAIAgentsTraceProcessor {
       if (usage.input_tokens_details?.cached_tokens != null)
         data.metrics.prompt_cached_tokens =
           usage.input_tokens_details.cached_tokens;
+      if (usage.input_tokens_details?.cache_write_tokens != null)
+        data.metrics.prompt_cache_creation_tokens =
+          usage.input_tokens_details.cache_write_tokens;
     }
 
     return data;


### PR DESCRIPTION
Capture response usage cache_write_tokens as prompt_cache_creation_tokens and add integration tests covering present, zero, and missing values.

resolves #1373 