### PR TITLE
Hydrate remote prompt `Parameters` in evals

### DIFF
--- a/js/src/eval-parameters.ts
+++ b/js/src/eval-parameters.ts
@@ -151,5 +151,51 @@ function validateParametersWithJsonSchema<T extends Record<string, unknown>>(
   }
 
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  return parameters as T;
+  return hydrateRemoteParameters(parameters, schema) as T;
+}
+
+function hydrateRemoteParameters(
+  parameters: Record<string, unknown>,
+  schema: Record<string, unknown>,
+): Record<string, unknown> {
+  const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === "object" && value !== null;
+  const properties =
+    "properties" in schema && isRecord(schema.properties)
+      ? schema.properties
+      : undefined;
+  if (!properties) {
+    return parameters;
+  }
+
+  return Object.fromEntries(
+    Object.entries(parameters).map(([name, value]) => {
+      const propertySchema = properties[name];
+      if (!propertySchema || typeof propertySchema !== "object") {
+        return [name, value];
+      }
+
+      if (
+        "x-bt-type" in propertySchema &&
+        propertySchema["x-bt-type"] === "prompt"
+      ) {
+        return [
+          name,
+          Prompt.fromPromptData(name, promptDataSchema.parse(value)),
+        ];
+      }
+
+      if (
+        "x-bt-type" in propertySchema &&
+        propertySchema["x-bt-type"] === "model" &&
+        typeof value !== "string"
+      ) {
+        throw Error(
+          `Invalid parameter '${name}': model values must be strings`,
+        );
+      }
+
+      return [name, value];
+    }),
+  );
 }

--- a/js/src/parameters.test.ts
+++ b/js/src/parameters.test.ts
@@ -3,6 +3,8 @@ import { runEvaluator } from "./framework";
 import { z } from "zod/v3";
 import { type ProgressReporter } from "./reporters/types";
 import { configureNode } from "./node/config";
+import { RemoteEvalParameters } from "./logger";
+import { validateParameters } from "./eval-parameters";
 
 beforeAll(() => {
   configureNode();
@@ -237,4 +239,45 @@ test("model parameter is required when default is missing", async () => {
       true,
     ),
   ).rejects.toThrow("Parameter 'model' is required");
+});
+
+test("remote prompt parameters are hydrated to Prompt objects", async () => {
+  const parameters = new RemoteEvalParameters({
+    id: "params-123",
+    project_id: "project-123",
+    name: "Saved parameters",
+    slug: "saved-parameters",
+    _xact_id: "v1",
+    function_type: "parameters",
+    function_data: {
+      type: "parameters",
+      data: {
+        main: {
+          prompt: {
+            type: "chat",
+            messages: [{ role: "user", content: "{{input}}" }],
+          },
+          options: {
+            model: "gpt-5-mini",
+          },
+        },
+      },
+      __schema: {
+        type: "object",
+        properties: {
+          main: {
+            type: "object",
+            "x-bt-type": "prompt",
+          },
+        },
+        additionalProperties: true,
+      },
+    },
+    created: "2023-10-01T00:00:00Z",
+  });
+
+  const result = await validateParameters({}, parameters);
+
+  expect(result.main).toBeDefined();
+  expect(typeof result.main.build).toBe("function");
 });


### PR DESCRIPTION
## Summary
This fixes the `loadParameters(...)` eval path for prompt-valued saved parameters. Remote parameter validation now rehydrates prompt fields into `Prompt` instances so evals can call prompt methods like `.build()` with the same runtime shape as inline parameters.

## Demo
- [ ] Add demo

## Related PRs
<!-- codex-related-prs:start -->
- [braintrustdata/braintrust #11831](https://github.com/braintrustdata/braintrust/pull/11831) - Parent PR
- [braintrustdata/braintrust-sdk-python #90](https://github.com/braintrustdata/braintrust-sdk-python/pull/90) - Sibling PR
<!-- codex-related-prs:end -->
