### PR TITLE
feat(eval): Allow for tags to be passed in at experiment creation time

### DIFF
--- a/js/src/cli/index.ts
+++ b/js/src/cli/index.ts
@@ -103,6 +103,7 @@ async function initExperiment(
     experiment: evaluator.experimentName,
     description: evaluator.description,
     metadata: evaluator.metadata,
+    tags: evaluator.tags,
     isPublic: evaluator.isPublic,
     update: evaluator.update,
     baseExperiment: evaluator.baseExperimentName ?? defaultBaseExperiment,

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -262,6 +262,11 @@ export interface Evaluator<
   metadata?: Record<string, unknown>;
 
   /**
+   * Optional tags for the experiment.
+   */
+  tags?: string[];
+
+  /**
    * Whether the experiment should be public. Defaults to false.
    */
   isPublic?: boolean;
@@ -662,6 +667,7 @@ export async function Eval<
             experiment: evaluator.experimentName,
             description: evaluator.description,
             metadata: evaluator.metadata,
+            tags: evaluator.tags,
             isPublic: evaluator.isPublic,
             update: evaluator.update,
             baseExperiment:

--- a/js/src/logger-misc.test.ts
+++ b/js/src/logger-misc.test.ts
@@ -24,7 +24,37 @@ import { configureNode } from "./node/config";
 
 configureNode();
 
-const { extractAttachments, deepCopyEvent } = _exportsForTestingOnly;
+const { extractAttachments, deepCopyEvent, validateTags } =
+  _exportsForTestingOnly;
+
+describe("validateTags", () => {
+  test("accepts valid tags", () => {
+    expect(() => validateTags(["foo", "bar", "baz"])).not.toThrow();
+  });
+
+  test("accepts empty array", () => {
+    expect(() => validateTags([])).not.toThrow();
+  });
+
+  test("accepts single tag", () => {
+    expect(() => validateTags(["solo"])).not.toThrow();
+  });
+
+  test("throws on non-string tag", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => validateTags([123 as any])).toThrow("tags must be strings");
+  });
+
+  test("throws on duplicate tags", () => {
+    expect(() => validateTags(["foo", "bar", "foo"])).toThrow(
+      "duplicate tag: foo",
+    );
+  });
+
+  test("throws on adjacent duplicate tags", () => {
+    expect(() => validateTags(["a", "a"])).toThrow("duplicate tag: a");
+  });
+});
 
 test("extractAttachments no op", () => {
   const attachments: BaseAttachment[] = [];

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -3266,6 +3266,7 @@ export type InitOptions<IsOpen extends boolean> = FullLoginOptions & {
   baseExperiment?: string;
   isPublic?: boolean;
   metadata?: Record<string, unknown>;
+  tags?: string[];
   gitMetadataSettings?: GitMetadataSettings;
   projectId?: string;
   baseExperimentId?: string;
@@ -3302,6 +3303,7 @@ type InitializedExperiment<IsOpen extends boolean | undefined> =
  * @param options.projectId The id of the project to create the experiment in. This takes precedence over `project` if specified.
  * @param options.baseExperimentId An optional experiment id to use as a base. If specified, the new experiment will be summarized and compared to this. This takes precedence over `baseExperiment` if specified.
  * @param options.repoInfo (Optional) Explicitly specify the git metadata for this experiment. This takes precedence over `gitMetadataSettings` if specified.
+ * @param options.tags (Optional) A list of tags to attach to the experiment.
  * @returns The newly created Experiment.
  */
 export function init<IsOpen extends boolean = false>(
@@ -3353,6 +3355,7 @@ export function init<IsOpen extends boolean = false>(
     forceLogin,
     fetch,
     metadata,
+    tags,
     gitMetadataSettings,
     projectId,
     baseExperimentId,
@@ -3495,6 +3498,11 @@ export function init<IsOpen extends boolean = false>(
 
       if (metadata) {
         args["metadata"] = metadata;
+      }
+
+      if (tags) {
+        validateTags(tags);
+        args["tags"] = tags;
       }
 
       let response = null;
@@ -5174,6 +5182,7 @@ function validateTags(tags: readonly string[]) {
     if (seen.has(tag)) {
       throw new Error(`duplicate tag: ${tag}`);
     }
+    seen.add(tag);
   }
 }
 
@@ -7753,5 +7762,6 @@ export const _exportsForTestingOnly = {
   isGeneratorFunction,
   isAsyncGeneratorFunction,
   resetIdGenStateForTests,
+  validateTags,
   isomorph: iso, // Expose isomorph for build type detection
 };


### PR DESCRIPTION
resolves https://github.com/braintrustdata/braintrust-sdk/issues/1376

Also fixes a bug with the `validateTags` function, and adds a test for it accordingly.