### PR TITLE
chore: Add vscode config for TS version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "typescript.tsdk": "js/node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": false
+}


### PR DESCRIPTION
I am normally against workspace configs for editors but this one is relatively uncontroversial and vscode has a hard time picking up the ts version from the workspace leading to random red squiggly lines.