### PR TITLE
build: Add timeout-minutes where missing to all GHA

### DIFF
--- a/.github/workflows/adk-py-test.yaml
+++ b/.github/workflows/adk-py-test.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   test:
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 15
 
     env:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -8,6 +8,7 @@ jobs:
   open-pr:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'run-integration-tests') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/js.yaml
+++ b/.github/workflows/js.yaml
@@ -30,6 +30,7 @@ permissions:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -146,6 +147,7 @@ jobs:
 
   api-compatibility:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     # Run in parallel with build job
     strategy:
       fail-fast: false
@@ -240,6 +242,7 @@ jobs:
   # Smoke v2: Auto-discovery of scenarios
   smoke-discover:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       scenarios: ${{ steps.discover.outputs.scenarios }}
     steps:
@@ -264,6 +267,7 @@ jobs:
   smoke-test:
     needs: [build, smoke-discover]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false

--- a/.github/workflows/langchain-py-test.yaml
+++ b/.github/workflows/langchain-py-test.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   test:
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 15
 
     defaults:
       run:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/npm-download-stats.yaml
+++ b/.github/workflows/npm-download-stats.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   report-stats:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/otel-js-test.yaml
+++ b/.github/workflows/otel-js-test.yaml
@@ -15,6 +15,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false

--- a/.github/workflows/publish-js-sdk.yaml
+++ b/.github/workflows/publish-js-sdk.yaml
@@ -27,6 +27,7 @@ jobs:
     # Only run validation for tag-based releases (not prereleases)
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       release_tag: ${{ steps.set_release_tag.outputs.release_tag }}
     steps:
