### PR TITLE
test(huggingface): Switch model for newer endpoint

### DIFF
--- a/e2e/scenarios/huggingface-instrumentation/__snapshots__/huggingface-v281.log-payloads.json
+++ b/e2e/scenarios/huggingface-instrumentation/__snapshots__/huggingface-v281.log-payloads.json
@@ -358,7 +358,7 @@
     "metadata": {
       "endpointUrl": "https://router.huggingface.co/featherless-ai/v1/completions",
       "max_tokens": 4,
-      "model": "meta-llama/Llama-3.1-8B",
+      "model": "arcee-ai/Trinity-Large-Thinking",
       "provider": "huggingface"
     },
     "metrics": {
@@ -382,9 +382,9 @@
     "log_id": "g",
     "metrics": {
       "completion_tokens": 4,
-      "prompt_tokens": 5,
+      "prompt_tokens": 6,
       "time_to_first_token": "<number>",
-      "tokens": 9
+      "tokens": 10
     },
     "project_id": "<project_id>",
     "root_span_id": "<span:2>",

--- a/e2e/scenarios/huggingface-instrumentation/__snapshots__/huggingface-v281.span-events.json
+++ b/e2e/scenarios/huggingface-instrumentation/__snapshots__/huggingface-v281.span-events.json
@@ -125,7 +125,7 @@
     "metadata": {
       "endpointUrl": "https://router.huggingface.co/featherless-ai/v1/completions",
       "finish_reason": "length",
-      "model": "meta-llama/Llama-3.1-8B",
+      "model": "arcee-ai/Trinity-Large-Thinking",
       "provider": "huggingface"
     },
     "metric_keys": [

--- a/e2e/scenarios/huggingface-instrumentation/scenario.impl.mjs
+++ b/e2e/scenarios/huggingface-instrumentation/scenario.impl.mjs
@@ -13,6 +13,7 @@ const ROOT_NAME = "huggingface-instrumentation-root";
 const SCENARIO_NAME = "huggingface-instrumentation";
 const TEXT_GENERATION_MODEL = "meta-llama/Llama-3.1-8B";
 const TEXT_GENERATION_PROVIDER = "featherless-ai";
+const V2_TEXT_GENERATION_MODEL = "arcee-ai/Trinity-Large-Thinking";
 const HUGGINGFACE_SCENARIO_TIMEOUT_MS = 150_000;
 const V2_CHAT_ENDPOINT_URL = "https://router.huggingface.co";
 const V2_FEATURE_EXTRACTION_ENDPOINT_URL =
@@ -168,7 +169,7 @@ async function runHuggingFaceInstrumentationScenario(sdk, options = {}) {
                   endpointUrl: V2_TEXT_GENERATION_ENDPOINT_URL,
                   inputs: "The capital of France is",
                   max_tokens: 4,
-                  model: TEXT_GENERATION_MODEL,
+                  model: V2_TEXT_GENERATION_MODEL,
                   prompt: "The capital of France is",
                 }),
           });


### PR DESCRIPTION
Fixes current CI failures because hf for some reason started to return 400s for the llama model with featherless.