### PR TITLE
Fix AI SDK wrapper double-counting token/cost metrics

### DIFF
--- a/js/src/wrappers/ai-sdk/ai-sdk.test.ts
+++ b/js/src/wrappers/ai-sdk/ai-sdk.test.ts
@@ -131,9 +131,20 @@ describe("ai sdk client unit tests", TEST_SUITE_OPTIONS, () => {
     expect(metrics.start).toBeLessThanOrEqual(metrics.end);
     expect(metrics.end).toBeLessThanOrEqual(end);
 
-    expect(metrics.tokens).toBeGreaterThan(0);
-    expect(metrics.prompt_tokens).toBeGreaterThan(0);
-    expect(metrics.completion_tokens).toBeGreaterThan(0);
+    // Token/cost metrics live on the child doGenerate span to avoid
+    // double-counting. Parent span should NOT have them.
+    expect(metrics.tokens).toBeUndefined();
+    expect(metrics.prompt_tokens).toBeUndefined();
+    expect(metrics.completion_tokens).toBeUndefined();
+
+    // Verify child doGenerate span carries the metrics
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const doGenSpan = spans.find(
+      (s: any) => s.span_attributes?.name === "doGenerate",
+    ) as any;
+    expect(doGenSpan).toBeDefined();
+    expect(doGenSpan.metrics.prompt_tokens).toBeGreaterThan(0);
+    expect(doGenSpan.metrics.completion_tokens).toBeGreaterThan(0);
 
     // Check that output is present and not omitted
     expect(span.output).toBeDefined();
@@ -268,9 +279,20 @@ describe("ai sdk client unit tests", TEST_SUITE_OPTIONS, () => {
     expect(metrics.start).toBeLessThanOrEqual(metrics.end);
     expect(metrics.end).toBeLessThanOrEqual(end);
 
-    expect(metrics.tokens).toBeGreaterThan(0);
-    expect(metrics.prompt_tokens).toBeGreaterThan(0);
-    expect(metrics.completion_tokens).toBeGreaterThan(0);
+    // Token/cost metrics live on the child doGenerate span to avoid
+    // double-counting. Parent span should NOT have them.
+    expect(metrics.tokens).toBeUndefined();
+    expect(metrics.prompt_tokens).toBeUndefined();
+    expect(metrics.completion_tokens).toBeUndefined();
+
+    // Verify child doGenerate span carries the metrics
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const doGenSpan = spans.find(
+      (s: any) => s.span_attributes?.name === "doGenerate",
+    ) as any;
+    expect(doGenSpan).toBeDefined();
+    expect(doGenSpan.metrics.prompt_tokens).toBeGreaterThan(0);
+    expect(doGenSpan.metrics.completion_tokens).toBeGreaterThan(0);
 
     // Verify image content is properly handled as attachment
     const messageContent = span.input.messages[0].content;
@@ -373,9 +395,20 @@ describe("ai sdk client unit tests", TEST_SUITE_OPTIONS, () => {
     expect(metrics.start).toBeLessThanOrEqual(metrics.end);
     expect(metrics.end).toBeLessThanOrEqual(end);
 
-    expect(metrics.tokens).toBeGreaterThan(0);
-    expect(metrics.prompt_tokens).toBeGreaterThan(0);
-    expect(metrics.completion_tokens).toBeGreaterThan(0);
+    // Token/cost metrics live on the child doGenerate span to avoid
+    // double-counting. Parent span should NOT have them.
+    expect(metrics.tokens).toBeUndefined();
+    expect(metrics.prompt_tokens).toBeUndefined();
+    expect(metrics.completion_tokens).toBeUndefined();
+
+    // Verify child doGenerate span carries the metrics
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const doGenSpan = spans.find(
+      (s: any) => s.span_attributes?.name === "doGenerate",
+    ) as any;
+    expect(doGenSpan).toBeDefined();
+    expect(doGenSpan.metrics.prompt_tokens).toBeGreaterThan(0);
+    expect(doGenSpan.metrics.completion_tokens).toBeGreaterThan(0);
 
     // Verify file content is properly handled as attachment
     const messageContent = span.input.messages[0].content;
@@ -453,9 +486,20 @@ describe("ai sdk client unit tests", TEST_SUITE_OPTIONS, () => {
       expect(ttft).toBeGreaterThanOrEqual(metrics.time_to_first_token);
     }
 
-    expect(metrics.tokens).toBeGreaterThan(0);
-    expect(metrics.prompt_tokens).toBeGreaterThan(0);
-    expect(metrics.completion_tokens).toBeGreaterThan(0);
+    // Token/cost metrics live on the child doStream span to avoid
+    // double-counting. Parent span should NOT have them.
+    expect(metrics.tokens).toBeUndefined();
+    expect(metrics.prompt_tokens).toBeUndefined();
+    expect(metrics.completion_tokens).toBeUndefined();
+
+    // Verify child doStream span carries the metrics
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const doStreamSpan = spans.find(
+      (s: any) => s.span_attributes?.name === "doStream",
+    ) as any;
+    expect(doStreamSpan).toBeDefined();
+    expect(doStreamSpan.metrics.prompt_tokens).toBeGreaterThan(0);
+    expect(doStreamSpan.metrics.completion_tokens).toBeGreaterThan(0);
   });
 
   test("ai sdk multi-turn conversation", async () => {
@@ -506,9 +550,20 @@ describe("ai sdk client unit tests", TEST_SUITE_OPTIONS, () => {
     expect(metrics.start).toBeLessThanOrEqual(metrics.end);
     expect(metrics.end).toBeLessThanOrEqual(end);
 
-    expect(metrics.tokens).toBeGreaterThan(0);
-    expect(metrics.prompt_tokens).toBeGreaterThan(0);
-    expect(metrics.completion_tokens).toBeGreaterThan(0);
+    // Token/cost metrics live on the child doGenerate span to avoid
+    // double-counting. Parent span should NOT have them.
+    expect(metrics.tokens).toBeUndefined();
+    expect(metrics.prompt_tokens).toBeUndefined();
+    expect(metrics.completion_tokens).toBeUndefined();
+
+    // Verify child doGenerate span carries the metrics
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const doGenSpan = spans.find(
+      (s: any) => s.span_attributes?.name === "doGenerate",
+    ) as any;
+    expect(doGenSpan).toBeDefined();
+    expect(doGenSpan.metrics.prompt_tokens).toBeGreaterThan(0);
+    expect(doGenSpan.metrics.completion_tokens).toBeGreaterThan(0);
   });
 
   test("ai sdk system prompt", async () => {
@@ -2375,8 +2430,16 @@ describe.skipIf(!AI_GATEWAY_API_KEY)(
       expect(generateTextSpan.metadata.model).toBe("gpt-4o-mini");
       expect(generateTextSpan.metadata.provider).toBe("openai");
 
-      // Verify cost is extracted from gateway marketCost
-      expect(generateTextSpan.metrics.estimated_cost).toBeGreaterThan(0);
+      // Cost should NOT be on the parent span (to avoid double-counting with
+      // child doGenerate spans). It should be on the doGenerate child span.
+      expect(generateTextSpan.metrics.estimated_cost).toBeUndefined();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const doGenerateSpan = spans.find(
+        (s: any) => s.span_attributes?.name === "doGenerate",
+      ) as any;
+      expect(doGenerateSpan).toBeDefined();
+      expect(doGenerateSpan.metrics.estimated_cost).toBeGreaterThan(0);
     });
 
     test("multi-step tool use extracts total cost", async () => {
@@ -2407,8 +2470,22 @@ describe.skipIf(!AI_GATEWAY_API_KEY)(
 
       expect(generateTextSpan).toBeDefined();
 
-      // Cost should be sum of all steps
-      expect(generateTextSpan.metrics.estimated_cost).toBeGreaterThan(0);
+      // Cost should NOT be on the parent span (to avoid double-counting).
+      // Individual doGenerate child spans carry per-step costs.
+      expect(generateTextSpan.metrics.estimated_cost).toBeUndefined();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const doGenerateSpans = spans.filter(
+        (s: any) => s.span_attributes?.name === "doGenerate",
+      ) as any[];
+      expect(doGenerateSpans.length).toBeGreaterThan(0);
+
+      // At least one doGenerate span should have cost
+      const totalCost = doGenerateSpans.reduce(
+        (sum: number, s: any) => sum + (s.metrics.estimated_cost ?? 0),
+        0,
+      );
+      expect(totalCost).toBeGreaterThan(0);
 
       // Verify model/provider in metadata
       expect(generateTextSpan.metadata.model).toBe("gpt-4o-mini");


### PR DESCRIPTION
## Summary

- When a model is wrapped by `wrapAISDK`, child `doGenerate`/`doStream` spans already carry per-step token counts and `estimated_cost`. The parent span (`generateText`, `streamText`, `generateObject`, `streamObject`, and agent wrappers like `ToolLoopAgent`) was also logging the same aggregated metrics, causing the Braintrust backend to double-count both tokens and cost.
- This change omits all token/cost metrics from the parent span when the model is wrapped (i.e. child spans exist), so metrics are only reported once on the leaf LLM call spans. This applies to all four wrapper functions: `generateText`, `streamText`, `generateObject`, and `streamObject`.
- Updated tests to assert that parent spans no longer carry token metrics and that child `doGenerate`/`doStream` spans do.

## Test plan

- [x] Unit tests updated to verify parent spans have no token/cost metrics when model is wrapped
- [x] Unit tests verify child `doGenerate`/`doStream` spans carry the token metrics
- [x] Gateway cost tests updated to verify cost appears on child spans, not parent
- [ ] Manual verification in eval mode confirms no more cost doubling


Made with [Cursor](https://cursor.com)