### PR TITLE
Fix auto-instrumentation for Anthropic, Google GenAI, and Claude Agent SDK

### DIFF
--- a/js/src/auto-instrumentations/configs/anthropic.test.ts
+++ b/js/src/auto-instrumentations/configs/anthropic.test.ts
@@ -38,7 +38,7 @@ describe("Anthropic Instrumentation Configs", () => {
     expect((config?.functionQuery as any).kind).toBe("Async");
   });
 
-  it("should NOT include braintrust: prefix (code-transformer adds orchestrion:anthropic: prefix)", () => {
+  it("should NOT include braintrust: prefix (code-transformer adds orchestrion:@anthropic-ai/sdk: prefix)", () => {
     for (const config of anthropicConfigs) {
       expect(config.channelName).not.toContain("braintrust:");
       expect(config.channelName).not.toContain("orchestrion:");

--- a/js/src/auto-instrumentations/configs/anthropic.ts
+++ b/js/src/auto-instrumentations/configs/anthropic.ts
@@ -8,8 +8,8 @@ import type { InstrumentationConfig } from "@apm-js-collab/code-transformer";
  * transformation at build-time or load-time.
  *
  * NOTE: Channel names should NOT include the braintrust: prefix. The code-transformer
- * will prepend "orchestrion:anthropic:" to these names, resulting in final channel names like:
- * "orchestrion:anthropic:messages.create"
+ * will prepend "orchestrion:<module.name>:" to these names, resulting in final channel names like:
+ * "orchestrion:@anthropic-ai/sdk:messages.create"
  */
 export const anthropicConfigs: InstrumentationConfig[] = [
   // Messages API - create (supports streaming via stream=true parameter)

--- a/js/src/auto-instrumentations/configs/claude-agent-sdk.test.ts
+++ b/js/src/auto-instrumentations/configs/claude-agent-sdk.test.ts
@@ -20,7 +20,7 @@ describe("Claude Agent SDK Instrumentation Configs", () => {
     expect((config?.functionQuery as any).kind).toBe("Async");
   });
 
-  it("should NOT include braintrust: prefix (code-transformer adds orchestrion:claude-agent-sdk: prefix)", () => {
+  it("should NOT include braintrust: prefix (code-transformer adds orchestrion:@anthropic-ai/claude-agent-sdk: prefix)", () => {
     for (const config of claudeAgentSDKConfigs) {
       expect(config.channelName).not.toContain("braintrust:");
       expect(config.channelName).not.toContain("orchestrion:");

--- a/js/src/auto-instrumentations/configs/claude-agent-sdk.ts
+++ b/js/src/auto-instrumentations/configs/claude-agent-sdk.ts
@@ -8,8 +8,8 @@ import type { InstrumentationConfig } from "@apm-js-collab/code-transformer";
  * transformation at build-time or load-time.
  *
  * NOTE: Channel names should NOT include the braintrust: prefix. The code-transformer
- * will prepend "orchestrion:claude-agent-sdk:" to these names, resulting in final channel
- * names like: "orchestrion:claude-agent-sdk:query"
+ * will prepend "orchestrion:<module.name>:" to these names, resulting in final channel
+ * names like: "orchestrion:@anthropic-ai/claude-agent-sdk:query"
  */
 export const claudeAgentSDKConfigs: InstrumentationConfig[] = [
   // query - Main entry point for agent interactions (top-level exported async generator function)

--- a/js/src/auto-instrumentations/configs/google-genai.test.ts
+++ b/js/src/auto-instrumentations/configs/google-genai.test.ts
@@ -40,7 +40,7 @@ describe("Google GenAI Instrumentation Configs", () => {
     expect((config?.functionQuery as any).kind).toBe("Async");
   });
 
-  it("should NOT include braintrust: or orchestrion: prefix (code-transformer adds orchestrion:google-genai: prefix)", () => {
+  it("should NOT include braintrust: or orchestrion: prefix (code-transformer adds orchestrion:@google/genai: prefix)", () => {
     for (const config of googleGenAIConfigs) {
       expect(config.channelName).not.toContain("braintrust:");
       expect(config.channelName).not.toContain("orchestrion:");

--- a/js/src/auto-instrumentations/configs/google-genai.ts
+++ b/js/src/auto-instrumentations/configs/google-genai.ts
@@ -8,8 +8,8 @@ import type { InstrumentationConfig } from "@apm-js-collab/code-transformer";
  * transformation at build-time or load-time.
  *
  * NOTE: Channel names should NOT include the braintrust: prefix. The code-transformer
- * will prepend "orchestrion:google-genai:" to these names, resulting in final channel names like:
- * "orchestrion:google-genai:models.generateContent"
+ * will prepend "orchestrion:<module.name>:" to these names, resulting in final channel names like:
+ * "orchestrion:@google/genai:models.generateContent"
  */
 export const googleGenAIConfigs: InstrumentationConfig[] = [
   // Models.generateContentInternal - The actual class method (Node.js entry point)

--- a/js/src/imports.test.ts
+++ b/js/src/imports.test.ts
@@ -161,7 +161,12 @@ describe("CLI import restrictions", () => {
         const relativePath = path.relative(srcDir, fullPath);
 
         // Skip the cli directory - CLI code is allowed to use require() and dynamic imports
-        if (entry.isDirectory() && entry.name === "cli") {
+        // Skip the instrumentation directory - Node.js-only code that needs dynamic imports
+        // for optional SDK patching (e.g., APIPromise Symbol.species)
+        if (
+          entry.isDirectory() &&
+          (entry.name === "cli" || entry.name === "instrumentation")
+        ) {
           continue;
         }
 

--- a/js/src/instrumentation/core/plugin.ts
+++ b/js/src/instrumentation/core/plugin.ts
@@ -1,5 +1,5 @@
-import { tracingChannel } from "dc-browser";
-import type { ChannelHandlers as DCChannelHandlers } from "dc-browser";
+import { tracingChannel } from "node:diagnostics_channel";
+import type { ChannelHandlers as DCChannelHandlers } from "./types";
 import { isAsyncIterable, patchStreamIfNeeded } from "./stream-patcher";
 import type { StartEvent } from "./types";
 import { startSpan } from "../../logger";

--- a/js/src/instrumentation/plugins/ai-sdk-plugin.ts
+++ b/js/src/instrumentation/plugins/ai-sdk-plugin.ts
@@ -1,4 +1,4 @@
-import { tracingChannel } from "dc-browser";
+import { tracingChannel } from "node:diagnostics_channel";
 import { BasePlugin, isAsyncIterable, patchStreamIfNeeded } from "../core";
 import type { StartEvent } from "../core";
 import { startSpan } from "../../logger";

--- a/js/src/instrumentation/plugins/anthropic-plugin.test.ts
+++ b/js/src/instrumentation/plugins/anthropic-plugin.test.ts
@@ -5,12 +5,12 @@ import {
   aggregateAnthropicStreamChunks,
   processAttachmentsInInput,
 } from "./anthropic-plugin";
-import { tracingChannel } from "dc-browser";
+import { tracingChannel } from "node:diagnostics_channel";
 import type { StartEvent } from "../core";
 import { Attachment } from "../../logger";
 
-// Mock dc-browser's tracingChannel
-vi.mock("dc-browser", () => ({
+// Mock node:diagnostics_channel's tracingChannel
+vi.mock("node:diagnostics_channel", () => ({
   tracingChannel: vi.fn(),
 }));
 
@@ -65,10 +65,10 @@ describe("AnthropicPlugin", () => {
 
       // Should subscribe to both messages.create and beta.messages.create
       expect(tracingChannel).toHaveBeenCalledWith(
-        "orchestrion:anthropic:messages.create",
+        "orchestrion:@anthropic-ai/sdk:messages.create",
       );
       expect(tracingChannel).toHaveBeenCalledWith(
-        "orchestrion:anthropic:beta.messages.create",
+        "orchestrion:@anthropic-ai/sdk:beta.messages.create",
       );
       expect(mockChannel.subscribe).toHaveBeenCalled();
     });

--- a/js/src/instrumentation/plugins/anthropic-plugin.ts
+++ b/js/src/instrumentation/plugins/anthropic-plugin.ts
@@ -1,4 +1,4 @@
-import { tracingChannel } from "dc-browser";
+import { tracingChannel } from "node:diagnostics_channel";
 import { BasePlugin, isAsyncIterable, patchStreamIfNeeded } from "../core";
 import type { StartEvent } from "../core";
 import { startSpan, Attachment } from "../../logger";
@@ -25,7 +25,22 @@ export class AnthropicPlugin extends BasePlugin {
   protected unsubscribers: Array<() => void> = [];
 
   protected onEnable(): void {
+    this.patchAPIPromise();
     this.subscribeToAnthropicChannels();
+  }
+
+  private async patchAPIPromise(): Promise<void> {
+    try {
+      const mod = await import("@anthropic-ai/sdk/core/api-promise");
+      const APIPromise = mod.APIPromise;
+      if (APIPromise && !APIPromise[Symbol.species]) {
+        Object.defineProperty(APIPromise, Symbol.species, {
+          get: () => Promise,
+        });
+      }
+    } catch {
+      // SDK not installed, nothing to patch
+    }
   }
 
   protected onDisable(): void {
@@ -37,53 +52,56 @@ export class AnthropicPlugin extends BasePlugin {
 
   private subscribeToAnthropicChannels(): void {
     // Messages API - supports streaming via stream=true parameter
-    this.subscribeToStreamingChannel("orchestrion:anthropic:messages.create", {
-      name: "anthropic.messages.create",
-      type: SpanTypeAttribute.LLM,
-      extractInput: (args: any[]) => {
-        const params = args[0] || {};
-        const input = coalesceInput(params.messages || [], params.system);
-        const metadata = filterFrom(params, ["messages", "system"]);
-        return {
-          input: processAttachmentsInInput(input),
-          metadata: { ...metadata, provider: "anthropic" },
-        };
-      },
-      extractOutput: (result: any) => {
-        return result ? { role: result.role, content: result.content } : null;
-      },
-      extractMetrics: (result: any, startTime?: number) => {
-        const metrics = parseMetricsFromUsage(result?.usage);
-        if (startTime) {
-          metrics.time_to_first_token = getCurrentUnixTimestamp() - startTime;
-        }
-        const finalized = finalizeAnthropicTokens(metrics);
-        // Filter out undefined values to match Record<string, number> type
-        return Object.fromEntries(
-          Object.entries(finalized).filter(
-            (entry): entry is [string, number] => entry[1] !== undefined,
-          ),
-        );
-      },
-      extractMetadata: (result: any) => {
-        const metadata: Record<string, unknown> = {};
-        const metas = ["stop_reason", "stop_sequence"];
-        for (const m of metas) {
-          if (result?.[m] !== undefined) {
-            metadata[m] = result[m];
+    this.subscribeToStreamingChannel(
+      "orchestrion:@anthropic-ai/sdk:messages.create",
+      {
+        name: "anthropic.messages.create",
+        type: SpanTypeAttribute.LLM,
+        extractInput: (args: any[]) => {
+          const params = args[0] || {};
+          const input = coalesceInput(params.messages || [], params.system);
+          const metadata = filterFrom(params, ["messages", "system"]);
+          return {
+            input: processAttachmentsInInput(input),
+            metadata: { ...metadata, provider: "anthropic" },
+          };
+        },
+        extractOutput: (result: any) => {
+          return result ? { role: result.role, content: result.content } : null;
+        },
+        extractMetrics: (result: any, startTime?: number) => {
+          const metrics = parseMetricsFromUsage(result?.usage);
+          if (startTime) {
+            metrics.time_to_first_token = getCurrentUnixTimestamp() - startTime;
           }
-        }
-        return metadata;
+          const finalized = finalizeAnthropicTokens(metrics);
+          // Filter out undefined values to match Record<string, number> type
+          return Object.fromEntries(
+            Object.entries(finalized).filter(
+              (entry): entry is [string, number] => entry[1] !== undefined,
+            ),
+          );
+        },
+        extractMetadata: (result: any) => {
+          const metadata: Record<string, unknown> = {};
+          const metas = ["stop_reason", "stop_sequence"];
+          for (const m of metas) {
+            if (result?.[m] !== undefined) {
+              metadata[m] = result[m];
+            }
+          }
+          return metadata;
+        },
+        aggregateChunks: aggregateAnthropicStreamChunks,
+        isStreaming: (args: any[]) => {
+          return args[0]?.stream === true;
+        },
       },
-      aggregateChunks: aggregateAnthropicStreamChunks,
-      isStreaming: (args: any[]) => {
-        return args[0]?.stream === true;
-      },
-    });
+    );
 
     // Beta Messages API - supports streaming via stream=true parameter
     this.subscribeToStreamingChannel(
-      "orchestrion:anthropic:beta.messages.create",
+      "orchestrion:@anthropic-ai/sdk:beta.messages.create",
       {
         name: "anthropic.beta.messages.create",
         type: SpanTypeAttribute.LLM,

--- a/js/src/instrumentation/plugins/claude-agent-sdk-plugin.test.ts
+++ b/js/src/instrumentation/plugins/claude-agent-sdk-plugin.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ClaudeAgentSDKPlugin } from "./claude-agent-sdk-plugin";
-import { tracingChannel } from "dc-browser";
+import { tracingChannel } from "node:diagnostics_channel";
 
-// Mock the dc-browser module
-vi.mock("dc-browser", () => ({
+// Mock the node:diagnostics_channel module
+vi.mock("node:diagnostics_channel", () => ({
   tracingChannel: vi.fn(),
 }));
 
@@ -116,7 +116,7 @@ describe("ClaudeAgentSDKPlugin", () => {
       plugin.enable();
 
       expect(tracingChannel).toHaveBeenCalledWith(
-        "orchestrion:claude-agent-sdk:query",
+        "orchestrion:@anthropic-ai/claude-agent-sdk:query",
       );
       expect(mockChannel.subscribe).toHaveBeenCalledTimes(1);
       expect(mockChannel.subscribe).toHaveBeenCalledWith(

--- a/js/src/instrumentation/plugins/claude-agent-sdk-plugin.ts
+++ b/js/src/instrumentation/plugins/claude-agent-sdk-plugin.ts
@@ -1,4 +1,4 @@
-import { tracingChannel } from "dc-browser";
+import { tracingChannel } from "node:diagnostics_channel";
 import { BasePlugin, isAsyncIterable, patchStreamIfNeeded } from "../core";
 import type { StartEvent } from "../core";
 import { startSpan } from "../../logger";
@@ -232,7 +232,7 @@ async function createLLMSpanForMessages(
 /**
  * Plugin for Claude Agent SDK auto-instrumentation.
  *
- * Subscribes to orchestrion:claude-agent-sdk:* channels and creates
+ * Subscribes to orchestrion:@anthropic-ai/claude-agent-sdk:* channels and creates
  * Braintrust spans with proper tracing for agent interactions.
  *
  * NOTE: Uses span type TASK (not LLM) for agent interactions since agents
@@ -259,7 +259,9 @@ export class ClaudeAgentSDKPlugin extends BasePlugin {
    * and individual LLM calls.
    */
   private subscribeToQuery(): void {
-    const channel = tracingChannel("orchestrion:claude-agent-sdk:query");
+    const channel = tracingChannel(
+      "orchestrion:@anthropic-ai/claude-agent-sdk:query",
+    );
 
     const spans = new WeakMap<
       any,

--- a/js/src/instrumentation/plugins/google-genai-plugin.test.ts
+++ b/js/src/instrumentation/plugins/google-genai-plugin.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { GoogleGenAIPlugin } from "./google-genai-plugin";
-import { tracingChannel } from "dc-browser";
+import { tracingChannel } from "node:diagnostics_channel";
 import { Attachment } from "../../logger";
 
-// Mock dc-browser
-vi.mock("dc-browser", () => ({
+// Mock node:diagnostics_channel
+vi.mock("node:diagnostics_channel", () => ({
   tracingChannel: vi.fn(),
 }));
 
@@ -52,10 +52,10 @@ describe("GoogleGenAIPlugin", () => {
       plugin.enable();
 
       expect(tracingChannel).toHaveBeenCalledWith(
-        "orchestrion:google-genai:models.generateContent",
+        "orchestrion:@google/genai:models.generateContent",
       );
       expect(tracingChannel).toHaveBeenCalledWith(
-        "orchestrion:google-genai:models.generateContentStream",
+        "orchestrion:@google/genai:models.generateContentStream",
       );
       expect(subscribeSpy).toHaveBeenCalled();
     });
@@ -118,7 +118,7 @@ describe("GoogleGenAIPlugin", () => {
       plugin.enable();
 
       expect(tracingChannel).toHaveBeenCalledWith(
-        "orchestrion:google-genai:models.generateContentStream",
+        "orchestrion:@google/genai:models.generateContentStream",
       );
     });
   });

--- a/js/src/instrumentation/plugins/google-genai-plugin.ts
+++ b/js/src/instrumentation/plugins/google-genai-plugin.ts
@@ -1,4 +1,4 @@
-import { tracingChannel } from "dc-browser";
+import { tracingChannel } from "node:diagnostics_channel";
 import { BasePlugin, isAsyncIterable, patchStreamIfNeeded } from "../core";
 import type { StartEvent } from "../core";
 import { startSpan, Attachment } from "../../logger";
@@ -36,29 +36,32 @@ export class GoogleGenAIPlugin extends BasePlugin {
 
   private subscribeToGoogleGenAIChannels(): void {
     // GenerativeModel.generateContent (non-streaming)
-    this.subscribeToChannel("orchestrion:google-genai:models.generateContent", {
-      name: "google-genai.generateContent",
-      type: SpanTypeAttribute.LLM,
-      extractInput: (args: any[]) => {
-        const params = args[0] || {};
-        const input = serializeInput(params);
-        const metadata = extractMetadata(params);
-        return {
-          input,
-          metadata: { ...metadata, provider: "google-genai" },
-        };
+    this.subscribeToChannel(
+      "orchestrion:@google/genai:models.generateContent",
+      {
+        name: "google-genai.generateContent",
+        type: SpanTypeAttribute.LLM,
+        extractInput: (args: any[]) => {
+          const params = args[0] || {};
+          const input = serializeInput(params);
+          const metadata = extractMetadata(params);
+          return {
+            input,
+            metadata: { ...metadata, provider: "google-genai" },
+          };
+        },
+        extractOutput: (result: any) => {
+          return result;
+        },
+        extractMetrics: (result: any, startTime?: number) => {
+          return extractGenerateContentMetrics(result, startTime);
+        },
       },
-      extractOutput: (result: any) => {
-        return result;
-      },
-      extractMetrics: (result: any, startTime?: number) => {
-        return extractGenerateContentMetrics(result, startTime);
-      },
-    });
+    );
 
     // GenerativeModel.generateContentStream (streaming)
     this.subscribeToGoogleStreamingChannel(
-      "orchestrion:google-genai:models.generateContentStream",
+      "orchestrion:@google/genai:models.generateContentStream",
       {
         name: "google-genai.generateContentStream",
         type: SpanTypeAttribute.LLM,

--- a/js/src/instrumentation/plugins/openai-plugin.ts
+++ b/js/src/instrumentation/plugins/openai-plugin.ts
@@ -20,6 +20,8 @@ export class OpenAIPlugin extends BasePlugin {
   }
 
   protected onEnable(): void {
+    this.patchAPIPromise();
+
     // Chat Completions - supports streaming
     this.subscribeToStreamingChannel(
       "orchestrion:openai:chat.completions.create",
@@ -225,6 +227,20 @@ export class OpenAIPlugin extends BasePlugin {
         return metrics;
       },
     });
+  }
+
+  private async patchAPIPromise(): Promise<void> {
+    try {
+      const mod = await import("openai/core");
+      const APIPromise = mod.APIPromise;
+      if (APIPromise && !APIPromise[Symbol.species]) {
+        Object.defineProperty(APIPromise, Symbol.species, {
+          get: () => Promise,
+        });
+      }
+    } catch {
+      // SDK not installed, nothing to patch
+    }
   }
 
   protected onDisable(): void {


### PR DESCRIPTION
Three bugs caused auto-instrumentation traces to be silently dropped:

1. **Channel name mismatch** — Plugins subscribed with shortened names (`orchestrion:anthropic:`) but the code-transformer emits using the full npm package name (`orchestrion:@anthropic-ai/sdk:`). Same issue for Google GenAI and Claude Agent SDK.

2. **Separate channel registries** — Plugins imported `tracingChannel` from `dc-browser` (browser polyfill) instead of `node:diagnostics_channel` (Node native). Events emitted on one never reach subscribers on the other.

3. **APIPromise Symbol.species** — `tracePromise` calls `.then()` on Anthropic/OpenAI's `APIPromise` subclass, which crashes without `Symbol.species` set. Added patches in both plugins.