### PR TITLE
fix: Make AI SDK Agent span nodes use use type `function`

### DIFF
--- a/e2e/scenarios/wrap-ai-sdk-generation-traces/__snapshots__/scenario.test.ts.snap
+++ b/e2e/scenarios/wrap-ai-sdk-generation-traces/__snapshots__/scenario.test.ts.snap
@@ -8248,7 +8248,7 @@ exports[`wrap-ai-sdk-generation-traces captures wrapper and child model spans (a
     "span_attributes": {
       "exec_counter": 24,
       "name": "Agent.generate",
-      "type": "llm",
+      "type": "function",
     },
     "span_id": "<span:70>",
     "span_parents": [
@@ -8604,7 +8604,7 @@ exports[`wrap-ai-sdk-generation-traces captures wrapper and child model spans (a
     "span_attributes": {
       "exec_counter": 27,
       "name": "Agent.stream",
-      "type": "llm",
+      "type": "function",
     },
     "span_id": "<span:78>",
     "span_parents": [
@@ -9280,7 +9280,7 @@ exports[`wrap-ai-sdk-generation-traces captures wrapper and child model spans (a
     "span_parents": [
       "<span:20>",
     ],
-    "type": "llm",
+    "type": "function",
   },
   {
     "has_input": true,
@@ -9344,7 +9344,7 @@ exports[`wrap-ai-sdk-generation-traces captures wrapper and child model spans (a
     "span_parents": [
       "<span:23>",
     ],
-    "type": "llm",
+    "type": "function",
   },
   {
     "has_input": true,
@@ -13471,7 +13471,7 @@ exports[`wrap-ai-sdk-generation-traces captures wrapper and child model spans (a
     "span_attributes": {
       "exec_counter": 24,
       "name": "ToolLoopAgent.generate",
-      "type": "llm",
+      "type": "function",
     },
     "span_id": "<span:70>",
     "span_parents": [
@@ -13893,7 +13893,7 @@ exports[`wrap-ai-sdk-generation-traces captures wrapper and child model spans (a
     "span_attributes": {
       "exec_counter": 27,
       "name": "ToolLoopAgent.stream",
-      "type": "llm",
+      "type": "function",
     },
     "span_id": "<span:78>",
     "span_parents": [
@@ -14637,7 +14637,7 @@ exports[`wrap-ai-sdk-generation-traces captures wrapper and child model spans (a
     "span_parents": [
       "<span:20>",
     ],
-    "type": "llm",
+    "type": "function",
   },
   {
     "has_input": true,
@@ -14700,7 +14700,7 @@ exports[`wrap-ai-sdk-generation-traces captures wrapper and child model spans (a
     "span_parents": [
       "<span:23>",
     ],
-    "type": "llm",
+    "type": "function",
   },
   {
     "has_input": true,

--- a/e2e/scenarios/wrap-ai-sdk-generation-traces/scenario.test.ts
+++ b/e2e/scenarios/wrap-ai-sdk-generation-traces/scenario.test.ts
@@ -363,8 +363,14 @@ test.each(WRAP_AI_SDK_SCENARIOS)(
       if (agentSpanName) {
         expect(agentGenerateOperation).toBeDefined();
         expect(agentStreamOperation).toBeDefined();
+        expect(agentGenerateParent?.row.span_attributes).toMatchObject({
+          type: "function",
+        });
         expect(agentGenerateParent?.output).toBeDefined();
         expect(agentGenerateChildren.length).toBeGreaterThanOrEqual(1);
+        expect(agentStreamParent?.row.span_attributes).toMatchObject({
+          type: "function",
+        });
         expect(agentStreamParent?.metrics?.time_to_first_token).toEqual(
           expect.any(Number),
         );

--- a/js/src/wrappers/ai-sdk/ai-sdk.test.ts
+++ b/js/src/wrappers/ai-sdk/ai-sdk.test.ts
@@ -1488,7 +1488,7 @@ describe("ai sdk client unit tests", TEST_SUITE_OPTIONS, () => {
     expect(span.span_id).toBeDefined();
     expect(span.root_span_id).toBeDefined();
     expect(span.span_attributes).toMatchObject({
-      type: "llm",
+      type: "function",
       name: "CustomAgent.generate",
     });
     expect(span.metadata).toMatchObject({

--- a/js/src/wrappers/ai-sdk/ai-sdk.ts
+++ b/js/src/wrappers/ai-sdk/ai-sdk.ts
@@ -212,6 +212,8 @@ const wrapAgentGenerate = (
       options,
       generate.bind(instance), // as of v5 this is just streamText under the hood
       // Follows what the AI SDK does under the hood when calling generateText
+      undefined,
+      SpanTypeAttribute.FUNCTION,
     )({ ...instance.settings, ...params });
 };
 
@@ -226,6 +228,7 @@ const wrapAgentStream = (
       options,
       stream.bind(instance), // as of v5 this is just streamText under the hood
       undefined, // aiSDK not needed since model is already on instance
+      SpanTypeAttribute.FUNCTION,
     )({ ...instance.settings, ...params });
 };
 
@@ -234,6 +237,7 @@ const makeGenerateTextWrapper = (
   options: WrapAISDKOptions,
   generateText: AISDKGenerateFunction,
   aiSDK?: AISDK,
+  spanType: SpanTypeAttribute = SpanTypeAttribute.LLM,
 ) => {
   const wrapper = async function (allParams: AISDKCallParams & SpanInfo) {
     // Extract span_info from params (used by Braintrust-managed prompts)
@@ -285,7 +289,7 @@ const makeGenerateTextWrapper = (
       {
         name: spanName || name,
         spanAttributes: {
-          type: SpanTypeAttribute.LLM,
+          type: spanType,
           ...spanInfoAttrs,
         },
         event: {
@@ -688,6 +692,7 @@ const makeStreamTextWrapper = (
   options: WrapAISDKOptions,
   streamText: AISDKStreamFunction,
   aiSDK?: AISDK,
+  spanType: SpanTypeAttribute = SpanTypeAttribute.LLM,
 ) => {
   // Note: streamText returns a sync result (stream object), so we cannot make this async
   // For v6, Output.object responseFormat is a Promise - we handle this by:
@@ -713,7 +718,7 @@ const makeStreamTextWrapper = (
     const span = startSpan({
       name: spanName || name,
       spanAttributes: {
-        type: SpanTypeAttribute.LLM,
+        type: spanType,
         ...spanInfoAttrs,
       },
       event: {


### PR DESCRIPTION
Changes AI SDK agent wrapper spans to log as `span_attributes.type = "function"` instead of `llm`.

`ToolLoopAgent` and other agent-level spans are orchestration nodes, while the actual model calls stay the child `doGenerate` / `doStream` `llm` spans.