### PR TITLE
deps: Bump node to `24`

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-nodejs 22.15.0
-npm 11.6.2
+nodejs 24.15.0
+npm 11.12.1
 pnpm 10.33.0
 deno 2.7.6

--- a/mise.toml
+++ b/mise.toml
@@ -8,8 +8,8 @@ experimental = true
 _.file = ".env"
 
 [tools]
-nodejs = "22.15.0"
-npm = "11.11.1"
+nodejs = "24.15.0"
+npm = "11.12.1"
 pnpm = "10.33.0"
 
 [hooks]


### PR DESCRIPTION
This is so that we pull an npm version that is compatible with trusted publishing.