### PR TITLE
test(e2e): Simplify hermetic/external distinction

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -58,14 +58,17 @@ jobs:
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: denoland/setup-deno@ff4860f9d7236f320afa0f82b7e6457384805d05 # v2.0.4
+        with:
+          deno-version-file: .tool-versions
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .tool-versions
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Run external-api e2e tests
-        run: pnpm test:e2e:external
+      - name: Run e2e tests
+        run: pnpm test:e2e
 
   e2e-canary:
     if: ${{ github.event_name == 'pull_request' }}

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -70,12 +70,9 @@ Use `normalizeForSnapshot(...)` before snapshotting. It replaces timestamps and 
 
 ### Test tags
 
-Every `scenario.test.ts` must tag each test with exactly one e2e tag from `e2e/helpers/tags.ts`:
+Hermetic tests (those that use only the mock Braintrust server and local fixtures) must be tagged with `E2E_TAGS.hermetic` from `e2e/helpers/tags.ts`. This allows CI to run hermetic tests separately without provider credentials.
 
-- `E2E_TAGS.hermetic` - Uses only the mock Braintrust server and local fixtures. These run in the GitHub checks workflow.
-- `E2E_TAGS.externalApi` - Calls a real provider API. These automatically get `retry: 1` from `e2e/vitest.config.mts`.
-
-Use the tag directly in the Vitest test options:
+Tests that call real provider APIs do not need a tag.
 
 ```ts
 import { E2E_TAGS } from "../../helpers/tags";
@@ -113,7 +110,7 @@ The Deno scenarios follow the same pattern, except the harness invokes `deno tes
 
 ### Environment variables
 
-`externalApi` scenarios require provider credentials in addition to the mock Braintrust server config supplied by the harness:
+Non-hermetic scenarios require provider credentials in addition to the mock Braintrust server config supplied by the harness:
 
 - `OPENAI_API_KEY`
 - `ANTHROPIC_API_KEY`
@@ -133,6 +130,5 @@ Scenario-local manifests are optional and should stay slim. They are only for sc
 ```bash
 pnpm run test:e2e            # Run all e2e tests
 pnpm run test:e2e:hermetic   # Run hermetic-only e2e tests
-pnpm run test:e2e:external   # Run external-api-only e2e tests
 pnpm run test:e2e:update     # Run tests and update snapshots
 ```

