### PR TITLE
chore: add gitleaks secret scanning to pre-commit hook

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+title = "Braintrust SDK gitleaks config"
+
+[extend]
+# Use the default gitleaks ruleset as the base
+useDefault = true
+
+[[rules]]
+id = "braintrust-api-key"
+description = "Braintrust API key"
+regex = '''\bsk-[a-zA-Z0-9]{40,}\b'''
+tags = ["key", "braintrust"]

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,8 @@
+# Check for secrets in staged files before committing
+if command -v gitleaks &> /dev/null; then
+  gitleaks protect --staged --redact --no-banner
+else
+  echo "WARNING: gitleaks not installed — skipping secret scan. Install via: brew install gitleaks"
+fi
+
 pnpm exec lint-staged


### PR DESCRIPTION
## Summary

- Adds `gitleaks protect --staged` to the Husky pre-commit hook to scan staged files for API keys and secrets before each commit
- Adds `.gitleaks.toml` extending the default gitleaks ruleset with a custom rule for Braintrust API keys (`sk-` prefix)
- Gracefully degrades with a warning if `gitleaks` is not installed, so contributors aren't hard-blocked until they install it

## Setup

Developers need to install gitleaks once:

```bash
brew install gitleaks
```

## Test plan

- [ ] Stage a file containing a fake secret (e.g. `sk-abc123...`) and verify `git commit` is blocked
- [ ] Verify `git commit` proceeds normally when no secrets are present
- [ ] Verify the warning message appears when gitleaks is not installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)