### PR TITLE
fix(auto-instrumentation): Skip over file transforms in bundler plugins when `id` is undefined

### DIFF
--- a/.changeset/chilly-sites-greet.md
+++ b/.changeset/chilly-sites-greet.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+fix(auto-instrumentation): Skip over file transforms in bundler plugins when id is undefined

--- a/js/src/auto-instrumentations/bundler/plugin.ts
+++ b/js/src/auto-instrumentations/bundler/plugin.ts
@@ -94,6 +94,11 @@ export const unplugin = createUnplugin<BundlerPluginOptions>((options = {}) => {
     name: "code-transformer",
     enforce: "pre",
     transform(code: string, id: string) {
+      if (!id) {
+        // Some modules apparently don't have an id?
+        return null;
+      }
+
       // Convert file:// URLs to regular paths at entry point
       // Node.js ESM loader hooks provide file:// URLs, but downstream code expects paths
       const filePath = id.startsWith("file:") ? fileURLToPath(id) : id;


### PR DESCRIPTION
Ref https://linear.app/braintrustdata/issue/BT-4861/webpackplugin-crashes-on-nextjs-15-with-typeerror-cannot-read