### PR TITLE
fix: Don't have `output` in dataset pipeline row type definition

### DIFF
--- a/.changeset/tough-owls-unite.md
+++ b/.changeset/tough-owls-unite.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+fix: Don't have `output` in dataset pipeline row type definition

--- a/js/src/dataset-pipeline.ts
+++ b/js/src/dataset-pipeline.ts
@@ -2,7 +2,6 @@ import type { Trace } from "./trace";
 
 type DatasetPipelineRow = {
   input?: unknown;
-  output?: unknown;
   expected?: unknown;
   tags?: string[];
   metadata?: Record<string, unknown>;


### PR DESCRIPTION
Datasets don't have `output`