### PR TITLE
fix(ci): add COPILOT_API_KEY to e2e-canary workflow env

### DIFF
--- a/.github/workflows/e2e-canary.yaml
+++ b/.github/workflows/e2e-canary.yaml
@@ -35,6 +35,7 @@ jobs:
           BRAINTRUST_E2E_PROJECT_NAME: ${{ vars.BRAINTRUST_E2E_PROJECT_NAME }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
+          COPILOT_API_KEY: ${{ secrets.COPILOT_API_KEY }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## Summary

- `COPILOT_API_KEY` was set as a GHA secret but was not listed in the explicit `env:` block of the `e2e-canary` job's run step
- The subprocess running the copilot scenario inherits only the explicitly-listed env vars, so `process.env.COPILOT_API_KEY` was always `undefined` in that job
- The key is already correctly wired in `integration-tests.yaml` (lines 62, 116); this aligns the canary job

## Test plan

- [ ] Trigger a canary run and confirm the `github-copilot-instrumentation` tests no longer fail with "Either COPILOT_API_KEY or BRAINTRUST_E2E_MODEL_BASE_URL must be set"

🤖 Generated with [Claude Code](https://claude.com/claude-code)