### PR TITLE
feat(openai): Add cache write token metric for OpenAI Agents responses.

### DIFF
--- a/integrations/openai-agents-js/src/index.ts
+++ b/integrations/openai-agents-js/src/index.ts
@@ -409,6 +409,9 @@ export class OpenAIAgentsTraceProcessor {
       if (usage.input_tokens_details?.cached_tokens != null)
         data.metrics.prompt_cached_tokens =
           usage.input_tokens_details.cached_tokens;
+      if (usage.input_tokens_details?.cache_write_tokens != null)
+        data.metrics.prompt_cache_creation_tokens =
+          usage.input_tokens_details.cache_write_tokens;
     }
 
     return data;


### PR DESCRIPTION
resolves https://github.com/braintrustdata/braintrust-sdk/issues/1373

Opened a new PR for https://github.com/braintrustdata/braintrust-sdk/pull/1375 to fix some CI issues. Thanks to @OrGivati for reporting the issue (with openai and braintrust) and raising that PR!

Capture response usage `cache_write_tokens` as `prompt_cache_creation_tokens` and add integration tests covering present, zero, and missing values.

https://github.com/openai/openai-agents-js/blob/877ba57da56d3ab6c147aefc5cbe354164dd4538/packages/agents-extensions/src/ai-sdk/index.ts#L1601-L1608


