### PR TITLE
fix: Fix export map for bundler plugins

### DIFF
--- a/.changeset/cold-geese-move.md
+++ b/.changeset/cold-geese-move.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+fix: Fix export map for bundler plugins

--- a/js/package.json
+++ b/js/package.json
@@ -79,13 +79,13 @@
       "types": "./dist/auto-instrumentations/bundler/vite.d.ts",
       "import": "./dist/auto-instrumentations/bundler/vite.mjs",
       "module": "./dist/auto-instrumentations/bundler/vite.mjs",
-      "require": "./dist/auto-instrumentations/bundler/vite.js"
+      "require": "./dist/auto-instrumentations/bundler/vite.cjs"
     },
     "./webpack": {
       "types": "./dist/auto-instrumentations/bundler/webpack.d.ts",
       "import": "./dist/auto-instrumentations/bundler/webpack.mjs",
       "module": "./dist/auto-instrumentations/bundler/webpack.mjs",
-      "require": "./dist/auto-instrumentations/bundler/webpack.js"
+      "require": "./dist/auto-instrumentations/bundler/webpack.cjs"
     },
     "./webpack-loader": {
       "types": "./dist/auto-instrumentations/bundler/webpack-loader.d.ts",
@@ -95,13 +95,13 @@
       "types": "./dist/auto-instrumentations/bundler/esbuild.d.ts",
       "import": "./dist/auto-instrumentations/bundler/esbuild.mjs",
       "module": "./dist/auto-instrumentations/bundler/esbuild.mjs",
-      "require": "./dist/auto-instrumentations/bundler/esbuild.js"
+      "require": "./dist/auto-instrumentations/bundler/esbuild.cjs"
     },
     "./rollup": {
       "types": "./dist/auto-instrumentations/bundler/rollup.d.ts",
       "import": "./dist/auto-instrumentations/bundler/rollup.mjs",
       "module": "./dist/auto-instrumentations/bundler/rollup.mjs",
-      "require": "./dist/auto-instrumentations/bundler/rollup.js"
+      "require": "./dist/auto-instrumentations/bundler/rollup.cjs"
     }
   },
   "files": [


### PR DESCRIPTION
Ref https://linear.app/braintrustdata/issue/BT-4857/bundler-plugin-cjs-exports-map-may-be-broken-webpackjs-not-found-at