### PR TITLE
ref: Error on `no-unused-expressions`, `no-empty-object-type`, `no-restricted-syntax` and `no-unsafe-function-type` lint rules

### DIFF
--- a/js/eslint.config.ts
+++ b/js/eslint.config.ts
@@ -146,15 +146,5 @@ export default [
     plugins: {
       "@typescript-eslint": tseslint,
     },
-    rules: {
-      "no-restricted-syntax": [
-        "error",
-        {
-          selector: "ExportAllDeclaration[exported=null]",
-          message:
-            "Bare 'export *' is forbidden in entry point files. Use explicit named exports instead for better tree-shaking and clarity.",
-        },
-      ],
-    },
   },
 ];

--- a/js/src/browser/index.ts
+++ b/js/src/browser/index.ts
@@ -13,6 +13,5 @@ import { configureBrowser } from "./config";
 
 configureBrowser();
 
-// eslint-disable-next-line no-restricted-syntax
 export * from "../exports";
 export * as default from "../exports";

--- a/js/src/edge-light/index.ts
+++ b/js/src/edge-light/index.ts
@@ -9,6 +9,5 @@ import { configureEdgeLight } from "./config";
 
 configureEdgeLight();
 
-// eslint-disable-next-line no-restricted-syntax
 export * from "../exports";
 export * as default from "../exports";

--- a/js/src/node/index.ts
+++ b/js/src/node/index.ts
@@ -55,6 +55,5 @@ import { configureNode } from "./config";
 
 configureNode();
 
-// eslint-disable-next-line no-restricted-syntax
 export * from "../exports";
 export * as default from "../exports";

--- a/js/src/workerd/index.ts
+++ b/js/src/workerd/index.ts
@@ -9,6 +9,5 @@ import { configureWorkerd } from "./config";
 
 configureWorkerd();
 
-// eslint-disable-next-line no-restricted-syntax
 export * from "../exports";
 export * as default from "../exports";


### PR DESCRIPTION
Ref: https://github.com/braintrustdata/braintrust-sdk-javascript/issues/1405

The `no-restricted-syntax` is a weird one because we are like full on violating it seemingly intentionally - opted to just ignore the instances we have.

Fixes https://github.com/braintrustdata/braintrust-sdk-javascript/issues/1473