### PR TITLE
feat(vitest): Support projectId in wrapVitest config

### DIFF
--- a/.changeset/curvy-grapes-admire.md
+++ b/.changeset/curvy-grapes-admire.md
@@ -1,0 +1,5 @@
+---
+"braintrust": minor
+---
+
+feat(vitest): Support projectId in wrapVitest config

--- a/js/src/wrappers/vitest/README.md
+++ b/js/src/wrappers/vitest/README.md
@@ -314,6 +314,7 @@ wrapVitest(
   },
   config?: {
     projectName?: string;        // Project name (defaults to suite name)
+    projectId?: string;          // Stable project ID; takes precedence over projectName
     displaySummary?: boolean;    // Show summary after tests (default: true)
     onProgress?: (event: ProgressEvent) => void;  // Progress callback
   }

--- a/js/src/wrappers/vitest/types.ts
+++ b/js/src/wrappers/vitest/types.ts
@@ -154,6 +154,11 @@ export interface BraintrustVitest<
 export interface WrapperConfig {
   projectName?: string;
   /**
+   * The id of the project to create experiments in. Takes precedence over
+   * `projectName` if both are set.
+   */
+  projectId?: string;
+  /**
    * If true, displays a formatted experiment summary with scores and URL after the test suite completes.
    * Defaults to true. Set to false to suppress the summary output.
    */

--- a/js/src/wrappers/vitest/vitest-wrapper.test.ts
+++ b/js/src/wrappers/vitest/vitest-wrapper.test.ts
@@ -9,6 +9,7 @@ import {
   vi,
   expectTypeOf,
 } from "vitest";
+import { configureNode } from "../../node/config";
 import { wrapVitest } from "./index";
 import { wrapExpect } from "./expect-wrapper";
 import {
@@ -24,6 +25,8 @@ import {
 } from "./context-manager";
 import { flushExperimentWithSync } from "./flush-manager";
 
+configureNode();
+
 // ✅ Set up test state and background logger at module level for unit tests
 _exportsForTestingOnly.setInitialTestState();
 await _exportsForTestingOnly.simulateLoginForTests();
@@ -34,14 +37,23 @@ vi.spyOn(logger, "initDataset").mockReturnValue({
   insert: vi.fn(() => "test-example-id"),
 } as any);
 
-vi.spyOn(logger, "initExperiment").mockImplementation(
-  (projectName: string, options?: any) => {
+const initExperimentSpy = vi
+  .spyOn(logger, "initExperiment")
+  .mockImplementation((projectOrOptions: string | any, options?: any) => {
+    const experimentOptions =
+      typeof projectOrOptions === "string" ? options : projectOrOptions;
+    const projectName =
+      typeof projectOrOptions === "string"
+        ? projectOrOptions
+        : (projectOrOptions.project ??
+          projectOrOptions.projectId ??
+          "test-project");
+
     return _exportsForTestingOnly.initTestExperiment(
-      options?.experiment || "test-experiment",
+      experimentOptions?.experiment || "test-experiment",
       projectName,
     );
-  },
-);
+  });
 
 describe("Braintrust Vitest Wrapper", () => {
   // Test logger already set up at module level
@@ -406,6 +418,116 @@ describe("Configuration Options", () => {
     );
     expect(bt).toBeDefined();
     // Progress events will be emitted if onProgress is provided
+  });
+});
+
+describe("Project selection", () => {
+  function makeFakeVitestMethods() {
+    const fakeTest: any = vi.fn(
+      (_name: string, maybeOptions: any, maybeFn?: any) => {
+        const fn = typeof maybeOptions === "function" ? maybeOptions : maybeFn;
+        return fn ? fn({}) : undefined;
+      },
+    );
+    fakeTest.skip = fakeTest;
+    fakeTest.only = fakeTest;
+    fakeTest.concurrent = fakeTest;
+    fakeTest.todo = vi.fn();
+
+    const fakeDescribe: any = vi.fn((_name: string, factory: () => void) =>
+      factory(),
+    );
+    fakeDescribe.skip = fakeDescribe;
+    fakeDescribe.only = fakeDescribe;
+    fakeDescribe.concurrent = fakeDescribe;
+    fakeDescribe.todo = vi.fn();
+
+    return {
+      test: fakeTest,
+      expect,
+      describe: fakeDescribe,
+      afterAll: vi.fn(),
+    };
+  }
+
+  beforeEach(() => {
+    initExperimentSpy.mockClear();
+    _resetContextManager();
+  });
+
+  test("wrapVitest passes projectId to initExperiment", async () => {
+    const bt = wrapVitest(makeFakeVitestMethods(), {
+      projectId: "project-id-123",
+      displaySummary: false,
+    });
+
+    await bt.describe("project id suite", () => {
+      bt.test("uses project id", async () => undefined);
+    });
+
+    expect(initExperimentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "project-id-123",
+        experiment: expect.stringMatching(/^project id suite-/),
+      }),
+    );
+  });
+
+  test("wrapVitest uses projectId instead of projectName when both are set", async () => {
+    const bt = wrapVitest(makeFakeVitestMethods(), {
+      projectName: "project-name",
+      projectId: "project-id-123",
+      displaySummary: false,
+    });
+
+    await bt.describe("precedence suite", () => {
+      bt.test("uses project id", async () => undefined);
+    });
+
+    expect(initExperimentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "project-id-123",
+      }),
+    );
+    expect(initExperimentSpy).not.toHaveBeenCalledWith(
+      "project-name",
+      expect.anything(),
+    );
+  });
+
+  test("wrapVitest preserves projectName behavior when projectId is absent", async () => {
+    const bt = wrapVitest(makeFakeVitestMethods(), {
+      projectName: "project-name",
+      displaySummary: false,
+    });
+
+    await bt.describe("project name suite", () => {
+      bt.test("uses project name", async () => undefined);
+    });
+
+    expect(initExperimentSpy).toHaveBeenCalledWith(
+      "project-name",
+      expect.objectContaining({
+        experiment: expect.stringMatching(/^project name suite-/),
+      }),
+    );
+  });
+
+  test("wrapVitest preserves suite-name fallback", async () => {
+    const bt = wrapVitest(makeFakeVitestMethods(), {
+      displaySummary: false,
+    });
+
+    await bt.describe("fallback suite", () => {
+      bt.test("uses suite name", async () => undefined);
+    });
+
+    expect(initExperimentSpy).toHaveBeenCalledWith(
+      "fallback suite",
+      expect.objectContaining({
+        experiment: expect.stringMatching(/^fallback suite-/),
+      }),
+    );
   });
 });
 

