### PR TITLE
fix(openai-agents): End child spans on trace end

### DIFF
--- a/.changeset/lazy-dots-send.md
+++ b/.changeset/lazy-dots-send.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+fix(openai-agents): End child spans on trace end

--- a/integrations/openai-agents-js/src/index.ts
+++ b/integrations/openai-agents-js/src/index.ts
@@ -322,6 +322,11 @@ export class OpenAIAgentsTraceProcessor {
     const traceData = this.traceSpans.get(trace.traceId);
 
     if (traceData) {
+      for (const [spanId, braintrustSpan] of traceData.childSpans) {
+        braintrustSpan.end();
+        traceData.childSpans.delete(spanId);
+      }
+
       try {
         traceData.rootSpan.log({
           input: traceData.metadata.firstInput,


### PR DESCRIPTION
Supersedes https://github.com/braintrustdata/braintrust-sdk-javascript/pull/1361

Ends child spans of an openai agents trace before ending the root span - making sure that all the spans in the trace are properly ended.