### PR TITLE
chore: Bump valibot to `1.4.0` in `js/examples/ai-sdk/next-openai-app`

### DIFF
--- a/js/examples/ai-sdk/next-openai-app/package.json
+++ b/js/examples/ai-sdk/next-openai-app/package.json
@@ -45,7 +45,7 @@
     "streamdown": "^1.4.0",
     "tailwind-merge": "^3.0.2",
     "tailwindcss-animate": "^1.0.7",
-    "valibot": "1.1.0",
+    "valibot": "1.4.0",
     "zod": "3.25.76"
   },
   "devDependencies": {

--- a/js/examples/ai-sdk/next-openai-app/pnpm-lock.yaml
+++ b/js/examples/ai-sdk/next-openai-app/pnpm-lock.yaml
@@ -10,52 +10,52 @@ importers:
     dependencies:
       '@ai-sdk/amazon-bedrock':
         specifier: 4.0.0-beta.55
-        version: 4.0.0-beta.55(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+        version: 4.0.0-beta.55(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@ai-sdk/anthropic':
         specifier: 3.0.0-beta.50
-        version: 3.0.0-beta.50(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+        version: 3.0.0-beta.50(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@ai-sdk/cohere':
         specifier: 3.0.0-beta.32
-        version: 3.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+        version: 3.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@ai-sdk/deepseek':
         specifier: 2.0.0-beta.32
-        version: 2.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+        version: 2.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@ai-sdk/fireworks':
         specifier: 2.0.0-beta.32
-        version: 2.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+        version: 2.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@ai-sdk/google':
         specifier: 3.0.0-beta.39
-        version: 3.0.0-beta.39(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+        version: 3.0.0-beta.39(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@ai-sdk/google-vertex':
         specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+        version: 4.0.0-beta.59(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@ai-sdk/groq':
         specifier: 3.0.0-beta.31
-        version: 3.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+        version: 3.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@ai-sdk/mcp':
         specifier: 1.0.0-beta.13
-        version: 1.0.0-beta.13(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+        version: 1.0.0-beta.13(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@ai-sdk/mistral':
         specifier: 3.0.0-beta.32
-        version: 3.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+        version: 3.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@ai-sdk/openai':
         specifier: 3.0.0-beta.54
-        version: 3.0.0-beta.54(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+        version: 3.0.0-beta.54(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@ai-sdk/perplexity':
         specifier: 3.0.0-beta.31
-        version: 3.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+        version: 3.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@ai-sdk/provider-utils':
         specifier: 4.0.0-beta.31
-        version: 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+        version: 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@ai-sdk/react':
         specifier: 3.0.0-beta.94
-        version: 3.0.0-beta.94(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(react@18.3.1)(zod@3.25.76)
+        version: 3.0.0-beta.94(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(react@18.3.1)(zod@3.25.76)
       '@ai-sdk/rsc':
         specifier: 2.0.0-beta.94
-        version: 2.0.0-beta.94(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(react@18.3.1)(zod@3.25.76)
+        version: 2.0.0-beta.94(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(react@18.3.1)(zod@3.25.76)
       '@ai-sdk/xai':
         specifier: 3.0.0-beta.35
-        version: 3.0.0-beta.35(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+        version: 3.0.0-beta.35(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@modelcontextprotocol/sdk':
         specifier: ^1.10.2
         version: 1.29.0(zod@3.25.76)
@@ -67,7 +67,7 @@ importers:
         version: 1.2.2(@types/react@18.3.28)(react@18.3.1)
       '@valibot/to-json-schema':
         specifier: ^1.3.0
-        version: 1.6.0(valibot@1.1.0(typescript@5.8.3))
+        version: 1.6.0(valibot@1.4.0(typescript@5.8.3))
       '@vercel/blob':
         specifier: ^0.26.0
         version: 0.26.0
@@ -76,7 +76,7 @@ importers:
         version: 0.0.21
       ai:
         specifier: 6.0.0-beta.94
-        version: 6.0.0-beta.94(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+        version: 6.0.0-beta.94(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       braintrust:
         specifier: file:../../..
         version: file:../../..(zod@3.25.76)
@@ -117,8 +117,8 @@ importers:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.19)
       valibot:
-        specifier: 1.1.0
-        version: 1.1.0(typescript@5.8.3)
+        specifier: 1.4.0
+        version: 1.4.0(typescript@5.8.3)
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -290,8 +290,8 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  '@apm-js-collab/code-transformer@0.9.0':
-    resolution: {integrity: sha512-cfHtufVUBKJz6se/tQBJqizgoot5AOxhVy5B9Cuo493p6b7hXKBEIi6tcZEbr4XwN1VnV9JZOu52MMTCOCSBMw==}
+  '@apm-js-collab/code-transformer@0.12.0':
+    resolution: {integrity: sha512-5F2ob4cMYezbaUGAk+YltbDvb9BFIghN92ubct9Ho/0MFx4FkChCxYV99NkU6Kx+RAgaqBV6yxKuWreQ6K8SOw==}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -979,6 +979,12 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@simple-git/args-pathspec@1.0.3':
+    resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
+
+  '@simple-git/argv-parser@1.1.1':
+    resolution: {integrity: sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==}
+
   '@smithy/eventstream-codec@4.2.12':
     resolution: {integrity: sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==}
     engines: {node: '>=18.0.0'}
@@ -1203,6 +1209,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -1458,6 +1465,10 @@ packages:
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
+  astring@1.9.0:
+    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
+    hasBin: true
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -2920,6 +2931,10 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
+  meriyah@6.1.4:
+    resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
+    engines: {node: '>=18.0.0'}
+
   mermaid@11.14.0:
     resolution: {integrity: sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==}
 
@@ -3585,6 +3600,9 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
+  semifies@1.0.0:
+    resolution: {integrity: sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -3660,8 +3678,8 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  simple-git@3.33.0:
-    resolution: {integrity: sha512-D4V/tGC2sjsoNhoMybKyGoE+v8A60hRawKQ1iFRA1zwuDgGZCBJ4ByOzZ5J8joBbi4Oam0qiPH+GhzmSBwbJng==}
+  simple-git@3.36.0:
+    resolution: {integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==}
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -3669,6 +3687,10 @@ packages:
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   source-map@0.7.6:
@@ -3995,8 +4017,8 @@ packages:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
-  valibot@1.1.0:
-    resolution: {integrity: sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==}
+  valibot@1.4.0:
+    resolution: {integrity: sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -4115,11 +4137,11 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/amazon-bedrock@4.0.0-beta.55(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)':
+  '@ai-sdk/amazon-bedrock@4.0.0-beta.55(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/anthropic': 3.0.0-beta.50(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/anthropic': 3.0.0-beta.50(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@ai-sdk/provider': 3.0.0-beta.15
-      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@smithy/eventstream-codec': 4.2.12
       '@smithy/util-utf8': 4.2.2
       aws4fetch: 1.0.20
@@ -4129,52 +4151,52 @@ snapshots:
       - arktype
       - effect
 
-  '@ai-sdk/anthropic@3.0.0-beta.50(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)':
+  '@ai-sdk/anthropic@3.0.0-beta.50(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.0-beta.15
-      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@valibot/to-json-schema'
       - arktype
       - effect
 
-  '@ai-sdk/cohere@3.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)':
+  '@ai-sdk/cohere@3.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.0-beta.15
-      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@valibot/to-json-schema'
       - arktype
       - effect
 
-  '@ai-sdk/deepseek@2.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)':
+  '@ai-sdk/deepseek@2.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/openai-compatible': 2.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/openai-compatible': 2.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@ai-sdk/provider': 3.0.0-beta.15
-      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@valibot/to-json-schema'
       - arktype
       - effect
 
-  '@ai-sdk/fireworks@2.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)':
+  '@ai-sdk/fireworks@2.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/openai-compatible': 2.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/openai-compatible': 2.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@ai-sdk/provider': 3.0.0-beta.15
-      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@valibot/to-json-schema'
       - arktype
       - effect
 
-  '@ai-sdk/gateway@2.0.0-beta.50(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)':
+  '@ai-sdk/gateway@2.0.0-beta.50(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.0-beta.15
-      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@vercel/oidc': 3.0.3
       zod: 3.25.76
     transitivePeerDependencies:
@@ -4182,12 +4204,12 @@ snapshots:
       - arktype
       - effect
 
-  '@ai-sdk/google-vertex@4.0.0-beta.59(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)':
+  '@ai-sdk/google-vertex@4.0.0-beta.59(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/anthropic': 3.0.0-beta.50(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
-      '@ai-sdk/google': 3.0.0-beta.39(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/anthropic': 3.0.0-beta.50(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/google': 3.0.0-beta.39(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@ai-sdk/provider': 3.0.0-beta.15
-      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       google-auth-library: 9.15.1
       zod: 3.25.76
     transitivePeerDependencies:
@@ -4197,30 +4219,30 @@ snapshots:
       - encoding
       - supports-color
 
-  '@ai-sdk/google@3.0.0-beta.39(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)':
+  '@ai-sdk/google@3.0.0-beta.39(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.0-beta.15
-      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@valibot/to-json-schema'
       - arktype
       - effect
 
-  '@ai-sdk/groq@3.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)':
+  '@ai-sdk/groq@3.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.0-beta.15
-      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@valibot/to-json-schema'
       - arktype
       - effect
 
-  '@ai-sdk/mcp@1.0.0-beta.13(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)':
+  '@ai-sdk/mcp@1.0.0-beta.13(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.0-beta.15
-      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       pkce-challenge: 5.0.1
       zod: 3.25.76
     transitivePeerDependencies:
@@ -4228,54 +4250,54 @@ snapshots:
       - arktype
       - effect
 
-  '@ai-sdk/mistral@3.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)':
+  '@ai-sdk/mistral@3.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.0-beta.15
-      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@valibot/to-json-schema'
       - arktype
       - effect
 
-  '@ai-sdk/openai-compatible@2.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)':
+  '@ai-sdk/openai-compatible@2.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.0-beta.15
-      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@valibot/to-json-schema'
       - arktype
       - effect
 
-  '@ai-sdk/openai@3.0.0-beta.54(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)':
+  '@ai-sdk/openai@3.0.0-beta.54(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.0-beta.15
-      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@valibot/to-json-schema'
       - arktype
       - effect
 
-  '@ai-sdk/perplexity@3.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)':
+  '@ai-sdk/perplexity@3.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.0-beta.15
-      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@valibot/to-json-schema'
       - arktype
       - effect
 
-  '@ai-sdk/provider-utils@4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)':
+  '@ai-sdk/provider-utils@4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.0-beta.15
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 3.25.76
     optionalDependencies:
-      '@valibot/to-json-schema': 1.6.0(valibot@1.1.0(typescript@5.8.3))
+      '@valibot/to-json-schema': 1.6.0(valibot@1.4.0(typescript@5.8.3))
 
   '@ai-sdk/provider@1.1.3':
     dependencies:
@@ -4285,10 +4307,10 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@3.0.0-beta.94(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(react@18.3.1)(zod@3.25.76)':
+  '@ai-sdk/react@3.0.0-beta.94(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(react@18.3.1)(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
-      ai: 6.0.0-beta.94(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
+      ai: 6.0.0-beta.94(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       react: 18.3.1
       swr: 2.4.1(react@18.3.1)
       throttleit: 2.1.0
@@ -4298,11 +4320,11 @@ snapshots:
       - effect
       - zod
 
-  '@ai-sdk/rsc@2.0.0-beta.94(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(react@18.3.1)(zod@3.25.76)':
+  '@ai-sdk/rsc@2.0.0-beta.94(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(react@18.3.1)(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.0-beta.15
-      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
-      ai: 6.0.0-beta.94(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
+      ai: 6.0.0-beta.94(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       jsondiffpatch: 0.6.0
       react: 18.3.1
     optionalDependencies:
@@ -4312,11 +4334,11 @@ snapshots:
       - arktype
       - effect
 
-  '@ai-sdk/xai@3.0.0-beta.35(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)':
+  '@ai-sdk/xai@3.0.0-beta.35(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/openai-compatible': 2.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/openai-compatible': 2.0.0-beta.32(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@ai-sdk/provider': 3.0.0-beta.15
-      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@valibot/to-json-schema'
@@ -4330,7 +4352,14 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.0.4
 
-  '@apm-js-collab/code-transformer@0.9.0': {}
+  '@apm-js-collab/code-transformer@0.12.0':
+    dependencies:
+      '@types/estree': 1.0.8
+      astring: 1.9.0
+      esquery: 1.7.0
+      meriyah: 6.1.4
+      semifies: 1.0.0
+      source-map: 0.6.1
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -4878,6 +4907,12 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@simple-git/args-pathspec@1.0.3': {}
+
+  '@simple-git/argv-parser@1.1.1':
+    dependencies:
+      '@simple-git/args-pathspec': 1.0.3
+
   '@smithy/eventstream-codec@4.2.12':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
@@ -5205,9 +5240,9 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3))':
+  '@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3))':
     dependencies:
-      valibot: 1.1.0(typescript@5.8.3)
+      valibot: 1.4.0(typescript@5.8.3)
 
   '@vercel/blob@0.26.0':
     dependencies:
@@ -5258,11 +5293,11 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@6.0.0-beta.94(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76):
+  ai@6.0.0-beta.94(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 2.0.0-beta.50(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/gateway': 2.0.0-beta.50(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@ai-sdk/provider': 3.0.0-beta.15
-      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.1.0(typescript@5.8.3)))(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.0-beta.31(@valibot/to-json-schema@1.6.0(valibot@1.4.0(typescript@5.8.3)))(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -5388,6 +5423,8 @@ snapshots:
 
   ast-types-flow@0.0.8: {}
 
+  astring@1.9.0: {}
+
   async-function@1.0.0: {}
 
   async-retry@1.3.3:
@@ -5487,7 +5524,7 @@ snapshots:
   braintrust@file:../../..(zod@3.25.76):
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@apm-js-collab/code-transformer': 0.9.0
+      '@apm-js-collab/code-transformer': 0.12.0
       '@next/env': 14.2.35
       '@vercel/functions': 1.6.0
       ajv: 8.18.0
@@ -5508,7 +5545,7 @@ snapshots:
       module-details-from-path: 1.0.4
       mustache: 4.2.0
       pluralize: 8.0.0
-      simple-git: 3.33.0
+      simple-git: 3.36.0
       source-map: 0.7.6
       termi-link: 1.1.0
       unplugin: 2.3.11
@@ -6128,7 +6165,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -6158,7 +6195,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6173,7 +6210,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7314,6 +7351,8 @@ snapshots:
 
   merge2@1.4.1: {}
 
+  meriyah@6.1.4: {}
+
   mermaid@11.14.0:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
@@ -8170,6 +8209,8 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  semifies@1.0.0: {}
+
   semver@6.3.1: {}
 
   semver@7.7.4: {}
@@ -8329,10 +8370,12 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-git@3.33.0:
+  simple-git@3.36.0:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
+      '@simple-git/args-pathspec': 1.0.3
+      '@simple-git/argv-parser': 1.1.1
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -8340,6 +8383,8 @@ snapshots:
   slash@3.0.0: {}
 
   source-map-js@1.2.1: {}
+
+  source-map@0.6.1: {}
 
   source-map@0.7.6: {}
 
@@ -8785,7 +8830,7 @@ snapshots:
 
   uuid@9.0.1: {}
 
-  valibot@1.1.0(typescript@5.8.3):
+  valibot@1.4.0(typescript@5.8.3):
     optionalDependencies:
       typescript: 5.8.3
 


### PR DESCRIPTION
## Summary
- Bumps `valibot` from `1.1.0` → `1.4.0` in `js/examples/ai-sdk/next-openai-app` to patch [GHSA-vqpr-j7v3-hqw9](https://github.com/advisories/GHSA-vqpr-j7v3-hqw9) (CVE-2025-66020), a ReDoS in `EMOJI_REGEX`.
- Patched version is `>= 1.2.0`; chose `1.4.0` (latest) to also satisfy the `^1.3.0` peer dep declared by `@valibot/to-json-schema@1.6.0`.
- Regenerated `pnpm-lock.yaml` — all references to `valibot@1.1.0` now resolve to `valibot@1.4.0`. This is the only place in the repo that depends on valibot.

## Test plan
- [ ] CI passes
- [ ] Dependabot alert #55 closes