### PR TITLE
ci: Skip over skipping release for manual stable release

### DIFF
--- a/.github/workflows/publish-js-sdk.yaml
+++ b/.github/workflows/publish-js-sdk.yaml
@@ -211,7 +211,7 @@ jobs:
         id: detect
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node scripts/release/should-publish-stable.mjs --output .release-manifest.json
+        run: node scripts/release/should-publish-stable.mjs --allow-non-release-head --output .release-manifest.json
       - name: Configure git user
         run: |
           git config user.name "github-actions[bot]"

--- a/scripts/release/push-release-tags.mjs
+++ b/scripts/release/push-release-tags.mjs
@@ -6,10 +6,15 @@ import { appendSummary, parseArgs } from "./_shared.mjs";
 const args = parseArgs();
 const manifestPath = args.manifest ?? ".release-manifest.json";
 const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+const targetCommit = manifest.commit;
 
 if ((manifest.packages ?? []).length === 0) {
   console.log("No release tags to push.");
   process.exit(0);
+}
+
+if (!targetCommit) {
+  throw new Error("Release manifest is missing commit.");
 }
 
 const tags = manifest.packages.map(
@@ -28,13 +33,17 @@ for (const tag of tags) {
 
   if (!localTagExists(tag)) {
     toCreate.push(tag);
+  } else if (getLocalTagTarget(tag) !== targetCommit) {
+    throw new Error(
+      `Local tag ${tag} already exists on ${getLocalTagTarget(tag)}, expected ${targetCommit}.`,
+    );
   }
 
   toPush.push(tag);
 }
 
 for (const tag of toCreate) {
-  execFileSync("git", ["tag", tag], { stdio: "inherit" });
+  execFileSync("git", ["tag", tag, targetCommit], { stdio: "inherit" });
 }
 
 if (toPush.length > 0) {
@@ -63,6 +72,12 @@ function localTagExists(tag) {
       stdio: "ignore",
     }).status === 0
   );
+}
+
+function getLocalTagTarget(tag) {
+  return execFileSync("git", ["rev-list", "-n", "1", tag], {
+    encoding: "utf8",
+  }).trim();
 }
 
 function fetchRemoteTags(tagsToCheck) {

--- a/scripts/release/should-publish-stable.mjs
+++ b/scripts/release/should-publish-stable.mjs
@@ -14,6 +14,7 @@ import {
 
 const args = parseArgs();
 const outputPath = args.output ?? ".release-manifest.json";
+const allowNonReleaseHead = args["allow-non-release-head"] === true;
 const packages = PUBLISHABLE_PACKAGES.map((approved) => {
   const manifest = readPackage(approved.dir);
   const publishedToNpm = isPublishedToNpm(manifest.name, manifest.version);
@@ -31,19 +32,17 @@ const packages = PUBLISHABLE_PACKAGES.map((approved) => {
 });
 
 const actionablePackages = packages.filter((pkg) => pkg.needsPublish);
-const commit = execFileSync("git", ["rev-parse", "HEAD"], {
+const headCommit = execFileSync("git", ["rev-parse", "HEAD"], {
   encoding: "utf8",
 }).trim();
-const commitMessage = execFileSync("git", ["log", "-1", "--pretty=%B"], {
-  encoding: "utf8",
-}).trim();
-const isReleaseCommit = /\[ci\] release/i.test(commitMessage);
-const hasWork = actionablePackages.length > 0 && isReleaseCommit;
+const headIsReleaseCommit = isReleaseCommit(headCommit);
+const hasWork =
+  actionablePackages.length > 0 && (headIsReleaseCommit || allowNonReleaseHead);
 const releasePackages = hasWork ? actionablePackages : [];
 
 const manifest = {
   mode: "stable",
-  commit,
+  commit: headCommit,
   packages: releasePackages,
 };
 
@@ -63,9 +62,10 @@ writeGithubOutput("package_count", releasePackages.length);
 writeGithubOutput("manifest_path", outputPath);
 
 if (!hasWork) {
-  const message = actionablePackages.length
-    ? "Unpublished package versions exist, but HEAD is not a merged Changesets release commit, so stable publish is skipped."
-    : "No stable publish work is required on this main commit.";
+  const message =
+    actionablePackages.length === 0
+      ? "No stable publish work is required on this main commit."
+      : "Unpublished package versions exist, but HEAD is not a merged Changesets release commit, so stable publish is skipped.";
   console.log(message);
   appendSummary(`## Stable publish\n\n${message}`);
   process.exit(0);
@@ -95,4 +95,15 @@ function isPublishedToNpm(name, version) {
   }
 
   return result.stdout.trim() === version;
+}
+
+function isReleaseCommit(commit) {
+  const commitMessage = execFileSync(
+    "git",
+    ["log", "-1", "--pretty=%B", commit],
+    {
+      encoding: "utf8",
+    },
+  ).trim();
+  return /\[ci\] release/i.test(commitMessage);
 }


### PR DESCRIPTION
Annoyingly, releasing was skipped because we didn't run the release from a release commit https://github.com/braintrustdata/braintrust-sdk-javascript/actions/runs/24517456190/job/71665450112#step:7:11