### PR TITLE
ref: Set no-unused-vars eslint rule to error and clean up violations

### DIFF
--- a/js/eslint.config.ts
+++ b/js/eslint.config.ts
@@ -58,9 +58,8 @@ export default [
       ...tseslint.configs.recommended.rules,
       // TODO: Fix violations and re-enable as "error"
       "@typescript-eslint/no-explicit-any": "warn",
-      // TODO: Fix violations and re-enable as "error"
       "@typescript-eslint/no-unused-vars": [
-        "warn",
+        "error",
         {
           vars: "all",
           args: "none",

--- a/js/src/cli/functions/upload.ts
+++ b/js/src/cli/functions/upload.ts
@@ -1,9 +1,6 @@
 import {
-  CodeBundle as CodeBundleSchema,
   type CodeBundleType as CodeBundle,
-  Function as FunctionObjectSchema,
   type FunctionType as FunctionObject,
-  IfExists as IfExistsSchema,
   type IfExistsType as IfExists,
 } from "../../generated_types";
 import type { BuildSuccess, EvaluatorState, FileHandle } from "../types";

--- a/js/src/cli/reporters/eval.ts
+++ b/js/src/cli/reporters/eval.ts
@@ -152,7 +152,7 @@ function formatExperimentSummaryFancy(summary: ExperimentSummary) {
         borderStyle: "round",
       })
     );
-  } catch (error) {
+  } catch {
     return "\n" + chalk.gray("Experiment summary") + "\n" + boxContent + "\n";
   }
 }

--- a/js/src/cli/util/pull.ts
+++ b/js/src/cli/util/pull.ts
@@ -1,9 +1,7 @@
 import {
   Function as functionSchema,
   type FunctionType as FunctionObject,
-  SavedFunctionId as SavedFunctionIdSchema,
   type SavedFunctionIdType as SavedFunctionId,
-  ToolFunctionDefinition as ToolFunctionDefinitionSchema,
   type ToolFunctionDefinitionType as ToolFunctionDefinition,
 } from "../../generated_types";
 import { _internalGetGlobalState } from "../../logger";

--- a/js/src/framework2.ts
+++ b/js/src/framework2.ts
@@ -5,19 +5,14 @@ import { slugify } from "../util/string_util";
 import { z } from "zod/v3";
 import {
   type FunctionTypeEnumType as FunctionType,
-  IfExists as IfExistsSchema,
   type IfExistsType as IfExists,
-  SavedFunctionId as SavedFunctionIdSchema,
   type SavedFunctionIdType as SavedFunctionId,
-  PromptBlockData as PromptBlockDataSchema,
   type PromptBlockDataType as PromptBlockData,
-  PromptData as PromptDataSchema,
   type PromptDataType as PromptData,
   ToolFunctionDefinition as toolFunctionDefinitionSchema,
   type ToolFunctionDefinitionType as ToolFunctionDefinition,
   FunctionData as functionDataSchema,
   Project as projectSchema,
-  ExtendedSavedFunctionId as ExtendedSavedFunctionIdSchema,
   type ExtendedSavedFunctionIdType as ExtendedSavedFunctionId,
 } from "./generated_types";
 import { loadPrettyXact, TransactionId } from "../util/index";

--- a/js/src/functions/stream.ts
+++ b/js/src/functions/stream.ts
@@ -1,5 +1,4 @@
 import {
-  CallEvent as CallEventSchemaImport,
   type CallEventType as CallEventSchema,
   CallEvent as callEventSchema,
   SSEConsoleEventData as sseConsoleEventDataSchema,

--- a/js/src/gitutil.ts
+++ b/js/src/gitutil.ts
@@ -1,7 +1,5 @@
 import {
-  GitMetadataSettings as GitMetadataSettingsSchema,
   type GitMetadataSettingsType as GitMetadataSettings,
-  RepoInfo as RepoInfoSchema,
   type RepoInfoType as RepoInfo,
 } from "./generated_types";
 import { simpleGit } from "simple-git";
@@ -19,7 +17,7 @@ export async function currentRepo() {
     } else {
       return null;
     }
-  } catch (e) {
+  } catch {
     return null;
   }
 }
@@ -95,7 +93,7 @@ async function getBaseBranchAncestor(remote: string | undefined = undefined) {
       `${remoteName}/${baseBranch}`,
     ]);
     return ancestor.trim();
