### PR TITLE
Add support for nodejs 24 stacktraces

### DIFF
--- a/js/src/stackutil.test.ts
+++ b/js/src/stackutil.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "vitest";
+import {
+  callerFromAnonymousFunction,
+  callerFromModuleInit,
+  callerFromNamedFunction,
+} from "../tests/helpers/stackutil-caller";
+
+function normalizeFileName(fileName: string) {
+  return fileName.replace(/^file:\/\//, "");
+}
+
+test("getCallerLocation works with a real top-level caller frame", () => {
+  expect(callerFromModuleInit).toBeDefined();
+  expect(callerFromModuleInit!.caller_lineno).toBeGreaterThan(1);
+  expect(normalizeFileName(callerFromModuleInit!.caller_filename)).toMatch(
+    /tests[\\/]helpers[\\/]stackutil-caller\.(ts|js)$/,
+  );
+});
+
+test("getCallerLocation works with a real named function caller frame", () => {
+  const location = callerFromNamedFunction();
+  expect(location).toBeDefined();
+  expect(location!.caller_lineno).toBeGreaterThan(1);
+  expect(normalizeFileName(location!.caller_filename)).toMatch(
+    /tests[\\/]helpers[\\/]stackutil-caller\.(ts|js)$/,
+  );
+  expect(location!.caller_functionname).toContain("callerFromNamedFunction");
+});
+
+test("getCallerLocation works with a real anonymous function caller frame", () => {
+  const location = callerFromAnonymousFunction();
+  expect(location).toBeDefined();
+  expect(location!.caller_lineno).toBeGreaterThan(1);
+  expect(normalizeFileName(location!.caller_filename)).toMatch(
+    /tests[\\/]helpers[\\/]stackutil-caller\.(ts|js)$/,
+  );
+});

--- a/js/src/stackutil.ts
+++ b/js/src/stackutil.ts
@@ -22,7 +22,7 @@ function getStackTrace(): StackTraceEntry[] {
     const entry: StackTraceEntry = {
       functionName: matches[1]?.trim() ?? "",
       fileName: matches[2],
-      lineNo: parseInt(matches[3], 10),
+      lineNo: parseInt(matches[3]),
     };
     if (!isNaN(entry.lineNo)) {
       out.push(entry);

--- a/js/src/stackutil.ts
+++ b/js/src/stackutil.ts
@@ -13,16 +13,16 @@ function getStackTrace(): StackTraceEntry[] {
   }
   const traceLines = trace.split("\n");
   const out: StackTraceEntry[] = [];
-  const stackFrameRegex = /at(.*)\((.*):(\d+):(\d+)\)/;
+  const stackFrameRegex = /^\s*at\s+(?:(.+?)\s+\()?(.*):(\d+):(\d+)\)?\s*$/;
   for (const traceLine of traceLines.slice(1)) {
     const matches = traceLine.match(stackFrameRegex);
     if (matches === null || matches.length !== 5) {
       continue;
     }
     const entry: StackTraceEntry = {
-      functionName: matches[1].trim(),
+      functionName: matches[1]?.trim() ?? "",
       fileName: matches[2],
-      lineNo: parseInt(matches[3]),
+      lineNo: parseInt(matches[3], 10),
     };
     if (!isNaN(entry.lineNo)) {
       out.push(entry);

--- a/js/tests/helpers/stackutil-caller.ts
+++ b/js/tests/helpers/stackutil-caller.ts
@@ -1,0 +1,14 @@
+import { configureNode } from "../../src/node/config";
+import { getCallerLocation } from "../../src/stackutil";
+
+configureNode();
+
+export const callerFromModuleInit = getCallerLocation();
+
+export function callerFromNamedFunction() {
+  return getCallerLocation();
+}
+
+export function callerFromAnonymousFunction() {
+  return (() => getCallerLocation())();
+}


### PR DESCRIPTION
Nodejs 24 pulled in v8 updates that changed how stack traces are reported.

Before:
```
Error: Something went wrong
    at c (/app/index.js:10:9)
    at b (/app/index.js:6:3)
    at a (/app/index.js:2:3)
    at Object.<anonymous> (/app/index.js:13:1)
    at Module._compile (node:internal/modules/cjs/loader:1256:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
```

Node24:

```
Error: Something went wrong
    at c (file:///app/index.js:10:9)
    at b (file:///app/index.js:6:3)
    at a (file:///app/index.js:2:3)
    at file:///app/index.js:13:1
    at Module._compile (node:internal/modules/cjs/loader:1256:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at executeUserEntryPoint (node:internal/modules/run_main:81:12)
```

