### PR TITLE
fix(auto-instrumentation): Use sync channel for AI SDK CJS streamText/streamObject in v4+

### DIFF
--- a/js/src/auto-instrumentations/configs/ai-sdk.ts
+++ b/js/src/auto-instrumentations/configs/ai-sdk.ts
@@ -70,12 +70,24 @@ export const aiSDKConfigs: InstrumentationConfig[] = [
     channelName: aiSDKChannels.streamText.channelName,
     module: {
       name: "ai",
-      versionRange: ">=3.0.0",
+      versionRange: ">=3.0.0 <4.0.0",
       filePath: "dist/index.js",
     },
     functionQuery: {
       functionName: "streamText",
       kind: "Async",
+    },
+  },
+  {
+    channelName: aiSDKChannels.streamTextSync.channelName,
+    module: {
+      name: "ai",
+      versionRange: ">=4.0.0",
+      filePath: "dist/index.js",
+    },
+    functionQuery: {
+      functionName: "streamText",
+      kind: "Sync",
     },
   },
 
@@ -188,12 +200,24 @@ export const aiSDKConfigs: InstrumentationConfig[] = [
     channelName: aiSDKChannels.streamObject.channelName,
     module: {
       name: "ai",
-      versionRange: ">=3.0.0",
+      versionRange: ">=3.0.0 <4.0.0",
       filePath: "dist/index.js",
     },
     functionQuery: {
       functionName: "streamObject",
       kind: "Async",
+    },
+  },
+  {
+    channelName: aiSDKChannels.streamObjectSync.channelName,
+    module: {
+      name: "ai",
+      versionRange: ">=4.0.0",
+      filePath: "dist/index.js",
+    },
+    functionQuery: {
+      functionName: "streamObject",
+      kind: "Sync",
     },
   },
 


### PR DESCRIPTION
## Summary

- The CJS bundle entries for `streamText` and `streamObject` used `kind: "Async"` for all versions (`>=3.0.0`), but `DefaultStreamTextResult`/`DefaultStreamObjectResult` have no `.then()`, so `asyncEnd` never fires when the transformer wraps via `promise.then()`
- Splits the CJS entries to mirror the existing ESM split (which was already correct in main):
  - `>=3.0.0 <4.0.0`: `kind: "Async"` — v3, where the function was genuinely async
  - `>=4.0.0`: `kind: "Sync"` + sync channel — v4+, after the sync refactor
- The `traceSyncStreamChannel` handlers for `streamTextSync`/`streamObjectSync` already exist in `ai-sdk-plugin.ts` (they were added when the ESM path was fixed), so no plugin change is needed

## Test plan

- [x] `ai-sdk-plugin.test.ts` — 96 tests pass
- [x] Pre-existing test failures in `transformation.test.ts` / `loader-hook.test.ts` confirmed unrelated (same failures on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)