### PR TITLE
chore: Create playground setup to quickly test SDK changes

### DIFF
--- a/js/.gitignore
+++ b/js/.gitignore
@@ -11,3 +11,5 @@ braintrust-*.tgz
 
 # Vendor libraries (local-only for development)
 vendor/
+
+playground.ts

--- a/js/package.json
+++ b/js/package.json
@@ -127,7 +127,8 @@
     "test:vitest": "pnpm --filter @braintrust/vitest-wrapper-tests test",
     "test:output": "tsx scripts/test-output.ts --with-comparison --with-metrics --with-progress",
     "lint": "eslint .",
-    "fix:eslint": "eslint --fix ."
+    "fix:eslint": "eslint --fix .",
+    "playground": "tsx playground.ts"
   },
   "author": "",
   "license": "MIT",

--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -25,6 +25,7 @@
     "src/auto-instrumentations/configs/**",
     "src/auto-instrumentations/loader/**",
     "src/auto-instrumentations/index.ts",
-    "tests/auto-instrumentations/**"
+    "tests/auto-instrumentations/**",
+    "./playground.ts"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start": "turbo run start",
     "clean": "turbo run clean",
     "test": "dotenv -e .env -- turbo run test --filter=\"!@braintrust/otel\"",
+    "playground": "dotenv -e .env -- turbo run playground --filter=\"braintrust\"",
     "prepare": "husky || true",
     "lint:prettier": "prettier --check .",
     "lint:eslint": "turbo run lint",

--- a/turbo.json
+++ b/turbo.json
@@ -27,6 +27,15 @@
     "clean": {
       "cache": false
     },
-    "watch": {}
+    "watch": {},
+    "playground": {
+      "cache": false,
+      "passThroughEnv": [
+        "ANTHROPIC_API_KEY",
+        "BRAINTRUST_API_KEY",
+        "OPENAI_API_KEY"
+      ],
+      "dependsOn": ["^build", "build"]
+    }
   }
 }


### PR DESCRIPTION
Setup:

- Add a `playground.ts` file in the `js` package
- Put anything you want in there (import `"braintrust"`, run evals, ...)
- Run `pnpm run playground` from the root of the repo