@@ -55,6 +56,7 @@ jobs:
       always() &&
       (needs.validate.result == 'success' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
       id-token: write
@@ -151,6 +153,7 @@ jobs:
     needs: [validate, build-and-publish]
     if: always() && needs.build-and-publish.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Post to Slack on success (stable release)
         if: needs.build-and-publish.outputs.is_prerelease == 'false'
@@ -193,6 +196,7 @@ jobs:
     needs: [validate, build-and-publish]
     if: always() && (needs.validate.result == 'failure' || needs.build-and-publish.result == 'failure')
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Post to Slack on failure
         uses: slackapi/slack-github-action@v2.1.1

--- a/.github/workflows/publish-py-sdk.yaml
+++ b/.github/workflows/publish-py-sdk.yaml
@@ -14,6 +14,7 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       release_tag: ${{ steps.set_release_tag.outputs.release_tag }}
     steps:
@@ -33,6 +34,7 @@ jobs:
   build-and-publish:
     needs: validate
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
       id-token: write # Required for PyPI trusted publishing
@@ -96,6 +98,7 @@ jobs:
     needs: [validate, build-and-publish]
     if: always() && needs.build-and-publish.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Extract version from tag
         id: version
@@ -125,6 +128,7 @@ jobs:
     needs: [validate, build-and-publish]
     if: always() && (needs.validate.result == 'failure' || needs.build-and-publish.result == 'failure')
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Post to Slack on failure
         uses: slackapi/slack-github-action@v2.1.1

--- a/.github/workflows/py.yaml
+++ b/.github/workflows/py.yaml
@@ -22,6 +22,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -84,6 +85,7 @@ jobs:
   upload-wheel:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/templates-nunjucks-build-test.yaml
+++ b/.github/workflows/templates-nunjucks-build-test.yaml
@@ -15,6 +15,7 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false

--- a/.github/workflows/temporal-js-build-test.yaml
+++ b/.github/workflows/temporal-js-build-test.yaml
@@ -15,6 +15,7 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test-publish-py-sdk.yaml
+++ b/.github/workflows/test-publish-py-sdk.yaml
@@ -19,6 +19,7 @@ on:
 jobs:
   build-and-publish-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       id-token: write # Required for PyPI trusted publishing
 
@@ -63,6 +64,7 @@ jobs:
     needs: build-and-publish-test
     if: success()
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Post to Slack on success
         uses: slackapi/slack-github-action@v2.1.1
@@ -86,6 +88,7 @@ jobs:
     needs: build-and-publish-test
     if: failure()
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Post to Slack on failure
         uses: slackapi/slack-github-action@v2.1.1

--- a/.github/workflows/test-zod-versions.yaml
+++ b/.github/workflows/test-zod-versions.yaml
@@ -24,6 +24,7 @@ jobs:
   test-zod-versions:
     name: Test with zod ${{ matrix.zod-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -77,6 +78,7 @@ jobs:
     name: Test Summary
     needs: test-zod-versions
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: always()
     steps:
       - name: Check test results

--- a/.github/workflows/val.yaml
+++ b/.github/workflows/val.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
We found some examples of GHA actions running for a really long time: https://github.com/braintrustdata/braintrust-sdk/actions/runs/22194012217/job/64189398648?pr=1392. Although that's it's own problem, we should probably configure `timeout-minutes` so we don't waste resources uncessarily.

<details>

<summary>AI summary of timeouts added</summary>

  Timeouts Added
                                                                
  Workflow: adk-py-test.yaml                                
  Job: test
  Timeout: 15 min
  Rationale: Installs Python deps, runs ruff lint, pytest, and
    import checks. Standard lightweight Python test suite.
  ────────────────────────────────────────
  Workflow: integration-tests.yaml
  Job: open-pr
  Timeout: 10 min
  Rationale: Only does git operations (checkout, submodule
    update) and creates a PR via a shell script. No builds or
    tests.
  ────────────────────────────────────────
  Workflow: langchain-py-test.yaml
  Job: test
  Timeout: 15 min
  Rationale: Same profile as adk-py: install deps, lint, pytest,

    import check.
  ────────────────────────────────────────
  Workflow: lint.yaml
  Job: lint
  Timeout: 10 min
  Rationale: Runs pre-commit hooks on changed files only. Very
    lightweight, but fetches full git history.
  ────────────────────────────────────────
  Workflow: otel-js-test.yaml
  Job: test
  Timeout: 20 min
  Rationale: Builds a Docker image and runs tests inside it.
    Docker image builds can be slow due to layer caching misses
    on CI.
  ────────────────────────────────────────
  Workflow: publish-js-sdk.yaml
  Job: validate
  Timeout: 10 min
  Rationale: Just checks out code and validates a release tag.
    Minimal work.
  ────────────────────────────────────────
  Workflow:
  Job: build-and-publish
  Timeout: 20 min
  Rationale: Builds the JS SDK and publishes to npm. Build +
    publish + artifact upload needs headroom.
  ────────────────────────────────────────
  Workflow:
  Job: notify-success
  Timeout: 5 min
  Rationale: Single Slack API call. Should finish in seconds.
  ────────────────────────────────────────
  Workflow:
  Job: notify-failure
  Timeout: 5 min
  Rationale: Single Slack API call.
  ────────────────────────────────────────
  Workflow: publish-py-sdk.yaml
  Job: validate
  Timeout: 10 min
  Rationale: Checks out code and validates a release tag.
  ────────────────────────────────────────
  Workflow:
  Job: build-and-publish
  Timeout: 20 min
  Rationale: Installs dev deps, builds wheel, verifies,
  publishes
    to PyPI, creates GitHub release.
  ────────────────────────────────────────
  Workflow:
  Job: notify-success
  Timeout: 5 min
  Rationale: Single Slack API call.
  ────────────────────────────────────────
  Workflow:
  Job: notify-failure
  Timeout: 5 min
  Rationale: Single Slack API call.
  ────────────────────────────────────────
  Workflow: temporal-js-build-test.yaml
  Job: build-and-test
  Timeout: 15 min
  Rationale: pnpm install, builds braintrust + temporal package,

    runs tests. Straightforward JS build/test.
  ────────────────────────────────────────
  Workflow: test-publish-py-sdk.yaml
  Job: build-and-publish-test
  Timeout: 20 min
  Rationale: Same as publish-py but targets TestPyPI. Full build

    + verify + publish cycle.
  ────────────────────────────────────────
  Workflow:
  Job: notify-success
  Timeout: 5 min
  Rationale: Single Slack API call.
  ────────────────────────────────────────
  Workflow:
  Job: notify-failure
  Timeout: 5 min
  Rationale: Single Slack API call.
  ────────────────────────────────────────
  Workflow: val.yaml
  Job: update
  Timeout: 10 min
  Rationale: Sets up Deno and runs a CLI script to update a val.

    Lightweight.
  ────────────────────────────────────────
  Workflow: js.yaml
  Job: build
  Timeout: 30 min
  Rationale: The heaviest job: runs on a matrix of 2 OSes x 2
    Node versions, builds the SDK + browser + otel +
    templates-nunjucks packages, runs make js-verify-ci (which
    includes tests), and packs artifacts. Windows builds are
    notably slower.
  ────────────────────────────────────────
  Workflow:
  Job: api-compatibility
  Timeout: 20 min
  Rationale: Checks out main branch, builds a baseline, then
    builds the current branch, and runs API compat tests. Two
    full builds in one job.
  ────────────────────────────────────────
  Workflow:
  Job: smoke-discover
  Timeout: 5 min
  Rationale: Just runs find and jq to discover smoke test
    scenarios. No builds.
  ────────────────────────────────────────
  Workflow:
  Job: smoke-test
  Timeout: 15 min
  Rationale: Downloads artifacts, builds a shared test package,
    and runs a single smoke scenario per matrix entry.
  ────────────────────────────────────────
  Workflow: npm-download-stats.yaml
  Job: report-stats
  Timeout: 10 min
  Rationale: Runs a TypeScript script to fetch npm stats and
    report to Datadog. Lightweight but involves external API
    calls.
  ────────────────────────────────────────
  Workflow: py.yaml
  Job: build
  Timeout: 30 min
  Rationale: Matrix of 4 Python versions x 2 OSes x 2 shards.
    Installs dev deps, runs sharded nox test suites. Windows +
    older Python combos can be slow.
  ────────────────────────────────────────
  Workflow:
  Job: upload-wheel
  Timeout: 10 min
  Rationale: Builds and uploads a single wheel. Quick, but
    includes make install-build-deps.
  ────────────────────────────────────────
  Workflow: templates-nunjucks-build-test.yaml
  Job: build-and-test
  Timeout: 15 min
  Rationale: pnpm install, builds braintrust +
    templates-nunjucks, runs tests. Standard JS build/test.
  ────────────────────────────────────────
  Workflow: test-zod-versions.yaml
  Job: test-zod-versions
  Timeout: 20 min
  Rationale: Installs deps, swaps zod version, runs full make
    js-test plus version-specific zod tests. Full test run
    warrants extra time.
  ────────────────────────────────────────
  Workflow:
  Job: test-summary
  Timeout: 5 min
  Rationale: Just checks the result of the previous job and
    echoes a message.

  General philosophy: Without timeout-minutes, GitHub Actions
  defaults to 360 minutes (6 hours), which means a hung job can
  burn through runner minutes for hours before being killed. The
   timeouts above are set to ~2-3x what the jobs should normally
   take, giving enough headroom for slow CI days while catching
  genuinely stuck jobs early.
  </details>