### PR TITLE
[Python] Remove references to `performance` extra

### DIFF
--- a/py/README.md
+++ b/py/README.md
@@ -12,13 +12,7 @@ Install the library with pip.
 pip install braintrust
 ```
 
-**Performance tip**: For 3-5x faster JSON serialization, install with the optional `performance` extra:
-
-```bash
-pip install braintrust[performance]
-```
-
-Or install `orjson` separately:
+**Performance tip**: For 3-5x faster JSON serialization, install `orjson` separately:
 
 ```bash
 pip install orjson


### PR DESCRIPTION
The Python SDK's README indicates that there is a `performance` extra which automatically installs and uses `orjson` to improve JSON serialization performance. But this extra and the corresponding documentation don't seem to exist.