--- a/js/src/wrappers/vitest/wrapper.ts
+++ b/js/src/wrappers/vitest/wrapper.ts
@@ -212,11 +212,16 @@ export function wrapDescribe(
 
         const getOrCreateContext = (): VitestExperimentContext => {
           if (!context) {
-            const projectName = config.projectName || suiteName;
+            const experimentName = `${suiteName}-${new Date().toISOString()}`;
 
-            const experiment = initExperiment(projectName, {
-              experiment: `${suiteName}-${new Date().toISOString()}`,
-            });
+            const experiment = config.projectId
+              ? initExperiment({
+                  projectId: config.projectId,
+                  experiment: experimentName,
+                })
+              : initExperiment(config.projectName || suiteName, {
+                  experiment: experimentName,
+                });
 
             context = contextManager.createChildContext(undefined, experiment);
           }


### PR DESCRIPTION
## Summary

Adds an optional `projectId` field to the `wrapVitest` configuration, letting users target a specific Braintrust project by its stable ID instead of by name. When `projectId` is set, it takes precedence over `projectName`.

## Motivation

Project names can be renamed or collide across orgs. Users who already know the project ID (e.g. from CI config or another integration) had no way to bind Vitest experiments to that exact project. This brings the wrapper in line with `init` / `initExperiment`, which both accept `projectId`.

## Changes

- `js/src/wrappers/vitest/types.ts` — Add `projectId?: string` to `WrapperConfig` with a docstring noting precedence over `projectName`.
- `js/src/wrappers/vitest/wrapper.ts` — In `wrapDescribe`'s lazy `getOrCreateContext`, branch on `config.projectId`:
  - If set, call `initExperiment({ projectId, experiment })`.
  - Otherwise, preserve the existing `initExperiment(projectName ?? suiteName, { experiment })` call (no behavior change for existing users).
- `js/src/wrappers/vitest/README.md` — Document the new `projectId` parameter on `wrapVitest`.
- `js/src/wrappers/vitest/vitest-wrapper.test.ts`:
  - Update the `initExperiment` mock to handle both overloads (positional `projectName` and options object).
  - Add `configureNode()` at module load so AsyncLocalStorage actually propagates context — required for the new tests' synchronous fake `describe` factories to exercise experiment creation.
  - Add a `Project selection` describe block with four tests:
    1. `projectId` is forwarded to `initExperiment`.
    2. `projectId` takes precedence when both `projectId` and `projectName` are set.
    3. `projectName`-only path is unchanged.
    4. Suite-name fallback (no project config) is unchanged.

## Usage

```ts
import * as vitest from "vitest";
import { wrapVitest } from "braintrust";

const bt = wrapVitest(vitest, {
  projectId: "abc-123-stable-project-id",
});

bt.describe("my suite", () => {
  bt.test("logs to the project by id", async () => {
    /* ... */
  });
});