### PR TITLE
feat: Add auto and wrapper instrumentation for @github/copilot-sdk

### DIFF
--- a/.changeset/brave-copilot-trace.md
+++ b/.changeset/brave-copilot-trace.md
@@ -1,5 +1,0 @@
----
-"braintrust": minor
----
-
-feat: Add auto and wrapper instrumentation for `@github/copilot-sdk`

--- a/.changeset/brave-copilot-trace.md
+++ b/.changeset/brave-copilot-trace.md
@@ -1,0 +1,5 @@
+---
+"braintrust": minor
+---
+
+feat: Add auto and wrapper instrumentation for `@github/copilot-sdk`

--- a/.changeset/bright-cups-float.md
+++ b/.changeset/bright-cups-float.md
@@ -1,0 +1,5 @@
+---
+"braintrust": minor
+---
+
+feat: Add auto and wrapper instrumentation for `@github/copilot-sdk`

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -59,6 +59,7 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
+      COPILOT_API_KEY: ${{ secrets.COPILOT_API_KEY }}
       CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -112,6 +113,7 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
+      COPILOT_API_KEY: ${{ secrets.COPILOT_API_KEY }}
       CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/e2e/config/pr-comment-scenarios.json
+++ b/e2e/config/pr-comment-scenarios.json
@@ -139,5 +139,14 @@
     "label": "Cursor SDK Instrumentation",
     "metadataScenario": "cursor-sdk-instrumentation",
     "variants": [{ "variantKey": "cursor-sdk-v1", "label": "v1" }]
+  },
+  {
+    "scenarioDirName": "github-copilot-instrumentation",
+    "label": "GitHub Copilot SDK Instrumentation",
+    "metadataScenario": "github-copilot-instrumentation",
+    "variants": [
+      { "variantKey": "github-copilot-v0-wrapped", "label": "Wrapped" },
+      { "variantKey": "github-copilot-v0-auto", "label": "Auto-hook" }
+    ]
   }
 ]

--- a/e2e/scenarios/github-copilot-instrumentation/assertions.ts
+++ b/e2e/scenarios/github-copilot-instrumentation/assertions.ts
@@ -1,0 +1,243 @@
+import { beforeAll, describe, expect, test } from "vitest";
+import { normalizeForSnapshot, type Json } from "../../helpers/normalize";
+import type { CapturedLogEvent } from "../../helpers/mock-braintrust-server";
+import {
+  formatJsonFileSnapshot,
+  resolveFileSnapshotPath,
+} from "../../helpers/file-snapshot";
+import { withScenarioHarness } from "../../helpers/scenario-harness";
+import { findChildSpans, findLatestSpan } from "../../helpers/trace-selectors";
+import { summarizeWrapperContract } from "../../helpers/wrapper-contract";
+import { ROOT_NAME, SCENARIO_NAME } from "./constants.mjs";
+
+type RunCopilotScenario = (harness: {
+  runNodeScenarioDir: (options: {
+    entry: string;
+    nodeArgs: string[];
+    runContext?: { variantKey: string };
+    scenarioDir: string;
+    timeoutMs: number;
+  }) => Promise<unknown>;
+  runScenarioDir: (options: {
+    entry: string;
+    runContext?: { variantKey: string };
+    scenarioDir: string;
+    timeoutMs: number;
+  }) => Promise<unknown>;
+}) => Promise<void>;
+
+const SNAPSHOT_METADATA_KEYS = [
+  "model",
+  "scenario",
+  "github_copilot.model",
+  "github_copilot.provider_type",
+  "github_copilot.end_reason",
+  "gen_ai.tool.name",
+  "gen_ai.tool.call.id",
+  "mcp.server",
+  "github_copilot.agent_name",
+] as const;
+
+function summarizeSpan(event: CapturedLogEvent | undefined): Json {
+  if (!event) {
+    return null;
+  }
+
+  const summary = summarizeWrapperContract(event, [
+    ...SNAPSHOT_METADATA_KEYS,
+  ]) as Record<string, Json>;
+
+  // Normalize non-deterministic IDs in metadata
+  if (summary.metadata && typeof summary.metadata === "object") {
+    const metadata = summary.metadata as Record<string, Json>;
+    if (typeof metadata["gen_ai.tool.call.id"] === "string") {
+      metadata["gen_ai.tool.call.id"] = "<tool-call-id>";
+    }
+  }
+
+  return summary;
+}
+
+function buildSpanSummary(events: CapturedLogEvent[]): Json {
+  const root = findLatestSpan(events, ROOT_NAME);
+  const basicOperation = findLatestSpan(
+    events,
+    "github-copilot-basic-operation",
+  );
+  const toolOperation = findLatestSpan(events, "github-copilot-tool-operation");
+
+  const basicSession = findChildSpans(
+    events,
+    "Copilot Session",
+    basicOperation?.span.id,
+  ).at(-1);
+  const toolSession = findChildSpans(
+    events,
+    "Copilot Session",
+    toolOperation?.span.id,
+  ).at(-1);
+
+  const basicTurn = findChildSpans(
+    events,
+    "Copilot Turn",
+    basicSession?.span.id,
+  ).at(-1);
+  const toolTurn = findChildSpans(
+    events,
+    "Copilot Turn",
+    toolSession?.span.id,
+  ).at(-1);
+
+  const basicLlm = findChildSpans(
+    events,
+    "github.copilot.llm",
+    basicTurn?.span.id,
+  ).at(-1);
+
+  const toolLlm = findChildSpans(
+    events,
+    "github.copilot.llm",
+    toolTurn?.span.id,
+  ).at(-1);
+
+  const toolSpan = events.find(
+    (event) =>
+      event.span.type === "tool" &&
+      (event.span.parentIds.includes(toolTurn?.span.id ?? "") ||
+        event.span.parentIds.includes(toolSession?.span.id ?? "")),
+  );
+
+  return normalizeForSnapshot({
+    root: summarizeSpan(root),
+    basic: {
+      operation: summarizeSpan(basicOperation),
+      session: summarizeSpan(basicSession),
+      turn: summarizeSpan(basicTurn),
+      llm: summarizeSpan(basicLlm),
+    },
+    tool: {
+      operation: summarizeSpan(toolOperation),
+      session: summarizeSpan(toolSession),
+      turn: summarizeSpan(toolTurn),
+      llm: summarizeSpan(toolLlm),
+      tool: summarizeSpan(toolSpan),
+    },
+  } as Json);
+}
+
+export function defineGitHubCopilotInstrumentationAssertions(options: {
+  name: string;
+  runScenario: RunCopilotScenario;
+  snapshotName: string;
+  testFileUrl: string;
+  timeoutMs: number;
+}): void {
+  const snapshotPath = resolveFileSnapshotPath(
+    options.testFileUrl,
+    `${options.snapshotName}.span-events.json`,
+  );
+  const testConfig = { timeout: options.timeoutMs };
+
+  describe(options.name, () => {
+    let events: CapturedLogEvent[] = [];
+
+    beforeAll(async () => {
+      await withScenarioHarness(async (harness) => {
+        await options.runScenario(harness);
+        events = harness.events();
+      });
+    }, options.timeoutMs);
+
+    test("captures the root trace", testConfig, () => {
+      const root = findLatestSpan(events, ROOT_NAME);
+      expect(root).toBeDefined();
+      expect(root?.row.metadata).toMatchObject({ scenario: SCENARIO_NAME });
+    });
+
+    test(
+      "captures session and turn spans for basic operation",
+      testConfig,
+      () => {
+        const operation = findLatestSpan(
+          events,
+          "github-copilot-basic-operation",
+        );
+        const session = findChildSpans(
+          events,
+          "Copilot Session",
+          operation?.span.id,
+        ).at(-1);
+        const turn = findChildSpans(
+          events,
+          "Copilot Turn",
+          session?.span.id,
+        ).at(-1);
+
+        expect(operation).toBeDefined();
+        expect(session).toBeDefined();
+        expect(session?.span.type).toBe("task");
+        expect(turn).toBeDefined();
+        expect(turn?.span.type).toBe("task");
+      },
+    );
+
+    test(
+      "captures LLM span with metrics for basic operation",
+      testConfig,
+      () => {
+        const session = findChildSpans(
+          events,
+          "Copilot Session",
+          findLatestSpan(events, "github-copilot-basic-operation")?.span.id,
+        ).at(-1);
+        const turn = findChildSpans(
+          events,
+          "Copilot Turn",
+          session?.span.id,
+        ).at(-1);
+        const llm = findChildSpans(
+          events,
+          "github.copilot.llm",
+          turn?.span.id,
+        ).at(-1);
+
+        expect(llm).toBeDefined();
+        expect(llm?.span.type).toBe("llm");
+        expect(llm?.row.metadata).toMatchObject({
+          model: expect.any(String),
+        });
+        expect(llm?.metrics?.prompt_tokens).toBeGreaterThan(0);
+        expect(llm?.metrics?.completion_tokens).toBeGreaterThan(0);
+        expect(llm?.metrics?.tokens).toBeGreaterThan(0);
+      },
+    );
+
+    test("captures tool span for tool-using operation", testConfig, () => {
+      const session = findChildSpans(
+        events,
+        "Copilot Session",
+        findLatestSpan(events, "github-copilot-tool-operation")?.span.id,
+      ).at(-1);
+      const turn = findChildSpans(events, "Copilot Turn", session?.span.id).at(
+        -1,
+      );
+
+      const toolSpan = events.find(
+        (event) =>
+          event.span.type === "tool" &&
+          (event.span.name?.includes("get_weather") ?? false) &&
+          (event.span.parentIds.includes(turn?.span.id ?? "") ||
+            event.span.parentIds.includes(session?.span.id ?? "")),
+      );
+
+      expect(toolSpan).toBeDefined();
+      expect(toolSpan?.span.type).toBe("tool");
+    });
+
+    test("matches the span snapshot", testConfig, async () => {
+      await expect(
+        formatJsonFileSnapshot(buildSpanSummary(events)),
+      ).toMatchFileSnapshot(snapshotPath);
+    });
+  });
+}

--- a/e2e/scenarios/github-copilot-instrumentation/constants.mjs
+++ b/e2e/scenarios/github-copilot-instrumentation/constants.mjs
@@ -1,0 +1,4 @@
+export const CHAT_MODEL = "gpt-4.1";
+export const ROOT_NAME = "github-copilot-instrumentation-root";
+export const SCENARIO_NAME = "github-copilot-instrumentation";
+export const GITHUB_COPILOT_SCENARIO_TIMEOUT_MS = 180_000;

--- a/e2e/scenarios/github-copilot-instrumentation/package.json
+++ b/e2e/scenarios/github-copilot-instrumentation/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@braintrust/e2e-github-copilot-instrumentation",
+  "private": true,
+  "braintrustScenario": {
+    "canary": {
+      "dependencies": {
+        "@github/copilot-sdk": "latest"
+      }
+    }
+  },
+  "dependencies": {
+    "@github/copilot-sdk": "0.3.0"
+  }
+}

--- a/e2e/scenarios/github-copilot-instrumentation/package.json
+++ b/e2e/scenarios/github-copilot-instrumentation/package.json
@@ -9,6 +9,7 @@
     }
   },
   "dependencies": {
-    "@github/copilot-sdk": "0.3.0"
+    "@github/copilot-sdk": "0.3.0",
+    "vscode-jsonrpc": "8.2.1"
   }
 }

--- a/e2e/scenarios/github-copilot-instrumentation/pnpm-lock.yaml
+++ b/e2e/scenarios/github-copilot-instrumentation/pnpm-lock.yaml
@@ -1,0 +1,22 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@github/copilot-sdk':
+        specifier: 0.3.0
+        version: 0.3.0
+
+packages:
+
+  '@github/copilot-sdk@0.3.0':
+    resolution: {integrity: sha512-SUo35k56pzzgYgwmDPHcu7kZxPrzXbH66IWXaEf6pmb94DlA709F82HrrDeja087TL4djJ9OuvRFWWOKCosAsg==}
+
+snapshots:
+
+  '@github/copilot-sdk@0.3.0': {}

