### PR TITLE
meta: Remove CODEOWNERs from repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,0 @@
-# Any changes to deps / build configuration need additional scrutiny.
-#
-# For example, adding a required dependency to core or SDK will make it required
-# for all users of the SDK, so we should be extremely careful about which
-# dependencies we add.
-py/setup.py @ankrgyl @clutchski @ibolmo
-js/package.json @ankrgyl @clutchski @ibolmo


### PR DESCRIPTION
This removes codeowners from the repo. From a slack discussion we had we decided that codeowners wasn't necessary now that the sdk has a more robust set of tests. It also made version upgrades much more difficult.

As a bonus, this will make the splitting up python/js into separate repos much easier.