### PR TITLE
chore: Rename repo to braintrust-sdk-javascript

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -34,7 +34,7 @@ jobs:
           git submodule init
           git submodule update --init --recursive
           cd sdk
-          git remote set-url origin https://github.com/braintrustdata/braintrust-sdk.git
+          git remote set-url origin https://github.com/braintrustdata/braintrust-sdk-javascript.git
           git fetch origin
           git checkout ${{ github.event.pull_request.head.sha }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Development container for braintrust-sdk-ruby
+# Development container for braintrust-sdk-javascript
 FROM debian:trixie-slim
 
 # Set UTF-8 locale

--- a/integrations/browser-js/package.json
+++ b/integrations/browser-js/package.json
@@ -43,7 +43,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/braintrustdata/braintrust-sdk.git",
+    "url": "git+https://github.com/braintrustdata/braintrust-sdk-javascript.git",
     "directory": "sdk/integrations/browser-js"
   },
   "homepage": "https://www.braintrust.dev/docs",

--- a/integrations/val.town/vals/tutorial/README.md
+++ b/integrations/val.town/vals/tutorial/README.md
@@ -12,7 +12,7 @@ The Braintrust SDK enables you to:
 - Run comprehensive evaluations using the `Eval` framework
 - Track and improve your model's performance over time
 
-This template helps you get started with the Braintrust SDK. It's based on our [official GitHub repository](https://github.com/braintrustdata/braintrust-sdk).
+This template helps you get started with the Braintrust SDK. It's based on our [official GitHub repository](https://github.com/braintrustdata/braintrust-sdk-javascript).
 
 ## Getting started
 

--- a/js/package.json
+++ b/js/package.json
@@ -4,7 +4,7 @@
   "description": "SDK for integrating Braintrust",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/braintrustdata/braintrust-sdk.git",
+    "url": "git+https://github.com/braintrustdata/braintrust-sdk-javascript.git",
     "directory": "blob/main/js"
   },
   "homepage": "https://www.braintrust.dev/docs",

--- a/js/scripts/push-release-tag.sh
+++ b/js/scripts/push-release-tag.sh
@@ -24,7 +24,7 @@ done
 # Fetch latest tags
 git fetch --tags --prune
 
-REPO_URL="https://github.com/braintrustdata/braintrust-sdk"
+REPO_URL="https://github.com/braintrustdata/braintrust-sdk-javascript"
 TAG_PREFIX="js-sdk-v"
 COMMIT=$(git rev-parse --short HEAD)
 
@@ -98,5 +98,5 @@ git push origin "$TAG"
 
 echo ""
 echo "Tag ${TAG} has been created and pushed to origin. Check GitHub Actions for build progress:"
-echo "https://github.com/braintrustdata/braintrust-sdk/actions/workflows/publish-js-sdk.yaml"
+echo "https://github.com/braintrustdata/braintrust-sdk-javascript/actions/workflows/publish-js-sdk.yaml"
 echo ""

--- a/js/src/node/index.ts
+++ b/js/src/node/index.ts
@@ -3,7 +3,7 @@
  * for running evaluations, logging completions, loading and invoking functions, and more.
  *
  * `braintrust` is distributed as a [library on NPM](https://www.npmjs.com/package/braintrust).
- * It is also open source and available on [GitHub](https://github.com/braintrustdata/braintrust-sdk/tree/main/js).
+ * It is also open source and available on [GitHub](https://github.com/braintrustdata/braintrust-sdk-javascript/tree/main/js).
  *
  * ### Quickstart
  *

--- a/js/src/wrappers/ai-sdk/ai-sdk.ts
+++ b/js/src/wrappers/ai-sdk/ai-sdk.ts
@@ -103,7 +103,7 @@ export function wrapAISDK<T>(aiSDK: T, options: WrapAISDKOptions = {}): T {
   // These cause Proxy invariant violations because we return wrapped functions instead
   // of the original values. Using prototype chain preserves all properties (enumerable
   // and non-enumerable) while avoiding invariants since the target has no own properties.
-  // See: https://github.com/braintrustdata/braintrust-sdk/pull/1259
+  // See: https://github.com/braintrustdata/braintrust-sdk-javascript/pull/1259
   const target = isModuleNamespace(aiSDK)
     ? Object.setPrototypeOf({}, aiSDK)
     : aiSDK;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "braintrust-sdk-js",
   "version": "0.0.1",
-  "repository": "https://github.com/braintrustdata/braintrust-sdk",
+  "repository": "https://github.com/braintrustdata/braintrust-sdk-javascript",
   "license": "MIT",
   "private": true,
   "workspaces": [

--- a/scripts/claude-docker.sh
+++ b/scripts/claude-docker.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Docker container label
-DOCKER_LABEL="braintrust-sdk"
+DOCKER_LABEL="braintrust-sdk-javascript"
 
 COMMAND="${1:-}"
 

--- a/scripts/create-integration-test-pr.sh
+++ b/scripts/create-integration-test-pr.sh
@@ -55,7 +55,7 @@ fi
 git submodule init
 git submodule update --init --recursive
 cd sdk
-git remote set-url origin https://github.com/braintrustdata/braintrust-sdk.git
+git remote set-url origin https://github.com/braintrustdata/braintrust-sdk-javascript.git
 git fetch origin
 
 # Create a temporary branch to avoid detached HEAD state
@@ -66,7 +66,7 @@ git checkout "$COMMIT_HASH"
 # Get commit author and PR number
 COMMIT_AUTHOR=$(git log -1 --format='%an <%ae>')
 PR_NUMBER=$(gh pr list --head "$BRANCH_NAME" --json number --jq '.[0].number')
-SDK_PR_URL="https://github.com/braintrustdata/braintrust-sdk/pull/${PR_NUMBER}"
+SDK_PR_URL="https://github.com/braintrustdata/braintrust-sdk-javascript/pull/${PR_NUMBER}"
 
 cd ..
 git add sdk


### PR DESCRIPTION
This preps the repo to be renamed `braintrust-sdk-javascript`, matching the conventions for the rest of our SDKs. This is the final step of the plan to split up the repo: https://www.notion.so/braintrustdata/Splitting-up-braintrust-sdk-30df7858028980298731d3827a23cb70

This PR can't be merged until the repo actually gets renamed. Once this PR is approved, I'll rename the repo and merge it in, which should make everything work as expected.