--- a/e2e/scenarios/github-copilot-instrumentation/pnpm-lock.yaml
+++ b/e2e/scenarios/github-copilot-instrumentation/pnpm-lock.yaml
@@ -11,12 +11,98 @@ importers:
       '@github/copilot-sdk':
         specifier: 0.3.0
         version: 0.3.0
+      vscode-jsonrpc:
+        specifier: 8.2.1
+        version: 8.2.1
 
 packages:
 
+  '@github/copilot-darwin-arm64@1.0.42':
+    resolution: {integrity: sha512-2w89QLRgMR7hWwV1KG3uXqu98WST6afJCfvtYtqvPdf6ZQC7Fj2HhPNCrMxZk/H8mZwTgYJeg30gZjvV1698EA==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@github/copilot-darwin-x64@1.0.42':
+    resolution: {integrity: sha512-G2//tgGSKXx3ZGMqe774UnewasYMh+j0ZeQ3injtuZpSpzN+OAuNkzwXpvFHprdbgekMb0oAPN+Xm3rHuQY8Xw==}
+    cpu: [x64]
+    os: [darwin]
+    hasBin: true
+
+  '@github/copilot-linux-arm64@1.0.42':
+    resolution: {integrity: sha512-Ai6J4hUKVuE5ztsLspp/I7ByXtL2V6tF+AOn0q+hHp1MOA5JLq5/G8PE+c0VzG69x4hkt1lROQDjvXJGY7sv+g==}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
+  '@github/copilot-linux-x64@1.0.42':
+    resolution: {integrity: sha512-yYfuL6Hk3uLQuIgfxpEMCyoowFq2Bew1EaXmvg4lnDjj95tvEmyMCX77aIZ2AKwBOgp1nMV7L1B1QL9/mw6BTA==}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+
   '@github/copilot-sdk@0.3.0':
     resolution: {integrity: sha512-SUo35k56pzzgYgwmDPHcu7kZxPrzXbH66IWXaEf6pmb94DlA709F82HrrDeja087TL4djJ9OuvRFWWOKCosAsg==}
+    engines: {node: '>=20.0.0'}
+
+  '@github/copilot-win32-arm64@1.0.42':
+    resolution: {integrity: sha512-WgnV6AxsvbvZdNW/42JFikK/SqR1JMw6juRpGKXZr70ond/cHK6trtrmt3dXYPymBO14ppJMFdm4+chJzKGKMw==}
+    cpu: [arm64]
+    os: [win32]
+    hasBin: true
+
+  '@github/copilot-win32-x64@1.0.42':
+    resolution: {integrity: sha512-J5jtrcYuODuD4LPPRHjOCMJGO6+vKZ71n8PTiHPCg9lpfThXDDXxrB7nDDkhxl23zSXlUrpWwkMI+a2Ax/AxGg==}
+    cpu: [x64]
+    os: [win32]
+    hasBin: true
+
+  '@github/copilot@1.0.42':
+    resolution: {integrity: sha512-ODW5+aJi595Tb2WUaAlshBoUkOBuh9MegXXwXzMoar+k9fZzzDy3oNJLFg7ni4UtkUZvj/WL/y3s5O+FlsF2HA==}
+    hasBin: true
+
+  vscode-jsonrpc@8.2.1:
+    resolution: {integrity: sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==}
+    engines: {node: '>=14.0.0'}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
-  '@github/copilot-sdk@0.3.0': {}
+  '@github/copilot-darwin-arm64@1.0.42':
+    optional: true
+
+  '@github/copilot-darwin-x64@1.0.42':
+    optional: true
+
+  '@github/copilot-linux-arm64@1.0.42':
+    optional: true
+
+  '@github/copilot-linux-x64@1.0.42':
+    optional: true
+
+  '@github/copilot-sdk@0.3.0':
+    dependencies:
+      '@github/copilot': 1.0.42
+      vscode-jsonrpc: 8.2.1
+      zod: 4.4.3
+
+  '@github/copilot-win32-arm64@1.0.42':
+    optional: true
+
+  '@github/copilot-win32-x64@1.0.42':
+    optional: true
+
+  '@github/copilot@1.0.42':
+    optionalDependencies:
+      '@github/copilot-darwin-arm64': 1.0.42
+      '@github/copilot-darwin-x64': 1.0.42
+      '@github/copilot-linux-arm64': 1.0.42
+      '@github/copilot-linux-x64': 1.0.42
+      '@github/copilot-win32-arm64': 1.0.42
+      '@github/copilot-win32-x64': 1.0.42
+
+  vscode-jsonrpc@8.2.1: {}
+
+  zod@4.4.3: {}

--- a/e2e/scenarios/github-copilot-instrumentation/scenario.impl.mjs
+++ b/e2e/scenarios/github-copilot-instrumentation/scenario.impl.mjs
@@ -1,0 +1,124 @@
+import { wrapCopilotClient } from "braintrust";
+import {
+  runOperation,
+  runTracedScenario,
+} from "../../helpers/provider-runtime.mjs";
+import {
+  CHAT_MODEL,
+  GITHUB_COPILOT_SCENARIO_TIMEOUT_MS,
+  ROOT_NAME,
+  SCENARIO_NAME,
+} from "./constants.mjs";
+
+export { GITHUB_COPILOT_SCENARIO_TIMEOUT_MS };
+
+function getGitHubToken() {
+  return process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+}
+
+function getMockBaseUrl() {
+  return process.env.BRAINTRUST_E2E_MODEL_BASE_URL;
+}
+
+function buildProvider() {
+  const mockBaseUrl = getMockBaseUrl();
+  if (mockBaseUrl) {
+    // BYOK mode: point the Copilot CLI at a mock/local OpenAI-compatible server
+    return {
+      type: "openai",
+      baseUrl: mockBaseUrl,
+      apiKey: "test-key",
+    };
+  }
+
+  // No provider override — use default GitHub Copilot auth
+  return undefined;
+}
+
+async function runCopilotSession(options, decorateClient) {
+  const { CopilotClient, approveAll, defineTool } = options;
+
+  const githubToken = getGitHubToken();
+  if (!githubToken && !getMockBaseUrl()) {
+    throw new Error(
+      "Either GITHUB_TOKEN or BRAINTRUST_E2E_MODEL_BASE_URL must be set for the GitHub Copilot SDK e2e test",
+    );
+  }
+
+  const baseClient = new CopilotClient(
+    githubToken ? { gitHubToken: githubToken } : {},
+  );
+  const client = decorateClient ? decorateClient(baseClient) : baseClient;
+
+  const provider = buildProvider();
+
+  const getWeather = defineTool("get_weather", {
+    description: "Get current weather for a city",
+    parameters: {
+      type: "object",
+      properties: {
+        city: { type: "string", description: "City name" },
+      },
+      required: ["city"],
+    },
+    handler: async ({ city }) => {
+      return `The weather in ${city} is 72°F and sunny.`;
+    },
+    skipPermission: true,
+  });
+
+  await runTracedScenario({
+    callback: async () => {
+      // Basic turn operation
+      await runOperation(
+        "github-copilot-basic-operation",
+        "basic",
+        async () => {
+          const session = await client.createSession({
+            model: CHAT_MODEL,
+            onPermissionRequest: approveAll,
+            ...(provider ? { provider } : {}),
+          });
+
+          await session.sendAndWait({
+            prompt: "Reply with exactly: OK",
+          });
+
+          await session.disconnect();
+        },
+      );
+
+      // Tool-using operation
+      await runOperation("github-copilot-tool-operation", "tool", async () => {
+        const session = await client.createSession({
+          model: CHAT_MODEL,
+          onPermissionRequest: approveAll,
+          tools: [getWeather],
+          ...(provider ? { provider } : {}),
+        });
+
+        await session.sendAndWait({
+          prompt:
+            "What is the weather in Tokyo? Use the get_weather tool and report the result.",
+        });
+
+        await session.disconnect();
+      });
+    },
+    metadata: {
+      scenario: SCENARIO_NAME,
+    },
+    projectNameBase: "e2e-github-copilot-instrumentation",
+    rootName: ROOT_NAME,
+  });
+
+  await client.stop();
+}
+
+export async function runCopilotWrappedInstrumentation(options) {
+  await runCopilotSession(options, wrapCopilotClient);
+}
+
+export async function runCopilotAutoInstrumentation(options) {
+  await runCopilotSession(options, null);
+}

--- a/e2e/scenarios/github-copilot-instrumentation/scenario.impl.mjs
+++ b/e2e/scenarios/github-copilot-instrumentation/scenario.impl.mjs
@@ -13,7 +13,7 @@ import {
 export { GITHUB_COPILOT_SCENARIO_TIMEOUT_MS };
 
 function getGitHubToken() {
-  return process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  return process.env.COPILOT_API_KEY;
 }
 
 function getMockBaseUrl() {
@@ -41,7 +41,7 @@ async function runCopilotSession(options, decorateClient) {
   const githubToken = getGitHubToken();
   if (!githubToken && !getMockBaseUrl()) {
     throw new Error(
-      "Either GITHUB_TOKEN or BRAINTRUST_E2E_MODEL_BASE_URL must be set for the GitHub Copilot SDK e2e test",
+      "Either COPILOT_API_KEY or BRAINTRUST_E2E_MODEL_BASE_URL must be set for the GitHub Copilot SDK e2e test",
     );
   }
 

--- a/e2e/scenarios/github-copilot-instrumentation/scenario.mjs
+++ b/e2e/scenarios/github-copilot-instrumentation/scenario.mjs
@@ -1,0 +1,11 @@
+import { CopilotClient, approveAll, defineTool } from "@github/copilot-sdk";
+import { runMain } from "../../helpers/provider-runtime.mjs";
+import { runCopilotAutoInstrumentation } from "./scenario.impl.mjs";
+
+runMain(async () => {
+  await runCopilotAutoInstrumentation({
+    CopilotClient,
+    approveAll,
+    defineTool,
+  });
+});

--- a/e2e/scenarios/github-copilot-instrumentation/scenario.test.ts
+++ b/e2e/scenarios/github-copilot-instrumentation/scenario.test.ts
@@ -1,0 +1,49 @@
+import { describe } from "vitest";
+import {
+  prepareScenarioDir,
+  readInstalledPackageVersion,
+  resolveScenarioDir,
+} from "../../helpers/scenario-harness";
+import { defineGitHubCopilotInstrumentationAssertions } from "./assertions";
+import { GITHUB_COPILOT_SCENARIO_TIMEOUT_MS } from "./constants.mjs";
+
+const scenarioDir = await prepareScenarioDir({
+  scenarioDir: resolveScenarioDir(import.meta.url),
+});
+const copilotSdkVersion = await readInstalledPackageVersion(
+  scenarioDir,
+  "@github/copilot-sdk",
+);
+
+describe(`github copilot sdk ${copilotSdkVersion}`, () => {
+  defineGitHubCopilotInstrumentationAssertions({
+    name: "wrapped instrumentation",
+    runScenario: async ({ runScenarioDir }) => {
+      await runScenarioDir({
+        entry: "scenario.ts",
+        runContext: { variantKey: "github-copilot-v0-wrapped" },
+        scenarioDir,
+        timeoutMs: GITHUB_COPILOT_SCENARIO_TIMEOUT_MS,
+      });
+    },
+    snapshotName: "github-copilot-v0-wrapped",
+    testFileUrl: import.meta.url,
+    timeoutMs: GITHUB_COPILOT_SCENARIO_TIMEOUT_MS,
+  });
+
+  defineGitHubCopilotInstrumentationAssertions({
+    name: "auto-hook instrumentation",
+    runScenario: async ({ runNodeScenarioDir }) => {
+      await runNodeScenarioDir({
+        entry: "scenario.mjs",
+        nodeArgs: ["--import", "braintrust/hook.mjs"],
+        runContext: { variantKey: "github-copilot-v0-auto" },
+        scenarioDir,
+        timeoutMs: GITHUB_COPILOT_SCENARIO_TIMEOUT_MS,
+      });
+    },
+    snapshotName: "github-copilot-v0-auto",
+    testFileUrl: import.meta.url,
+    timeoutMs: GITHUB_COPILOT_SCENARIO_TIMEOUT_MS,
+  });
+});

--- a/e2e/scenarios/github-copilot-instrumentation/scenario.ts
+++ b/e2e/scenarios/github-copilot-instrumentation/scenario.ts
@@ -1,0 +1,11 @@
+import { CopilotClient, approveAll, defineTool } from "@github/copilot-sdk";
+import { runMain } from "../../helpers/provider-runtime.mjs";
+import { runCopilotWrappedInstrumentation } from "./scenario.impl.mjs";
+
+runMain(async () => {
+  await runCopilotWrappedInstrumentation({
+    CopilotClient,
+    approveAll,
+    defineTool,
+  });
+});

--- a/js/CHANGELOG.md
+++ b/js/CHANGELOG.md
@@ -20,6 +20,7 @@
 - fix: Capture reasoning in mistral (https://github.com/braintrustdata/braintrust-sdk-javascript/pull/1863)
 - fix(huggingface): Capture streamed tool calls (https://github.com/braintrustdata/braintrust-sdk-javascript/pull/1848)
 - fix(claude-agent-sdk): Nest built-in tools under sub-agents (https://github.com/braintrustdata/braintrust-sdk-javascript/pull/1881)
+
 ## 3.9.0
 
 ### Notable Changes

--- a/js/CHANGELOG.md
+++ b/js/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - feat: Add dataset versioning support (https://github.com/braintrustdata/braintrust-sdk-javascript/pull/1837)
 - feat: Add `@cursor/sdk` instrumentation (https://github.com/braintrustdata/braintrust-sdk-javascript/pull/1923)
+- feat: Add auto and wrapper instrumentation for `@github/copilot-sdk`
 - feat: Add experiment dataset filters to experiment metadata (https://github.com/braintrustdata/braintrust-sdk-javascript/pull/1898)
 
 ### Patch Changes
@@ -19,7 +20,6 @@
 - fix: Capture reasoning in mistral (https://github.com/braintrustdata/braintrust-sdk-javascript/pull/1863)
 - fix(huggingface): Capture streamed tool calls (https://github.com/braintrustdata/braintrust-sdk-javascript/pull/1848)
 - fix(claude-agent-sdk): Nest built-in tools under sub-agents (https://github.com/braintrustdata/braintrust-sdk-javascript/pull/1881)
-
 ## 3.9.0
 
 ### Notable Changes

--- a/js/src/auto-instrumentations/bundler/plugin.ts
+++ b/js/src/auto-instrumentations/bundler/plugin.ts
@@ -32,6 +32,7 @@ import { openRouterConfigs } from "../configs/openrouter";
 import { mistralConfigs } from "../configs/mistral";
 import { cohereConfigs } from "../configs/cohere";
 import { groqConfigs } from "../configs/groq";
+import { gitHubCopilotConfigs } from "../configs/github-copilot";
 
 export interface BundlerPluginOptions {
   /**
@@ -85,6 +86,7 @@ export const unplugin = createUnplugin<BundlerPluginOptions>((options = {}) => {
     ...mistralConfigs,
     ...cohereConfigs,
     ...groqConfigs,
+    ...gitHubCopilotConfigs,
     ...(options.instrumentations || []),
   ];
 

--- a/js/src/auto-instrumentations/bundler/webpack-loader.ts
+++ b/js/src/auto-instrumentations/bundler/webpack-loader.ts
@@ -41,6 +41,7 @@ import { openRouterConfigs } from "../configs/openrouter";
 import { mistralConfigs } from "../configs/mistral";
 import { cohereConfigs } from "../configs/cohere";
 import { groqConfigs } from "../configs/groq";
+import { gitHubCopilotConfigs } from "../configs/github-copilot";
 import { type BundlerPluginOptions } from "./plugin";
 
 /**
@@ -80,6 +81,7 @@ function getMatcher(options: BundlerPluginOptions): InstrumentationMatcher {
     ...mistralConfigs,
     ...cohereConfigs,
     ...groqConfigs,
+    ...gitHubCopilotConfigs,
     ...(options.instrumentations ?? []),
   ];
   const dcModule = options.browser ? "dc-browser" : undefined;

--- a/js/src/auto-instrumentations/configs/github-copilot.test.ts
+++ b/js/src/auto-instrumentations/configs/github-copilot.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { gitHubCopilotChannels } from "../../instrumentation/plugins/github-copilot-channels";
+import { gitHubCopilotConfigs } from "./github-copilot";
+
+function findConfigsByMethod(methodName: string) {
+  return gitHubCopilotConfigs.filter((config) => {
+    if (!("functionQuery" in config)) {
+      return false;
+    }
+    const query = config.functionQuery as { methodName?: string };
+    return query.methodName === methodName;
+  });
+}
+
+describe("gitHubCopilotConfigs", () => {
+  it("defines channels for createSession, resumeSession, sendAndWait", () => {
+    expect(gitHubCopilotChannels.createSession.channelName).toContain(
+      "createSession",
+    );
+    expect(gitHubCopilotChannels.resumeSession.channelName).toContain(
+      "resumeSession",
+    );
+    expect(gitHubCopilotChannels.sendAndWait.channelName).toContain(
+      "sendAndWait",
+    );
+  });
+
+  it("instruments createSession in both ESM and CJS", () => {
+    const configs = findConfigsByMethod("createSession");
+    expect(configs).toHaveLength(2);
+    expect(configs.map((c) => c.channelName)).toEqual([
+      gitHubCopilotChannels.createSession.channelName,
+      gitHubCopilotChannels.createSession.channelName,
+    ]);
+    expect(configs.map((c) => c.module.filePath).sort()).toEqual([
+      "dist/cjs/client.js",
+      "dist/client.js",
+    ]);
+    for (const config of configs) {
+      expect(config.module.name).toBe("@github/copilot-sdk");
+      expect(config.module.versionRange).toBe(">=0.3.0");
+      expect((config.functionQuery as { className?: string }).className).toBe(
+        "CopilotClient",
+      );
+    }
+  });
+
+  it("instruments resumeSession in both ESM and CJS", () => {
+    const configs = findConfigsByMethod("resumeSession");
+    expect(configs).toHaveLength(2);
+    expect(configs.map((c) => c.channelName)).toEqual([
+      gitHubCopilotChannels.resumeSession.channelName,
+      gitHubCopilotChannels.resumeSession.channelName,
+    ]);
+    expect(configs.map((c) => c.module.filePath).sort()).toEqual([
+      "dist/cjs/client.js",
+      "dist/client.js",
+    ]);
+    for (const config of configs) {
+      expect((config.functionQuery as { className?: string }).className).toBe(
+        "CopilotClient",
+      );
+    }
+  });
+
+  it("instruments sendAndWait in both ESM and CJS", () => {
+    const configs = findConfigsByMethod("sendAndWait");
+    expect(configs).toHaveLength(2);
+    expect(configs.map((c) => c.channelName)).toEqual([
+      gitHubCopilotChannels.sendAndWait.channelName,
+      gitHubCopilotChannels.sendAndWait.channelName,
+    ]);
+    expect(configs.map((c) => c.module.filePath).sort()).toEqual([
+      "dist/cjs/session.js",
+      "dist/session.js",
+    ]);
+    for (const config of configs) {
+      expect((config.functionQuery as { className?: string }).className).toBe(
+        "CopilotSession",
+      );
+    }
+  });
+
+  it("all configs target @github/copilot-sdk >=0.3.0", () => {
+    for (const config of gitHubCopilotConfigs) {
+      expect(config.module.name).toBe("@github/copilot-sdk");
+      expect(config.module.versionRange).toBe(">=0.3.0");
+    }
+  });
+});

--- a/js/src/auto-instrumentations/configs/github-copilot.ts
+++ b/js/src/auto-instrumentations/configs/github-copilot.ts
@@ -1,0 +1,89 @@
+import type { InstrumentationConfig } from "@apm-js-collab/code-transformer";
+import { gitHubCopilotChannels } from "../../instrumentation/plugins/github-copilot-channels";
+
+export const gitHubCopilotConfigs: InstrumentationConfig[] = [
+  // ESM: CopilotClient.createSession
+  {
+    channelName: gitHubCopilotChannels.createSession.channelName,
+    module: {
+      name: "@github/copilot-sdk",
+      versionRange: ">=0.3.0",
+      filePath: "dist/client.js",
+    },
+    functionQuery: {
+      className: "CopilotClient",
+      methodName: "createSession",
+      kind: "Async",
+    },
+  },
+  // CJS: CopilotClient.createSession
+  {
+    channelName: gitHubCopilotChannels.createSession.channelName,
+    module: {
+      name: "@github/copilot-sdk",
+      versionRange: ">=0.3.0",
+      filePath: "dist/cjs/client.js",
+    },
+    functionQuery: {
+      className: "CopilotClient",
+      methodName: "createSession",
+      kind: "Async",
+    },
+  },
+  // ESM: CopilotClient.resumeSession
+  {
+    channelName: gitHubCopilotChannels.resumeSession.channelName,
+    module: {
+      name: "@github/copilot-sdk",
+      versionRange: ">=0.3.0",
+      filePath: "dist/client.js",
+    },
+    functionQuery: {
+      className: "CopilotClient",
+      methodName: "resumeSession",
+      kind: "Async",
+    },
+  },
+  // CJS: CopilotClient.resumeSession
+  {
+    channelName: gitHubCopilotChannels.resumeSession.channelName,
+    module: {
+      name: "@github/copilot-sdk",
+      versionRange: ">=0.3.0",
+      filePath: "dist/cjs/client.js",
+    },
+    functionQuery: {
+      className: "CopilotClient",
+      methodName: "resumeSession",
+      kind: "Async",
+    },
+  },
+  // ESM: CopilotSession.sendAndWait
+  {
+    channelName: gitHubCopilotChannels.sendAndWait.channelName,
+    module: {
+      name: "@github/copilot-sdk",
+      versionRange: ">=0.3.0",
+      filePath: "dist/session.js",
+    },
+    functionQuery: {
+      className: "CopilotSession",
+      methodName: "sendAndWait",
+      kind: "Async",
+    },
+  },
+  // CJS: CopilotSession.sendAndWait
+  {
+    channelName: gitHubCopilotChannels.sendAndWait.channelName,
+    module: {
+      name: "@github/copilot-sdk",
+      versionRange: ">=0.3.0",
+      filePath: "dist/cjs/session.js",
+    },
+    functionQuery: {
+      className: "CopilotSession",
+      methodName: "sendAndWait",
+      kind: "Async",
+    },
+  },
+];

--- a/js/src/auto-instrumentations/hook.mts
+++ b/js/src/auto-instrumentations/hook.mts
@@ -27,6 +27,7 @@ import { mistralConfigs } from "./configs/mistral.js";
 import { googleADKConfigs } from "./configs/google-adk.js";
 import { cohereConfigs } from "./configs/cohere.js";
 import { groqConfigs } from "./configs/groq.js";
+import { gitHubCopilotConfigs } from "./configs/github-copilot.js";
 import { ModulePatch } from "./loader/cjs-patch.js";
 import { patchTracingChannel } from "./patch-tracing-channel.js";
 
@@ -88,6 +89,14 @@ const allConfigs = [
     : googleADKConfigs),
   ...(isDisabled(disabledIntegrations, "cohere") ? [] : cohereConfigs),
   ...(isDisabled(disabledIntegrations, "groq", "groq-sdk") ? [] : groqConfigs),
+  ...(isDisabled(
+    disabledIntegrations,
+    "githubcopilot",
+    "github-copilot",
+    "copilot-sdk",
+  )
+    ? []
+    : gitHubCopilotConfigs),
 ];
 
 // 1. Register ESM loader for ESM modules

--- a/js/src/auto-instrumentations/index.ts
+++ b/js/src/auto-instrumentations/index.ts
@@ -41,6 +41,7 @@ export { mistralConfigs } from "./configs/mistral";
 export { googleADKConfigs } from "./configs/google-adk";
 export { cohereConfigs } from "./configs/cohere";
 export { groqConfigs } from "./configs/groq";
+export { gitHubCopilotConfigs } from "./configs/github-copilot";
 
 // Re-export orchestrion configuration types
 // Note: ModuleMetadata and FunctionQuery are properties of InstrumentationConfig,

--- a/js/src/exports.ts
+++ b/js/src/exports.ts
@@ -186,6 +186,7 @@ export { wrapOpenRouter } from "./wrappers/openrouter";
 export { wrapMistral } from "./wrappers/mistral";
 export { wrapCohere } from "./wrappers/cohere";
 export { wrapGroq } from "./wrappers/groq";
+export { wrapCopilotClient } from "./wrappers/github-copilot";
 export { wrapVitest } from "./wrappers/vitest";
 export { initNodeTestSuite } from "./wrappers/node-test";
 

--- a/js/src/imports.test.ts
+++ b/js/src/imports.test.ts
@@ -19,11 +19,17 @@ describe("CLI import restrictions", () => {
           continue;
         }
 
+        if (entry.isDirectory() && entry.name === "node_modules") {
+          continue;
+        }
+
         if (entry.isDirectory()) {
           walkDirectory(fullPath);
         } else if (
           entry.isFile() &&
-          (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx"))
+          (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx")) &&
+          !entry.name.endsWith(".d.ts") &&
+          !entry.name.endsWith(".d.tsx")
         ) {
           checkFileForCliImports(fullPath, relativePath);
         }
@@ -94,11 +100,17 @@ describe("CLI import restrictions", () => {
           continue;
         }
 
+        if (entry.isDirectory() && entry.name === "node_modules") {
+          continue;
+        }
+
         if (entry.isDirectory()) {
           walkDirectory(fullPath);
         } else if (
           entry.isFile() &&
           (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx")) &&
+          !entry.name.endsWith(".d.ts") &&
+          !entry.name.endsWith(".d.tsx") &&
           !entry.name.endsWith(".test.ts") &&
           !entry.name.endsWith(".test.tsx")
         ) {
@@ -165,11 +177,18 @@ describe("CLI import restrictions", () => {
           continue;
         }
 
+        // Skip node_modules directories (test fixture deps, not SDK source)
+        if (entry.isDirectory() && entry.name === "node_modules") {
+          continue;
+        }
+
         if (entry.isDirectory()) {
           walkDirectory(fullPath);
         } else if (
           entry.isFile() &&
           (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx")) &&
+          !entry.name.endsWith(".d.ts") &&
+          !entry.name.endsWith(".d.tsx") &&
           !entry.name.endsWith(".test.ts") &&
           !entry.name.endsWith(".test.tsx")
         ) {

--- a/js/src/instrumentation/braintrust-plugin.test.ts
+++ b/js/src/instrumentation/braintrust-plugin.test.ts
@@ -11,6 +11,7 @@ import { OpenRouterPlugin } from "./plugins/openrouter-plugin";
 import { MistralPlugin } from "./plugins/mistral-plugin";
 import { CoherePlugin } from "./plugins/cohere-plugin";
 import { GroqPlugin } from "./plugins/groq-plugin";
+import { GitHubCopilotPlugin } from "./plugins/github-copilot-plugin";
 
 function createPluginClassMock() {
   return vi.fn(function MockPlugin(this: {
@@ -71,6 +72,10 @@ vi.mock("./plugins/cohere-plugin", () => ({
 
 vi.mock("./plugins/groq-plugin", () => ({
   GroqPlugin: createPluginClassMock(),
+}));
+
+vi.mock("./plugins/github-copilot-plugin", () => ({
+  GitHubCopilotPlugin: createPluginClassMock(),
 }));
 
 describe("BraintrustPlugin", () => {
@@ -181,6 +186,15 @@ describe("BraintrustPlugin", () => {
       expect(mockInstance.enable).toHaveBeenCalledTimes(1);
     });
 
+    it("should create and enable GitHubCopilot plugin by default", () => {
+      const plugin = new BraintrustPlugin();
+      plugin.enable();
+
+      expect(GitHubCopilotPlugin).toHaveBeenCalledTimes(1);
+      const mockInstance = vi.mocked(GitHubCopilotPlugin).mock.results[0].value;
+      expect(mockInstance.enable).toHaveBeenCalledTimes(1);
+    });
+
     it("should create all plugins when enabled with no config", () => {
       const plugin = new BraintrustPlugin();
       plugin.enable();
@@ -196,6 +210,7 @@ describe("BraintrustPlugin", () => {
       expect(MistralPlugin).toHaveBeenCalledTimes(1);
       expect(CoherePlugin).toHaveBeenCalledTimes(1);
       expect(GroqPlugin).toHaveBeenCalledTimes(1);
+      expect(GitHubCopilotPlugin).toHaveBeenCalledTimes(1);
     });
 
     it("should create all plugins when enabled with empty config", () => {
@@ -213,6 +228,7 @@ describe("BraintrustPlugin", () => {
       expect(MistralPlugin).toHaveBeenCalledTimes(1);
       expect(CoherePlugin).toHaveBeenCalledTimes(1);
       expect(GroqPlugin).toHaveBeenCalledTimes(1);
+      expect(GitHubCopilotPlugin).toHaveBeenCalledTimes(1);
     });
 
     it("should create all plugins when enabled with empty integrations config", () => {
@@ -403,6 +419,17 @@ describe("BraintrustPlugin", () => {
       expect(MistralPlugin).toHaveBeenCalledTimes(1);
     });
 
+    it("should not create GitHubCopilot plugin when gitHubCopilot: false", () => {
+      const plugin = new BraintrustPlugin({
+        integrations: { gitHubCopilot: false },
+      });
+      plugin.enable();
+
+      expect(GitHubCopilotPlugin).not.toHaveBeenCalled();
+      expect(OpenAIPlugin).toHaveBeenCalledTimes(1);
+      expect(GroqPlugin).toHaveBeenCalledTimes(1);
+    });
+
     it("should not create OpenRouter Agent plugin when openrouterAgent: false", () => {
       const plugin = new BraintrustPlugin({
         integrations: { openrouterAgent: false },
@@ -427,6 +454,7 @@ describe("BraintrustPlugin", () => {
           mistral: false,
           cohere: false,
           groq: false,
+          gitHubCopilot: false,
         },
       });
       plugin.enable();
@@ -442,6 +470,7 @@ describe("BraintrustPlugin", () => {
       expect(MistralPlugin).not.toHaveBeenCalled();
       expect(CoherePlugin).not.toHaveBeenCalled();
       expect(GroqPlugin).not.toHaveBeenCalled();
+      expect(GitHubCopilotPlugin).not.toHaveBeenCalled();
     });
 
     it("should allow selective enabling of plugins", () => {

--- a/js/src/instrumentation/braintrust-plugin.ts
+++ b/js/src/instrumentation/braintrust-plugin.ts
@@ -12,6 +12,7 @@ import { MistralPlugin } from "./plugins/mistral-plugin";
 import { GoogleADKPlugin } from "./plugins/google-adk-plugin";
 import { CoherePlugin } from "./plugins/cohere-plugin";
 import { GroqPlugin } from "./plugins/groq-plugin";
+import { GitHubCopilotPlugin } from "./plugins/github-copilot-plugin";
 
 export interface BraintrustPluginConfig {
   integrations?: {
@@ -31,6 +32,7 @@ export interface BraintrustPluginConfig {
     googleADK?: boolean;
     cohere?: boolean;
     groq?: boolean;
+    gitHubCopilot?: boolean;
   };
 }
 
@@ -65,6 +67,7 @@ export class BraintrustPlugin extends BasePlugin {
   private googleADKPlugin: GoogleADKPlugin | null = null;
   private coherePlugin: CoherePlugin | null = null;
   private groqPlugin: GroqPlugin | null = null;
+  private gitHubCopilotPlugin: GitHubCopilotPlugin | null = null;
 
   constructor(config: BraintrustPluginConfig = {}) {
     super();
@@ -146,6 +149,11 @@ export class BraintrustPlugin extends BasePlugin {
       this.groqPlugin = new GroqPlugin();
       this.groqPlugin.enable();
     }
+
+    if (integrations.gitHubCopilot !== false) {
+      this.gitHubCopilotPlugin = new GitHubCopilotPlugin();
+      this.gitHubCopilotPlugin.enable();
+    }
   }
 
   protected onDisable(): void {
@@ -212,6 +220,11 @@ export class BraintrustPlugin extends BasePlugin {
     if (this.groqPlugin) {
       this.groqPlugin.disable();
       this.groqPlugin = null;
+    }
+
+    if (this.gitHubCopilotPlugin) {
+      this.gitHubCopilotPlugin.disable();
+      this.gitHubCopilotPlugin = null;
     }
   }
 }

--- a/js/src/instrumentation/braintrust-plugin.ts
+++ b/js/src/instrumentation/braintrust-plugin.ts
@@ -32,8 +32,14 @@ export interface BraintrustPluginConfig {
     googleADK?: boolean;
     cohere?: boolean;
     groq?: boolean;
-    gitHubCopilot?: boolean;
   };
+}
+
+function getIntegrationConfig(
+  integrations: NonNullable<BraintrustPluginConfig["integrations"]>,
+  key: string,
+): boolean | undefined {
+  return (integrations as Record<string, boolean | undefined>)[key];
 }
 
 /**
@@ -150,7 +156,7 @@ export class BraintrustPlugin extends BasePlugin {
       this.groqPlugin.enable();
     }
 
-    if (integrations.gitHubCopilot !== false) {
+    if (getIntegrationConfig(integrations, "gitHubCopilot") !== false) {
       this.gitHubCopilotPlugin = new GitHubCopilotPlugin();
       this.gitHubCopilotPlugin.enable();
     }

--- a/js/src/instrumentation/plugins/github-copilot-channels.ts
+++ b/js/src/instrumentation/plugins/github-copilot-channels.ts
@@ -1,0 +1,29 @@
+import { channel, defineChannels } from "../core/channel-definitions";
+import type {
+  GitHubCopilotAssistantMessageEvent,
+  GitHubCopilotMessageOptions,
+  GitHubCopilotResumeSessionConfig,
+  GitHubCopilotSession,
+  GitHubCopilotSessionConfig,
+} from "../../vendor-sdk-types/github-copilot";
+
+export const gitHubCopilotChannels = defineChannels("@github/copilot-sdk", {
+  createSession: channel<[GitHubCopilotSessionConfig], GitHubCopilotSession>({
+    channelName: "client.createSession",
+    kind: "async",
+  }),
+  resumeSession: channel<
+    [string, GitHubCopilotResumeSessionConfig],
+    GitHubCopilotSession
+  >({
+    channelName: "client.resumeSession",
+    kind: "async",
+  }),
+  sendAndWait: channel<
+    [GitHubCopilotMessageOptions, number?],
+    GitHubCopilotAssistantMessageEvent | undefined
+  >({
+    channelName: "session.sendAndWait",
+    kind: "async",
+  }),
+});

--- a/js/src/instrumentation/plugins/github-copilot-plugin.test.ts
+++ b/js/src/instrumentation/plugins/github-copilot-plugin.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import {
+  GitHubCopilotPlugin,
+  extractMetricsFromUsage,
+} from "./github-copilot-plugin";
+
+describe("extractMetricsFromUsage", () => {
+  it("maps input/output tokens to standard metric keys", () => {
+    const result = extractMetricsFromUsage({
+      model: "gpt-4.1",
+      inputTokens: 100,
+      outputTokens: 50,
+    });
+
+    expect(result.metrics.prompt_tokens).toBe(100);
+    expect(result.metrics.completion_tokens).toBe(50);
+    expect(result.metrics.tokens).toBe(150);
+  });
+
+  it("maps cache tokens via Anthropic-style helpers", () => {
+    const result = extractMetricsFromUsage({
+      model: "gpt-4.1",
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 20,
+      cacheWriteTokens: 10,
+    });
+
+    expect(result.metrics.prompt_cached_tokens).toBe(20);
+    expect(result.metrics.prompt_cache_creation_tokens).toBe(10);
+    // finalizeAnthropicTokens includes cache tokens in prompt_tokens
+    expect(result.metrics.prompt_tokens).toBe(130); // 100 + 20 + 10
+    expect(result.metrics.tokens).toBe(180); // 130 + 50
+  });
+
+  it("maps reasoning tokens to both completion_reasoning_tokens and reasoning_tokens", () => {
+    const result = extractMetricsFromUsage({
+      model: "o4-mini",
+      inputTokens: 50,
+      outputTokens: 30,
+      reasoningTokens: 15,
+    });
+
+    expect(result.metrics.completion_reasoning_tokens).toBe(15);
+    expect(result.metrics.reasoning_tokens).toBe(15);
+  });
+
+  it("puts billing/perf fields in metadata, not metrics", () => {
+    const result = extractMetricsFromUsage({
+      model: "gpt-4.1",
+      cost: 0.42,
+      duration: 1234,
+      ttftMs: 100,
+      interTokenLatencyMs: 50,
+      apiCallId: "chatcmpl-abc",
+      providerCallId: "gh-req-id",
+      interactionId: "capi-id",
+      initiator: "sub-agent",
+      reasoningEffort: "high",
+    });
+
+    expect(result.metadata["model"]).toBe("gpt-4.1");
+    expect(result.metadata["github_copilot.cost"]).toBe(0.42);
+    expect(result.metadata["github_copilot.duration_ms"]).toBe(1234);
+    expect(result.metadata["github_copilot.time_to_first_token_ms"]).toBe(100);
+    expect(result.metadata["github_copilot.intertoken_latency_ms"]).toBe(50);
+    expect(result.metadata["github_copilot.api_call_id"]).toBe("chatcmpl-abc");
+    expect(result.metadata["github_copilot.provider_call_id"]).toBe(
+      "gh-req-id",
+    );
+    expect(result.metadata["github_copilot.interaction_id"]).toBe("capi-id");
+    expect(result.metadata["github_copilot.initiator"]).toBe("sub-agent");
+    expect(result.metadata["github_copilot.reasoning_effort"]).toBe("high");
+  });
+
+  it("includes copilotUsage and quotaSnapshots as raw metadata passthrough", () => {
+    const copilotUsage = {
+      tokenDetails: [
+        { batchSize: 1, costPerBatch: 0.1, tokenCount: 10, tokenType: "input" },
+      ],
+      totalNanoAiu: 1000,
+    };
+    const quotaSnapshots = {
+      "premium-requests": {
+        entitlementRequests: 300,
+        isUnlimitedEntitlement: false,
+        overage: 0,
+        usedRequests: 42,
+        remainingPercentage: 0.86,
+      },
+    };
+
+    const result = extractMetricsFromUsage({
+      model: "gpt-4.1",
+      copilotUsage,
+      quotaSnapshots,
+    });
+
+    expect(result.metadata["github_copilot.copilot_usage"]).toBe(copilotUsage);
+    expect(result.metadata["github_copilot.quota_snapshots"]).toBe(
+      quotaSnapshots,
+    );
+  });
+
+  it("omits undefined optional metadata fields", () => {
+    const result = extractMetricsFromUsage({ model: "gpt-4.1" });
+
+    expect(result.metadata["github_copilot.cost"]).toBeUndefined();
+    expect(result.metadata["github_copilot.duration_ms"]).toBeUndefined();
+    expect(result.metadata["github_copilot.copilot_usage"]).toBeUndefined();
+  });
+
+  it("handles missing token counts without throwing", () => {
+    const result = extractMetricsFromUsage({ model: "gpt-4.1" });
+
+    expect(result.metrics.prompt_tokens).toBe(0);
+    expect(result.metrics.completion_tokens).toBeUndefined();
+    expect(result.metrics.tokens).toBe(0);
+  });
+});
+
+describe("GitHubCopilotPlugin lifecycle", () => {
+  it("enables without throwing", () => {
+    const plugin = new GitHubCopilotPlugin();
+    expect(() => plugin.enable()).not.toThrow();
+    plugin.disable();
+  });
+
+  it("disables without throwing", () => {
+    const plugin = new GitHubCopilotPlugin();
+    plugin.enable();
+    expect(() => plugin.disable()).not.toThrow();
+  });
+
+  it("enable is idempotent", () => {
+    const plugin = new GitHubCopilotPlugin();
+    plugin.enable();
+    expect(() => plugin.enable()).not.toThrow();
+    plugin.disable();
+  });
+
+  it("disable is idempotent", () => {
+    const plugin = new GitHubCopilotPlugin();
+    plugin.enable();
+    plugin.disable();
+    expect(() => plugin.disable()).not.toThrow();
+  });
+
+  it("can be re-enabled after disable", () => {
+    const plugin = new GitHubCopilotPlugin();
+    plugin.enable();
+    plugin.disable();
+    expect(() => plugin.enable()).not.toThrow();
+    plugin.disable();
+  });
+});

--- a/js/src/instrumentation/plugins/github-copilot-plugin.ts
+++ b/js/src/instrumentation/plugins/github-copilot-plugin.ts
@@ -1,5 +1,4 @@
 import { BasePlugin } from "../core";
-import type { ChannelMessage } from "../core/channel-definitions";
 import type { IsoChannelHandlers } from "../../isomorph";
 import { startSpan } from "../../logger";
 import type { Span } from "../../logger";

--- a/js/src/instrumentation/plugins/github-copilot-plugin.ts
+++ b/js/src/instrumentation/plugins/github-copilot-plugin.ts
@@ -1,0 +1,766 @@
+import { BasePlugin } from "../core";
+import type { ChannelMessage } from "../core/channel-definitions";
+import type { IsoChannelHandlers } from "../../isomorph";
+import { startSpan } from "../../logger";
+import type { Span } from "../../logger";
+import { SpanTypeAttribute } from "../../../util/index";
+import {
+  extractAnthropicCacheTokens,
+  finalizeAnthropicTokens,
+} from "../../wrappers/anthropic-tokens-util";
+import type { AnthropicTokenMetrics } from "../../wrappers/anthropic-tokens-util";
+import { gitHubCopilotChannels } from "./github-copilot-channels";
+import type {
+  GitHubCopilotSession,
+  GitHubCopilotSessionConfig,
+  GitHubCopilotSessionHooks,
+  GitHubCopilotTrackedEvent,
+  GitHubCopilotUsageData,
+} from "../../vendor-sdk-types/github-copilot";
+
+const ROOT_AGENT_KEY = "__root__";
+
+function agentKey(agentId: string | undefined): string {
+  return agentId ?? ROOT_AGENT_KEY;
+}
+
+function getStringProperty(obj: unknown, key: string): string | undefined {
+  if (!obj || typeof obj !== "object" || !(key in obj)) {
+    return undefined;
+  }
+  const value = Reflect.get(obj as object, key);
+  return typeof value === "string" ? value : undefined;
+}
+
+export function extractMetricsFromUsage(usage: GitHubCopilotUsageData): {
+  metrics: AnthropicTokenMetrics;
+  metadata: Record<string, unknown>;
+} {
+  const metrics: AnthropicTokenMetrics = {
+    prompt_tokens: usage.inputTokens,
+    completion_tokens: usage.outputTokens,
+    ...extractAnthropicCacheTokens(
+      usage.cacheReadTokens,
+      usage.cacheWriteTokens,
+    ),
+  };
+
+  if (usage.reasoningTokens !== undefined) {
+    metrics.completion_reasoning_tokens = usage.reasoningTokens;
+    metrics.reasoning_tokens = usage.reasoningTokens;
+  }
+
+  Object.assign(metrics, finalizeAnthropicTokens(metrics));
+
+  const metadata: Record<string, unknown> = {
+    model: usage.model,
+  };
+
+  if (usage.cost !== undefined) {
+    metadata["github_copilot.cost"] = usage.cost;
+  }
+  if (usage.duration !== undefined) {
+    metadata["github_copilot.duration_ms"] = usage.duration;
+  }
+  if (usage.ttftMs !== undefined) {
+    metadata["github_copilot.time_to_first_token_ms"] = usage.ttftMs;
+  }
+  if (usage.interTokenLatencyMs !== undefined) {
+    metadata["github_copilot.intertoken_latency_ms"] =
+      usage.interTokenLatencyMs;
+  }
+  if (usage.apiCallId !== undefined) {
+    metadata["github_copilot.api_call_id"] = usage.apiCallId;
+  }
+  if (usage.providerCallId !== undefined) {
+    metadata["github_copilot.provider_call_id"] = usage.providerCallId;
+  }
+  if (usage.interactionId !== undefined) {
+    metadata["github_copilot.interaction_id"] = usage.interactionId;
+  }
+  if (usage.initiator !== undefined) {
+    metadata["github_copilot.initiator"] = usage.initiator;
+  }
+  if (usage.reasoningEffort !== undefined) {
+    metadata["github_copilot.reasoning_effort"] = usage.reasoningEffort;
+  }
+  if (usage.copilotUsage !== undefined) {
+    metadata["github_copilot.copilot_usage"] = usage.copilotUsage;
+  }
+  if (usage.quotaSnapshots !== undefined) {
+    metadata["github_copilot.quota_snapshots"] = usage.quotaSnapshots;
+  }
+
+  return { metadata, metrics };
+}
+
+// ---------------------------------------------------------------------------
+// Session state — stores spans AND their exported ID strings (Promise<string>)
+// because startSpan requires parent?: string, not a Span object.
+// ---------------------------------------------------------------------------
+
+type SpanWithId = { span: Span; id: Promise<string> };
+
+type SessionState = {
+  session: SpanWithId;
+  // Active turn span per agentKey
+  activeTurns: Map<string, SpanWithId>;
+  // Last user message content per agentKey (for turn span input)
+  pendingUserMessages: Map<string, string>;
+  // Accumulated assistant message content for current LLM call, per agentKey
+  currentMessageContent: Map<string, string>;
+  // Active tool spans, keyed by toolCallId
+  activeTools: Map<string, SpanWithId>;
+  // Sub-agent spans, keyed by spawning toolCallId
+  subAgents: Map<string, SpanWithId>;
+  // agentId → spawning toolCallId (populated by subagent.started)
+  agentIdToToolCallId: Map<string, string>;
+  // Unsubscribe from session.on(handler)
+  unsubscribeEvents?: () => void;
+  // Async event processing chain (keeps ordering guarantees)
+  processing: Promise<void>;
+  // Aggregate session-level token counts
+  totalInputTokens: number;
+  totalOutputTokens: number;
+};
+
+function makeSpanWithId(span: Span): SpanWithId {
+  return { span, id: span.export() };
+}
+
+async function getParentIdForAgent(
+  state: SessionState,
+  agentId: string | undefined,
+): Promise<string> {
+  if (agentId) {
+    const toolCallId = state.agentIdToToolCallId.get(agentId);
+    if (toolCallId) {
+      const subAgent = state.subAgents.get(toolCallId);
+      if (subAgent) {
+        return subAgent.id;
+      }
+    }
+  }
+  return state.session.id;
+}
+
+async function getToolParentId(
+  state: SessionState,
+  agentId: string | undefined,
+): Promise<string> {
+  const turn = state.activeTurns.get(agentKey(agentId));
+  return turn ? turn.id : state.session.id;
+}
+
+// ---------------------------------------------------------------------------
+// Span lifecycle handlers (all async — they await parent IDs)
+// ---------------------------------------------------------------------------
+
+async function handleTurnStart(
+  state: SessionState,
+  agentId: string | undefined,
+): Promise<void> {
+  const key = agentKey(agentId);
+  if (state.activeTurns.has(key)) {
+    return;
+  }
+
+  const parentId = await getParentIdForAgent(state, agentId);
+  const span = startSpan({
+    name: "Copilot Turn",
+    parent: parentId,
+    spanAttributes: { type: SpanTypeAttribute.TASK },
+  });
+
+  const pendingUserMessage = state.pendingUserMessages.get(key);
+  if (pendingUserMessage) {
+    span.log({ input: pendingUserMessage });
+    state.pendingUserMessages.delete(key);
+  }
+
+  state.activeTurns.set(key, makeSpanWithId(span));
+}
+
+function handleTurnEnd(state: SessionState, agentId: string | undefined): void {
+  const key = agentKey(agentId);
+  const turn = state.activeTurns.get(key);
+  if (!turn) {
+    return;
+  }
+
+  turn.span.end();
+  state.activeTurns.delete(key);
+  state.currentMessageContent.delete(key);
+}
+
+function handleAssistantMessage(
+  state: SessionState,
+  agentId: string | undefined,
+  content: string,
+): void {
+  state.currentMessageContent.set(agentKey(agentId), content);
+  const turn = state.activeTurns.get(agentKey(agentId));
+  if (turn) {
+    turn.span.log({ output: content });
+  }
+}
+
+async function handleUsage(
+  state: SessionState,
+  agentId: string | undefined,
+  usage: GitHubCopilotUsageData,
+): Promise<void> {
+  const key = agentKey(agentId);
+  const turn = state.activeTurns.get(key);
+  const parentId = turn ? await turn.id : await state.session.id;
+  const content = state.currentMessageContent.get(key);
+
+  const { metrics, metadata } = extractMetricsFromUsage(usage);
+
+  const llmSpan = startSpan({
+    name: "github.copilot.llm",
+    parent: parentId,
+    spanAttributes: { type: SpanTypeAttribute.LLM },
+  });
+
+  llmSpan.log({
+    output: content ?? undefined,
+    metadata,
+    metrics,
+  });
+
+  llmSpan.end();
+
+  state.currentMessageContent.delete(key);
+  state.totalInputTokens += usage.inputTokens ?? 0;
+  state.totalOutputTokens += usage.outputTokens ?? 0;
+}
+
+function handleUserMessage(
+  state: SessionState,
+  agentId: string | undefined,
+  content: string,
+): void {
+  const key = agentKey(agentId);
+  const turn = state.activeTurns.get(key);
+  if (turn) {
+    turn.span.log({ input: content });
+  } else {
+    state.pendingUserMessages.set(key, content);
+  }
+}
+
+async function handleToolStart(
+  state: SessionState,
+  agentId: string | undefined,
+  toolCallId: string,
+  toolName: string,
+  args: Record<string, unknown> | undefined,
+  mcpServerName: string | undefined,
+): Promise<void> {
+  if (state.activeTools.has(toolCallId)) {
+    return;
+  }
+
+  const parentId = await getToolParentId(state, agentId);
+  const displayName = mcpServerName
+    ? `tool: ${mcpServerName}/${toolName}`
+    : `tool: ${toolName}`;
+
+  const span = startSpan({
+    name: displayName,
+    parent: parentId,
+    spanAttributes: { type: SpanTypeAttribute.TOOL },
+  });
+
+  const metadata: Record<string, unknown> = {
+    "gen_ai.tool.name": toolName,
+    "gen_ai.tool.call.id": toolCallId,
+  };
+  if (mcpServerName) {
+    metadata["mcp.server"] = mcpServerName;
+  }
+
+  span.log({ input: args, metadata });
+  state.activeTools.set(toolCallId, makeSpanWithId(span));
+}
+
+function handleToolComplete(
+  state: SessionState,
+  toolCallId: string,
+  success: boolean,
+  result: unknown,
+  error: { message?: string; code?: string } | undefined,
+): void {
+  const tool = state.activeTools.get(toolCallId);
+  if (!tool) {
+    return;
+  }
+
+  try {
+    if (!success && error) {
+      tool.span.log({ error: error.message ?? "tool execution failed" });
+    } else {
+      tool.span.log({ output: result });
+    }
+  } finally {
+    tool.span.end();
+    state.activeTools.delete(toolCallId);
+  }
+}
+
+async function handleSubagentStarted(
+  state: SessionState,
+  agentId: string | undefined,
+  toolCallId: string,
+  agentDisplayName: string,
+  agentDescription: string,
+): Promise<void> {
+  if (state.subAgents.has(toolCallId)) {
+    return;
+  }
+
+  if (agentId) {
+    state.agentIdToToolCallId.set(agentId, toolCallId);
+  }
+
+  const tool = state.activeTools.get(toolCallId);
+  const parentId = tool ? await tool.id : await state.session.id;
+
+  const span = startSpan({
+    name: `Agent: ${agentDisplayName}`,
+    parent: parentId,
+    spanAttributes: { type: SpanTypeAttribute.TASK },
+  });
+
+  span.log({
+    metadata: {
+      "github_copilot.agent_name": agentDisplayName,
+      "github_copilot.agent_description": agentDescription,
+    },
+  });
+
+  state.subAgents.set(toolCallId, makeSpanWithId(span));
+}
+
+function handleSubagentCompleted(
+  state: SessionState,
+  toolCallId: string,
+  model: string | undefined,
+  totalTokens: number | undefined,
+  totalToolCalls: number | undefined,
+  durationMs: number | undefined,
+): void {
+  const subAgent = state.subAgents.get(toolCallId);
+  if (!subAgent) {
+    return;
+  }
+
+  try {
+    const metadata: Record<string, unknown> = {};
+    if (model !== undefined) {
+      metadata["github_copilot.agent_model"] = model;
+    }
+    if (totalTokens !== undefined) {
+      metadata["github_copilot.agent_total_tokens"] = totalTokens;
+    }
+    if (totalToolCalls !== undefined) {
+      metadata["github_copilot.agent_tool_calls"] = totalToolCalls;
+    }
+    if (durationMs !== undefined) {
+      metadata["github_copilot.agent_duration_ms"] = durationMs;
+    }
+
+    subAgent.span.log({ metadata });
+  } finally {
+    subAgent.span.end();
+    state.subAgents.delete(toolCallId);
+  }
+}
+
+function handleSubagentFailed(
+  state: SessionState,
+  toolCallId: string,
+  error: string,
+): void {
+  const subAgent = state.subAgents.get(toolCallId);
+  if (!subAgent) {
+    return;
+  }
+
+  try {
+    subAgent.span.log({ error });
+  } finally {
+    subAgent.span.end();
+    state.subAgents.delete(toolCallId);
+  }
+}
+
+function handleSessionEnd(
+  state: SessionState,
+  reason: string,
+  error: string | undefined,
+): void {
+  try {
+    for (const tool of state.activeTools.values()) {
+      tool.span.end();
+    }
+    state.activeTools.clear();
+
+    for (const subAgent of state.subAgents.values()) {
+      subAgent.span.end();
+    }
+    state.subAgents.clear();
+
+    for (const turn of state.activeTurns.values()) {
+      turn.span.end();
+    }
+    state.activeTurns.clear();
+    state.agentIdToToolCallId.clear();
+
+    const sessionMetadata: Record<string, unknown> = {
+      "github_copilot.end_reason": reason,
+    };
+    if (state.totalInputTokens > 0 || state.totalOutputTokens > 0) {
+      sessionMetadata["github_copilot.total_input_tokens"] =
+        state.totalInputTokens;
+      sessionMetadata["github_copilot.total_output_tokens"] =
+        state.totalOutputTokens;
+    }
+
+    if (error) {
+      state.session.span.log({ error, metadata: sessionMetadata });
+    } else {
+      state.session.span.log({ metadata: sessionMetadata });
+    }
+  } finally {
+    state.session.span.end();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Event dispatch — async so handlers can await parent IDs
+// ---------------------------------------------------------------------------
+
+async function dispatchEvent(
+  state: SessionState,
+  event: GitHubCopilotTrackedEvent,
+): Promise<void> {
+  switch (event.type) {
+    case "user.message": {
+      const content = getStringProperty(event.data, "content");
+      if (content !== undefined) {
+        handleUserMessage(state, event.agentId, content);
+      }
+      break;
+    }
+    case "assistant.turn_start": {
+      await handleTurnStart(state, event.agentId);
+      break;
+    }
+    case "assistant.message": {
+      const content = getStringProperty(event.data, "content");
+      if (content !== undefined) {
+        handleAssistantMessage(state, event.agentId, content);
+      }
+      break;
+    }
+    case "assistant.usage": {
+      const usage = event.data as GitHubCopilotUsageData;
+      if (
+        usage &&
+        typeof usage === "object" &&
+        typeof usage.model === "string"
+      ) {
+        await handleUsage(state, event.agentId, usage);
+      }
+      break;
+    }
+    case "assistant.turn_end": {
+      handleTurnEnd(state, event.agentId);
+      break;
+    }
+    case "tool.execution_start": {
+      const d = event.data as {
+        toolCallId?: string;
+        toolName?: string;
+        arguments?: Record<string, unknown>;
+        mcpServerName?: string;
+      };
+      if (
+        d &&
+        typeof d.toolCallId === "string" &&
+        typeof d.toolName === "string"
+      ) {
+        await handleToolStart(
+          state,
+          event.agentId,
+          d.toolCallId,
+          d.toolName,
+          d.arguments,
+          d.mcpServerName,
+        );
+      }
+      break;
+    }
+    case "tool.execution_complete": {
+      const d = event.data as {
+        toolCallId?: string;
+        success?: boolean;
+        result?: unknown;
+        error?: { message?: string; code?: string };
+      };
+      if (d && typeof d.toolCallId === "string") {
+        handleToolComplete(
+          state,
+          d.toolCallId,
+          d.success ?? false,
+          d.result,
+          d.error,
+        );
+      }
+      break;
+    }
+    case "subagent.started": {
+      const d = event.data as {
+        toolCallId?: string;
+        agentDisplayName?: string;
+        agentDescription?: string;
+      };
+      if (d && typeof d.toolCallId === "string") {
+        await handleSubagentStarted(
+          state,
+          event.agentId,
+          d.toolCallId,
+          d.agentDisplayName ?? "sub-agent",
+          d.agentDescription ?? "",
+        );
+      }
+      break;
+    }
+    case "subagent.completed": {
+      const d = event.data as {
+        toolCallId?: string;
+        model?: string;
+        totalTokens?: number;
+        totalToolCalls?: number;
+        durationMs?: number;
+      };
+      if (d && typeof d.toolCallId === "string") {
+        handleSubagentCompleted(
+          state,
+          d.toolCallId,
+          d.model,
+          d.totalTokens,
+          d.totalToolCalls,
+          d.durationMs,
+        );
+      }
+      break;
+    }
+    case "subagent.failed": {
+      const d = event.data as { toolCallId?: string; error?: string };
+      if (d && typeof d.toolCallId === "string") {
+        handleSubagentFailed(
+          state,
+          d.toolCallId,
+          d.error ?? "sub-agent failed",
+        );
+      }
+      break;
+    }
+    case "session.usage_info": {
+      const d = event.data as {
+        tokenLimit?: number;
+        currentTokens?: number;
+        messagesLength?: number;
+      };
+      if (d && typeof d.currentTokens === "number") {
+        state.session.span.log({
+          metadata: {
+            "github_copilot.context_window.limit": d.tokenLimit,
+            "github_copilot.context_window.current": d.currentTokens,
+            "github_copilot.context_window.messages": d.messagesLength,
+          },
+        });
+      }
+      break;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hooks injection and event subscription
+// ---------------------------------------------------------------------------
+
+function injectTracingHooks(
+  config: GitHubCopilotSessionConfig,
+  state: SessionState,
+): void {
+  const existingHooks: GitHubCopilotSessionHooks = config.hooks ?? {};
+
+  const onSessionEnd: GitHubCopilotSessionHooks["onSessionEnd"] = async (
+    input,
+    invocation,
+  ) => {
+    try {
+      await existingHooks.onSessionEnd?.(input, invocation);
+    } finally {
+      handleSessionEnd(state, input.reason, input.error);
+      state.unsubscribeEvents?.();
+    }
+  };
+
+  config.hooks = {
+    ...existingHooks,
+    onSessionEnd,
+  };
+}
+
+function attachSessionEventListener(
+  session: GitHubCopilotSession,
+  state: SessionState,
+): void {
+  const handler = (event: GitHubCopilotTrackedEvent) => {
+    state.processing = state.processing
+      .then(() => dispatchEvent(state, event))
+      .catch((err) => {
+        // eslint-disable-next-line no-restricted-properties -- preserving intentional console usage.
+        console.error(
+          "[Braintrust] Error processing GitHub Copilot SDK event:",
+          err,
+        );
+      });
+  };
+
+  state.unsubscribeEvents = session.on(
+    handler as (event: GitHubCopilotTrackedEvent) => void,
+  );
+}
+
+function isGitHubCopilotSession(value: unknown): value is GitHubCopilotSession {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof (value as GitHubCopilotSession).on === "function"
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Plugin and handler factory
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeSessionHandlers(
+  sessionStates: WeakMap<object, SessionState>,
+  configArgIndex: number,
+  includeProviderMetadata: boolean,
+): IsoChannelHandlers<any> {
+  return {
+    start: (event) => {
+      const config = event.arguments[configArgIndex] as
+        | GitHubCopilotSessionConfig
+        | undefined;
+      if (!config || typeof config !== "object") {
+        return;
+      }
+
+      const sessionSpan = startSpan({
+        name: "Copilot Session",
+        spanAttributes: { type: SpanTypeAttribute.TASK },
+      });
+
+      const metadata: Record<string, unknown> = {};
+      if (config.model) {
+        metadata["github_copilot.model"] = config.model;
+      }
+      if (includeProviderMetadata && config.provider?.type) {
+        metadata["github_copilot.provider_type"] = config.provider.type;
+      }
+      if (Object.keys(metadata).length > 0) {
+        sessionSpan.log({ metadata });
+      }
+
+      const state: SessionState = {
+        session: makeSpanWithId(sessionSpan),
+        activeTurns: new Map(),
+        pendingUserMessages: new Map(),
+        currentMessageContent: new Map(),
+        activeTools: new Map(),
+        subAgents: new Map(),
+        agentIdToToolCallId: new Map(),
+        processing: Promise.resolve(),
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+      };
+
+      injectTracingHooks(config, state);
+      sessionStates.set(event, state);
+    },
+
+    asyncEnd: (event) => {
+      const state = sessionStates.get(event);
+      if (!state) {
+        return;
+      }
+
+      const session = event.result;
+      if (isGitHubCopilotSession(session)) {
+        attachSessionEventListener(session, state);
+      } else {
+        state.session.span.end();
+      }
+      sessionStates.delete(event);
+    },
+
+    error: (event) => {
+      const state = sessionStates.get(event);
+      if (!state || !event.error) {
+        return;
+      }
+
+      state.session.span.log({ error: event.error.message });
+      state.session.span.end();
+      sessionStates.delete(event);
+    },
+  };
+}
+
+export class GitHubCopilotPlugin extends BasePlugin {
+  protected onEnable(): void {
+    this.subscribeToSessionChannels();
+  }
+
+  protected onDisable(): void {
+    for (const unsubscribe of this.unsubscribers) {
+      unsubscribe();
+    }
+    this.unsubscribers = [];
+  }
+
+  private subscribeToSessionChannels(): void {
+    const createChannel = gitHubCopilotChannels.createSession.tracingChannel();
+    const resumeChannel = gitHubCopilotChannels.resumeSession.tracingChannel();
+
+    const sessionStates = new WeakMap<object, SessionState>();
+
+    const createHandlers = makeSessionHandlers(
+      sessionStates,
+      0, // config is arg 0 of createSession(config)
+      true, // include provider metadata
+    );
+    const resumeHandlers = makeSessionHandlers(
+      sessionStates,
+      1, // config is arg 1 of resumeSession(sessionId, config)
+      false, // resumeSession config has no provider field
+    );
+
+    createChannel.subscribe(createHandlers);
+    resumeChannel.subscribe(resumeHandlers);
+
+    this.unsubscribers.push(
+      () => createChannel.unsubscribe(createHandlers),
+      () => resumeChannel.unsubscribe(resumeHandlers),
+    );
+  }
+}

--- a/js/src/instrumentation/registry.ts
+++ b/js/src/instrumentation/registry.ts
@@ -27,6 +27,7 @@ export interface InstrumentationConfig {
     openrouterAgent?: boolean;
     mistral?: boolean;
     cohere?: boolean;
+    gitHubCopilot?: boolean;
   };
 }
 
@@ -119,6 +120,7 @@ class PluginRegistry {
       openrouterAgent: true,
       mistral: true,
       cohere: true,
+      gitHubCopilot: true,
     };
   }
 

--- a/js/src/instrumentation/registry.ts
+++ b/js/src/instrumentation/registry.ts
@@ -27,7 +27,6 @@ export interface InstrumentationConfig {
     openrouterAgent?: boolean;
     mistral?: boolean;
     cohere?: boolean;
-    gitHubCopilot?: boolean;
   };
 }
 

--- a/js/src/vendor-sdk-types/github-copilot.ts
+++ b/js/src/vendor-sdk-types/github-copilot.ts
@@ -1,0 +1,363 @@
+/**
+ * Vendored types for @github/copilot-sdk which our wrapper consumes.
+ *
+ * Should never be exposed to users of the SDK!
+ *
+ * Sourced from @github/copilot-sdk@0.3.0:
+ *   dist/types.d.ts
+ *   dist/generated/session-events.d.ts
+ */
+
+// ---------------------------------------------------------------------------
+// Session event types (subset we care about)
+// ---------------------------------------------------------------------------
+
+/** Turn start — opens a new agentic turn */
+export interface GitHubCopilotTurnStartData {
+  turnId: string;
+  interactionId?: string;
+}
+
+/** Turn end — closes the agentic turn */
+export interface GitHubCopilotTurnEndData {
+  turnId: string;
+}
+
+/** Final assistant message in a turn */
+export interface GitHubCopilotAssistantMessageData {
+  messageId: string;
+  content: string;
+  reasoningText?: string;
+  toolRequests?: Array<{
+    toolCallId: string;
+    name: string;
+    arguments?: Record<string, unknown>;
+    mcpServerName?: string;
+  }>;
+  outputTokens?: number;
+  parentToolCallId?: string;
+}
+
+/** Per-LLM-call usage metrics */
+export interface GitHubCopilotUsageData {
+  /** Model identifier (required) */
+  model: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  reasoningTokens?: number;
+  cost?: number;
+  duration?: number;
+  ttftMs?: number;
+  interTokenLatencyMs?: number;
+  apiCallId?: string;
+  providerCallId?: string;
+  interactionId?: string;
+  initiator?: string;
+  reasoningEffort?: string;
+  /** @deprecated use event.agentId instead */
+  parentToolCallId?: string;
+  copilotUsage?: {
+    tokenDetails: Array<{
+      batchSize: number;
+      costPerBatch: number;
+      tokenCount: number;
+      tokenType: string;
+    }>;
+    totalNanoAiu: number;
+  };
+  quotaSnapshots?: Record<
+    string,
+    {
+      entitlementRequests: number;
+      isUnlimitedEntitlement: boolean;
+      overage: number;
+      usedRequests: number;
+      remainingPercentage: number;
+      resetDate?: string;
+    }
+  >;
+}
+
+/** User message event */
+export interface GitHubCopilotUserMessageData {
+  content: string;
+  interactionId?: string;
+}
+
+/** Context window usage info */
+export interface GitHubCopilotUsageInfoData {
+  tokenLimit: number;
+  currentTokens: number;
+  messagesLength: number;
+}
+
+/** Idle event data (turn complete) */
+export interface GitHubCopilotIdleData {
+  aborted?: boolean;
+}
+
+/** Tool execution start */
+export interface GitHubCopilotToolExecutionStartData {
+  toolCallId: string;
+  toolName: string;
+  arguments?: Record<string, unknown>;
+  mcpServerName?: string;
+  mcpToolName?: string;
+  /** @deprecated */
+  parentToolCallId?: string;
+}
+
+/** Tool execution result */
+export interface GitHubCopilotToolExecutionCompleteData {
+  toolCallId: string;
+  success: boolean;
+  result?: {
+    content?: Array<{ type: string; text?: string; [key: string]: unknown }>;
+    isError?: boolean;
+  };
+  error?: {
+    message?: string;
+    code?: string;
+  };
+  /** @deprecated */
+  parentToolCallId?: string;
+}
+
+/** Sub-agent started */
+export interface GitHubCopilotSubagentStartedData {
+  toolCallId: string;
+  agentName: string;
+  agentDisplayName: string;
+  agentDescription: string;
+}
+
+/** Sub-agent completed */
+export interface GitHubCopilotSubagentCompletedData {
+  toolCallId: string;
+  agentName: string;
+  agentDisplayName: string;
+  durationMs?: number;
+  model?: string;
+  totalTokens?: number;
+  totalToolCalls?: number;
+}
+
+/** Sub-agent failed */
+export interface GitHubCopilotSubagentFailedData {
+  toolCallId: string;
+  agentName: string;
+  agentDisplayName: string;
+  error: string;
+  durationMs?: number;
+  totalTokens?: number;
+}
+
+/** Union of all session events we handle */
+export type GitHubCopilotTrackedEvent =
+  | {
+      type: "assistant.turn_start";
+      agentId?: string;
+      data: GitHubCopilotTurnStartData;
+    }
+  | {
+      type: "assistant.turn_end";
+      agentId?: string;
+      data: GitHubCopilotTurnEndData;
+    }
+  | {
+      type: "assistant.message";
+      agentId?: string;
+      data: GitHubCopilotAssistantMessageData;
+    }
+  | { type: "assistant.usage"; agentId?: string; data: GitHubCopilotUsageData }
+  | {
+      type: "user.message";
+      agentId?: string;
+      data: GitHubCopilotUserMessageData;
+    }
+  | {
+      type: "session.usage_info";
+      agentId?: string;
+      data: GitHubCopilotUsageInfoData;
+    }
+  | { type: "session.idle"; agentId?: string; data: GitHubCopilotIdleData }
+  | {
+      type: "tool.execution_start";
+      agentId?: string;
+      data: GitHubCopilotToolExecutionStartData;
+    }
+  | {
+      type: "tool.execution_complete";
+      agentId?: string;
+      data: GitHubCopilotToolExecutionCompleteData;
+    }
+  | {
+      type: "subagent.started";
+      agentId?: string;
+      data: GitHubCopilotSubagentStartedData;
+    }
+  | {
+      type: "subagent.completed";
+      agentId?: string;
+      data: GitHubCopilotSubagentCompletedData;
+    }
+  | {
+      type: "subagent.failed";
+      agentId?: string;
+      data: GitHubCopilotSubagentFailedData;
+    }
+  | { type: string; agentId?: string; data?: unknown };
+
+// ---------------------------------------------------------------------------
+// Session / client types
+// ---------------------------------------------------------------------------
+
+export interface GitHubCopilotSessionHooks {
+  onPreToolUse?: (
+    input: {
+      toolName: string;
+      toolArgs: unknown;
+      cwd: string;
+      timestamp: number;
+    },
+    invocation: { sessionId: string },
+  ) =>
+    | Promise<{
+        permissionDecision?: string;
+        modifiedArgs?: unknown;
+        additionalContext?: string;
+      } | void>
+    | {
+        permissionDecision?: string;
+        modifiedArgs?: unknown;
+        additionalContext?: string;
+      }
+    | void;
+  onPostToolUse?: (
+    input: {
+      toolName: string;
+      toolArgs: unknown;
+      toolResult: unknown;
+      cwd: string;
+      timestamp: number;
+    },
+    invocation: { sessionId: string },
+  ) =>
+    | Promise<{ modifiedResult?: unknown; additionalContext?: string } | void>
+    | { modifiedResult?: unknown; additionalContext?: string }
+    | void;
+  onUserPromptSubmitted?: (
+    input: { prompt: string; cwd: string; timestamp: number },
+    invocation: { sessionId: string },
+  ) =>
+    | Promise<{ modifiedPrompt?: string; additionalContext?: string } | void>
+    | { modifiedPrompt?: string; additionalContext?: string }
+    | void;
+  onSessionStart?: (
+    input: {
+      source: string;
+      initialPrompt?: string;
+      cwd: string;
+      timestamp: number;
+    },
+    invocation: { sessionId: string },
+  ) =>
+    | Promise<{ additionalContext?: string } | void>
+    | { additionalContext?: string }
+    | void;
+  onSessionEnd?: (
+    input: {
+      reason: string;
+      finalMessage?: string;
+      error?: string;
+      cwd: string;
+      timestamp: number;
+    },
+    invocation: { sessionId: string },
+  ) => Promise<void> | void;
+  onErrorOccurred?: (
+    input: {
+      error: string;
+      errorContext: string;
+      recoverable: boolean;
+      cwd: string;
+      timestamp: number;
+    },
+    invocation: { sessionId: string },
+  ) =>
+    | Promise<{
+        errorHandling?: string;
+        retryCount?: number;
+        userNotification?: string;
+      } | void>
+    | { errorHandling?: string; retryCount?: number; userNotification?: string }
+    | void;
+}
+
+export interface GitHubCopilotSessionConfig {
+  model?: string;
+  streaming?: boolean;
+  onPermissionRequest: (
+    request: unknown,
+    invocation: { sessionId: string },
+  ) => Promise<unknown> | unknown;
+  hooks?: GitHubCopilotSessionHooks;
+  provider?: {
+    type?: string;
+    baseUrl?: string;
+    apiKey?: string;
+    bearerToken?: string;
+  };
+  [key: string]: unknown;
+}
+
+export interface GitHubCopilotResumeSessionConfig {
+  model?: string;
+  streaming?: boolean;
+  onPermissionRequest: (
+    request: unknown,
+    invocation: { sessionId: string },
+  ) => Promise<unknown> | unknown;
+  hooks?: GitHubCopilotSessionHooks;
+  [key: string]: unknown;
+}
+
+export interface GitHubCopilotMessageOptions {
+  prompt?: string;
+  attachments?: unknown[];
+  [key: string]: unknown;
+}
+
+export interface GitHubCopilotAssistantMessageEvent {
+  type: "assistant.message";
+  agentId?: string;
+  data: GitHubCopilotAssistantMessageData;
+  id: string;
+  timestamp: string;
+}
+
+export interface GitHubCopilotSession {
+  on(handler: (event: GitHubCopilotTrackedEvent) => void): () => void;
+  on<K extends string>(
+    eventType: K,
+    handler: (event: GitHubCopilotTrackedEvent & { type: K }) => void,
+  ): () => void;
+  send(options: GitHubCopilotMessageOptions): Promise<string>;
+  sendAndWait(
+    options: GitHubCopilotMessageOptions,
+    timeout?: number,
+  ): Promise<GitHubCopilotAssistantMessageEvent | undefined>;
+  disconnect(): Promise<void>;
+}
+
+export interface GitHubCopilotClient {
+  createSession(
+    config: GitHubCopilotSessionConfig,
+  ): Promise<GitHubCopilotSession>;
+  resumeSession(
+    sessionId: string,
+    config: GitHubCopilotResumeSessionConfig,
+  ): Promise<GitHubCopilotSession>;
+}

--- a/js/src/wrappers/anthropic.test.ts
+++ b/js/src/wrappers/anthropic.test.ts
@@ -387,7 +387,12 @@ describe("anthropic client unit tests", { retry: 3 }, () => {
       .toLowerCase()
       .replace(/\s/g, "")
       .replace(/'/g, "");
-    expect(output).toContain("btanthropicstreamok");
+    // Validate we collected the streamed text without relying on one exact phrasing.
+    // The system prompt says "Just the poem" so the model returns the poem only,
+    // not the author's name — only assert on poem content.
+    expect(output).toContain("shall i compare thee to a summers day");
+    expect(output).toContain("summer");
+    expect(output.length).toBeGreaterThan(200);
 
     expect(span["span_attributes"].type).toBe("llm");
     expect(span["span_attributes"].name).toBe("anthropic.messages.create");

--- a/js/src/wrappers/anthropic.test.ts
+++ b/js/src/wrappers/anthropic.test.ts
@@ -387,12 +387,7 @@ describe("anthropic client unit tests", { retry: 3 }, () => {
       .toLowerCase()
       .replace(/\s/g, "")
       .replace(/'/g, "");
-    // Validate we collected the streamed text without relying on one exact phrasing.
-    // The system prompt says "Just the poem" so the model returns the poem only,
-    // not the author's name — only assert on poem content.
-    expect(output).toContain("shall i compare thee to a summers day");
-    expect(output).toContain("summer");
-    expect(output.length).toBeGreaterThan(200);
+    expect(output).toContain("btanthropicstreamok");
 
     expect(span["span_attributes"].type).toBe("llm");
     expect(span["span_attributes"].name).toBe("anthropic.messages.create");

--- a/js/src/wrappers/github-copilot.ts
+++ b/js/src/wrappers/github-copilot.ts
@@ -1,0 +1,111 @@
+import { gitHubCopilotChannels } from "../instrumentation/plugins/github-copilot-channels";
+import type {
+  GitHubCopilotClient,
+  GitHubCopilotResumeSessionConfig,
+  GitHubCopilotSession,
+  GitHubCopilotSessionConfig,
+} from "../vendor-sdk-types/github-copilot";
+
+function isGitHubCopilotClient(value: unknown): value is GitHubCopilotClient {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof (value as GitHubCopilotClient).createSession === "function" &&
+    typeof (value as GitHubCopilotClient).resumeSession === "function"
+  );
+}
+
+/**
+ * Wrap a CopilotClient instance (created with `new CopilotClient(...)`) with
+ * Braintrust tracing.
+ *
+ * The wrapper intercepts `createSession` and `resumeSession` so that the same
+ * plugin logic used by auto-instrumentation applies — session spans, turn
+ * spans, LLM spans with token metrics, and tool spans are all produced.
+ *
+ * @example
+ * ```ts
+ * import { CopilotClient, approveAll } from "@github/copilot-sdk";
+ * import { wrapCopilotClient } from "braintrust";
+ *
+ * const client = wrapCopilotClient(new CopilotClient());
+ * const session = await client.createSession({
+ *   model: "gpt-4.1",
+ *   onPermissionRequest: approveAll,
+ * });
+ * ```
+ */
+export function wrapCopilotClient<T extends object>(client: T): T {
+  if (!isGitHubCopilotClient(client)) {
+    // eslint-disable-next-line no-restricted-properties -- preserving intentional console usage.
+    console.warn(
+      "[Braintrust] wrapCopilotClient: argument does not look like a CopilotClient. Not wrapping.",
+    );
+    return client;
+  }
+
+  return copilotClientProxy(client) as T;
+}
+
+function copilotClientProxy(client: GitHubCopilotClient): GitHubCopilotClient {
+  const privateMethodCache = new WeakMap<
+    (...args: unknown[]) => unknown,
+    (...args: unknown[]) => unknown
+  >();
+
+  const proxy: GitHubCopilotClient = new Proxy(client, {
+    get(target, prop, receiver) {
+      if (prop === "createSession") {
+        return wrappedCreateSession(target);
+      }
+
+      if (prop === "resumeSession") {
+        return wrappedResumeSession(target);
+      }
+
+      const value = Reflect.get(target, prop, target);
+      if (typeof value !== "function") {
+        return value;
+      }
+
+      const cached = privateMethodCache.get(value);
+      if (cached) {
+        return cached;
+      }
+
+      const bound = function (this: unknown, ...args: unknown[]): unknown {
+        const thisArg = this === proxy ? target : this;
+        const result = Reflect.apply(value, thisArg, args);
+        return result === target ? proxy : result;
+      };
+
+      privateMethodCache.set(value, bound);
+      return bound;
+    },
+  });
+
+  return proxy;
+}
+
+function wrappedCreateSession(
+  client: GitHubCopilotClient,
+): (config: GitHubCopilotSessionConfig) => Promise<GitHubCopilotSession> {
+  return (config: GitHubCopilotSessionConfig) =>
+    gitHubCopilotChannels.createSession.tracePromise(
+      () => client.createSession(config),
+      { arguments: [config] },
+    );
+}
+
+function wrappedResumeSession(
+  client: GitHubCopilotClient,
+): (
+  sessionId: string,
+  config: GitHubCopilotResumeSessionConfig,
+) => Promise<GitHubCopilotSession> {
+  return (sessionId: string, config: GitHubCopilotResumeSessionConfig) =>
+    gitHubCopilotChannels.resumeSession.tracePromise(
+      () => client.resumeSession(sessionId, config),
+      { arguments: [sessionId, config] },
+    );
+}


### PR DESCRIPTION
## Summary

- Adds auto-instrumentation (via `--import braintrust/hook.mjs` and bundler plugins) and a `wrapCopilotClient(client)` manual wrapper for [`@github/copilot-sdk`](https://www.npmjs.com/package/@github/copilot-sdk) v0.3+
- Span tree: **Copilot Session** (TASK) → **Copilot Turn** (TASK) → **github.copilot.llm** (LLM) / **tool: \<name\>** (TOOL) / **Agent: \<name\>** (TASK for sub-agents)
- Token metrics on LLM spans use the shared Anthropic cache-token helpers: `prompt_tokens`, `completion_tokens`, `prompt_cached_tokens`, `prompt_cache_creation_tokens`, `completion_reasoning_tokens`, `reasoning_tokens`, `tokens`
- Copilot-specific billing fields (`cost`, `quotaSnapshots`, `copilotUsage`) flow into namespaced `github_copilot.*` metadata, not metrics
- Orchestrion configs target `CopilotClient.{createSession,resumeSession}` in `dist/client.js` and `CopilotSession.sendAndWait` in `dist/session.js` (both ESM and CJS)
- Also fixes `imports.test.ts` to skip `node_modules` and `.d.ts` files during the dynamic-import scan (those directories can be populated by test fixture installs)

## Architecture notes

The Copilot SDK is an agent-runtime client (JSON-RPC over a CLI subprocess), not a chat-completions wrapper — so instrumentation follows the lifecycle/processor pattern used for `@anthropic-ai/claude-agent-sdk` rather than the per-method pattern used for Groq/OpenAI.

Span lifecycle is driven by the `assistant.turn_start`/`turn_end` event stream and `assistant.usage` (per-LLM-call metrics). Tool and sub-agent spans use `tool.execution_start`/`complete` and `subagent.started`/`completed`/`failed` events. Session close is triggered by the injected `onSessionEnd` hook.

Parent span IDs are resolved by awaiting `span.export()` (same pattern as `claude-agent-sdk-plugin.ts`). Async event handlers are chained through `state.processing: Promise<void>` to preserve ordering.

## Test plan

- [x] `tsc --noEmit` clean (no type errors)
- [x] `pnpm run build` succeeds
- [x] All 961 unit tests pass
- [x] `pnpm run lint` — warnings only (same pattern as rest of codebase)
- [x] `pnpm run formatting` clean
- Unit tests cover: `extractMetricsFromUsage` (all token/cache/reasoning/billing fields), plugin lifecycle, orchestrion config shape, `BraintrustPlugin` wiring
- E2e scenario at `e2e/scenarios/github-copilot-instrumentation/` requires a GitHub Copilot subscription or a BYOK provider endpoint (`BRAINTRUST_E2E_MODEL_BASE_URL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)