### PR TITLE
fix: Make param types that are forwarded backwards compatible with older open ai SDKs

### DIFF
--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -7098,11 +7098,18 @@ type CompiledPromptResponseFormat =
       : ResponseFormat
     : never;
 
+// "none" is not assignable to older openai clients so we gotta exclude it
+type CompiledPromptReasoningEffort = Exclude<
+  AnyModelParam["reasoning_effort"],
+  "none"
+>;
+
 export type CompiledPromptParams = Omit<
   NonNullable<PromptData["options"]>["params"],
-  "use_cache" | "response_format"
+  "use_cache" | "response_format" | "reasoning_effort"
 > &
-  Omit<AnyModelParam, "use_cache" | "response_format"> & {
+  Omit<AnyModelParam, "use_cache" | "response_format" | "reasoning_effort"> & {
+    reasoning_effort?: CompiledPromptReasoningEffort;
     response_format?: CompiledPromptResponseFormat;
     model: NonNullable<NonNullable<PromptData["options"]>["model"]>;
   };


### PR DESCRIPTION
Sorta adjusts #1558 because it started failing here https://github.com/braintrustdata/braintrust/actions/runs/23257638886/job/67617203251?pr=11883 and hopefully fixes it.

