### PR TITLE
revert: use npm in publish workflow instead of pnpm

### DIFF
--- a/.github/workflows/publish-js-sdk.yaml
+++ b/.github/workflows/publish-js-sdk.yaml
@@ -72,12 +72,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history for changelog generation
-      - uses: pnpm/action-setup@v4
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
+      - name: Install npm 11.6.2
+        run: npm install -g npm@11.6.2
 
       - name: Determine version
         id: set_version

--- a/js/Makefile
+++ b/js/Makefile
@@ -150,9 +150,9 @@ verify-ci: build docs test
 
 publish-sdk-js:
 	./scripts/validate-release.sh
-	pnpm install
-	pnpm run build
-	pnpm publish --no-git-checks --provenance
+	npm install
+	npm run build
+	npm publish
 
 # This is the only method I could find to install a package without explicitly
 # adding a dependency or modifying lock files.

--- a/js/scripts/publish-prerelease.sh
+++ b/js/scripts/publish-prerelease.sh
@@ -74,8 +74,8 @@ echo ""
 
 # Build the SDK
 echo "Building SDK..."
-pnpm install
-pnpm run build
+npm install
+npm run build
 echo "Build complete."
 echo ""
 
@@ -87,13 +87,13 @@ echo ""
 # In CI, just publish. Locally, ask for confirmation
 if [ -n "${CI:-}" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
   # Running in CI - publish without confirmation
-  pnpm publish --tag "$DIST_TAG" --no-git-checks --provenance
+  npm publish --tag "$DIST_TAG"
 else
   # Running locally - ask for confirmation
   read -p "Ready to publish version $NEW_VERSION to npm with tag @$DIST_TAG? (y/N) " -n 1 -r
   echo
   if [[ $REPLY =~ ^[Yy]$ ]]; then
-    pnpm publish --tag "$DIST_TAG" --no-git-checks
+    npm publish --tag "$DIST_TAG"
   else
     echo "Publish cancelled."
     echo ""


### PR DESCRIPTION
Reverts the publish-related changes from #1450 and #1451, restoring npm for the publish workflow and scripts while keeping the husky || true fix.

pnpm publish has a ton of drawbacks compared to using plain npm.