### PR TITLE
chore: Split lint and formatting scripts/tasks/jobs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: lint
+name: quality
 
 on:
   pull_request:
@@ -6,6 +6,20 @@ on:
     branches: [main]
 
 jobs:
+  formatting:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: pnpm/action-setup@v4
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Check formatting
+        run: pnpm run formatting
+
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,9 @@ This repository uses `pnpm` workspaces.
 pnpm install        # Install dependencies
 pnpm run build      # Build all workspace packages
 pnpm run test       # Run workspace tests (via turbo)
-pnpm run lint       # Prettier + ESLint checks
-pnpm run fix        # Auto-fix Prettier + ESLint
+pnpm run formatting # Check formatting
+pnpm run lint       # Run lint checks
+pnpm run fix:formatting # Auto-fix formatting
+pnpm run fix:lint   # Auto-fix lint issues
 make test           # Full JS-oriented test flow used in this repo
 ```

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ lint:
 
 .PHONY: fixup
 fixup:
-	pnpm run fix
+	pnpm run fix:formatting && pnpm run fix:lint
 
 #
 # js stuff

--- a/js/CLAUDE.md
+++ b/js/CLAUDE.md
@@ -25,12 +25,10 @@ pnpm build
 From the repository root:
 
 ```bash
-pnpm run lint                # Check formatting + eslint
-pnpm run fix                 # Auto-fix formatting + eslint
-pnpm run lint:prettier       # Check formatting only
-pnpm run lint:eslint         # Run eslint only
-pnpm run fix:prettier        # Auto-fix formatting only
-pnpm run fix:eslint          # Auto-fix eslint only
+pnpm run formatting          # Check formatting
+pnpm run lint                # Run eslint checks
+pnpm run fix:formatting      # Auto-fix formatting
+pnpm run fix:lint            # Auto-fix eslint issues
 ```
 
 ## Before Committing
@@ -38,7 +36,7 @@ pnpm run fix:eslint          # Auto-fix eslint only
 Always run formatting before committing to avoid pre-commit hook failures:
 
 ```bash
-pnpm run fix:prettier        # Format all files
+pnpm run fix:formatting      # Format all files
 ```
 
 ## Test Framework

--- a/js/package.json
+++ b/js/package.json
@@ -127,7 +127,7 @@
     "test:vitest": "pnpm --filter @braintrust/vitest-wrapper-tests test",
     "test:output": "tsx scripts/test-output.ts --with-comparison --with-metrics --with-progress",
     "lint": "eslint .",
-    "fix:eslint": "eslint --fix .",
+    "fix:lint": "eslint --fix .",
     "playground": "tsx playground.ts"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -17,12 +17,10 @@
     "test": "dotenv -e .env -- turbo run test --filter=\"!@braintrust/otel\"",
     "playground": "dotenv -e .env -- turbo run playground --filter=\"braintrust\"",
     "prepare": "husky || true",
-    "lint:prettier": "prettier --check .",
-    "lint:eslint": "turbo run lint",
-    "fix:prettier": "prettier --write .",
-    "fix:eslint": "turbo run fix:eslint",
-    "lint": "pnpm run lint:prettier && pnpm run lint:eslint",
-    "fix": "pnpm run fix:prettier && pnpm run fix:eslint"
+    "formatting": "prettier --check .",
+    "lint": "turbo run lint",
+    "fix:formatting": "prettier --write .",
+    "fix:lint": "turbo run fix:lint"
   },
   "devDependencies": {
     "dotenv-cli": "11.0.0",

--- a/turbo.json
+++ b/turbo.json
@@ -15,7 +15,7 @@
     "lint": {
       "outputs": []
     },
-    "fix:eslint": {
+    "fix:lint": {
       "outputs": []
     },
     "dev": {


### PR DESCRIPTION
Main one: Splits lint and formatting CI tasks

Secondary, adds separate scripts for lint and formatting in the root of the repo. I don't like these catchall scripts.