--- a/e2e/helpers/tags.ts
+++ b/e2e/helpers/tags.ts
@@ -1,5 +1,4 @@
 export const E2E_TAGS = {
-  externalApi: "external-api",
   hermetic: "hermetic",
 } as const;
 

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "scripts": {
     "test:e2e": "vitest run",
-    "test:e2e:external": "vitest run --tags-filter=external-api",
     "test:e2e:hermetic": "vitest run --tags-filter=hermetic",
     "test:e2e:canary": "node ./scripts/run-canary-tests.mjs",
     "test:e2e:update": "vitest run --update"

--- a/e2e/scenarios/ai-sdk-instrumentation/assertions.ts
+++ b/e2e/scenarios/ai-sdk-instrumentation/assertions.ts
@@ -11,7 +11,7 @@ import {
   findChildSpans,
   findLatestSpan,
 } from "../../helpers/trace-selectors";
-import { E2E_TAGS } from "../../helpers/tags";
+
 import { ROOT_NAME, SCENARIO_NAME } from "./scenario.impl.mjs";
 
 type AgentSpanName = "Agent" | "ToolLoopAgent";
@@ -508,7 +508,6 @@ export function defineAISDKInstrumentationAssertions(options: {
     `${options.snapshotName}.log-payloads.json`,
   );
   const testConfig = {
-    tags: [E2E_TAGS.externalApi],
     timeout: options.timeoutMs,
   };
 

--- a/e2e/scenarios/ai-sdk-otel-export/scenario.test.ts
+++ b/e2e/scenarios/ai-sdk-otel-export/scenario.test.ts
@@ -13,7 +13,6 @@ import {
   extractOtelSpans,
   summarizeRequest,
 } from "../../helpers/trace-summary";
-import { E2E_TAGS } from "../../helpers/tags";
 
 const scenarioDir = await prepareScenarioDir({
   scenarioDir: resolveScenarioDir(import.meta.url),
@@ -44,7 +43,6 @@ for (const scenario of scenarios) {
   test(
     `ai-sdk-otel-export sends AI SDK telemetry spans to Braintrust via BraintrustExporter (ai ${scenario.version})`,
     {
-      tags: [E2E_TAGS.externalApi],
       timeout: TIMEOUT_MS,
     },
     async () => {

--- a/e2e/scenarios/anthropic-instrumentation/assertions.ts
+++ b/e2e/scenarios/anthropic-instrumentation/assertions.ts
@@ -8,7 +8,7 @@ import {
 import { withScenarioHarness } from "../../helpers/scenario-harness";
 import { findChildSpans, findLatestSpan } from "../../helpers/trace-selectors";
 import { summarizeWrapperContract } from "../../helpers/wrapper-contract";
-import { E2E_TAGS } from "../../helpers/tags";
+
 import { ROOT_NAME, SCENARIO_NAME } from "./scenario.impl.mjs";
 
 type RunAnthropicScenario = (harness: {
@@ -289,7 +289,6 @@ export function defineAnthropicInstrumentationAssertions(options: {
     `${options.snapshotName}.log-payloads.json`,
   );
   const testConfig = {
-    tags: [E2E_TAGS.externalApi],
     timeout: options.timeoutMs,
   };
 

--- a/e2e/scenarios/claude-agent-sdk-instrumentation/assertions.ts
+++ b/e2e/scenarios/claude-agent-sdk-instrumentation/assertions.ts
@@ -11,7 +11,7 @@ import {
   findChildSpans,
   findLatestSpan,
 } from "../../helpers/trace-selectors";
-import { E2E_TAGS } from "../../helpers/tags";
+
 import { summarizeWrapperContract } from "../../helpers/wrapper-contract";
 import { ROOT_NAME, SCENARIO_NAME } from "./scenario.impl.mjs";
 
@@ -206,7 +206,6 @@ export function defineClaudeAgentSDKInstrumentationAssertions(options: {
     `${options.snapshotName}.span-events.json`,
   );
   const testConfig = {
-    tags: [E2E_TAGS.externalApi],
     timeout: options.timeoutMs,
   };
 

--- a/e2e/scenarios/google-genai-instrumentation/assertions.ts
+++ b/e2e/scenarios/google-genai-instrumentation/assertions.ts
@@ -8,7 +8,7 @@ import {
 import { withScenarioHarness } from "../../helpers/scenario-harness";
 import { findChildSpans, findLatestSpan } from "../../helpers/trace-selectors";
 import { summarizeWrapperContract } from "../../helpers/wrapper-contract";
-import { E2E_TAGS } from "../../helpers/tags";
+
 import { ROOT_NAME, SCENARIO_NAME } from "./scenario.impl.mjs";
 
 type RunGoogleGenAIScenario = (harness: {
@@ -312,7 +312,6 @@ export function defineGoogleGenAIInstrumentationAssertions(options: {
     `${options.snapshotName}.log-payloads.json`,
   );
   const testConfig = {
-    tags: [E2E_TAGS.externalApi],
     timeout: options.timeoutMs,
   };
 

--- a/e2e/scenarios/openai-instrumentation/assertions.ts
+++ b/e2e/scenarios/openai-instrumentation/assertions.ts
@@ -7,7 +7,7 @@ import {
 } from "../../helpers/file-snapshot";
 import { withScenarioHarness } from "../../helpers/scenario-harness";
 import { findChildSpans, findLatestSpan } from "../../helpers/trace-selectors";
-import { E2E_TAGS } from "../../helpers/tags";
+
 import { ROOT_NAME, SCENARIO_NAME } from "./scenario.impl.mjs";
 
 type RunOpenAIScenario = (harness: {
@@ -443,7 +443,6 @@ export function defineOpenAIInstrumentationAssertions(options: {
     `${options.snapshotName}.log-payloads.json`,
   );
   const testConfig = {
-    tags: [E2E_TAGS.externalApi],
     timeout: options.timeoutMs,
   };
 

--- a/e2e/scenarios/openrouter-instrumentation/assertions.ts
+++ b/e2e/scenarios/openrouter-instrumentation/assertions.ts
@@ -8,7 +8,7 @@ import {
 import { withScenarioHarness } from "../../helpers/scenario-harness";
 import { findChildSpans, findLatestSpan } from "../../helpers/trace-selectors";
 import { summarizeWrapperContract } from "../../helpers/wrapper-contract";
-import { E2E_TAGS } from "../../helpers/tags";
+
 import {
   CHAT_MODEL,
   EMBEDDING_MODEL,
@@ -130,7 +130,6 @@ export function defineOpenRouterTraceAssertions(options: {
     "span-events.json",
   );
   const testConfig = {
-    tags: [E2E_TAGS.externalApi],
     timeout: options.timeoutMs,
   };
 

--- a/e2e/scenarios/wrap-langchain-js-traces/scenario.test.ts
+++ b/e2e/scenarios/wrap-langchain-js-traces/scenario.test.ts
@@ -8,7 +8,7 @@ import {
   resolveScenarioDir,
   withScenarioHarness,
 } from "../../helpers/scenario-harness";
-import { E2E_TAGS } from "../../helpers/tags";
+
 import { assertLangchainTraces } from "./assertions";
 
 const scenarioDir = await prepareScenarioDir({
@@ -19,7 +19,6 @@ const TIMEOUT_MS = 90_000;
 test(
   "wrap-langchain-js-traces captures invoke, chain, stream, and tool spans via BraintrustCallbackHandler",
   {
-    tags: [E2E_TAGS.externalApi],
     timeout: TIMEOUT_MS,
   },
   async () => {

--- a/e2e/vitest.config.mts
+++ b/e2e/vitest.config.mts
@@ -8,12 +8,6 @@ export default defineConfig({
     setupFiles: ["./vitest.setup.ts"],
     tags: [
       {
-        name: E2E_TAGS.externalApi,
-        description:
-          "Tests that call real external APIs and require provider credentials.",
-        retry: 1,
-      },
-      {
         name: E2E_TAGS.hermetic,
         description:
           "Tests that run entirely against local mocks and fixtures.",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "knip": "knip --config knip.jsonc --no-config-hints",
     "test": "turbo run test --filter=\"!@braintrust/otel\"",
     "test:e2e": "turbo run test:e2e",
-    "test:e2e:external": "turbo run test:e2e:external",
     "test:e2e:hermetic": "turbo run test:e2e:hermetic",
     "test:e2e:canary": "turbo run test:e2e:canary",
     "test:e2e:update": "turbo run test:e2e:update",

--- a/turbo.json
+++ b/turbo.json
@@ -41,17 +41,6 @@
       "dependsOn": ["^build"],
       "outputs": []
     },
-    "test:e2e:external": {
-      "env": [
-        "ANTHROPIC_API_KEY",
-        "BRAINTRUST_API_KEY",
-        "GEMINI_API_KEY",
-        "OPENAI_API_KEY",
-        "OPENAI_BASE_URL"
-      ],
-      "dependsOn": ["^build"],
-      "outputs": []
-    },
     "test:e2e:hermetic": {
       "dependsOn": ["^build"],
       "outputs": []


### PR DESCRIPTION
Removes the external tag because I didn't like that if someone forgot to add either of the hermetic or external tag that ci would basically skip over the entire test. No bueno.