### PR TITLE
ci: Disable husky in CI

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -9,6 +9,9 @@ permissions:
   contents: read
   actions: write
 
+env:
+  HUSKY: "0"
+
 jobs:
   formatting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We added husky hooks in https://github.com/braintrustdata/braintrust-sdk-javascript/pull/1596, but that breaks CI. This disables husky in CI more generally.