### PR TITLE
chore: Rely on mise for env vars and pin mise node version

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -8,6 +8,7 @@ experimental = true
 _.file = ".env"
 
 [tools]
+nodejs = "22.15.0"
 pnpm = "10.26.2"
 
 [hooks]

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "start": "turbo run start",
     "clean": "turbo run clean",
     "knip": "knip --config knip.jsonc --no-config-hints",
-    "test": "dotenv -e .env -- turbo run test --filter=\"!@braintrust/otel\"",
-    "playground": "dotenv -e .env -- turbo run playground --filter=\"braintrust\"",
+    "test": "turbo run test --filter=\"!@braintrust/otel\"",
+    "playground": "turbo run playground --filter=\"braintrust\"",
     "prepare": "husky || true",
     "lint:prettier": "prettier --check .",
     "lint:eslint": "turbo run lint",
@@ -25,7 +25,6 @@
     "fix": "pnpm run fix:prettier && pnpm run fix:eslint"
   },
   "devDependencies": {
-    "dotenv-cli": "11.0.0",
     "eslint": "^9.39.2",
     "husky": "^9.1.7",
     "knip": "^5.85.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     devDependencies:
-      dotenv-cli:
-        specifier: 11.0.0
-        version: 11.0.0
       eslint:
         specifier: ^9.39.2
         version: 9.39.2(jiti@2.6.1)
@@ -3434,20 +3431,8 @@ packages:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
 
-  dotenv-cli@11.0.0:
-    resolution: {integrity: sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==}
-    hasBin: true
-
-  dotenv-expand@12.0.3:
-    resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
-    engines: {node: '>=12'}
-
   dotenv@16.4.5:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
-    engines: {node: '>=12'}
-
-  dotenv@17.3.1:
-    resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -9486,20 +9471,7 @@ snapshots:
   diff@4.0.4:
     optional: true
 
-  dotenv-cli@11.0.0:
-    dependencies:
-      cross-spawn: 7.0.6
-      dotenv: 17.3.1
-      dotenv-expand: 12.0.3
-      minimist: 1.2.8
-
-  dotenv-expand@12.0.3:
-    dependencies:
-      dotenv: 16.4.5
-
   dotenv@16.4.5: {}
-
-  dotenv@17.3.1: {}
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
- rely on mise for env vars for top level scripts
- pin node version