### PR TITLE
fix: upgrade minimatch dependency

### DIFF
--- a/.changeset/late-wolves-upgrade.md
+++ b/.changeset/late-wolves-upgrade.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+Upgrade minimatch from v9 to v10.

--- a/js/package.json
+++ b/js/package.json
@@ -212,7 +212,7 @@
     "express": "^4.21.2",
     "graceful-fs": "^4.2.11",
     "http-errors": "^2.0.0",
-    "minimatch": "^9.0.3",
+    "minimatch": "^10.2.5",
     "module-details-from-path": "^1.0.4",
     "mustache": "^4.2.0",
     "pluralize": "^8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -376,8 +376,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.1
       minimatch:
-        specifier: ^9.0.3
-        version: 9.0.5
+        specifier: ^10.2.5
+        version: 10.2.5
       module-details-from-path:
         specifier: ^1.0.4
         version: 1.0.4
@@ -2752,8 +2752,8 @@ packages:
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
-  brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -4288,8 +4288,8 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
@@ -7328,7 +7328,7 @@ snapshots:
       pkce-challenge: 5.0.0
       raw-body: 3.0.2
       zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -8237,7 +8237,7 @@ snapshots:
       '@typescript-eslint/types': 8.50.0
       '@typescript-eslint/visitor-keys': 8.50.0
       debug: 4.4.3
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       semver: 7.8.0
       tinyglobby: 0.2.16
       ts-api-utils: 2.1.0(typescript@5.4.4)
@@ -8700,7 +8700,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.1:
+  brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
 
@@ -8729,7 +8729,7 @@ snapshots:
       express: 4.22.1
       graceful-fs: 4.2.11
       http-errors: 2.0.1
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       mustache: 4.2.0
       pluralize: 8.0.0
       simple-git: 3.36.0
@@ -9666,7 +9666,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -10402,9 +10402,9 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
-  minimatch@9.0.5:
+  minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 2.1.0
 
   minimist@1.2.8: {}
 
@@ -11949,7 +11949,7 @@ snapshots:
     dependencies:
       lunr: 2.3.9
       marked: 4.3.0
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       shiki: 0.14.7
       typescript: 5.4.4
 
@@ -11957,7 +11957,7 @@ snapshots:
     dependencies:
       lunr: 2.3.9
       marked: 4.3.0
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       shiki: 0.14.7
       typescript: 5.9.3
 
@@ -11966,7 +11966,7 @@ snapshots:
       '@gerrit0/mini-shiki': 3.21.0
       lunr: 2.3.9
       markdown-it: 14.1.0
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       typescript: 5.5.4
       yaml: 2.8.2
 


### PR DESCRIPTION
resolves https://github.com/braintrustdata/braintrust-sdk-javascript/security/dependabot/20
resolves https://github.com/braintrustdata/braintrust-sdk-javascript/security/dependabot/413
resolves https://github.com/braintrustdata/braintrust-sdk-javascript/security/dependabot/246
resolves https://github.com/braintrustdata/braintrust-sdk-javascript/security/dependabot/303
resolves https://github.com/braintrustdata/braintrust-sdk-javascript/security/dependabot/305