-  } catch (e) {
+  } catch {
     /*
     console.warn(
       `Warning: Could not find a common ancestor with ${remoteName}/${baseBranch}`
@@ -133,7 +131,7 @@ export async function getPastNAncestors(
 async function attempt<T>(fn: () => Promise<T>): Promise<T | undefined> {
   try {
     return await fn();
-  } catch (e) {
+  } catch {
     return undefined;
   }
 }

--- a/js/src/graph-framework.ts
+++ b/js/src/graph-framework.ts
@@ -1,14 +1,9 @@
 import { newId, Prompt } from "./logger";
 import {
-  FunctionId as FunctionIdSchema,
   type FunctionIdType as FunctionId,
-  GraphData as GraphDataSchema,
   type GraphDataType as GraphData,
-  GraphNode as GraphNodeSchema,
   type GraphNodeType as GraphNode,
-  GraphEdge as GraphEdgeSchema,
   type GraphEdgeType as GraphEdge,
-  PromptBlockData as PromptBlockDataSchema,
   type PromptBlockDataType as PromptBlockData,
 } from "./generated_types";
 

--- a/js/src/instrumentation/plugins/ai-sdk-plugin.ts
+++ b/js/src/instrumentation/plugins/ai-sdk-plugin.ts
@@ -1,9 +1,9 @@
 import { tracingChannel } from "dc-browser";
 import { BasePlugin, isAsyncIterable, patchStreamIfNeeded } from "../core";
-import type { StartEvent, EndEvent, ErrorEvent } from "../core";
-import { startSpan, Attachment } from "../../logger";
+import type { StartEvent } from "../core";
+import { startSpan } from "../../logger";
 import type { Span } from "../../logger";
-import { SpanTypeAttribute, isObject } from "../../../util/index";
+import { SpanTypeAttribute } from "../../../util/index";
 import { getCurrentUnixTimestamp } from "../../util";
 import { processInputAttachments } from "../../wrappers/attachment-utils";
 

--- a/js/src/instrumentation/plugins/google-genai-plugin.ts
+++ b/js/src/instrumentation/plugins/google-genai-plugin.ts
@@ -3,7 +3,7 @@ import { BasePlugin, isAsyncIterable, patchStreamIfNeeded } from "../core";
 import type { StartEvent } from "../core";
 import { startSpan, Attachment } from "../../logger";
 import type { Span } from "../../logger";
-import { SpanTypeAttribute, isObject } from "../../../util/index";
+import { SpanTypeAttribute } from "../../../util/index";
 import { getCurrentUnixTimestamp } from "../../util";
 
 /**

--- a/js/src/instrumentation/plugins/openai-plugin.ts
+++ b/js/src/instrumentation/plugins/openai-plugin.ts
@@ -186,7 +186,7 @@ export class OpenAIPlugin extends BasePlugin {
 
           // Extract metadata - preserve response fields except usage and output
           if (response) {
-            const { usage, output, ...metadata } = response;
+            const { usage: _usage, output: _output, ...metadata } = response;
             if (Object.keys(metadata).length > 0) {
               data.metadata = metadata;
             }

--- a/js/src/isomorph.ts
+++ b/js/src/isomorph.ts
@@ -1,7 +1,5 @@
 import {
-  GitMetadataSettings as GitMetadataSettingsSchema,
   type GitMetadataSettingsType as GitMetadataSettings,
-  RepoInfo as RepoInfoSchema,
   type RepoInfoType as RepoInfo,
 } from "./generated_types";
 

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -121,7 +121,7 @@ import {
   SyncLazyValue,
   runCatchFinally,
 } from "./util";
-import { lintTemplate as lintMustacheTemplate } from "./template/mustache-utils";
+import { lintTemplate as _lintMustacheTemplate } from "./template/mustache-utils";
 import { prettifyXact } from "../util/index";
 import { SpanCache, CachedSpan } from "./span-cache";
 import type { EvalParameters, InferParameters } from "./eval-parameters";
@@ -1046,7 +1046,7 @@ class HTTPConnection {
     try {
       const resp = await this.get("ping");
       return resp.status === 200;
-    } catch (e) {
+    } catch {
       return false;
     }
   }

--- a/js/src/queue.bench.ts
+++ b/js/src/queue.bench.ts
@@ -10,7 +10,6 @@ const partialData = Array.from({ length: 100 }, (_, i) => i);
 // Initialize queues once
 const fullQueue = new Queue<number>(1000);
 const wrappedQueue = new Queue<number>(1000);
-const smallQueue = new Queue<number>(50);
 const partialQueue = new Queue<number>(1000);
 
 bench

--- a/js/src/wrappers/ai-sdk/ai-sdk.ts
+++ b/js/src/wrappers/ai-sdk/ai-sdk.ts
@@ -1139,10 +1139,6 @@ const serializeError = (error: unknown) => {
   return String(error);
 };
 
-const serializeModel = (model: any) => {
-  return typeof model === "string" ? model : model?.modelId;
-};
-
 /**
  * Parses a gateway model string like "openai/gpt-5-mini" into provider and model.
  * Returns { provider, model } if parseable, otherwise { model } only.

--- a/js/src/wrappers/attachment-utils.ts
+++ b/js/src/wrappers/attachment-utils.ts
@@ -63,7 +63,7 @@ export function convertDataToBlob(data: any, mediaType: string): Blob | null {
     } else if (typeof Buffer !== "undefined" && data instanceof Buffer) {
       return new Blob([data as any], { type: mediaType });
     }
-  } catch (error) {
+  } catch {
     // If conversion fails, return null
     return null;
   }

--- a/js/src/wrappers/claude-agent-sdk/claude-agent-sdk.ts
+++ b/js/src/wrappers/claude-agent-sdk/claude-agent-sdk.ts
@@ -20,35 +20,9 @@ type QueryOptions = {
   [key: string]: any;
 };
 
-type CallToolResult = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  content: Array<any>;
-  isError?: boolean;
-};
-
-type ToolHandler<T> = (
-  args: T,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  extra: any,
-) => Promise<CallToolResult>;
-
-type SdkMcpToolDefinition<T> = {
-  name: string;
-  description: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  inputSchema: any;
-  handler: ToolHandler<T>;
-};
-
 /**
  * Hook types from @anthropic-ai/claude-agent-sdk
  */
-type HookEvent =
-  | "PreToolUse"
-  | "PostToolUse"
-  | "PostToolUseFailure"
-  | "SubagentStart"
-  | "SubagentStop";
 
 type BaseHookInput = {
   session_id: string;

--- a/js/src/wrappers/oai.ts
+++ b/js/src/wrappers/oai.ts
@@ -367,7 +367,7 @@ function wrapChatCompletion<
               const { data: ret, response } =
                 await completionResponse.withResponse();
               logHeaders(response, span);
-              const { messages, ...rest } = params;
+              const { messages: _messages, ...rest } = params;
               span.log({
                 metadata: {
                   ...rest,

--- a/js/src/wrappers/oai_responses.ts
+++ b/js/src/wrappers/oai_responses.ts
@@ -65,7 +65,7 @@ function parseEventFromResponseCreateResult(result: any) {
 
   // Extract metadata - preserve all response fields except output and usage
   if (result) {
-    const { output, usage, ...metadata } = result;
+    const { output: _output, usage: _usage, ...metadata } = result;
     if (Object.keys(metadata).length > 0) {
       data.metadata = metadata;
     }
@@ -154,7 +154,7 @@ function parseEventFromResponseParseResult(result: any) {
 
   // Extract metadata - preserve all response fields except output and usage
   if (result) {
-    const { output, usage, ...metadata } = result;
+    const { output: _output, usage: _usage, ...metadata } = result;
     if (Object.keys(metadata).length > 0) {
       data.metadata = metadata;
     }
@@ -214,7 +214,7 @@ function parseLogFromItem(item: any): {} {
 
       // Extract metadata - preserve response fields except usage and output
       if (response) {
-        const { usage, output, ...metadata } = response;
+        const { usage: _usage, output: _output, ...metadata } = response;
         if (Object.keys(metadata).length > 0) {
           data.metadata = metadata;
         }

--- a/js/src/zod/zod-serialization-test-shared.ts
+++ b/js/src/zod/zod-serialization-test-shared.ts
@@ -1,4 +1,3 @@
-import { expect } from "vitest";
 /**
  * Shared test expectations for zod serialization tests
  *


### PR DESCRIPTION
resolves https://github.com/braintrustdata/braintrust-sdk/issues/1406

### AI Summary

**why this change is important**:

The `@typescript-eslint/no-unused-vars` rule catches dead code — unused imports, variables, and type definitions that add noise, increase bundle size (for non-type imports), and make the codebase harder to maintain. Promoting it from `"warn"` to `"error"` means:

1. **It blocks CI** — unused variables can no longer slip in unnoticed. Previously warnings were easy to ignore.
2. **Cleaner imports** — many files were importing Zod runtime schemas (e.g., `CodeBundleSchema`, `RepoInfoSchema`) that were never used, only their TypeScript types were needed. These unused runtime imports could pull in unnecessary code.
3. **Removes dead code** — things like `serializeModel`, `SdkMcpToolDefinition`, and `HookEvent` were defined but never referenced anywhere, creating confusion about whether they're part of the API surface.
4. **Prevents regressions** — as an error, any future unused variable is caught at lint time rather than accumulating as tech debt.