### PR TITLE
fix: prevent duplicate LLM spans when multiple SDK instances coexist (BT-5139)

### DIFF
--- a/.changeset/fix-bt-5139-duplicate-spans.md
+++ b/.changeset/fix-bt-5139-duplicate-spans.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+fix: prevent duplicate LLM spans when multiple SDK instances are loaded in the same process

--- a/js/src/instrumentation/registry.test.ts
+++ b/js/src/instrumentation/registry.test.ts
@@ -50,6 +50,28 @@ describe("Plugin Registry", () => {
     testRegistry.disable();
   });
 
+  it("should block a second instance from subscribing when another is already enabled", () => {
+    // Regression test for BT-5139: when the SDK is loaded from two different
+    // module paths in the same process, each gets its own PluginRegistry
+    // instance. Without cross-instance deduplication, both would subscribe to
+    // the same diagnostics_channel, causing every OpenAI call to produce two
+    // LLM spans.
+    const instanceA = new (registry.constructor as any)();
+    const instanceB = new (registry.constructor as any)();
+
+    try {
+      instanceA.enable();
+      expect(instanceA.isEnabled()).toBe(true);
+
+      // instanceB should be blocked — the channel is already subscribed
+      instanceB.enable();
+      expect(instanceB.isEnabled()).toBe(false);
+    } finally {
+      instanceA.disable();
+      instanceB.disable();
+    }
+  });
+
   it("should warn if configureInstrumentation is called after enable", () => {
     const testRegistry = new (registry.constructor as any)();
     const warnSpy = [] as string[];

--- a/js/src/instrumentation/registry.test.ts
+++ b/js/src/instrumentation/registry.test.ts
@@ -56,6 +56,14 @@ describe("Plugin Registry", () => {
     // instance. Without cross-instance deduplication, both would subscribe to
     // the same diagnostics_channel, causing every OpenAI call to produce two
     // LLM spans.
+    //
+    // The dedup mechanism checks globalThis[Symbol.for("braintrust-state")],
+    // which is the shared state object that all SDK instances reuse (see
+    // _internalSetInitialState in logger.ts). We simulate that here.
+    const sharedState = {};
+    const stateKey = Symbol.for("braintrust-state");
+    (globalThis as any)[stateKey] = sharedState;
+
     const instanceA = new (registry.constructor as any)();
     const instanceB = new (registry.constructor as any)();
 
@@ -69,6 +77,7 @@ describe("Plugin Registry", () => {
     } finally {
       instanceA.disable();
       instanceB.disable();
+      delete (globalThis as any)[stateKey];
     }
   });
 

--- a/js/src/instrumentation/registry.ts
+++ b/js/src/instrumentation/registry.ts
@@ -8,10 +8,30 @@
 import { BraintrustPlugin } from "./braintrust-plugin";
 import iso from "../isomorph";
 
-// Process-global deduplication key: prevents multiple SDK instances loaded
-// from different module paths from each subscribing to the same
-// diagnostics_channel, which would create duplicate spans per API call.
-const GLOBAL_REGISTRY_ENABLED_KEY = Symbol.for("braintrust.registry.enabled");
+// Key used to stamp the active PluginRegistry instance onto the shared
+// braintrust state object (globalThis[Symbol.for("braintrust-state")]).
+//
+// The braintrust state is already shared across all SDK instances loaded in
+// the same process (see _internalSetInitialState in logger.ts), so using it
+// as the carrier gives us cross-instance deduplication for free:
+//
+// - BT-5139 scenario: two SDK instances share the same state object → the
+//   second instance sees the marker left by the first and skips subscription,
+//   preventing duplicate diagnostics_channel listeners.
+//
+// - vi.resetModules() test scenario: the test deletes the state from
+//   globalThis between runs, so the next import creates a fresh state with no
+//   marker and can subscribe normally.
+const REGISTRY_STATE_KEY = Symbol.for("braintrust.registry");
+
+function getSharedState(): Record<symbol, unknown> | undefined {
+  const state = (globalThis as Record<symbol, unknown>)[
+    Symbol.for("braintrust-state")
+  ];
+  return state && typeof state === "object"
+    ? (state as Record<symbol, unknown>)
+    : undefined;
+}
 
 export interface InstrumentationConfig {
   /**
@@ -67,12 +87,15 @@ class PluginRegistry {
 
     // If another SDK instance in the same process already registered plugins,
     // skip to avoid duplicate diagnostics_channel subscriptions.
-    if ((globalThis as Record<symbol, unknown>)[GLOBAL_REGISTRY_ENABLED_KEY]) {
-      return;
+    const sharedState = getSharedState();
+    if (sharedState) {
+      if (sharedState[REGISTRY_STATE_KEY] !== undefined) {
+        return;
+      }
+      sharedState[REGISTRY_STATE_KEY] = this;
     }
 
     this.enabled = true;
-    (globalThis as Record<symbol, unknown>)[GLOBAL_REGISTRY_ENABLED_KEY] = true;
 
     // Read config from environment variables
     const envConfig = this.readEnvConfig();
@@ -99,7 +122,11 @@ class PluginRegistry {
     }
 
     this.enabled = false;
-    delete (globalThis as Record<symbol, unknown>)[GLOBAL_REGISTRY_ENABLED_KEY];
+
+    const sharedState = getSharedState();
+    if (sharedState && sharedState[REGISTRY_STATE_KEY] === this) {
+      delete sharedState[REGISTRY_STATE_KEY];
+    }
 
     if (this.braintrustPlugin) {
       this.braintrustPlugin.disable();

--- a/js/src/instrumentation/registry.ts
+++ b/js/src/instrumentation/registry.ts
@@ -8,6 +8,11 @@
 import { BraintrustPlugin } from "./braintrust-plugin";
 import iso from "../isomorph";
 
+// Process-global deduplication key: prevents multiple SDK instances loaded
+// from different module paths from each subscribing to the same
+// diagnostics_channel, which would create duplicate spans per API call.
+const GLOBAL_REGISTRY_ENABLED_KEY = Symbol.for("braintrust.registry.enabled");
+
 export interface InstrumentationConfig {
   /**
    * Configuration for individual SDK integrations.
@@ -60,7 +65,14 @@ class PluginRegistry {
       return;
     }
 
+    // If another SDK instance in the same process already registered plugins,
+    // skip to avoid duplicate diagnostics_channel subscriptions.
+    if ((globalThis as Record<symbol, unknown>)[GLOBAL_REGISTRY_ENABLED_KEY]) {
+      return;
+    }
+
     this.enabled = true;
+    (globalThis as Record<symbol, unknown>)[GLOBAL_REGISTRY_ENABLED_KEY] = true;
 
     // Read config from environment variables
     const envConfig = this.readEnvConfig();
@@ -87,6 +99,7 @@ class PluginRegistry {
     }
 
     this.enabled = false;
+    delete (globalThis as Record<symbol, unknown>)[GLOBAL_REGISTRY_ENABLED_KEY];
 
     if (this.braintrustPlugin) {
       this.braintrustPlugin.disable();


### PR DESCRIPTION
## Summary

- When the Braintrust SDK is loaded from two different module paths in the same process (e.g. a cloud runner's bundled copy + the user's scorer dependency), each `PluginRegistry` instance independently subscribed to the same process-global `diagnostics_channel`. Every OpenAI API call fired one channel event, but with two subscribers, two LLM spans were created — the duplicate spans reported in BT-5139.
- Fix adds a `Symbol.for("braintrust.registry.enabled")` guard on `globalThis` so only the first `PluginRegistry` to call `enable()` registers channel subscriptions. `disable()` clears the flag so test enable/disable cycles work correctly.
- Regression test added: creates two registry instances, enables both, asserts only the first one's `isEnabled()` returns `true`.

## Test plan

- [ ] `pnpm exec vitest run src/instrumentation/registry.test.ts` — all 15 tests pass
- [ ] Verified new test fails on old code (`instanceB.isEnabled()` returns `true` without the fix) and passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)