### PR TITLE
ref: Set prefer-const eslint rule to error

### DIFF
--- a/js/eslint.config.ts
+++ b/js/eslint.config.ts
@@ -68,8 +68,7 @@ export default [
           varsIgnorePattern: "^_",
         },
       ],
-      // TODO: Fix violations and re-enable as "error"
-      "prefer-const": "warn",
+      "prefer-const": "error",
       "@typescript-eslint/ban-types": "off",
       "@typescript-eslint/ban-ts-comment": "off",
       "@typescript-eslint/no-require-imports": "off",

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -1770,9 +1770,9 @@ function logFeedbackImpl(
     tags,
   });
 
-  let { metadata, ...updateEvent } = deepCopyEvent(validatedEvent);
-  updateEvent = Object.fromEntries(
-    Object.entries(updateEvent).filter(([_, v]) => !isEmpty(v)),
+  const { metadata, ...rawUpdateEvent } = deepCopyEvent(validatedEvent);
+  const updateEvent = Object.fromEntries(
+    Object.entries(rawUpdateEvent).filter(([_, v]) => !isEmpty(v)),
   );
 
   const parentIds = async () =>
@@ -5193,7 +5193,8 @@ function validateAndSanitizeExperimentLogPartialArgs(
     if (Array.isArray(event.scores)) {
       throw new Error("scores must be an object, not an array");
     }
-    for (let [name, score] of Object.entries(event.scores)) {
+    for (const [name, rawScore] of Object.entries(event.scores)) {
+      let score = rawScore;
       if (typeof name !== "string") {
         throw new Error("score names must be strings");
       }
@@ -5836,8 +5837,11 @@ export class Experiment
       readonly comparisonExperimentId?: string;
     } = {},
   ): Promise<ExperimentSummary> {
-    let { summarizeScores = true, comparisonExperimentId = undefined } =
-      options || {};
+    const {
+      summarizeScores = true,
+      comparisonExperimentId: comparisonExperimentIdOpt,
+    } = options || {};
+    let comparisonExperimentId = comparisonExperimentIdOpt;
 
     const state = await this.getState();
     const projectUrl = `${state.appPublicUrl}/app/${encodeURIComponent(


### PR DESCRIPTION
resolves https://github.com/braintrustdata/braintrust-sdk/issues/1409

### AI Summary

**`js/eslint.config.ts`**: Changed `"prefer-const": "warn"` to `"prefer-const": "error"` (and removed the TODO comment).

**`js/src/logger.ts`** — 3 violations fixed:
1. **Line 1773**: Renamed spread variable to `rawUpdateEvent` and assigned filtered result to a new `const updateEvent`, since the original was being reassigned.
2. **Line 5196**: Changed `for (let [name, score]` to `for (const [name, rawScore]` with a `let score = rawScore` inside the loop body, since `score` is reassigned but `name` isn't.
3. **Line 5839**: Changed `let { summarizeScores, comparisonExperimentId }` destructuring to `const` with renaming (`comparisonExperimentIdOpt`), then added a `let comparisonExperimentId` since it's reassigned later.