### PR TITLE
fix(deps): upgrade express

### DIFF
--- a/.changeset/upgrade-express-security-deps.md
+++ b/.changeset/upgrade-express-security-deps.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+fix(deps): Upgrade Express to remove vulnerable transitive dependencies

--- a/integrations/browser-js/package.json
+++ b/integrations/browser-js/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "als-browser": "^1.0.1",
-    "braintrust": ">=3.0.0-rc.29"
+    "braintrust": "workspace:^"
   },
   "devDependencies": {
     "@types/node": "^20.10.5",

--- a/js/package.json
+++ b/js/package.json
@@ -209,7 +209,7 @@
     "dotenv": "^16.4.5",
     "esbuild": "0.28.0",
     "eventsource-parser": "^1.1.2",
-    "express": "^4.21.2",
+    "express": "^5.2.1",
     "graceful-fs": "^4.2.11",
     "http-errors": "^2.0.0",
     "minimatch": "^10.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,8 +117,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
       braintrust:
-        specifier: '>=3.0.0-rc.29'
-        version: 3.0.0-rc.29(zod@3.25.76)
+        specifier: workspace:^
+        version: link:../../js
       zod:
         specifier: ^3.25.34 || ^4.0
         version: 3.25.76
@@ -367,8 +367,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2
       express:
-        specifier: ^4.21.2
-        version: 4.22.1
+        specifier: ^5.2.1
+        version: 5.2.1
       graceful-fs:
         specifier: ^4.2.11
         version: 4.2.11
@@ -621,10 +621,6 @@ packages:
 
   '@ai-sdk/provider@0.0.11':
     resolution: {integrity: sha512-VTipPQ92Moa5Ovg/nZIc8yNoIFfukZjUHZcQMduJbiUh3CLQyrBAKTEV9AwjPy8wgVxj3+GZjon0yyOJKhfp5g==}
-    engines: {node: '>=18'}
-
-  '@ai-sdk/provider@1.1.3':
-    resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@2.0.0':
@@ -2762,12 +2758,6 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
-
-  braintrust@3.0.0-rc.29:
-    resolution: {integrity: sha512-MTY0hCsBlRZcpYUf+WYeQOFcKK6Wto9P71q5UktAhIna+Gr6ZDPfp7jKIl6Mv9O8cD+PKBYBvL7pPwNTIfLkeA==}
-    hasBin: true
-    peerDependencies:
-      zod: ^3.25.34 || ^4.0
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
@@ -6071,10 +6061,6 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/provider@1.1.3':
-    dependencies:
-      json-schema: 0.4.0
-
   '@ai-sdk/provider@2.0.0':
     dependencies:
       json-schema: 0.4.0
@@ -7328,7 +7314,7 @@ snapshots:
       pkce-challenge: 5.0.0
       raw-body: 3.0.2
       zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -8711,35 +8697,6 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
-
-  braintrust@3.0.0-rc.29(zod@3.25.76):
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@next/env': 14.2.3
-      '@vercel/functions': 1.0.2
-      argparse: 2.0.1
-      boxen: 8.0.1
-      chalk: 4.1.2
-      cli-progress: 3.12.0
-      cli-table3: 0.6.5
-      cors: 2.8.5
-      dotenv: 16.4.5
-      esbuild: 0.27.4
-      eventsource-parser: 1.1.2
-      express: 4.22.1
-      graceful-fs: 4.2.11
-      http-errors: 2.0.1
-      minimatch: 9.0.9
-      mustache: 4.2.0
-      pluralize: 8.0.0
-      simple-git: 3.36.0
-      source-map: 0.7.6
-      termi-link: 1.1.0
-      uuid: 9.0.1
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
 
   browserslist@4.28.1:
     dependencies:


### PR DESCRIPTION
Upgrade the braintrust package to Express 5.2.1 to remove vulnerable transitive production dependencies from Express 4, including path-to-regexp 0.1.x and older qs versions.

resolves https://github.com/braintrustdata/braintrust-sdk-javascript/security/dependabot/422
resolves https://github.com/braintrustdata/braintrust-sdk-javascript/security/dependabot/105
resolves https://github.com/braintrustdata/braintrust-sdk-javascript/security/dependabot/211