### PR TITLE
ci: fix pnpm publish to use OIDC trusted publishing with provenance

### DIFF
--- a/js/Makefile
+++ b/js/Makefile
@@ -152,7 +152,7 @@ publish-sdk-js:
 	./scripts/validate-release.sh
 	pnpm install
 	pnpm run build
-	pnpm publish --no-git-checks
+	pnpm publish --no-git-checks --provenance
 
 # This is the only method I could find to install a package without explicitly
 # adding a dependency or modifying lock files.

--- a/js/scripts/publish-prerelease.sh
+++ b/js/scripts/publish-prerelease.sh
@@ -87,7 +87,7 @@ echo ""
 # In CI, just publish. Locally, ask for confirmation
 if [ -n "${CI:-}" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
   # Running in CI - publish without confirmation
-  pnpm publish --tag "$DIST_TAG" --no-git-checks
+  pnpm publish --tag "$DIST_TAG" --no-git-checks --provenance
 else
   # Running locally - ask for confirmation
   read -p "Ready to publish version $NEW_VERSION to npm with tag @$DIST_TAG? (y/N) " -n 1 -r


### PR DESCRIPTION
Add --provenance flag to pnpm publish commands so pnpm performs the OIDC token exchange with GitHub Actions instead of looking for a static npm token.