### PR TITLE
fix(ci): Make api-compatibility compare main vs PR

### DIFF
--- a/.github/workflows/js.yaml
+++ b/.github/workflows/js.yaml
@@ -189,27 +189,12 @@ jobs:
           pnpm install --frozen-lockfile || { echo "Baseline install failed"; git checkout "$CURRENT_REF"; exit 0; }
           pnpm run build || { echo "Baseline build failed"; git checkout "$CURRENT_REF"; exit 0; }
 
-          # Copy built .d.ts files to baseline directory
-          if [ -d "js/dist" ]; then
-            mkdir -p "$BASELINE_DIR/js/dist"
-            cp js/dist/*.d.ts "$BASELINE_DIR/js/dist/" 2>/dev/null || true
-            cp js/dist/*.d.mts "$BASELINE_DIR/js/dist/" 2>/dev/null || true
-            echo "Copied main/browser dist files"
-          fi
-
-          if [ -d "js/dev/dist" ]; then
-            mkdir -p "$BASELINE_DIR/js/dev/dist"
-            cp js/dev/dist/*.d.ts "$BASELINE_DIR/js/dev/dist/" 2>/dev/null || true
-            cp js/dev/dist/*.d.mts "$BASELINE_DIR/js/dev/dist/" 2>/dev/null || true
-            echo "Copied dev dist files"
-          fi
-
-          if [ -d "js/util/dist" ]; then
-            mkdir -p "$BASELINE_DIR/js/util/dist"
-            cp js/util/dist/*.d.ts "$BASELINE_DIR/js/util/dist/" 2>/dev/null || true
-            cp js/util/dist/*.d.mts "$BASELINE_DIR/js/util/dist/" 2>/dev/null || true
-            echo "Copied util dist files"
-          fi
+          # Copy built files to baseline directory
+          mkdir -p "$BASELINE_DIR/js/dev" "$BASELINE_DIR/js/util"
+          cp -R js/dist "$BASELINE_DIR/js/"
+          cp -R js/dev/dist "$BASELINE_DIR/js/dev/"
+          cp -R js/util/dist "$BASELINE_DIR/js/util/"
+          echo "Copied js/dist, js/dev/dist, and js/util/dist to baseline"
 
           # Return to original commit
           git checkout "$CURRENT_REF"


### PR DESCRIPTION
`api-compatibility` was inconsistently comparing main vs PR because nested baseline files were missing defaulting back to the ones that are in the published package.

We're
- simpifying the script a bit by just recursively copying over everything to the baseline
- thus fixing the recursive dts files not being transferred over