### PR TITLE
chore: Add stale bot for JS SDK repo

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -16,14 +16,13 @@ jobs:
         with:
           days-before-stale: 30
           days-before-pr-stale: 14
-          days-before-close: 7
+          days-before-close: -1
+          days-before-pr-close: 7
           stale-issue-label: stale
           stale-pr-label: stale
-          close-issue-reason: not_planned
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not
-            had recent activity. It will be closed in 7 days if no further
-            activity occurs. If this issue is still relevant, please leave a
+            had recent activity. If this issue is still relevant, please leave a
             comment or remove the stale label. Thank you for your contributions!
           stale-pr-message: >
             This pull request has been automatically marked as stale because it
@@ -31,11 +30,6 @@ jobs:
             further activity occurs. If this PR is still relevant, please leave a
             comment, push an update, or remove the stale label. Thank you for
             your contributions!
-          close-issue-message: >
-            This issue was closed because it has been inactive for 37 days (30
-            days of inactivity before being marked stale, plus 7 additional
-            days). If you believe this issue is still relevant, please feel free
-            to reopen it. Thank you!
           close-pr-message: >
             This pull request was closed because it has been inactive for 21 days
             (14 days of inactivity before being marked stale, plus 7 additional


### PR DESCRIPTION
Adds a stale bot action for the JS SDK repo.

This does the following

- Marks issues as stale if have not been interacted with in 30d. It does not automatically close issues, it is up to repo maintainers to do that.
- Marks PRs as stale after 14d. If the stale label has been applied for 7d, then the PR is automatically closed.