### PR TITLE
chore: Fix ci git error

### DIFF
--- a/.github/workflows/prepare-js-release.yaml
+++ b/.github/workflows/prepare-js-release.yaml
@@ -46,7 +46,7 @@ jobs:
         run: |
           main_sha="$(git rev-parse HEAD)"
           short_main_sha="$(git rev-parse --short=12 HEAD)"
-          release_branch="release/${short_main_sha}"
+          release_branch="prepare-release/${short_main_sha}"
 
           {
             echo "main_sha=$main_sha"


### PR DESCRIPTION
Fix: https://github.com/braintrustdata/braintrust-sdk-javascript/actions/runs/24690176706/job/72209768755 (` ! [remote rejected]   HEAD -> release/c1428905886e (directory file conflict)
`)