### PR TITLE
chore: Set environment on publish workflow

### DIFF
--- a/.github/workflows/_run-js-release-mode.yaml
+++ b/.github/workflows/_run-js-release-mode.yaml
@@ -49,6 +49,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: npm-publish
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Best guess as to why npm is returning a 404 when releasing,