### PR TITLE
chore: Make dependabot less annoying

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,53 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
     versioning-strategy: increase
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3
+      semver-major-days: 14
+    exclude-paths:
+      - "e2e/**"
+      - "js/examples/**"
+      - "js/smoke/**"
+      - "js/tests/**"
+      - "integrations/**/examples/**"
+      - "integrations/**/smoke/**"
+      - "js/src/wrappers/**"
+    groups:
+      production-patch-minor:
+        dependency-type: "production"
+        update-types:
+          - "patch"
+          - "minor"
+      dev-tooling-patch-minor:
+        dependency-type: "development"
+        patterns:
+          - "eslint"
+          - "@typescript-eslint/*"
+          - "prettier"
+          - "turbo"
+          - "typescript"
+          - "tsup"
+          - "tsx"
+          - "vitest"
+          - "vite"
+          - "vite-tsconfig-paths"
+          - "rollup"
+          - "webpack"
+          - "typedoc"
+          - "typedoc-*"
+          - "cross-env"
+        update-types:
+          - "patch"
+          - "minor"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     commit-message:
       prefix: feat
       prefix-development: chore


### PR DESCRIPTION
- Dependabot npm PRs run weekly on Monday 06:00 UTC.
- New releases are delayed: patch/minor by 3 days, majors by 14 days.
- It no longer opens version-update PRs for `e2e`, examples, smoke, `js/tests`, and wrapper test manifests.
- Production dependency patch/minor updates are batched into one PR.
- Selected dev-tooling patch/minor updates are batched into one PR.
- Version-update major bumps are fully suppressed (security updates still separate).