### PR TITLE
chore: Add dependabot config for the repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: ci
+      include: scope
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    versioning-strategy: increase
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: feat
+      prefix-development: chore
+      include: scope
+    exclude-paths:
+      - "internal/golden/**"


### PR DESCRIPTION
PRs like https://github.com/braintrustdata/braintrust-sdk-javascript/pull/1412 and https://github.com/braintrustdata/braintrust-sdk-javascript/pull/1413 are unfeasible for us to review and merge in. I'm adding a dependabot config that should make handling these much easier.