### PR TITLE
feat: Allow setting tags via `prompts.create()`

### DIFF
--- a/js/src/framework.test.ts
+++ b/js/src/framework.test.ts
@@ -992,6 +992,81 @@ describe("framework2 metadata support", () => {
     });
   });
 
+  describe("CodePrompt tags", () => {
+    test("prompt stores tags correctly", () => {
+      const project = projects.create({ name: "test-project" });
+      const tags = ["ci", "production"];
+
+      project.prompts.create({
+        name: "test-prompt",
+        prompt: "Hello {{name}}",
+        model: "gpt-4",
+        tags,
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const prompts = (project as any)._publishablePrompts;
+      expect(prompts).toHaveLength(1);
+      expect(prompts[0].tags).toEqual(tags);
+    });
+
+    test("toFunctionDefinition includes tags when present", async () => {
+      const project = projects.create({ name: "test-project" });
+      const tags = ["ci", "production"];
+
+      const codePrompt = new CodePrompt(
+        project,
+        {
+          prompt: { type: "completion", content: "Hello {{name}}" },
+          options: { model: "gpt-4" },
+        },
+        [],
+        {
+          name: "test-prompt",
+          slug: "test-prompt",
+          tags,
+        },
+      );
+
+      const mockProjectMap = {
+        resolve: vi.fn().mockResolvedValue("project-123"),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+
+      const funcDef = await codePrompt.toFunctionDefinition(mockProjectMap);
+
+      expect(funcDef.tags).toEqual(tags);
+      expect(funcDef.name).toBe("test-prompt");
+      expect(funcDef.project_id).toBe("project-123");
+    });
+
+    test("toFunctionDefinition excludes tags when undefined", async () => {
+      const project = projects.create({ name: "test-project" });
+
+      const codePrompt = new CodePrompt(
+        project,
+        {
+          prompt: { type: "completion", content: "Hello {{name}}" },
+          options: { model: "gpt-4" },
+        },
+        [],
+        {
+          name: "test-prompt",
+          slug: "test-prompt",
+        },
+      );
+
+      const mockProjectMap = {
+        resolve: vi.fn().mockResolvedValue("project-123"),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+
+      const funcDef = await codePrompt.toFunctionDefinition(mockProjectMap);
+
+      expect(funcDef.tags).toBeUndefined();
+    });
+  });
+
   describe("CodeParameters defaults", () => {
     test("toFunctionDefinition initializes data with schema defaults", async () => {
       const project = projects.create({ name: "test-project" });

--- a/js/src/framework2.ts
+++ b/js/src/framework2.ts
@@ -424,6 +424,7 @@ export class CodePrompt {
   public readonly id?: string;
   public readonly functionType?: FunctionType;
   public readonly toolFunctions: (SavedFunctionId | GenericCodeFunction)[];
+  public readonly tags?: string[];
   public readonly metadata?: Record<string, unknown>;
 
   constructor(
@@ -445,6 +446,7 @@ export class CodePrompt {
     this.description = opts.description;
     this.id = opts.id;
     this.functionType = functionType;
+    this.tags = opts.tags;
     this.metadata = opts.metadata;
   }
 
@@ -486,6 +488,7 @@ export class CodePrompt {
       function_type: this.functionType,
       prompt_data,
       if_exists: this.ifExists,
+      tags: this.tags,
       metadata: this.metadata,
     };
   }
@@ -518,8 +521,9 @@ export type PromptOpts<
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   (HasTools extends true ? Partial<PromptTools> : {}) &
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-  (HasNoTrace extends true ? Partial<PromptNoTrace> : {}) &
-  PromptDefinition;
+  (HasNoTrace extends true ? Partial<PromptNoTrace> : {}) & {
+    tags?: string[];
+  } & PromptDefinition;
 
 export class PromptBuilder {
   constructor(private readonly project: Project) {}
@@ -552,6 +556,7 @@ export class PromptBuilder {
       name: opts.name,
       slug: slug,
       prompt_data: promptData,
+      tags: opts.tags,
       ...(this.project.id !== undefined ? { project_id: this.project.id } : {}),
     } as PromptRowWithId<HasId, HasVersion>;
 
@@ -782,6 +787,7 @@ export interface FunctionEvent {
   function_data: z.infer<typeof functionDataSchema>;
   function_type?: FunctionType;
   if_exists?: IfExists;
+  tags?: string[];
   metadata?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
Resolves https://github.com/braintrustdata/braintrust-sdk-javascript/issues/1050