### PR TITLE
feat: Add per-input `trialCount` support to `Eval()`

### DIFF
--- a/.changeset/ninety-windows-act.md
+++ b/.changeset/ninety-windows-act.md
@@ -1,0 +1,5 @@
+---
+"braintrust": minor
+---
+
+- feat: Add per-input trialCount support to Eval()

--- a/js/src/framework.test.ts
+++ b/js/src/framework.test.ts
@@ -553,6 +553,96 @@ test("trialIndex with multiple inputs", async () => {
   expect(input2Trials).toEqual([0, 1]);
 });
 
+test("per-input trialCount overrides global trialCount", async () => {
+  const trialData: Array<{ input: number; trialIndex: number }> = [];
+
+  const { results } = await runEvaluator(
+    null,
+    {
+      projectName: "proj",
+      evalName: "eval",
+      data: [
+        { input: 1, expected: 2 },
+        { input: 2, expected: 4, trialCount: 5 },
+        { input: 3, expected: 6, trialCount: 1 },
+      ],
+      task: async (input: number, { trialIndex }) => {
+        trialData.push({ input, trialIndex });
+        return input * 2;
+      },
+      scores: [],
+      trialCount: 2,
+    },
+    new NoopProgressReporter(),
+    [],
+    undefined,
+    undefined,
+    true,
+  );
+
+  expect(results).toHaveLength(8);
+  expect(trialData).toHaveLength(8);
+
+  const input1Trials = trialData
+    .filter((d) => d.input === 1)
+    .map((d) => d.trialIndex)
+    .sort();
+  expect(input1Trials).toEqual([0, 1]);
+
+  const input2Trials = trialData
+    .filter((d) => d.input === 2)
+    .map((d) => d.trialIndex)
+    .sort();
+  expect(input2Trials).toEqual([0, 1, 2, 3, 4]);
+
+  const input3Trials = trialData
+    .filter((d) => d.input === 3)
+    .map((d) => d.trialIndex)
+    .sort();
+  expect(input3Trials).toEqual([0]);
+});
+
+test("per-input trialCount works without global trialCount", async () => {
+  const trialData: Array<{ input: number; trialIndex: number }> = [];
+
+  const { results } = await runEvaluator(
+    null,
+    {
+      projectName: "proj",
+      evalName: "eval",
+      data: [
+        { input: 1, expected: 2 },
+        { input: 2, expected: 4, trialCount: 3 },
+      ],
+      task: async (input: number, { trialIndex }) => {
+        trialData.push({ input, trialIndex });
+        return input * 2;
+      },
+      scores: [],
+    },
+    new NoopProgressReporter(),
+    [],
+    undefined,
+    undefined,
+    true,
+  );
+
+  expect(results).toHaveLength(4);
+  expect(trialData).toHaveLength(4);
+
+  const input1Trials = trialData
+    .filter((d) => d.input === 1)
+    .map((d) => d.trialIndex)
+    .sort();
+  expect(input1Trials).toEqual([0]);
+
+  const input2Trials = trialData
+    .filter((d) => d.input === 2)
+    .map((d) => d.trialIndex)
+    .sort();
+  expect(input2Trials).toEqual([0, 1, 2]);
+});
+
 test("Eval with noSendLogs: true runs locally without creating experiment", async () => {
   const memoryLogger = _exportsForTestingOnly.useTestBackgroundLogger();
 

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -1538,7 +1538,7 @@ async function runEvaluatorInternal(
         if (!filters.every((f) => evaluateFilter(datum, f))) {
           continue;
         }
-        const trialCount = evaluator.trialCount ?? 1;
+        const trialCount = datum.trialCount ?? evaluator.trialCount ?? 1;
         for (let trialIndex = 0; trialIndex < trialCount; trialIndex++) {
           if (cancelled) {
             break;

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -5852,6 +5852,8 @@ export type EvalCase<Input, Expected, Metadata> = {
   created?: string | null;
   // This field is used to help re-run a particular experiment row.
   upsert_id?: string;
+  // The number of times to run the evaluator for this specific input.
+  trialCount?: number;
 } & (Expected extends void ? object : { expected: Expected }) &
   (Metadata extends void ? object : { metadata: Metadata });
 


### PR DESCRIPTION
Based on https://github.com/braintrustdata/braintrust-sdk-javascript/pull/1341