### PR TITLE
fix: upgrade ajv to address dependabot alerts

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -198,7 +198,7 @@
     "@apm-js-collab/code-transformer": "^0.12.0",
     "@next/env": "^14.2.3",
     "@vercel/functions": "^1.0.2",
-    "ajv": "^8.17.1",
+    "ajv": "^8.20.0",
     "argparse": "^2.0.1",
     "boxen": "^8.0.1",
     "chalk": "^4.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,13 +91,13 @@ importers:
         version: 2.6.1(@opentelemetry/api@1.9.0)
       '@types/node':
         specifier: ^20.10.5
-        version: 20.19.16
+        version: 20.19.40
       braintrust:
         specifier: workspace:^
         version: link:../js
       msw:
         specifier: ^2.6.6
-        version: 2.13.6(@types/node@20.19.16)(typescript@5.4.4)
+        version: 2.13.6(@types/node@20.19.40)(typescript@5.4.4)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -106,7 +106,7 @@ importers:
         version: 5.4.4
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.16)(msw@2.13.6(@types/node@20.19.16)(typescript@5.4.4))(vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(msw@2.13.6(@types/node@20.19.40)(typescript@5.4.4))(vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -125,7 +125,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ^20.10.5
-        version: 20.19.16
+        version: 20.19.40
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -134,7 +134,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.16)(msw@2.13.6(@types/node@20.19.16)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(msw@2.13.6(@types/node@20.19.40)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
 
   integrations/langchain-js:
     devDependencies:
@@ -152,13 +152,13 @@ importers:
         version: 1.2.1(@langchain/core@1.1.10(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.18.3)(zod@3.25.76)))(ws@8.18.3)
       '@types/node':
         specifier: ^20.10.5
-        version: 20.19.16
+        version: 20.19.40
       braintrust:
         specifier: workspace:*
         version: link:../../js
       msw:
         specifier: ^2.6.6
-        version: 2.13.6(@types/node@20.19.16)(typescript@5.9.3)
+        version: 2.13.6(@types/node@20.19.40)(typescript@5.9.3)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -170,7 +170,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.16)(msw@2.13.6(@types/node@20.19.16)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(msw@2.13.6(@types/node@20.19.40)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       zod:
         specifier: ^3.25.34
         version: 3.25.76
@@ -185,7 +185,7 @@ importers:
         version: 0.0.15(ws@8.18.3)(zod@3.25.76)
       '@types/node':
         specifier: ^20.10.5
-        version: 20.19.16
+        version: 20.19.40
       braintrust:
         specifier: workspace:^
         version: link:../../js
@@ -203,7 +203,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.16)(msw@2.13.6(@types/node@20.19.16)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(msw@2.13.6(@types/node@20.19.40)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       zod:
         specifier: ^3.25.34
         version: 3.25.76
@@ -247,7 +247,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ^20.10.5
-        version: 20.19.16
+        version: 20.19.40
       '@types/nunjucks':
         specifier: ^3.2.6
         version: 3.2.6
@@ -262,7 +262,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.16)(msw@2.13.6(@types/node@20.19.16)(typescript@5.5.4))(vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(msw@2.13.6(@types/node@20.19.40)(typescript@5.5.4))(vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
 
   integrations/temporal-js:
     devDependencies:
@@ -311,7 +311,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ^20.10.5
-        version: 20.19.16
+        version: 20.19.40
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -320,7 +320,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.16)(msw@2.13.6(@types/node@20.19.16)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(msw@2.13.6(@types/node@20.19.40)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
 
   js:
     dependencies:
@@ -334,8 +334,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       ajv:
-        specifier: ^8.17.1
-        version: 8.17.1
+        specifier: ^8.20.0
+        version: 8.20.0
       argparse:
         specifier: ^2.0.1
         version: 2.0.1
@@ -414,7 +414,7 @@ importers:
         version: 0.60.0
       '@google/adk':
         specifier: ^0.6.1
-        version: 0.6.1(0af3d300c950f2f737f3f545297b1874)
+        version: 0.6.1(b571df4ee46c3f316296f66a0f9fb318)
       '@google/genai':
         specifier: ^1.25.0
         version: 1.49.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))
@@ -447,7 +447,7 @@ importers:
         version: 4.2.5
       '@types/node':
         specifier: ^20.10.5
-        version: 20.19.16
+        version: 20.19.40
       '@types/pluralize':
         specifier: ^0.0.30
         version: 0.0.30
@@ -510,13 +510,13 @@ importers:
         version: 5.4.4
       vite:
         specifier: ^6.4.2
-        version: 6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.4.4)(vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.3.2(typescript@5.4.4)(vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.16)(msw@2.13.6(@types/node@20.19.16)(typescript@5.4.4))(vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(msw@2.13.6(@types/node@20.19.40)(typescript@5.4.4))(vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       webpack:
         specifier: ^5.106.2
         version: 5.106.2(@swc/core@1.15.8)(esbuild@0.27.4)(postcss@8.5.14)
@@ -531,16 +531,16 @@ importers:
         version: 0.1.23(zod@3.25.76)
       '@types/node':
         specifier: ^20.10.5
-        version: 20.19.16
+        version: 20.19.40
       typescript:
         specifier: 5.4.4
         version: 5.4.4
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.4.4)(vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.3.2(typescript@5.4.4)(vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.16)(msw@2.13.6(@types/node@20.19.16)(typescript@5.4.4))(vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(msw@2.13.6(@types/node@20.19.40)(typescript@5.4.4))(vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       zod:
         specifier: ^3.25.34
         version: 3.25.76
@@ -552,7 +552,7 @@ importers:
         version: 2.0.53(zod@4.3.6)
       '@types/node':
         specifier: ^20.10.5
-        version: 20.19.16
+        version: 20.19.40
       ai:
         specifier: 5.0.76
         version: 5.0.76(zod@4.3.6)
@@ -561,10 +561,10 @@ importers:
         version: 5.4.4
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.4.4)(vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.3.2(typescript@5.4.4)(vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.16)(msw@2.13.6(@types/node@20.19.16)(typescript@5.4.4))(vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(msw@2.13.6(@types/node@20.19.40)(typescript@5.4.4))(vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
 
 packages:
 
@@ -2288,8 +2288,8 @@ packages:
   '@types/node@18.19.123':
     resolution: {integrity: sha512-K7DIaHnh0mzVxreCR9qwgNxp3MH9dltPNIEddW9MYUlcKAzm+3grKNSTe2vCJHI1FaLpvpL5JGJrz1UZDKYvDg==}
 
-  '@types/node@20.19.16':
-    resolution: {integrity: sha512-VS6TTONVdgwJwtJr7U+ghEjpfmQdqehLLpg/iMYGOd1+ilaFjdBJwFuPggJ4EAYPDCzWfDUHoIxyVnu+tOWVuQ==}
+  '@types/node@20.19.40':
+    resolution: {integrity: sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q==}
 
   '@types/node@22.19.1':
     resolution: {integrity: sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==}
@@ -2606,8 +2606,8 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   als-browser@1.0.1:
     resolution: {integrity: sha512-DjavKf6zf4DFPdEmgsEM474MBjFcZG/1amv2/+WHGf61kVQWqf7XEn4jvpjFS4ssQbh/pkmYThaPfQK1ERC+3g==}
@@ -3393,8 +3393,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.0.6:
-    resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -6123,8 +6123,8 @@ snapshots:
       '@apidevtools/openapi-schemas': 2.1.0
       '@apidevtools/swagger-methods': 3.0.2
       '@jsdevtools/ono': 7.1.3
-      ajv: 8.17.1
-      ajv-draft-04: 1.0.0(ajv@8.17.1)
+      ajv: 8.20.0
+      ajv-draft-04: 1.0.0(ajv@8.20.0)
       call-me-maybe: 1.0.2
       openapi-types: 12.1.3
 
@@ -6774,7 +6774,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@google/adk@0.6.1(0af3d300c950f2f737f3f545297b1874)':
+  '@google/adk@0.6.1(b571df4ee46c3f316296f66a0f9fb318)':
     dependencies:
       '@a2a-js/sdk': 0.3.13(@grpc/grpc-js@1.14.3)(express@4.22.1)
       '@google-cloud/opentelemetry-cloud-monitoring-exporter': 0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
@@ -6784,7 +6784,7 @@ snapshots:
       '@mikro-orm/core': 6.6.13
       '@mikro-orm/mariadb': 6.6.13(@mikro-orm/core@6.6.13)(pg@8.20.0)
       '@mikro-orm/mssql': 6.6.13(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.13)(mariadb@3.4.5)(pg@8.20.0)
-      '@mikro-orm/mysql': 6.6.13(@mikro-orm/core@6.6.13)(@types/node@20.19.16)(mariadb@3.4.5)(pg@8.20.0)
+      '@mikro-orm/mysql': 6.6.13(@mikro-orm/core@6.6.13)(@types/node@20.19.40)(mariadb@3.4.5)(pg@8.20.0)
       '@mikro-orm/postgresql': 6.6.13(@mikro-orm/core@6.6.13)(mariadb@3.4.5)
       '@mikro-orm/reflection': 6.6.13(@mikro-orm/core@6.6.13)
       '@mikro-orm/sqlite': 6.6.13(@mikro-orm/core@6.6.13)(mariadb@3.4.5)(pg@8.20.0)
@@ -6904,12 +6904,12 @@ snapshots:
 
   '@inquirer/ansi@2.0.5': {}
 
-  '@inquirer/confirm@6.0.12(@types/node@20.19.16)':
+  '@inquirer/confirm@6.0.12(@types/node@20.19.40)':
     dependencies:
-      '@inquirer/core': 11.1.9(@types/node@20.19.16)
-      '@inquirer/type': 4.0.5(@types/node@20.19.16)
+      '@inquirer/core': 11.1.9(@types/node@20.19.40)
+      '@inquirer/type': 4.0.5(@types/node@20.19.40)
     optionalDependencies:
-      '@types/node': 20.19.16
+      '@types/node': 20.19.40
 
   '@inquirer/confirm@6.0.12(@types/node@22.19.1)':
     dependencies:
@@ -6918,17 +6918,17 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.1
 
-  '@inquirer/core@11.1.9(@types/node@20.19.16)':
+  '@inquirer/core@11.1.9(@types/node@20.19.40)':
     dependencies:
       '@inquirer/ansi': 2.0.5
       '@inquirer/figures': 2.0.5
-      '@inquirer/type': 4.0.5(@types/node@20.19.16)
+      '@inquirer/type': 4.0.5(@types/node@20.19.40)
       cli-width: 4.1.0
       fast-wrap-ansi: 0.2.0
       mute-stream: 3.0.0
       signal-exit: 4.1.0
     optionalDependencies:
-      '@types/node': 20.19.16
+      '@types/node': 20.19.40
 
   '@inquirer/core@11.1.9(@types/node@22.19.1)':
     dependencies:
@@ -6951,9 +6951,9 @@ snapshots:
 
   '@inquirer/figures@2.0.5': {}
 
-  '@inquirer/type@4.0.5(@types/node@20.19.16)':
+  '@inquirer/type@4.0.5(@types/node@20.19.40)':
     optionalDependencies:
-      '@types/node': 20.19.16
+      '@types/node': 20.19.40
 
   '@inquirer/type@4.0.5(@types/node@22.19.1)':
     optionalDependencies:
@@ -7138,11 +7138,11 @@ snapshots:
       mikro-orm: 6.6.13
       reflect-metadata: 0.2.2
 
-  '@mikro-orm/knex@6.6.13(@mikro-orm/core@6.6.13)(mariadb@3.4.5)(mysql2@3.20.0(@types/node@20.19.16))(pg@8.20.0)':
+  '@mikro-orm/knex@6.6.13(@mikro-orm/core@6.6.13)(mariadb@3.4.5)(mysql2@3.20.0(@types/node@20.19.40))(pg@8.20.0)':
     dependencies:
       '@mikro-orm/core': 6.6.13
       fs-extra: 11.3.3
-      knex: 3.2.8(mysql2@3.20.0(@types/node@20.19.16))(pg@8.20.0)
+      knex: 3.2.8(mysql2@3.20.0(@types/node@20.19.40))(pg@8.20.0)
       sqlstring: 2.3.3
     optionalDependencies:
       mariadb: 3.4.5
@@ -7246,11 +7246,11 @@ snapshots:
       - sqlite3
       - supports-color
 
-  '@mikro-orm/mysql@6.6.13(@mikro-orm/core@6.6.13)(@types/node@20.19.16)(mariadb@3.4.5)(pg@8.20.0)':
+  '@mikro-orm/mysql@6.6.13(@mikro-orm/core@6.6.13)(@types/node@20.19.40)(mariadb@3.4.5)(pg@8.20.0)':
     dependencies:
       '@mikro-orm/core': 6.6.13
-      '@mikro-orm/knex': 6.6.13(@mikro-orm/core@6.6.13)(mariadb@3.4.5)(mysql2@3.20.0(@types/node@20.19.16))(pg@8.20.0)
-      mysql2: 3.20.0(@types/node@20.19.16)
+      '@mikro-orm/knex': 6.6.13(@mikro-orm/core@6.6.13)(mariadb@3.4.5)(mysql2@3.20.0(@types/node@20.19.40))(pg@8.20.0)
+      mysql2: 3.20.0(@types/node@20.19.40)
     transitivePeerDependencies:
       - '@types/node'
       - better-sqlite3
@@ -7313,8 +7313,8 @@ snapshots:
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.13(hono@4.12.12)
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.5
       cross-spawn: 7.0.6
@@ -7336,8 +7336,8 @@ snapshots:
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.13(hono@4.12.12)
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.5
       cross-spawn: 7.0.6
@@ -8101,7 +8101,7 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@20.19.16':
+  '@types/node@20.19.40':
     dependencies:
       undici-types: 6.21.0
 
@@ -8284,32 +8284,32 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(msw@2.13.6(@types/node@20.19.16)(typescript@5.4.4))(vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.5(msw@2.13.6(@types/node@20.19.40)(typescript@5.4.4))(vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.13.6(@types/node@20.19.16)(typescript@5.4.4)
-      vite: 6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      msw: 2.13.6(@types/node@20.19.40)(typescript@5.4.4)
+      vite: 6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@vitest/mocker@4.1.5(msw@2.13.6(@types/node@20.19.16)(typescript@5.5.4))(vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.5(msw@2.13.6(@types/node@20.19.40)(typescript@5.5.4))(vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.13.6(@types/node@20.19.16)(typescript@5.5.4)
-      vite: 6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      msw: 2.13.6(@types/node@20.19.40)(typescript@5.5.4)
+      vite: 6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@vitest/mocker@4.1.5(msw@2.13.6(@types/node@20.19.16)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.5(msw@2.13.6(@types/node@20.19.40)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.13.6(@types/node@20.19.16)(typescript@5.9.3)
-      vite: 6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      msw: 2.13.6(@types/node@20.19.40)(typescript@5.9.3)
+      vite: 6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/mocker@4.1.5(msw@2.13.6(@types/node@22.19.1)(typescript@5.5.4))(vite@6.4.2(@types/node@22.19.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -8501,21 +8501,21 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 
-  ajv-draft-04@1.0.0(ajv@8.17.1):
+  ajv-draft-04@1.0.0(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.20.0
 
-  ajv-formats@2.1.1(ajv@8.17.1):
+  ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.20.0
 
-  ajv-formats@3.0.1(ajv@8.17.1):
+  ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.20.0
 
-  ajv-keywords@5.1.0(ajv@8.17.1):
+  ajv-keywords@5.1.0(ajv@8.20.0):
     dependencies:
-      ajv: 8.17.1
+      ajv: 8.20.0
       fast-deep-equal: 3.1.3
 
   ajv@6.15.0:
@@ -8525,10 +8525,10 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ajv@8.17.1:
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.0.6
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8597,7 +8597,7 @@ snapshots:
 
   autoevals@0.0.131(encoding@0.1.13)(ws@8.18.3):
     dependencies:
-      ajv: 8.17.1
+      ajv: 8.20.0
       compute-cosine-similarity: 1.1.0
       js-levenshtein: 1.1.6
       js-yaml: 4.1.1
@@ -9381,7 +9381,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.0.6: {}
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -10064,7 +10064,7 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  knex@3.2.8(mysql2@3.20.0(@types/node@20.19.16))(pg@8.20.0):
+  knex@3.2.8(mysql2@3.20.0(@types/node@20.19.40))(pg@8.20.0):
     dependencies:
       colorette: 2.0.19
       commander: 10.0.1
@@ -10081,7 +10081,7 @@ snapshots:
       tarn: 3.0.2
       tildify: 2.0.0
     optionalDependencies:
-      mysql2: 3.20.0(@types/node@20.19.16)
+      mysql2: 3.20.0(@types/node@20.19.40)
       pg: 8.20.0
     transitivePeerDependencies:
       - supports-color
@@ -10509,9 +10509,9 @@ snapshots:
 
   ms@3.0.0-canary.1: {}
 
-  msw@2.13.6(@types/node@20.19.16)(typescript@5.4.4):
+  msw@2.13.6(@types/node@20.19.40)(typescript@5.4.4):
     dependencies:
-      '@inquirer/confirm': 6.0.12(@types/node@20.19.16)
+      '@inquirer/confirm': 6.0.12(@types/node@20.19.40)
       '@mswjs/interceptors': 0.41.6
       '@open-draft/deferred-promise': 3.0.0
       '@types/statuses': 2.0.6
@@ -10534,9 +10534,9 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  msw@2.13.6(@types/node@20.19.16)(typescript@5.5.4):
+  msw@2.13.6(@types/node@20.19.40)(typescript@5.5.4):
     dependencies:
-      '@inquirer/confirm': 6.0.12(@types/node@20.19.16)
+      '@inquirer/confirm': 6.0.12(@types/node@20.19.40)
       '@mswjs/interceptors': 0.41.6
       '@open-draft/deferred-promise': 3.0.0
       '@types/statuses': 2.0.6
@@ -10560,9 +10560,9 @@ snapshots:
       - '@types/node'
     optional: true
 
-  msw@2.13.6(@types/node@20.19.16)(typescript@5.9.3):
+  msw@2.13.6(@types/node@20.19.40)(typescript@5.9.3):
     dependencies:
-      '@inquirer/confirm': 6.0.12(@types/node@20.19.16)
+      '@inquirer/confirm': 6.0.12(@types/node@20.19.40)
       '@mswjs/interceptors': 0.41.6
       '@open-draft/deferred-promise': 3.0.0
       '@types/statuses': 2.0.6
@@ -10640,9 +10640,9 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  mysql2@3.20.0(@types/node@20.19.16):
+  mysql2@3.20.0(@types/node@20.19.40):
     dependencies:
-      '@types/node': 20.19.16
+      '@types/node': 20.19.40
       aws-ssl-profiles: 1.1.2
       denque: 2.1.0
       generate-function: 2.3.1
@@ -11316,9 +11316,9 @@ snapshots:
   schema-utils@4.3.3:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.17.1
-      ajv-formats: 2.1.1(ajv@8.17.1)
-      ajv-keywords: 5.1.0(ajv@8.17.1)
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
+      ajv-keywords: 5.1.0(ajv@8.20.0)
 
   semifies@1.0.0: {}
 
@@ -12050,18 +12050,18 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-tsconfig-paths@4.3.2(typescript@5.4.4)(vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vite-tsconfig-paths@4.3.2(typescript@5.4.4)(vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.1(typescript@5.4.4)
     optionalDependencies:
-      vite: 6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
+  vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.4)
@@ -12070,7 +12070,7 @@ snapshots:
       rollup: 4.60.3
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 20.19.16
+      '@types/node': 20.19.40
       fsevents: 2.3.3
       jiti: 2.6.1
       terser: 5.44.1
@@ -12093,10 +12093,10 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.16)(msw@2.13.6(@types/node@20.19.16)(typescript@5.4.4))(vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(msw@2.13.6(@types/node@20.19.40)(typescript@5.4.4))(vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(msw@2.13.6(@types/node@20.19.16)(typescript@5.4.4))(vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.1.5(msw@2.13.6(@types/node@20.19.40)(typescript@5.4.4))(vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -12113,18 +12113,18 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 20.19.16
+      '@types/node': 20.19.40
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.16)(msw@2.13.6(@types/node@20.19.16)(typescript@5.5.4))(vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(msw@2.13.6(@types/node@20.19.40)(typescript@5.5.4))(vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(msw@2.13.6(@types/node@20.19.16)(typescript@5.5.4))(vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.1.5(msw@2.13.6(@types/node@20.19.40)(typescript@5.5.4))(vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -12141,18 +12141,18 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 20.19.16
+      '@types/node': 20.19.40
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.16)(msw@2.13.6(@types/node@20.19.16)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(msw@2.13.6(@types/node@20.19.40)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(msw@2.13.6(@types/node@20.19.16)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.1.5(msw@2.13.6(@types/node@20.19.40)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -12169,11 +12169,11 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 6.4.2(@types/node@20.19.16)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.2(@types/node@20.19.40)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 20.19.16
+      '@types/node': 20.19.40
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
resolves https://github.com/braintrustdata/braintrust-sdk-javascript/security/dependabot/585
resolves https://github.com/braintrustdata/braintrust-sdk-javascript/security/dependabot/586
resolves https://github.com/braintrustdata/braintrust-sdk-javascript/security/dependabot/242