### PR TITLE
chore: Bump `@braintrust/browser` to `0.0.3`

### DIFF
--- a/integrations/browser-js/package.json
+++ b/integrations/browser-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@braintrust/browser",
-  "version": "0.0.2-rc.4",
+  "version": "0.0.3",
   "description": "Braintrust SDK for browser environments with AsyncLocalStorage polyfill",
   "type": "module",
   "module": "./dist/index.js",


### PR DESCRIPTION
It being a prerelease actually tripped up our release process because we didn't define a tag. In general we should probably not have rc versions in the package jsons too.