### PR TITLE
build: Run all CI workflows on pushes to main

### DIFF
--- a/.github/workflows/js.yaml
+++ b/.github/workflows/js.yaml
@@ -13,15 +13,6 @@ on:
       - "pnpm-workspace.yaml"
   push:
     branches: [main]
-    paths:
-      - "js/**"
-      - "integrations/otel-js/**"
-      - "integrations/temporal-js/**"
-      - ".github/workflows/js.yaml"
-      - ".github/workflows/otel-js-test.yaml"
-      - ".github/workflows/temporal-js-build-test.yaml"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
 
 permissions:
   contents: read

--- a/.github/workflows/otel-js-test.yaml
+++ b/.github/workflows/otel-js-test.yaml
@@ -8,9 +8,6 @@ on:
       - ".github/workflows/otel-js-test.yaml"
   push:
     branches: [main]
-    paths:
-      - "integrations/otel-js/**"
-      - "js/**"
 
 jobs:
   test:

--- a/.github/workflows/py.yaml
+++ b/.github/workflows/py.yaml
@@ -11,13 +11,6 @@ on:
       - ".github/workflows/langchain-py-test.yaml"
   push:
     branches: [main]
-    paths:
-      - "py/**"
-      - "integrations/langchain-py/**"
-      - "integrations/adk-py/**"
-      - ".github/workflows/py.yaml"
-      - ".github/workflows/adk-py-test.yaml"
-      - ".github/workflows/langchain-py-test.yaml"
 
 jobs:
   build:

--- a/.github/workflows/templates-nunjucks-build-test.yaml
+++ b/.github/workflows/templates-nunjucks-build-test.yaml
@@ -8,9 +8,6 @@ on:
       - ".github/workflows/templates-nunjucks-build-test.yaml"
   push:
     branches: [main]
-    paths:
-      - "integrations/templates-nunjucks/**"
-      - "js/**"
 
 jobs:
   build-and-test:

--- a/.github/workflows/temporal-js-build-test.yaml
+++ b/.github/workflows/temporal-js-build-test.yaml
@@ -8,9 +8,6 @@ on:
       - ".github/workflows/temporal-js-test.yaml"
   push:
     branches: [main]
-    paths:
-      - "integrations/temporal-js/**"
-      - "js/**"
 
 jobs:
   build-and-test:

--- a/.github/workflows/test-zod-versions.yaml
+++ b/.github/workflows/test-zod-versions.yaml
@@ -9,11 +9,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "js/**"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - ".github/workflows/test-zod-versions.yaml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/val.yaml
+++ b/.github/workflows/val.yaml
@@ -7,8 +7,6 @@ on:
       - "integrations/val.town/vals/**"
   push:
     branches: [main]
-    paths:
-      - "integrations/val.town/vals/**"
 
 jobs:
   update:


### PR DESCRIPTION
We ran into some python test failures because CI was not always running on main due to the changes in https://github.com/braintrustdata/braintrust-sdk/pull/1380.

This PR removes path filters from the push trigger so every commit to main runs all workflows. Path-based filtering is kept for pull requests only.