### PR TITLE
scorer can talk to a task

### DIFF
--- a/js/src/framework.test.ts
+++ b/js/src/framework.test.ts
@@ -688,6 +688,150 @@ test("Eval with noSendLogs: true runs locally without creating experiment", asyn
   expect(await memoryLogger.drain()).toHaveLength(0);
 });
 
+test("Eval scorer can call context exposed by the same task instance", async () => {
+  const scorerQuestions: string[] = [];
+
+  const result = await Eval(
+    "test-scorer-context",
+    {
+      data: [{ input: "research X", expected: "source" }],
+      task: async (input, hooks) => {
+        const agentSession = {
+          messages: [`task:${input}`],
+          async ask(question: string) {
+            this.messages.push(`scorer:${question}`);
+            return this.messages.join("|");
+          },
+        };
+
+        const output = `answer for ${input}`;
+        agentSession.messages.push(`output:${output}`);
+
+        hooks.exposeScorerContext(async (question: string) => {
+          scorerQuestions.push(question);
+          return agentSession.ask(question);
+        });
+
+        return output;
+      },
+      scores: [
+        async ({ scorerContext }) => {
+          const ask = scorerContext as (question: string) => Promise<string>;
+          const answer = await ask("what happened?");
+
+          return {
+            name: "has_task_history",
+            score:
+              answer.includes("task:research X") &&
+              answer.includes("output:answer for research X") &&
+              answer.includes("scorer:what happened?")
+                ? 1
+                : 0,
+          };
+        },
+      ],
+    },
+    { noSendLogs: true, returnResults: true },
+  );
+
+  expect(scorerQuestions).toEqual(["what happened?"]);
+  expect(result.results[0].scores.has_task_history).toBe(1);
+});
+
+test("Eval scorer context is isolated per row under concurrency", async () => {
+  const seenContexts: Array<{ input: number; contextInput: number }> = [];
+
+  const result = await Eval(
+    "test-scorer-context-isolation",
+    {
+      data: [1, 2, 3, 4].map((input) => ({ input, expected: input * 10 })),
+      maxConcurrency: 4,
+      task: async (input, hooks) => {
+        const session = {
+          input,
+          output: input * 10,
+        };
+
+        await new Promise((resolve) => setTimeout(resolve, 10 - input));
+        hooks.exposeScorerContext(() => session);
+
+        return session.output;
+      },
+      scores: [
+        ({ input, output, scorerContext }) => {
+          const getSession = scorerContext as () => {
+            input: number;
+            output: number;
+          };
+          const session = getSession();
+          seenContexts.push({ input, contextInput: session.input });
+
+          return {
+            name: "same_context",
+            score: session.input === input && session.output === output ? 1 : 0,
+          };
+        },
+      ],
+    },
+    { noSendLogs: true, returnResults: true },
+  );
+
+  expect(result.results).toHaveLength(4);
+  expect(result.results.every((r) => r.scores.same_context === 1)).toBe(true);
+  expect(
+    seenContexts
+      .map(({ input, contextInput }) => `${input}:${contextInput}`)
+      .sort(),
+  ).toEqual(["1:1", "2:2", "3:3", "4:4"]);
+});
+
+test("Eval scorer receives undefined context when task does not expose one", async () => {
+  const result = await Eval(
+    "test-scorer-context-undefined",
+    {
+      data: [{ input: "hello" }],
+      task: (input) => input,
+      scores: [
+        ({ scorerContext }) => ({
+          name: "missing_context",
+          score: scorerContext === undefined ? 1 : 0,
+        }),
+      ],
+    },
+    { noSendLogs: true, returnResults: true },
+  );
+
+  expect(result.results[0].scores.missing_context).toBe(1);
+});
+
+test("Eval classifiers receive scorer context", async () => {
+  const result = await Eval(
+    "test-classifier-scorer-context",
+    {
+      data: [{ input: "hello" }],
+      task: (input, hooks) => {
+        hooks.exposeScorerContext(() => `category:${input}`);
+        return input;
+      },
+      classifiers: [
+        ({ scorerContext }) => {
+          const getCategory = scorerContext as () => string;
+          return {
+            name: "category",
+            id: getCategory(),
+            label: "Context category",
+          };
+        },
+      ],
+    },
+    { noSendLogs: true, returnResults: true },
+  );
+
+  expect(result.results[0].classifications?.category).toEqual([
+    { id: "category:hello", label: "Context category" },
+  ]);
+});
+
 test("Eval with returnResults: false produces empty results but valid summary", async () => {
   const result = await Eval(
     "test-no-results-project",

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -111,14 +111,15 @@ export type EvalTask<
   Expected,
   Metadata extends BaseMetadata,
   Parameters extends EvalParameters,
+  ScorerContext = unknown,
 > =
   | ((
       input: Input,
-      hooks: EvalHooks<Expected, Metadata, Parameters>,
+      hooks: EvalHooks<Expected, Metadata, Parameters, ScorerContext>,
     ) => Promise<Output>)
   | ((
       input: Input,
-      hooks: EvalHooks<Expected, Metadata, Parameters>,
+      hooks: EvalHooks<Expected, Metadata, Parameters, ScorerContext>,
     ) => Output);
 
 export type TaskProgressEvent = Omit<
@@ -130,6 +131,7 @@ export interface EvalHooks<
   Expected,
   Metadata extends BaseMetadata,
   Parameters extends EvalParameters,
+  ScorerContext = unknown,
 > {
   /**
    * @deprecated Use `metadata` instead.
@@ -164,6 +166,10 @@ export interface EvalHooks<
    * The tags for the current evaluation.
    */
   tags: string[] | undefined;
+  /**
+   * Expose an in-memory value from this task run to its scorers.
+   */
+  exposeScorerContext: (context: ScorerContext) => void;
 }
 
 // This happens to be compatible with ScorerArgs defined in "../util".
@@ -172,9 +178,11 @@ export type EvalScorerArgs<
   Output,
   Expected,
   Metadata extends BaseMetadata = DefaultMetadataType,
+  ScorerContext = unknown,
 > = EvalCase<Input, Expected, Metadata> & {
   output: Output;
   trace?: Trace;
+  scorerContext?: ScorerContext;
 };
 
 export type OneOrMoreScores = Score | number | null | Array<Score>;
@@ -184,8 +192,9 @@ export type EvalScorer<
   Output,
   Expected,
   Metadata extends BaseMetadata = DefaultMetadataType,
+  ScorerContext = unknown,
 > = (
-  args: EvalScorerArgs<Input, Output, Expected, Metadata>,
+  args: EvalScorerArgs<Input, Output, Expected, Metadata, ScorerContext>,
 ) => OneOrMoreScores | Promise<OneOrMoreScores>;
 
 export type OneOrMoreClassifications = Classification | Classification[] | null;
@@ -195,8 +204,9 @@ export type EvalClassifier<
   Output,
   Expected,
   Metadata extends BaseMetadata = DefaultMetadataType,
+  ScorerContext = unknown,
 > = (
-  args: EvalScorerArgs<Input, Output, Expected, Metadata>,
+  args: EvalScorerArgs<Input, Output, Expected, Metadata, ScorerContext>,
 ) => OneOrMoreClassifications | Promise<OneOrMoreClassifications>;
 
 export type EvalResult<
@@ -228,6 +238,7 @@ export interface Evaluator<
   Expected,
   Metadata extends BaseMetadata = DefaultMetadataType,
   Parameters extends EvalParameters = EvalParameters,
+  ScorerContext = unknown,
 > {
   /**
    * A function that returns a list of inputs, expected outputs, and metadata.
@@ -237,20 +248,26 @@ export interface Evaluator<
   /**
    * A function that takes an input and returns an output.
    */
-  task: EvalTask<Input, Output, Expected, Metadata, Parameters>;
+  task: EvalTask<Input, Output, Expected, Metadata, Parameters, ScorerContext>;
 
   /**
    * A set of functions that take an input, output, and expected value and return a {@link Score}.
    * At least one of `scores` or `classifiers` must be provided.
    */
-  scores?: EvalScorer<Input, Output, Expected, Metadata>[];
+  scores?: EvalScorer<Input, Output, Expected, Metadata, ScorerContext>[];
 
   /**
    * A set of functions that take an input, output, and expected value and return a
    * {@link Classification}. Results are recorded under the `classifications` column.
    * At least one of `scores` or `classifiers` must be provided.
    */
-  classifiers?: EvalClassifier<Input, Output, Expected, Metadata>[];
+  classifiers?: EvalClassifier<
+    Input,
+    Output,
+    Expected,
+    Metadata,
+    ScorerContext
+  >[];
 
   /**
    * A set of parameters that will be passed to the evaluator.
@@ -424,10 +441,11 @@ export type EvaluatorDef<
   Expected,
   Metadata extends BaseMetadata = DefaultMetadataType,
   Parameters extends EvalParameters = EvalParameters,
+  ScorerContext = unknown,
 > = {
   projectName: string;
   evalName: string;
-} & Evaluator<Input, Output, Expected, Metadata, Parameters>;
+} & Evaluator<Input, Output, Expected, Metadata, Parameters, ScorerContext>;
 
 export type EvaluatorFile = {
   functions: CodeFunction<
@@ -647,9 +665,17 @@ export async function Eval<
   Metadata extends BaseMetadata = DefaultMetadataType,
   EvalReport = boolean,
   Parameters extends EvalParameters = EvalParameters,
+  ScorerContext = unknown,
 >(
   name: string,
-  evaluator: Evaluator<Input, Output, Expected, Metadata, Parameters>,
+  evaluator: Evaluator<
+    Input,
+    Output,
+    Expected,
+    Metadata,
+    Parameters,
+    ScorerContext
+  >,
   reporterOrOpts?:
     | ReporterDef<EvalReport>
     | string
@@ -1015,7 +1041,7 @@ function logScoringFailures(
 export async function runEvaluator(
   experiment: Experiment | null,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  evaluator: EvaluatorDef<any, any, any, any, any>,
+  evaluator: EvaluatorDef<any, any, any, any, any, any>,
   progressReporter: ProgressReporter,
   filters: Filter[],
   stream: ((data: SSEProgressEventData) => void) | undefined,
@@ -1054,7 +1080,7 @@ export const defaultErrorScoreHandler: ErrorScoreHandler = ({
 async function runEvaluatorInternal(
   experiment: Experiment | null,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  evaluator: EvaluatorDef<any, any, any, any>,
+  evaluator: EvaluatorDef<any, any, any, any, any, any>,
   progressReporter: ProgressReporter,
   filters: Filter[],
   stream: ((data: SSEProgressEventData) => void) | undefined,
@@ -1241,6 +1267,7 @@ async function runEvaluatorInternal(
           let output: unknown = undefined;
           let error: unknown | undefined = undefined;
           let tags: string[] = [...(datum.tags ?? [])];
+          let scorerContext: unknown | undefined = undefined;
           const scores: Record<string, number | null> = {};
           const classifications: Record<string, ClassificationItem[]> = {};
           const scorerNames = (evaluator.scores ?? []).map(scorerName);
@@ -1275,6 +1302,9 @@ async function runEvaluatorInternal(
                   },
                   trialIndex,
                   tags,
+                  exposeScorerContext: (context: unknown) => {
+                    scorerContext = context;
+                  },
                 };
 
                 const outputResult = evaluator.task(datum.input, hooksForTask);
@@ -1310,8 +1340,13 @@ async function runEvaluatorInternal(
               metadata,
               output,
               trace,
+              scorerContext,
             };
-            const { trace: _trace, ...scoringArgsForLogging } = scoringArgs;
+            const {
+              trace: _trace,
+              scorerContext: _scorerContext,
+              ...scoringArgsForLogging
+            } = scoringArgs;
             const propagatedEvent = makeScorerPropagatedEvent(
               await rootSpan.export(),
             );
@@ -1709,7 +1744,7 @@ function ensureScoreAccumulator(
 
 export function buildLocalSummary(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  evaluator: EvaluatorDef<any, any, any, any>,
+  evaluator: EvaluatorDef<any, any, any, any, any, any>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   results: EvalResult<any, any, any, any>[],
   precomputedScores?: ScoreAccumulator,

--- a/js/src/reporters/types.ts
+++ b/js/src/reporters/types.ts
@@ -24,7 +24,7 @@ export interface ReporterBody<EvalReport> {
     // These any's are required because these function specifications don't know
     // or need to know the types of the input/output/etc for the evaluator.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    evaluator: EvaluatorDef<any, any, any, any, any>,
+    evaluator: EvaluatorDef<any, any, any, any, any, any>,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     result: EvalResultWithSummary<any, any, any, any>,
     opts: ReporterOpts,


### PR DESCRIPTION
```typescript
await Eval("agent-eval", {
  data: [{ input: "research X", expected: "..." }],

  task: async (input, hooks) => {
    const agent = createAgentSession();

    const output = await agent.run(input);

    hooks.exposeScorerContext(async (question: string) => {
      return agent.ask(question);
    });

    return output;
  },

  scores: [
    async ({ output, expected, scorerContext }) => {
      if (!scorerContext) {
        return { name: "followup_quality", score: 0 };
      }

      const answer = await scorerContext("What sources did you use?");
      return {
        name: "followup_quality",
        score: answer.includes("source") ? 1 : 0,
      };
    },
  ],
});
```