### PR TITLE
ci: use pnpm in publish workflow and tolerate missing husky

### DIFF
--- a/.github/workflows/publish-js-sdk.yaml
+++ b/.github/workflows/publish-js-sdk.yaml
@@ -72,13 +72,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history for changelog generation
+      - uses: pnpm/action-setup@v4
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
-      - name: Install npm 11.6.2
-        run: npm install -g npm@11.6.2
 
       - name: Determine version
         id: set_version

--- a/js/Makefile
+++ b/js/Makefile
@@ -150,9 +150,9 @@ verify-ci: build docs test
 
 publish-sdk-js:
 	./scripts/validate-release.sh
-	npm install
-	npm run build
-	npm publish
+	pnpm install
+	pnpm run build
+	pnpm publish --no-git-checks
 
 # This is the only method I could find to install a package without explicitly
 # adding a dependency or modifying lock files.

--- a/js/scripts/publish-prerelease.sh
+++ b/js/scripts/publish-prerelease.sh
@@ -74,8 +74,8 @@ echo ""
 
 # Build the SDK
 echo "Building SDK..."
-npm install
-npm run build
+pnpm install
+pnpm run build
 echo "Build complete."
 echo ""
 
@@ -87,13 +87,13 @@ echo ""
 # In CI, just publish. Locally, ask for confirmation
 if [ -n "${CI:-}" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
   # Running in CI - publish without confirmation
-  npm publish --tag "$DIST_TAG"
+  pnpm publish --tag "$DIST_TAG" --no-git-checks
 else
   # Running locally - ask for confirmation
   read -p "Ready to publish version $NEW_VERSION to npm with tag @$DIST_TAG? (y/N) " -n 1 -r
   echo
   if [[ $REPLY =~ ^[Yy]$ ]]; then
-    npm publish --tag "$DIST_TAG"
+    pnpm publish --tag "$DIST_TAG" --no-git-checks
   else
     echo "Publish cancelled."
     echo ""

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "turbo run start",
     "clean": "turbo run clean",
     "test": "turbo run test --filter=\"!@braintrust/otel\"",
-    "prepare": "husky",
+    "prepare": "husky || true",
     "lint:prettier": "prettier --check .",
     "lint:eslint": "turbo run lint",
     "fix:prettier": "prettier --write .",


### PR DESCRIPTION
## Summary
- Switch publish workflow and scripts from `npm` to `pnpm` for consistency with the rest of the repo
- Add `pnpm/action-setup@v4` to the publish CI workflow (replacing `npm install -g npm@11.6.2`)
- Make root `prepare` script tolerate missing `husky` (`husky || true`)

Fixes the failed publish run: https://github.com/braintrustdata/braintrust-sdk-javascript/actions/runs/22496559262/job/65172571387

## Test plan
- [ ] Re-run the publish workflow and confirm it passes
- [x] Verify local `pnpm install` still runs husky prepare successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)