### PR TITLE
fix(api-compat): allow optional property additions to inline object literals

### DIFF
--- a/js/tests/api-compatibility/api-compatibility.test.ts
+++ b/js/tests/api-compatibility/api-compatibility.test.ts
@@ -785,6 +785,11 @@ function normalizeTypeReference(type: string): string {
   return type;
 }
 
+function isObjectLiteralType(def: string): boolean {
+  const trimmed = def.trim();
+  return trimmed.startsWith("{") && trimmed.endsWith("}");
+}
+
 function parseObjectTypeProps(
   def: string,
 ): Map<string, { type: string; optional: boolean }> {
@@ -877,7 +882,15 @@ function areObjectTypeDefinitionsCompatible(
     const newTypeNorm = normalizeType(newProp.type);
 
     if (oldTypeNorm !== newTypeNorm) {
-      if (!isUnionTypeWidening(oldTypeNorm, newTypeNorm)) {
+      if (isUnionTypeWidening(oldTypeNorm, newTypeNorm)) {
+        // accepted
+      } else if (
+        isObjectLiteralType(oldProp.type) &&
+        isObjectLiteralType(newProp.type) &&
+        areObjectTypeDefinitionsCompatible(oldProp.type, newProp.type)
+      ) {
+        // accepted: nested object literal is structurally compatible
+      } else {
         return false;
       }
     }
@@ -1040,10 +1053,7 @@ function areTypeAliasSignaturesCompatible(
     return true;
   }
 
-  // Check if it's an object type
-  const isObjectType = (def: string) => def.trim().startsWith("{");
-
-  if (isObjectType(oldDef) && isObjectType(newDef)) {
+  if (isObjectLiteralType(oldDef) && isObjectLiteralType(newDef)) {
     return areObjectTypeDefinitionsCompatible(oldDef, newDef);
   }
 
@@ -1089,8 +1099,8 @@ function areTypeAliasSignaturesCompatible(
         }
 
         if (
-          isObjectType(oldPart) &&
-          isObjectType(newPart) &&
+          isObjectLiteralType(oldPart) &&
+          isObjectLiteralType(newPart) &&
           areObjectTypeDefinitionsCompatible(oldPart, newPart)
         ) {
           usedNewIndices.add(index);
@@ -1337,8 +1347,16 @@ function areInterfaceSignaturesCompatible(
     const newTypeNorm = normalizeType(newField.type);
 
     if (oldTypeNorm !== newTypeNorm) {
-      // Check if it's a union type widening (backwards compatible)
-      if (!isUnionTypeWidening(oldTypeNorm, newTypeNorm)) {
+      if (isUnionTypeWidening(oldTypeNorm, newTypeNorm)) {
+        // accepted: union type widened (e.g. `T` → `T | U`)
+      } else if (
+        isObjectLiteralType(oldField.type) &&
+        isObjectLiteralType(newField.type) &&
+        areObjectTypeDefinitionsCompatible(oldField.type, newField.type)
+      ) {
+        // accepted: inline object literal field is structurally compatible
+        // (e.g. an optional property added to `integrations`)
+      } else {
         // Field type changed in an incompatible way - breaking change
         return false;
       }
@@ -2242,6 +2260,39 @@ describe("areInterfaceSignaturesCompatible", () => {
 
     const result = areInterfaceSignaturesCompatible(oldInterface, newInterface);
     expect(result).toBe(false);
+  });
+
+  test("should allow adding optional property to an inline object literal field", () => {
+    // Real-world case: adding `mastra?: boolean` to InstrumentationConfig.integrations
+    const oldInterface = `export interface InstrumentationConfig { integrations?: { openai?: boolean; openaiCodexSDK?: boolean; }; }`;
+    const newInterface = `export interface InstrumentationConfig { integrations?: { openai?: boolean; openaiCodexSDK?: boolean; mastra?: boolean; }; }`;
+
+    const result = areInterfaceSignaturesCompatible(oldInterface, newInterface);
+    expect(result).toBe(true);
+  });
+
+  test("should reject adding required property to an inline object literal field", () => {
+    const oldInterface = `export interface Config { options: { foo?: string; }; }`;
+    const newInterface = `export interface Config { options: { foo?: string; bar: number; }; }`;
+
+    const result = areInterfaceSignaturesCompatible(oldInterface, newInterface);
+    expect(result).toBe(false);
+  });
+
+  test("should reject removing property from an inline object literal field", () => {
+    const oldInterface = `export interface Config { options: { foo?: string; bar?: number; }; }`;
+    const newInterface = `export interface Config { options: { foo?: string; }; }`;
+
+    const result = areInterfaceSignaturesCompatible(oldInterface, newInterface);
+    expect(result).toBe(false);
+  });
+
+  test("should allow adding optional property to a deeply nested inline object literal field", () => {
+    const oldInterface = `export interface Config { outer: { inner: { a?: string; }; }; }`;
+    const newInterface = `export interface Config { outer: { inner: { a?: string; b?: number; }; }; }`;
+
+    const result = areInterfaceSignaturesCompatible(oldInterface, newInterface);
+    expect(result).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- `areInterfaceSignaturesCompatible` was flagging adding an optional property to an inline object literal type (e.g. `mastra?: boolean` on `InstrumentationConfig.integrations`) as a breaking change.
- Root cause: it compared each property's *type* as a string, then only re-checked via `isUnionTypeWidening` when the strings differed. Inline object literals aren't unions, so any new field tipped it into "modified" territory.
- Fix: delegate to the existing `areObjectTypeDefinitionsCompatible` helper when both sides are inline object literals, mirroring the pattern already in `areTypeAliasSignaturesCompatible`. Also apply the same delegation inside `areObjectTypeDefinitionsCompatible` itself so nested object literals are handled the same way.
- Lifted the inline `isObjectType` helper to a module-scope `isObjectLiteralType` so the interface, object-literal, and intersection comparators share one definition.

After this lands, the `js-api-compatibility (20)` check on PRs that add optional integration keys (#1891, #1897, #1901, future SDK integrations) will pass instead of failing informationally.

## Test plan

- [x] Added 4 regression tests in `describe("areInterfaceSignaturesCompatible", ...)`:
  - optional property added to inline object literal (the `InstrumentationConfig` case) → passes
  - required property added → still rejected
  - property removed → still rejected
  - optional property added to deeply nested inline object literal → passes
- [x] `pnpm exec vitest run tests/api-compatibility/api-compatibility.test.ts` — all 14 interface-compat tests pass plus the rest of the file
- [x] `pnpm run fix:formatting` and `pnpm run lint` clean

#skip-changeset — this is a test-only change with no impact on the published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)