### PR TITLE
parameters tags

### DIFF
--- a/js/src/framework.test.ts
+++ b/js/src/framework.test.ts
@@ -1283,6 +1283,83 @@ describe("framework2 metadata support", () => {
     });
   });
 
+  describe("CodeParameters tags", () => {
+    test("parameters stores tags correctly", () => {
+      const project = projects.create({ name: "test-project" });
+      const tags = ["ci", "production"];
+
+      project.parameters.create({
+        name: "test-parameters",
+        schema: {
+          model: {
+            type: "model",
+            default: "gpt-5-mini",
+          },
+        },
+        tags,
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const parameters = (project as any)._publishableParameters;
+      expect(parameters).toHaveLength(1);
+      expect(parameters[0].tags).toEqual(tags);
+    });
+
+    test("toFunctionDefinition includes tags when present", async () => {
+      const project = projects.create({ name: "test-project" });
+      const tags = ["ci", "production"];
+
+      project.parameters.create({
+        name: "test-parameters",
+        schema: {
+          model: {
+            type: "model",
+            default: "gpt-5-mini",
+          },
+        },
+        tags,
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const parameters = (project as any)._publishableParameters;
+      const mockProjectMap = {
+        resolve: vi.fn().mockResolvedValue("project-123"),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+
+      const funcDef = await parameters[0].toFunctionDefinition(mockProjectMap);
+
+      expect(funcDef.tags).toEqual(tags);
+      expect(funcDef.name).toBe("test-parameters");
+      expect(funcDef.project_id).toBe("project-123");
+    });
+
+    test("toFunctionDefinition excludes tags when undefined", async () => {
+      const project = projects.create({ name: "test-project" });
+
+      project.parameters.create({
+        name: "test-parameters",
+        schema: {
+          model: {
+            type: "model",
+            default: "gpt-5-mini",
+          },
+        },
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const parameters = (project as any)._publishableParameters;
+      const mockProjectMap = {
+        resolve: vi.fn().mockResolvedValue("project-123"),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+
+      const funcDef = await parameters[0].toFunctionDefinition(mockProjectMap);
+
+      expect(funcDef.tags).toBeUndefined();
+    });
+  });
+
   describe("CodeParameters defaults", () => {
     test("toFunctionDefinition initializes data with schema defaults", async () => {
       const project = projects.create({ name: "test-project" });

--- a/js/src/framework2.ts
+++ b/js/src/framework2.ts
@@ -586,6 +586,7 @@ export interface ParametersOpts<S extends EvalParameters> {
   description?: string;
   schema: S;
   ifExists?: IfExists;
+  tags?: string[];
   metadata?: Record<string, unknown>;
 }
 
@@ -596,6 +597,7 @@ export class CodeParameters {
   public readonly description?: string;
   public readonly schema: EvalParameters;
   public readonly ifExists?: IfExists;
+  public readonly tags?: string[];
   public readonly metadata?: Record<string, unknown>;
 
   constructor(
@@ -606,6 +608,7 @@ export class CodeParameters {
       description?: string;
       schema: EvalParameters;
       ifExists?: IfExists;
+      tags?: string[];
       metadata?: Record<string, unknown>;
     },
   ) {
@@ -615,6 +618,7 @@ export class CodeParameters {
     this.description = opts.description;
     this.schema = opts.schema;
     this.ifExists = opts.ifExists;
+    this.tags = opts.tags;
     this.metadata = opts.metadata;
   }
 
@@ -634,6 +638,7 @@ export class CodeParameters {
         __schema: schema,
       },
       if_exists: this.ifExists,
+      tags: this.tags,
       metadata: this.metadata,
     };
   }
@@ -651,6 +656,7 @@ class ParametersBuilder {
       description: opts.description,
       schema: opts.schema,
       ifExists: opts.ifExists,
+      tags: opts.tags,
       metadata: opts.metadata,
     });
 


### PR DESCRIPTION
Support tags in the sdk for parameters. Allows something like this:

`bt functions push params.js`

<details>

```
import * as braintrust from "braintrust";
import { z } from "zod";

const project = braintrust.projects.create({
  name: "My Project",
});

export const evalConfig = project.parameters.create({
  name: "my_params_js",
  slug: "my-params-js",
  description: "Configuration for model evaluation",
  schema: {
    foo: z.string().default("hello world"),
  },
  metadata: { version: "1.0" },
  tags: ["tag-1", "tag-2"],
});
```

</details>

Produces this in the product:

<img width="1535" height="133" alt="image" src="https://github.com/user-attachments/assets/35501cee-c7a1-4fbb-a1c9-b9faf286d41a" />
