### PR TITLE
ci: Fix canary publish by replacing npm version with direct JSON edit

### DIFF
--- a/.github/workflows/publish-js-sdk.yaml
+++ b/.github/workflows/publish-js-sdk.yaml
@@ -332,7 +332,15 @@ jobs:
 
           CURRENT_SHA=$(git rev-parse --short=7 HEAD)
           CANARY_NAME="braintrust"
-          npm version "$VERSION" --no-git-tag-version --allow-same-version
+          # Do not use `npm version` or `pnpm version` here — both delegate to
+          # npm's arborist which crashes when it encounters pnpm's workspace:*
+          # protocol specifiers in node_modules after `pnpm install`.
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.version = process.env.VERSION;
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
 
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "package_name=${CANARY_NAME}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
npm version and pnpm version both invoke npm's arborist to update workspace dependents, which crashes with "Cannot read properties of null (reading 'matches')" when traversing pnpm's node_modules/.pnpm virtual store — arborist can't parse pnpm's workspace:* protocol as a semver range. Replace with a direct node JSON edit that bypasses arborist entirely.

Entirely done with claude code (as it had to reproduce). 