### PR TITLE
fix: propagate templateFormat in ScorerBuilder.create()

### DIFF
--- a/js/src/framework.test.ts
+++ b/js/src/framework.test.ts
@@ -1439,6 +1439,63 @@ describe("framework2 metadata support", () => {
       expect(scorers).toHaveLength(1);
       expect(scorers[0].tags).toBeUndefined();
     });
+
+    test("LLM scorer (chat) stores templateFormat in promptData", () => {
+      const project = projects.create({ name: "test-project" });
+
+      project.scorers.create({
+        name: "nunjucks-scorer",
+        messages: [{ role: "user", content: "Grade: {{ output }}" }],
+        model: "gpt-4o",
+        useCot: true,
+        choiceScores: { pass: 1, fail: 0 },
+        templateFormat: "nunjucks",
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const prompts = (project as any)._publishablePrompts;
+      expect(prompts).toHaveLength(1);
+      // template_format must be present on the stored PromptData, which is
+      // spread directly into the API payload by toFunctionDefinition().
+      expect(prompts[0].prompt.template_format).toBe("nunjucks");
+    });
+
+    test("LLM scorer (completion) stores templateFormat in promptData", () => {
+      const project = projects.create({ name: "test-project" });
+
+      project.scorers.create({
+        name: "none-format-scorer",
+        prompt: "Grade the output.",
+        model: "gpt-4o",
+        useCot: false,
+        choiceScores: { pass: 1, fail: 0 },
+        templateFormat: "none",
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const prompts = (project as any)._publishablePrompts;
+      expect(prompts).toHaveLength(1);
+      expect(prompts[0].prompt.template_format).toBe("none");
+    });
+
+    test("LLM scorer without templateFormat leaves template_format absent", () => {
+      const project = projects.create({ name: "test-project" });
+
+      project.scorers.create({
+        name: "default-format-scorer",
+        prompt: "Is this correct?",
+        model: "gpt-4o",
+        useCot: false,
+        choiceScores: { yes: 1, no: 0 },
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const prompts = (project as any)._publishablePrompts;
+      expect(prompts).toHaveLength(1);
+      // No templateFormat passed → field must be absent so the API applies its
+      // own default rather than receiving an explicit undefined.
+      expect(prompts[0].prompt.template_format).toBeUndefined();
+    });
   });
 
   describe("Project with messages", () => {

--- a/js/src/framework2.ts
+++ b/js/src/framework2.ts
@@ -272,6 +272,9 @@ export class ScorerBuilder {
           use_cot: opts.useCot,
           choice_scores: opts.choiceScores,
         },
+        ...(opts.templateFormat
+          ? { template_format: opts.templateFormat }
+          : {}),
       };
       const codePrompt = new CodePrompt(
         this.project,


### PR DESCRIPTION
  ## Summary
                                                                                                         
  `ScorerBuilder.create()` accepted `templateFormat` in its options but silently dropped it when         
  constructing `PromptData`, causing scorers to always be saved with `mustache` as the template format
  regardless of what was passed.   

Linear bug [here](https://linear.app/braintrustdata/issue/BT-4586/ts-sdk-scorerbuildercreate-silently-drops-templateformat-ui-defaults)               

Recreated [here](https://www.braintrust.dev/app/evan-test-test/p/evan-test/scorers/5469fed0-b5ed-46ce-83ac-29c5712bee7e).                                                       
                  
  ## Root Cause

  `ScorerBuilder.create()` in `framework2.ts:264-275` manually constructs the `PromptData` object without
   including `template_format`. `PromptBuilder.create()` (line 549) uses `promptDefinitionToPromptData()`
   which correctly maps `opts.templateFormat → template_format`. The scorer code path bypassed this      
  helper entirely.

  ## Fix

  Added a conditional spread to include `template_format` in the `PromptData` object, matching the       
  pattern already used in `prompt-schemas.ts:69-71`:
                                                                                                         
  ```typescript   
  ...(opts.templateFormat ? { template_format: opts.templateFormat } : {})

  Callers that don't specify templateFormat are unaffected — the spread adds nothing, and the API        
  continues to default to mustache.
                                                                                                         
  Testing         

  Added a unit test to framework.test.ts covering:                                                       
  - Chat messages scorer with templateFormat: "nunjucks" → template_format stored correctly
  - Completion prompt scorer with templateFormat: "nunjucks" → template_format stored correctly          
  - No templateFormat specified → template_format remains undefined (API defaults to mustache, no
  behavior change)                                                                                       
                                                                                                         
  Fixes BT-4586 / Pylon #13819.
  ```                             