### PR TITLE
fix(cli): Use correct filename for eval.js

### DIFF
--- a/.changeset/fuzzy-evals-warn.md
+++ b/.changeset/fuzzy-evals-warn.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+fix: Correct the eval file extension shown in CLI directory warnings

--- a/js/src/cli/index.ts
+++ b/js/src/cli/index.ts
@@ -719,7 +719,7 @@ async function collectFiles(
       console.warn(
         warning(
           `Reading ${inputPath} because it was specified directly. Rename it to end in ${prefix}.ts or ` +
-            `.${prefix}.js to include it automatically when you specify a directory.`,
+            `${prefix}.js to include it automatically when you specify a directory.`,
         ),
       );
     }


### PR DESCRIPTION
`..eval.js` -> `.eval.js`