### PR TITLE
fix: Align `wrapTraced` with types by not returning a promise if `asyncFlush` is undefined

### DIFF
--- a/js/src/logger.test.ts
+++ b/js/src/logger.test.ts
@@ -1024,6 +1024,61 @@ describe("parent precedence", () => {
   });
 });
 
+describe("wrapTraced return type preservation", () => {
+  beforeEach(async () => {
+    await _exportsForTestingOnly.simulateLoginForTests();
+    _exportsForTestingOnly.useTestBackgroundLogger();
+  });
+
+  afterEach(() => {
+    _exportsForTestingOnly.clearTestBackgroundLogger();
+    _exportsForTestingOnly.simulateLogoutForTests();
+  });
+
+  test("wrapping a sync function with default asyncFlush returns its value directly, not a Promise", () => {
+    initLogger({ projectName: "test", projectId: "pid" });
+
+    const wrapped = wrapTraced(function syncFn() {
+      return 42;
+    });
+
+    const result = wrapped();
+    expect(result).not.toBeInstanceOf(Promise);
+    expect(result).toBe(42);
+  });
+
+  test("wrapping an async function with default asyncFlush returns a Promise", async () => {
+    initLogger({ projectName: "test", projectId: "pid" });
+
+    const wrapped = wrapTraced(async function fetchData() {
+      return 42;
+    });
+
+    const result = wrapped();
+    expect(result).toBeInstanceOf(Promise);
+    expect(await result).toBe(42);
+  });
+
+  test("wrapping a sync function with asyncFlush: false returns a Promise", async () => {
+    initLogger({
+      projectName: "test",
+      projectId: "pid",
+      asyncFlush: false,
+    });
+
+    const wrapped = wrapTraced(
+      function syncFn() {
+        return { value: 1 };
+      },
+      { name: "syncFn", asyncFlush: false },
+    );
+
+    const result = wrapped();
+    expect(result).toBeInstanceOf(Promise);
+    expect(await result).toEqual({ value: 1 });
+  });
+});
+
 test("attachment with unreadable path logs warning", () => {
   const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -4939,7 +4939,7 @@ export function wrapTraced<
     return wrapTracedAsyncGenerator(fn, spanArgs, !!noTraceIO);
   }
 
-  if (args?.asyncFlush) {
+  if (args?.asyncFlush === undefined || args.asyncFlush) {
     return ((...fnArgs: Parameters<F>) =>
       traced((span) => {
         if (!hasExplicitInput) {


### PR DESCRIPTION
Resolves https://github.com/braintrustdata/braintrust-sdk-javascript/issues/1022

The type definition of `wrapTraced`currently clashes with the implementation. We advertise via typing that if you don't define an `asyncFlush` argument it defaults to `true`, meaning that we shouldn't transform the return value of the wrapped function, however, we are in fact doing that because we are going into the "await" branch if asyncFlush is not provided.