### PR TITLE
fix(otel): propagate TracingChannel span context in OTEL compat mode

### DIFF
--- a/integrations/otel-js/src/context.ts
+++ b/integrations/otel-js/src/context.ts
@@ -1,11 +1,19 @@
 import {
   ContextManager,
+  BRAINTRUST_CURRENT_SPAN_STORE,
+  _internalIso as iso,
   type ContextParentSpanIds,
+  type CurrentSpanStore,
   type Span,
 } from "braintrust";
 
 import { trace as otelTrace, context as otelContext } from "@opentelemetry/api";
 import { getOtelParentFromSpan } from "./otel";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const BT_SPAN_KEY = "braintrust_span" as any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const BT_PARENT_KEY = "braintrust.parent" as any;
 
 function isOtelSpan(span: unknown): span is {
   spanContext: () => { spanId: string; traceId: string };
@@ -46,7 +54,76 @@ function isValidSpanContext(spanContext: unknown): boolean {
   );
 }
 
+/**
+ * Builds an OTEL Context containing a NonRecordingSpan wrapper around the
+ * Braintrust span's IDs, plus the BT span stored under BT_SPAN_KEY for
+ * retrieval by getCurrentSpan().
+ */
+function buildBtOtelContext(span: Span): unknown {
+  const btSpan = span as { spanId: string; rootSpanId: string };
+  const spanContext = {
+    traceId: btSpan.rootSpanId,
+    spanId: btSpan.spanId,
+    traceFlags: 1, // sampled
+  };
+  const wrappedSpan = otelTrace.wrapSpanContext(spanContext);
+  const currentContext = otelContext.active();
+  let newContext = otelTrace.setSpan(currentContext, wrappedSpan);
+  newContext = newContext.setValue(BT_SPAN_KEY, span);
+
+  if (isBraintrustSpan(span)) {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const parentValue = getOtelParentFromSpan(span as never);
+    if (parentValue) {
+      newContext = newContext.setValue(BT_PARENT_KEY, parentValue);
+    }
+  }
+
+  return newContext;
+}
+
 export class OtelContextManager extends ContextManager {
+  /** Fallback ALS used when the OTEL context manager doesn't expose _asyncLocalStorage. */
+  private _ownAls: CurrentSpanStore | undefined;
+
+  private _getOtelAls(): CurrentSpanStore | undefined {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (otelContext as any)._getContextManager?.()._asyncLocalStorage;
+  }
+
+  constructor() {
+    super();
+    // Expose whichever ALS is in use via BRAINTRUST_CURRENT_SPAN_STORE so that
+    // TracingChannel's bindStore can propagate span context. We prefer OTEL's own
+    // ALS (AsyncLocalStorageContextManager._asyncLocalStorage) so that spans
+    // stored by runStores are visible to OTEL's context APIs. If the active OTEL
+    // context manager doesn't expose an ALS (e.g. AsyncHooksContextManager), we
+    // fall back to our own IsoAsyncLocalStorage<Span> and behave like the default
+    // BraintrustContextManager for TracingChannel binding.
+    //
+    // A lazy getter is required because the global OTEL context manager may not be
+    // registered until after this instance is constructed.
+    const self = this;
+    Object.defineProperty(this, BRAINTRUST_CURRENT_SPAN_STORE, {
+      get(): CurrentSpanStore {
+        const otelAls = self._getOtelAls();
+        if (otelAls) return otelAls;
+        if (!self._ownAls) self._ownAls = iso.newAsyncLocalStorage<unknown>();
+        return self._ownAls;
+      },
+      configurable: true,
+      enumerable: false,
+    });
+  }
+
+  wrapSpanForStore(span: Span): unknown {
+    // When using OTEL's ALS the stored value must be an OTEL Context, not a raw
+    // Span, so that OTEL's own context propagation sees a valid Context object.
+    // When using our own fallback ALS we store the Span directly (default mode).
+    if (this._getOtelAls()) return buildBtOtelContext(span);
+    return span;
+  }
+
   getParentSpanIds(): ContextParentSpanIds | undefined {
     const currentSpan = otelTrace.getActiveSpan();
     if (!currentSpan || !isOtelSpan(currentSpan)) {
@@ -59,8 +136,7 @@ export class OtelContextManager extends ContextManager {
     }
 
     // Check if this is a wrapped BT span
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any
-    const btSpan = otelContext?.active().getValue?.("braintrust_span" as any);
+    const btSpan = otelContext?.active().getValue?.(BT_SPAN_KEY);
     if (
       btSpan &&
       currentSpan.constructor.name === "NonRecordingSpan" &&
@@ -88,46 +164,12 @@ export class OtelContextManager extends ContextManager {
 
   runInContext<R>(span: Span, callback: () => R): R {
     try {
-      if (
-        typeof span === "object" &&
-        span !== null &&
-        "spanId" in span &&
-        "rootSpanId" in span
-      ) {
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        const btSpan = span as { spanId: string; rootSpanId: string };
-
-        // Create a span context for the NonRecordingSpan
-        const spanContext = {
-          traceId: btSpan.rootSpanId,
-          spanId: btSpan.spanId,
-          traceFlags: 1, // sampled
-        };
-
-        // Wrap the span context
-        const wrappedContext = otelTrace.wrapSpanContext(spanContext);
-
-        // Get current context and add both the wrapped span and the BT span
-        const currentContext = otelContext.active();
-        let newContext = otelTrace.setSpan(currentContext, wrappedContext);
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any
-        newContext = newContext.setValue("braintrust_span" as any, span);
-
-        // Get parent value and store it in context (matching Python's behavior)
-        if (isBraintrustSpan(span)) {
+      if (isBraintrustSpan(span)) {
+        return otelContext.with(
           // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          const parentValue = getOtelParentFromSpan(span as never);
-          if (parentValue) {
-            newContext = newContext.setValue(
-              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any
-              "braintrust.parent" as any,
-              parentValue,
-            );
-          }
-        }
-
-        // Run the callback in the new context
-        return otelContext.with(newContext, callback);
+          buildBtOtelContext(span) as Parameters<typeof otelContext.with>[0],
+          callback,
+        );
       }
     } catch (error) {
       console.warn("Failed to run in OTEL context:", error);
@@ -137,9 +179,9 @@ export class OtelContextManager extends ContextManager {
   }
 
   getCurrentSpan(): Span | undefined {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any
-    const btSpan = otelContext.active().getValue?.("braintrust_span" as any);
-
+    // Check OTEL context first — this covers both runInContext and the OTEL-ALS
+    // TracingChannel path where runStores stores a Context under BT_SPAN_KEY.
+    const btSpan = otelContext.active().getValue?.(BT_SPAN_KEY);
     if (
       btSpan &&
       typeof btSpan === "object" &&
@@ -150,6 +192,14 @@ export class OtelContextManager extends ContextManager {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       return btSpan as Span;
     }
+
+    // If we're using the fallback ALS (non-ALS OTEL context manager), spans are
+    // stored directly in our own ALS by TracingChannel's runStores.
+    if (this._ownAls) {
+      const stored = this._ownAls.getStore();
+      if (isBraintrustSpan(stored)) return stored;
+    }
+
     return undefined;
   }
 }

--- a/integrations/otel-js/src/otel-compat.test.ts
+++ b/integrations/otel-js/src/otel-compat.test.ts
@@ -10,6 +10,7 @@ import {
   initLogger,
   currentSpan,
   getContextManager,
+  BRAINTRUST_CURRENT_SPAN_STORE,
   _exportsForTestingOnly,
   runEvaluator,
 } from "braintrust";
@@ -18,8 +19,11 @@ import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
-import { context as otelContext } from "@opentelemetry/api";
-import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
+import { context as otelContext, trace as otelTrace } from "@opentelemetry/api";
+import {
+  AsyncHooksContextManager,
+  AsyncLocalStorageContextManager,
+} from "@opentelemetry/context-async-hooks";
 import {
   getExportVersion,
   createTracerProvider,
@@ -673,6 +677,218 @@ describe("OTEL compatibility mode", () => {
 
       childSpan.end();
     });
+  });
+});
+
+describe("OtelContextManager TracingChannel integration", () => {
+  let contextManager: AsyncLocalStorageContextManager;
+
+  beforeEach(async () => {
+    setupOtelCompat();
+    await _exportsForTestingOnly.simulateLoginForTests();
+    _exportsForTestingOnly.useTestBackgroundLogger();
+
+    // AsyncLocalStorageContextManager (not AsyncHooksContextManager) exposes
+    // _asyncLocalStorage which is required for TracingChannel bindStore.
+    contextManager = new AsyncLocalStorageContextManager();
+    contextManager.enable();
+    otelContext.setGlobalContextManager(contextManager);
+  });
+
+  afterEach(() => {
+    if (contextManager) {
+      otelContext.disable();
+      contextManager.disable();
+    }
+    _exportsForTestingOnly.clearTestBackgroundLogger();
+    _exportsForTestingOnly.simulateLogoutForTests();
+    resetOtelCompat();
+  });
+
+  test("OtelContextManager exposes OTEL ALS via BRAINTRUST_CURRENT_SPAN_STORE", () => {
+    const cm = getContextManager();
+    expect(cm.constructor.name).toBe("OtelContextManager");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const store = (cm as any)[BRAINTRUST_CURRENT_SPAN_STORE];
+    expect(store).toBeDefined();
+    expect(typeof store.run).toBe("function");
+    expect(typeof store.getStore).toBe("function");
+  });
+
+  test("wrapSpanForStore returns OTEL Context that makes currentSpan() work", () => {
+    const cm = getContextManager();
+    const mockSpan = {
+      spanId: "abc123def456789a",
+      rootSpanId: "00000000000000000000000000000001",
+      spanParents: [],
+      getParentInfo: () => undefined,
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ctx = cm.wrapSpanForStore(mockSpan as any);
+    expect(ctx).toBeDefined();
+
+    // Running in the returned context should expose the BT span via currentSpan()
+    otelContext.with(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ctx as any,
+      () => {
+        expect(currentSpan()).toBe(mockSpan);
+      },
+    );
+  });
+
+  test("store.run() with wrapSpanForStore output propagates span to currentSpan()", () => {
+    const cm = getContextManager();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const store = (cm as any)[BRAINTRUST_CURRENT_SPAN_STORE];
+    expect(store).toBeDefined();
+
+    const mockSpan = {
+      spanId: "deadbeef12345678",
+      rootSpanId: "00000000000000000000000000000002",
+      spanParents: [],
+      getParentInfo: () => undefined,
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const wrappedCtx = cm.wrapSpanForStore(mockSpan as any);
+
+    // Simulate what TracingChannel's runStores does: call store.run(value, fn)
+    store.run(wrappedCtx, () => {
+      expect(currentSpan()).toBe(mockSpan);
+    });
+  });
+
+  test("nested store.run() calls maintain correct span chain", () => {
+    const cm = getContextManager();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const store = (cm as any)[BRAINTRUST_CURRENT_SPAN_STORE];
+
+    const parentSpan = {
+      spanId: "1111111111111111",
+      rootSpanId: "00000000000000000000000000000003",
+      spanParents: [],
+      getParentInfo: () => undefined,
+    };
+    const childSpan = {
+      spanId: "2222222222222222",
+      rootSpanId: "00000000000000000000000000000003",
+      spanParents: ["1111111111111111"],
+      getParentInfo: () => undefined,
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    store.run(cm.wrapSpanForStore(parentSpan as any), () => {
+      expect(currentSpan()).toBe(parentSpan);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      store.run(cm.wrapSpanForStore(childSpan as any), () => {
+        expect(currentSpan()).toBe(childSpan);
+      });
+
+      // After inner run completes, outer span is restored
+      expect(currentSpan()).toBe(parentSpan);
+    });
+
+    // After all runs, no BT span is active (getCurrentSpan returns undefined)
+    expect(getContextManager().getCurrentSpan()).toBeUndefined();
+  });
+
+  test("wrapSpanForStore result sets OTEL active span with matching IDs", () => {
+    const cm = getContextManager();
+    const mockSpan = {
+      spanId: "aabbccddeeff0011",
+      rootSpanId: "aabbccddeeff00112233445566778899",
+      spanParents: [],
+      getParentInfo: () => undefined,
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ctx = cm.wrapSpanForStore(mockSpan as any);
+
+    otelContext.with(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ctx as any,
+      () => {
+        const activeSpan = otelTrace.getActiveSpan();
+        expect(activeSpan).toBeDefined();
+
+        const spanCtx = activeSpan!.spanContext();
+        expect(spanCtx.traceId).toBe(mockSpan.rootSpanId);
+        expect(spanCtx.spanId).toBe(mockSpan.spanId);
+      },
+    );
+  });
+});
+
+describe("OtelContextManager fallback ALS (AsyncHooksContextManager)", () => {
+  let hooksContextManager: AsyncHooksContextManager;
+
+  beforeEach(async () => {
+    setupOtelCompat();
+    await _exportsForTestingOnly.simulateLoginForTests();
+    _exportsForTestingOnly.useTestBackgroundLogger();
+
+    // AsyncHooksContextManager does NOT expose _asyncLocalStorage, so
+    // OtelContextManager should create its own fallback ALS.
+    hooksContextManager = new AsyncHooksContextManager();
+    hooksContextManager.enable();
+    otelContext.setGlobalContextManager(hooksContextManager);
+  });
+
+  afterEach(() => {
+    if (hooksContextManager) {
+      otelContext.disable();
+      hooksContextManager.disable();
+    }
+    _exportsForTestingOnly.clearTestBackgroundLogger();
+    _exportsForTestingOnly.simulateLogoutForTests();
+    resetOtelCompat();
+  });
+
+  test("exposes fallback ALS via BRAINTRUST_CURRENT_SPAN_STORE when OTEL ALS is unavailable", () => {
+    const cm = getContextManager();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const store = (cm as any)[BRAINTRUST_CURRENT_SPAN_STORE];
+    expect(store).toBeDefined();
+    expect(typeof store.run).toBe("function");
+    expect(typeof store.getStore).toBe("function");
+  });
+
+  test("wrapSpanForStore returns span directly (not OTEL Context) in fallback mode", () => {
+    const cm = getContextManager();
+    const mockSpan = {
+      spanId: "1234567890abcdef",
+      rootSpanId: "00000000000000000000000000000010",
+      spanParents: [],
+      getParentInfo: () => undefined,
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = cm.wrapSpanForStore(mockSpan as any);
+    // In fallback mode, the span is stored directly (not wrapped in OTEL Context)
+    expect(result).toBe(mockSpan);
+  });
+
+  test("store.run() with span in fallback mode makes getCurrentSpan() work", () => {
+    const cm = getContextManager();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const store = (cm as any)[BRAINTRUST_CURRENT_SPAN_STORE];
+
+    const mockSpan = {
+      spanId: "fedcba0987654321",
+      rootSpanId: "00000000000000000000000000000011",
+      spanParents: [],
+      getParentInfo: () => undefined,
+    };
+
+    store.run(mockSpan, () => {
+      expect(cm.getCurrentSpan()).toBe(mockSpan);
+    });
+
+    expect(cm.getCurrentSpan()).toBeUndefined();
   });
 });
 

--- a/js/src/exports.ts
+++ b/js/src/exports.ts
@@ -49,8 +49,10 @@ export type {
 export {
   Attachment,
   BaseAttachment,
+  BRAINTRUST_CURRENT_SPAN_STORE,
   BraintrustState,
   ContextManager,
+  CurrentSpanStore,
   DEFAULT_FETCH_BATCH_SIZE,
   DEFAULT_MAX_REQUEST_SIZE,
   Dataset,

--- a/js/src/instrumentation/core/channel-tracing.ts
+++ b/js/src/instrumentation/core/channel-tracing.ts
@@ -1,14 +1,10 @@
-import type {
-  IsoAsyncLocalStorage,
-  IsoChannelHandlers,
-  IsoTracingChannel,
-} from "../../isomorph";
+import type { IsoChannelHandlers, IsoTracingChannel } from "../../isomorph";
 import {
   _internalGetGlobalState,
   BRAINTRUST_CURRENT_SPAN_STORE,
   startSpan,
 } from "../../logger";
-import type { Span } from "../../logger";
+import type { CurrentSpanStore, Span } from "../../logger";
 import { getCurrentUnixTimestamp, isObject } from "../../util";
 import type {
   AnyAsyncChannel,
@@ -252,10 +248,11 @@ function bindCurrentSpanStoreToStart<
 ): (() => void) | undefined {
   const state = _internalGetGlobalState();
   const startChannel = tracingChannel.start;
-  const currentSpanStore = state?.contextManager
+  const contextManager = state?.contextManager;
+  const currentSpanStore = contextManager
     ? (
-        state.contextManager as {
-          [BRAINTRUST_CURRENT_SPAN_STORE]?: IsoAsyncLocalStorage<Span>;
+        contextManager as {
+          [BRAINTRUST_CURRENT_SPAN_STORE]?: CurrentSpanStore;
         }
       )[BRAINTRUST_CURRENT_SPAN_STORE]
     : undefined;
@@ -266,13 +263,15 @@ function bindCurrentSpanStoreToStart<
 
   startChannel.bindStore(
     currentSpanStore,
-    (event: ChannelMessage<TChannel>) =>
-      ensureSpanStateForEvent<TChannel>(
+    (event: ChannelMessage<TChannel>) => {
+      const span = ensureSpanStateForEvent<TChannel>(
         states,
         config,
         event as StartOf<TChannel>,
         channelName,
-      ).span,
+      ).span;
+      return contextManager!.wrapSpanForStore(span);
+    },
   );
 
   return () => {

--- a/js/src/instrumentation/plugins/google-genai-plugin.ts
+++ b/js/src/instrumentation/plugins/google-genai-plugin.ts
@@ -5,16 +5,13 @@ import type {
   ErrorOf,
   StartOf,
 } from "../core/channel-definitions";
-import type {
-  IsoAsyncLocalStorage,
-  IsoChannelHandlers,
-  IsoTracingChannel,
-} from "../../isomorph";
+import type { IsoChannelHandlers, IsoTracingChannel } from "../../isomorph";
 import {
   _internalGetGlobalState,
   Attachment,
   BRAINTRUST_CURRENT_SPAN_STORE,
   startSpan,
+  type CurrentSpanStore,
   type StartSpanArgs,
   type Span,
 } from "../../logger";
@@ -227,19 +224,20 @@ function bindCurrentSpanStoreToStart<TChannel extends GenerateContentChannel>(
   create: (event: StartOf<TChannel>) => SpanState,
 ): (() => void) | undefined {
   const state = _internalGetGlobalState();
+  const contextManager = state?.contextManager;
   const startChannel = tracingChannel.start as
     | ({
         bindStore?: (
-          store: IsoAsyncLocalStorage<Span>,
-          callback: (event: ChannelMessage<TChannel>) => Span,
+          store: CurrentSpanStore,
+          callback: (event: ChannelMessage<TChannel>) => unknown,
         ) => void;
-        unbindStore?: (store: IsoAsyncLocalStorage<Span>) => void;
+        unbindStore?: (store: CurrentSpanStore) => void;
       } & object)
     | undefined;
-  const currentSpanStore = state?.contextManager
+  const currentSpanStore = contextManager
     ? (
-        state.contextManager as {
-          [BRAINTRUST_CURRENT_SPAN_STORE]?: IsoAsyncLocalStorage<Span>;
+        contextManager as {
+          [BRAINTRUST_CURRENT_SPAN_STORE]?: CurrentSpanStore;
         }
       )[BRAINTRUST_CURRENT_SPAN_STORE]
     : undefined;
@@ -248,13 +246,12 @@ function bindCurrentSpanStoreToStart<TChannel extends GenerateContentChannel>(
     return undefined;
   }
 
-  startChannel.bindStore(
-    currentSpanStore,
-    (event) =>
-      ensureSpanState(states, event as object, () =>
-        create(event as StartOf<TChannel>),
-      ).span,
-  );
+  startChannel.bindStore(currentSpanStore, (event) => {
+    const span = ensureSpanState(states, event as object, () =>
+      create(event as StartOf<TChannel>),
+    ).span;
+    return contextManager!.wrapSpanForStore(span);
+  });
 
   return () => {
     startChannel.unbindStore?.(currentSpanStore);

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -414,10 +414,33 @@ export const BRAINTRUST_CURRENT_SPAN_STORE = Symbol.for(
   "braintrust.currentSpanStore",
 );
 
+/**
+ * The type of AsyncLocalStorage exposed via {@link BRAINTRUST_CURRENT_SPAN_STORE}.
+ *
+ * The stored value is intentionally opaque (`unknown`) because the concrete type
+ * depends on the active context manager:
+ * - Default (`BraintrustContextManager`): stores a `Span`
+ * - OTEL compat (`OtelContextManager`): stores an OTEL `Context` object
+ *
+ * TracingChannel's `bindStore` transform (via `wrapSpanForStore`) produces the
+ * correct value type for whichever mode is active.
+ */
+export type CurrentSpanStore = IsoAsyncLocalStorage<unknown>;
+
 export abstract class ContextManager {
   abstract getParentSpanIds(): ContextParentSpanIds | undefined;
   abstract runInContext<R>(span: Span, callback: () => R): R;
   abstract getCurrentSpan(): Span | undefined;
+
+  /**
+   * Returns the value to store in the ALS bound to a TracingChannel's start event.
+   * In default mode this is the Span itself; in OTEL mode it is the OTEL Context
+   * containing the span so that OTEL's own ALS stores a proper Context object.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  wrapSpanForStore(span: Span): unknown {
+    return span;
+  }
 }
 
 class BraintrustContextManager extends ContextManager {


### PR DESCRIPTION
## Problem

When `setupOtelCompat()` is active, `OtelContextManager` did not expose `[BRAINTRUST_CURRENT_SPAN_STORE]`, so `bindCurrentSpanStoreToStart()` silently skipped context binding. Auto-instrumented spans (Anthropic, OpenAI, Google GenAI) had no parent context in OTEL compat mode.

## Solution

Make `ContextManager` a thin abstraction over whichever ALS is in use:

- **`wrapSpanForStore(span)`** added to `ContextManager` base class (default: identity — returns span directly)
- **`OtelContextManager`** overrides with two-mode behavior:
  - **OTEL ALS available** (`AsyncLocalStorageContextManager`): exposes OTEL's internal `_asyncLocalStorage`, `wrapSpanForStore` returns an OTEL `Context` wrapping the span
  - **OTEL ALS unavailable** (`AsyncHooksContextManager`): falls back to its own `IsoAsyncLocalStorage<Span>`, `wrapSpanForStore` returns the span directly — same behavior as `BraintrustContextManager`
- **`bindCurrentSpanStoreToStart`** (and `google-genai-plugin.ts`) call `contextManager.wrapSpanForStore(span)` in the bindStore transform
- `getCurrentSpan()` checks both `otelContext.active().getValue(BT_SPAN_KEY)` and the fallback ALS, so spans propagated by either path are visible

## Additional cleanup

- Extract `buildBtOtelContext()` helper (eliminates 40-line duplication in `runInContext`)
- Unify `BT_SPAN_KEY` / `BT_PARENT_KEY` as module-level constants
- Add `CurrentSpanStore = IsoAsyncLocalStorage<unknown>` type alias
- Export `CurrentSpanStore` from `braintrust` package

## Tests

8 new tests in `otel-compat.test.ts`:
- OTEL ALS exposed via `BRAINTRUST_CURRENT_SPAN_STORE` ✓
- `wrapSpanForStore` returns Context → `currentSpan()` works ✓
- `store.run()` propagation ✓
- Nested runs maintain span chain ✓
- OTEL active span has matching IDs ✓
- `AsyncHooksContextManager` fallback: ALS always exposed ✓
- `AsyncHooksContextManager` fallback: `wrapSpanForStore` returns span directly ✓
- `AsyncHooksContextManager` fallback: `getCurrentSpan()` reads from fallback ALS ✓

All tests pass on both otel-v1 (OTel 1.x) and otel-v2 (OTel 2.x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)