### PR TITLE
chore: Fix val.town example zod import

### DIFF
--- a/integrations/val.town/src/commands/update.ts
+++ b/integrations/val.town/src/commands/update.ts
@@ -1,7 +1,7 @@
 import { Command } from "@cliffy/command";
 import { colors } from "@cliffy/ansi/colors";
 import { expandGlob } from "@std/fs";
-import { z } from "zod/v3";
+import { z } from "zod";
 import { join } from "@std/path";
 
 const configSchema = z.object({


### PR DESCRIPTION
CI is failing on latest commit (https://github.com/braintrustdata/braintrust-sdk/actions/runs/22328046143/job/64604525627). This fixes that by adjusting the import. The import map points to zod v3: https://github.com/braintrustdata/braintrust-sdk/blob/99a5cb75b08c5e2bff6e96614cfe8c0573f0c19d/integrations/val.town/deno.json#L12