### PR TITLE
chore: Put `provenance` into `publishConfig` and call `npm publish` directly

### DIFF
--- a/.github/workflows/publish-js-sdk.yaml
+++ b/.github/workflows/publish-js-sdk.yaml
@@ -58,7 +58,8 @@ jobs:
         if: steps.detect.outputs.needs_publish == 'true'
         env:
           NODE_AUTH_TOKEN: ""
-        run: pnpm exec changeset publish
+          NPM_TOKEN: ""
+        run: node scripts/release/publish-release-manifest.mjs --manifest .release-manifest.json
       - name: Push Changesets release tags
         if: steps.detect.outputs.has_work == 'true'
         run: |
@@ -168,7 +169,8 @@ jobs:
         if: steps.manifest.outputs.has_packages == 'true'
         env:
           NODE_AUTH_TOKEN: ""
-        run: pnpm exec changeset publish --tag rc --no-git-tag
+          NPM_TOKEN: ""
+        run: node scripts/release/publish-release-manifest.mjs --manifest .release-manifest.json --tag rc
       - name: Post prerelease to Slack
         if: steps.manifest.outputs.has_packages == 'true'
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1

--- a/integrations/browser-js/package.json
+++ b/integrations/browser-js/package.json
@@ -50,6 +50,7 @@
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
   }
 }

--- a/integrations/langchain-js/package.json
+++ b/integrations/langchain-js/package.json
@@ -58,6 +58,7 @@
   "homepage": "https://www.braintrust.dev/docs",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
   }
 }

--- a/integrations/openai-agents-js/package.json
+++ b/integrations/openai-agents-js/package.json
@@ -45,6 +45,7 @@
   "homepage": "https://www.braintrust.dev/docs",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
   }
 }

--- a/integrations/otel-js/package.json
+++ b/integrations/otel-js/package.json
@@ -64,6 +64,7 @@
   "homepage": "https://www.braintrust.dev/docs",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
   }
 }

--- a/integrations/templates-nunjucks/package.json
+++ b/integrations/templates-nunjucks/package.json
@@ -48,6 +48,7 @@
   "homepage": "https://www.braintrust.dev/docs",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
   }
 }

--- a/integrations/temporal-js/package.json
+++ b/integrations/temporal-js/package.json
@@ -77,6 +77,7 @@
   "homepage": "https://www.braintrust.dev/docs",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
   }
 }

--- a/integrations/vercel-ai-sdk/package.json
+++ b/integrations/vercel-ai-sdk/package.json
@@ -45,6 +45,7 @@
   "homepage": "https://www.braintrust.dev/docs",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
   }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -232,6 +232,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
   }
 }

--- a/scripts/release/publish-release-manifest.mjs
+++ b/scripts/release/publish-release-manifest.mjs
@@ -1,0 +1,102 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+import { parseArgs, readPackage, repoPath } from "./_shared.mjs";
+
+const args = parseArgs();
+const manifestPath = args.manifest ?? ".release-manifest.json";
+const npmTag = args.tag;
+
+const manifest = JSON.parse(readFileSync(repoPath(manifestPath), "utf8"));
+const packages = orderPackagesForPublish(manifest.packages ?? []);
+
+if (packages.length === 0) {
+  console.log(`No packages to publish from ${manifestPath}.`);
+  process.exit(0);
+}
+
+for (const pkg of packages) {
+  const packageDir = repoPath(pkg.dir);
+  const packageJson = readPackage(pkg.dir);
+  const publishArgs = ["publish"];
+
+  if (packageJson.publishConfig?.access) {
+    publishArgs.push("--access", packageJson.publishConfig.access);
+  }
+
+  if (npmTag) {
+    publishArgs.push("--tag", npmTag);
+  }
+
+  console.log(
+    `Publishing ${packageJson.name}@${packageJson.version} from ${pkg.dir} with npm`,
+  );
+
+  execFileSync("npm", publishArgs, {
+    cwd: packageDir,
+    stdio: "inherit",
+  });
+}
+
+function orderPackagesForPublish(packages) {
+  const packageMap = new Map(
+    packages.map((pkg) => [
+      pkg.name,
+      { ...pkg, manifest: readPackage(pkg.dir) },
+    ]),
+  );
+  const visiting = new Set();
+  const visited = new Set();
+  const ordered = [];
+
+  for (const pkg of packageMap.values()) {
+    visit(pkg);
+  }
+
+  return ordered.map(({ manifest: _manifest, ...pkg }) => pkg);
+
+  function visit(pkg) {
+    if (visited.has(pkg.name)) {
+      return;
+    }
+
+    if (visiting.has(pkg.name)) {
+      throw new Error(
+        `Detected a publish dependency cycle involving ${pkg.name}`,
+      );
+    }
+
+    visiting.add(pkg.name);
+
+    for (const dependencyName of getWorkspaceReleaseDependencies(
+      pkg.manifest,
+    )) {
+      const dependency = packageMap.get(dependencyName);
+      if (dependency) {
+        visit(dependency);
+      }
+    }
+
+    visiting.delete(pkg.name);
+    visited.add(pkg.name);
+    ordered.push(pkg);
+  }
+}
+
+function getWorkspaceReleaseDependencies(manifest) {
+  const dependencyNames = new Set();
+
+  for (const field of [
+    "dependencies",
+    "optionalDependencies",
+    "peerDependencies",
+    "devDependencies",
+  ]) {
+    for (const dependencyName of Object.keys(manifest[field] ?? {})) {
+      dependencyNames.add(dependencyName);
+    }
+  }
+
+  dependencyNames.delete(manifest.name);
+  return dependencyNames;
+}

--- a/scripts/release/validate-publishable-packages.mjs
+++ b/scripts/release/validate-publishable-packages.mjs
@@ -92,6 +92,12 @@ function validatePublishablePackage(workspaceDir, manifest) {
     );
   }
 
+  if (manifest.publishConfig?.provenance !== true) {
+    errors.push(
+      `${workspaceDir} (${manifest.name}) must set publishConfig.provenance to true`,
+    );
+  }
+
   if (manifest.repository?.url !== GITHUB_REPO_URL) {
     errors.push(
       `${workspaceDir} (${manifest.name}) must point repository.url at ${GITHUB_REPO_URL}`,


### PR DESCRIPTION
Just throwing stuff at the wall now tbh. Currently fighting ENEEDAUTH: https://github.com/braintrustdata/braintrust-sdk-javascript/actions/runs/24687031527/job/72198977988