### PR TITLE
feat(invoke): expose overrides field on invoke()

### DIFF
--- a/.changeset/invoke-overrides.md
+++ b/.changeset/invoke-overrides.md
@@ -1,5 +1,0 @@
----
-"braintrust": minor
----
-
-feat(invoke): expose `overrides` field on `invoke()` so callers can deep-merge into the resolved function data server-side (facet, code, global, and remote_eval functions; no effect on prompt functions)

--- a/.changeset/invoke-overrides.md
+++ b/.changeset/invoke-overrides.md
@@ -1,0 +1,5 @@
+---
+"braintrust": minor
+---
+
+feat(invoke): expose `overrides` field on `invoke()` so callers can deep-merge into the resolved function data server-side (facet, code, global, and remote_eval functions; no effect on prompt functions)

--- a/.changeset/tidy-facts-admire.md
+++ b/.changeset/tidy-facts-admire.md
@@ -1,0 +1,5 @@
+---
+"braintrust": minor
+---
+
+feat(invoke): Allow passing `overrides` to `invoke()`

--- a/js/src/functions/invoke.ts
+++ b/js/src/functions/invoke.ts
@@ -112,6 +112,13 @@ export interface InvokeFunctionArgs<
    */
   strict?: boolean;
   /**
+   * Per-call deep-merge into the resolved function data server-side. Useful for facet,
+   * code, global, and remote_eval functions (for example, overriding a facet's `model`
+   * or a global function's `config`). Has no effect on prompt functions, whose
+   * parameters live on a separate field that the override path does not touch.
+   */
+  overrides?: Record<string, unknown>;
+  /**
    * A Zod schema to validate the output of the function and return a typed value. This
    * is only used if `stream` is false.
    */
@@ -159,6 +166,7 @@ export async function invoke<Input, Output, Stream extends boolean = false>(
     mode,
     schema,
     strict,
+    overrides,
     projectId,
     ...functionIdArgs
   } = args;
@@ -204,6 +212,7 @@ export async function invoke<Input, Output, Stream extends boolean = false>(
     stream,
     mode,
     strict,
+    overrides,
   };
 
   const headers: Record<string, string> = {


### PR DESCRIPTION
## Summary

- Add `overrides` field to `InvokeFunctionArgs` and pass it through in the request body to `/function/invoke`.

## Context

The `/function/invoke` REST endpoint accepts an `overrides` field that deep-merges into the resolved function data server-side (see `applyFunctionDataOverrides` in `api-ts/src/proxy/call.ts`). The wire schema in `generated_types.ts` includes `overrides`, and the proxy applies it, but the SDK destructures known fields and rebuilds the request, so the parameter was dropped before reaching the wire even via type assertion.

The change is purely additive — no schema or server changes. Mirrors how `strict` was added in #621.

**Limitation:** overrides deep-merge into `function_data` only. Prompt-type functions have their parameters (model, options.params, messages, tool_functions, etc.) on a separate `prompt_data` field that the override path does not touch — for prompt functions this passthrough has no effect. The JSDoc on the new field documents this. The matching docs PR (braintrustdata/braintrust#15157) documents the same limitation user-facing.

Related Pylon ticket: braintrustdata/braintrust#17344.

## Test plan

- [x] `pnpm run fix:formatting` — clean
- [x] `pnpm run lint` — 0 errors (pre-existing warnings only)
- [x] `npx tsc --noEmit -p .` — passes
- [x] `npx vitest run src/functions/invoke.test.ts` — 5/5 passing
- [x] `npx vitest run src/logger.test.ts -t loadPrompt` — passes
- [ ] CI green