### PR TITLE
chore: Add nightly claude CI job to identify SDK support gaps

### DIFF
--- a/.github/workflows/agent-automations.yaml
+++ b/.github/workflows/agent-automations.yaml
@@ -1,7 +1,6 @@
 name: Agent Automation
 
 on:
-  pull_request:
   schedule:
     - cron: "0 6 * * *"
   workflow_dispatch:


### PR DESCRIPTION
Just a small experiment to automate staying on top of things.