### PR TITLE
ref: Set `@typescript-eslint/prefer-as-const` lint rule from warn to error

### DIFF
--- a/js/eslint.config.ts
+++ b/js/eslint.config.ts
@@ -84,8 +84,7 @@ export default [
       "@typescript-eslint/no-empty-object-type": "warn",
       // TODO: Fix violations and re-enable as "error"
       "@typescript-eslint/no-unsafe-function-type": "warn",
-      // TODO: Fix violations and re-enable as "error"
-      "@typescript-eslint/prefer-as-const": "warn",
+      "@typescript-eslint/prefer-as-const": "error",
       // Require node: protocol for Node.js built-in imports (for Deno compatibility)
       // This plugin automatically detects ALL Node.js built-ins - no manual list needed!
       "node-import/prefer-node-protocol": "error",

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -2155,7 +2155,7 @@ export class Logger<IsAsyncFlush extends boolean> implements Exportable {
   private calledStartSpan: boolean;
 
   // For type identification.
-  public kind: "logger" = "logger";
+  public kind = "logger" as const;
 
   constructor(
     state: BraintrustState,
@@ -6134,7 +6134,7 @@ export class SpanImpl implements Span {
   private _rootSpanId: string;
   private _spanParents: string[] | undefined;
 
-  public kind: "span" = "span";
+  public kind = "span" as const;
 
   constructor(
     args: {


### PR DESCRIPTION
Fixes 2 occurences of the warning and sets the lint rule to error.

Fixes https://github.com/braintrustdata/braintrust-sdk-javascript/issues/1457