### PR TITLE
chore: Fix using github token for github changelog plugin

### DIFF
--- a/.github/workflows/_run-js-release-mode.yaml
+++ b/.github/workflows/_run-js-release-mode.yaml
@@ -108,6 +108,8 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Version packages
         if: steps.plan.outputs.should_run == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: ${{ inputs.version_command }}
       - name: Prepare release manifest
         if: steps.plan.outputs.should_run == 'true'

--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -1,0 +1,33 @@
+name: changeset
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+
+env:
+  HUSKY: "0"
+
+jobs:
+  changeset-required:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .tool-versions
+      - name: Fetch pull request base ref
+        run: git fetch origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+      - name: Enforce changeset requirement for publishable package changes
+        run: node scripts/release/enforce-changeset.mjs

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -81,22 +81,6 @@ jobs:
       - name: Ensure SHA pinned actions
         uses: zgosalvez/github-actions-ensure-sha-pinned-actions@ca46236c6ce584ae24bc6283ba8dcf4b3ec8a066 # v5.0.4
 
-  changeset-required:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version-file: .tool-versions
-      - name: Fetch pull request base ref
-        run: git fetch origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
-      - name: Enforce changeset requirement for publishable package changes
-        run: node scripts/release/enforce-changeset.mjs
-
   js-test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -472,7 +456,6 @@ jobs:
       - check-typings
       - dead-code
       - ensure-pinned-actions
-      - changeset-required
       - js-test
       - js-build
       - e2e-hermetic
@@ -506,7 +489,6 @@ jobs:
           check_result "check-typings" "${{ needs.check-typings.result }}"
           check_result "dead-code" "${{ needs.dead-code.result }}"
           check_result "ensure-pinned-actions" "${{ needs.ensure-pinned-actions.result }}"
-          check_result "changeset-required" "${{ needs.changeset-required.result }}"
           check_result "js-test" "${{ needs.js-test.result }}"
           check_result "js-build" "${{ needs.js-build.result }}"
           check_result "e2e-hermetic" "${{ needs.e2e-hermetic.result }}"

--- a/.github/workflows/publish-js-sdk.yaml
+++ b/.github/workflows/publish-js-sdk.yaml
@@ -59,7 +59,7 @@ jobs:
         id: changesets
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
-          version: pnpm exec changeset version && pnpm install --lockfile-only
+          version: pnpm changeset:version:lockfile
           commit: "[ci] release"
           title: "[ci] release"
         env:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "changeset": "changeset",
     "changeset:status": "changeset status",
     "changeset:version": "changeset version",
+    "changeset:version:lockfile": "changeset version && pnpm install --lockfile-only",
     "playground": "turbo run playground --filter=\"braintrust\"",
     "playground:cli:push": "turbo run playground:cli:push --filter=\"braintrust\"",
     "playground:cli:eval": "turbo run playground:cli:eval --filter=\"braintrust\"",


### PR DESCRIPTION
- One step is calling the changesets GitHub changelog plugin and that requires the github token.
- The changeset action interpreted the && weridly and actually wants a script
- The changeset-required job needs to rerun when a tag is added and removed

Failure run: https://github.com/braintrustdata/braintrust-sdk-javascript/actions/runs/24437145174