### PR TITLE
Parameters update values

### DIFF
--- a/js/src/eval-parameters.ts
+++ b/js/src/eval-parameters.ts
@@ -7,23 +7,35 @@ import {
 } from "./prompt-schemas";
 import { PromptData as promptDataSchema } from "./generated_types";
 
+// Schema for a prompt-typed evaluation parameter
+export const promptParameterSchema = z.object({
+  type: z.literal("prompt"),
+  default: promptDefinitionWithToolsSchema.optional(),
+  description: z.string().optional(),
+});
+
+export type PromptParameter = z.infer<typeof promptParameterSchema>;
+
+// Schema for a model-typed evaluation parameter
+export const modelParameterSchema = z.object({
+  type: z.literal("model"),
+  default: z.string().optional(),
+  description: z.string().optional(),
+});
+
+export type ModelParameter = z.infer<typeof modelParameterSchema>;
+
+// Schema for a single evaluation parameter
+export const evalParameterSchema = z.union([
+  promptParameterSchema,
+  modelParameterSchema,
+  z.instanceof(z.ZodType), // For Zod schemas
+]);
+
+export type EvalParameter = z.infer<typeof evalParameterSchema>;
+
 // Schema for evaluation parameters
-export const evalParametersSchema = z.record(
-  z.string(),
-  z.union([
-    z.object({
-      type: z.literal("prompt"),
-      default: promptDefinitionWithToolsSchema.optional(),
-      description: z.string().optional(),
-    }),
-    z.object({
-      type: z.literal("model"),
-      default: z.string().optional(),
-      description: z.string().optional(),
-    }),
-    z.instanceof(z.ZodType), // For Zod schemas
-  ]),
-);
+export const evalParametersSchema = z.record(z.string(), evalParameterSchema);
 
 export type EvalParameters = z.infer<typeof evalParametersSchema>;
 

--- a/js/src/framework.test.ts
+++ b/js/src/framework.test.ts
@@ -17,6 +17,7 @@ import {
   _exportsForTestingOnly,
   BraintrustState,
   initLogger,
+  Prompt,
   TestBackgroundLogger,
 } from "./logger";
 import { configureNode } from "./node/config";
@@ -1284,7 +1285,7 @@ describe("framework2 metadata support", () => {
   });
 
   describe("CodeParameters defaults", () => {
-    test("toFunctionDefinition initializes data with schema defaults", async () => {
+    test("toFunctionDefinition does not initialize data from schema defaults", async () => {
       const project = projects.create({ name: "test-project" });
       project.parameters.create({
         name: "test-parameters",
@@ -1329,26 +1330,7 @@ describe("framework2 metadata support", () => {
       const funcDef = await parameters[0].toFunctionDefinition(mockProjectMap);
 
       expect(funcDef.function_data.type).toBe("parameters");
-      expect(funcDef.function_data.data).toMatchObject({
-        title: "default-title",
-        numSamples: 10,
-        enabled: true,
-        tags: ["default-tag"],
-        config: {
-          retryCount: 3,
-          strategy: "balanced",
-        },
-        main: {
-          prompt: {
-            type: "chat",
-            messages: [{ role: "user", content: "{{input}}" }],
-          },
-          options: {
-            model: "gpt-4",
-          },
-        },
-        model: "gpt-5-mini",
-      });
+      expect(funcDef.function_data.data).toEqual({});
       expect(funcDef.function_data.__schema.properties.model).toMatchObject({
         type: "string",
         "x-bt-type": "model",
@@ -1399,6 +1381,120 @@ describe("framework2 metadata support", () => {
       expect(funcDef.function_data.data).not.toHaveProperty("config");
       expect(funcDef.function_data.data).not.toHaveProperty("main");
       expect(funcDef.function_data.data).not.toHaveProperty("model");
+    });
+
+    test("toFunctionDefinition initializes data with validated values", async () => {
+      const project = projects.create({ name: "test-project" });
+      const mainPrompt = Prompt.fromPromptData("main", {
+        prompt: {
+          type: "chat",
+          messages: [{ role: "user", content: "{{input}}" }],
+        },
+        options: {
+          model: "gpt-4o",
+        },
+      });
+
+      const codeParameters = project.parameters.create({
+        name: "test-parameters-values",
+        schema: {
+          title: z.string(),
+          numSamples: z.number(),
+          enabled: z.boolean(),
+          config: z.object({
+            retryCount: z.number(),
+            strategy: z.string(),
+          }),
+          main: {
+            type: "prompt",
+          },
+          model: {
+            type: "model",
+          },
+        },
+      });
+
+      codeParameters.updateValues({
+        title: "configured-title",
+        numSamples: 5,
+        enabled: false,
+        config: {
+          retryCount: 5,
+          strategy: "fast",
+        },
+        main: mainPrompt,
+        model: "gpt-5-mini",
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const parameters = (project as any)._publishableParameters;
+      expect(parameters).toHaveLength(1);
+
+      const mockProjectMap = {
+        resolve: vi.fn().mockResolvedValue("project-123"),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+
+      const funcDef = await parameters[0].toFunctionDefinition(mockProjectMap);
+
+      expect(funcDef.function_data.type).toBe("parameters");
+      expect(funcDef.function_data.data).toEqual({
+        title: "configured-title",
+        numSamples: 5,
+        enabled: false,
+        config: {
+          retryCount: 5,
+          strategy: "fast",
+        },
+        main: {
+          prompt: {
+            type: "chat",
+            messages: [{ role: "user", content: "{{input}}" }],
+          },
+          options: {
+            model: "gpt-4o",
+          },
+        },
+        model: "gpt-5-mini",
+      });
+    });
+
+    test("updateValues rejects values that do not match the schema", async () => {
+      const project = projects.create({ name: "test-project" });
+      const codeParameters = project.parameters.create({
+        name: "test-parameters-invalid-values",
+        schema: {
+          numSamples: z.number(),
+          model: {
+            type: "model",
+          },
+        },
+      });
+
+      codeParameters.updateValues({
+        model: "gpt-5-mini",
+      });
+
+      expect(() =>
+        codeParameters.updateValues({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          numSamples: "ten" as any,
+          model: "gpt-5-mini",
+        }),
+      ).toThrow("Invalid parameter value 'numSamples'");
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((project as any)._publishableParameters).toHaveLength(1);
+
+      const mockProjectMap = {
+        resolve: vi.fn().mockResolvedValue("project-123"),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+
+      const funcDef = await codeParameters.toFunctionDefinition(mockProjectMap);
+      expect(funcDef.function_data.data).toEqual({
+        model: "gpt-5-mini",
+      });
     });
   });
 

--- a/js/src/framework2.ts
+++ b/js/src/framework2.ts
@@ -627,7 +627,7 @@ export class CodeParameters<S extends EvalParameters = EvalParameters> {
     this.metadata = opts.metadata;
   }
 
-  public updateValues(values: InferParameters<S>): this {
+  public updateValues(values: Partial<InferParameters<S>>): this {
     const validatedValues = validateParameterValues(this.schema, values);
     this.values = validatedValues;
     return this;
@@ -679,7 +679,7 @@ class ParametersBuilder {
 
 function validateParameterValues<S extends EvalParameters>(
   schema: S,
-  values?: InferParameters<S>,
+  values?: Partial<InferParameters<S>>,
 ): Record<string, unknown> {
   if (!values) {
     return {};

--- a/js/src/framework2.ts
+++ b/js/src/framework2.ts
@@ -9,6 +9,7 @@ import {
   type SavedFunctionIdType as SavedFunctionId,
   type PromptBlockDataType as PromptBlockData,
   type PromptDataType as PromptData,
+  PromptData as promptDataSchema,
   ToolFunctionDefinition as toolFunctionDefinitionSchema,
   type ToolFunctionDefinitionType as ToolFunctionDefinition,
   FunctionData as functionDataSchema,
@@ -24,8 +25,15 @@ import {
   RemoteEvalParameters,
 } from "./logger";
 import type { BaseFnOpts, GenericFunction } from "./framework-types";
-import type { EvalParameters } from "./eval-parameters";
+import type {
+  EvalParameter,
+  EvalParameters,
+  InferParameters,
+  ModelParameter,
+  PromptParameter,
+} from "./eval-parameters";
 import {
+  promptDefinitionWithToolsSchema,
   promptDefinitionToPromptData,
   type PromptDefinition,
 } from "./prompt-schemas";
@@ -589,14 +597,15 @@ export interface ParametersOpts<S extends EvalParameters> {
   metadata?: Record<string, unknown>;
 }
 
-export class CodeParameters {
+export class CodeParameters<S extends EvalParameters = EvalParameters> {
   public readonly project: Project;
   public readonly name: string;
   public readonly slug: string;
   public readonly description?: string;
-  public readonly schema: EvalParameters;
+  public readonly schema: S;
   public readonly ifExists?: IfExists;
   public readonly metadata?: Record<string, unknown>;
+  private values: Record<string, unknown> = {};
 
   constructor(
     project: Project,
@@ -604,7 +613,7 @@ export class CodeParameters {
       name: string;
       slug: string;
       description?: string;
-      schema: EvalParameters;
+      schema: S;
       ifExists?: IfExists;
       metadata?: Record<string, unknown>;
     },
@@ -616,6 +625,12 @@ export class CodeParameters {
     this.schema = opts.schema;
     this.ifExists = opts.ifExists;
     this.metadata = opts.metadata;
+  }
+
+  public updateValues(values: InferParameters<S>): this {
+    const validatedValues = validateParameterValues(this.schema, values);
+    this.values = validatedValues;
+    return this;
   }
 
   async toFunctionDefinition(
@@ -630,7 +645,7 @@ export class CodeParameters {
       function_type: "parameters",
       function_data: {
         type: "parameters",
-        data: getDefaultDataFromParametersSchema(schema),
+        data: this.values,
         __schema: schema,
       },
       if_exists: this.ifExists,
@@ -642,10 +657,12 @@ export class CodeParameters {
 class ParametersBuilder {
   constructor(private readonly project: Project) {}
 
-  public create<S extends EvalParameters>(opts: ParametersOpts<S>): S {
+  public create<S extends EvalParameters>(
+    opts: ParametersOpts<S>,
+  ): CodeParameters<S> {
     const slug = opts.slug ?? slugify(opts.name, { lower: true, strict: true });
 
-    const codeParameters = new CodeParameters(this.project, {
+    const codeParameters = new CodeParameters<S>(this.project, {
       name: opts.name,
       slug,
       description: opts.description,
@@ -656,8 +673,82 @@ class ParametersBuilder {
 
     this.project.addParameters(codeParameters);
 
-    return opts.schema;
+    return codeParameters;
   }
+}
+
+function validateParameterValues<S extends EvalParameters>(
+  schema: S,
+  values?: InferParameters<S>,
+): Record<string, unknown> {
+  if (!values) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(values).flatMap(([name, value]) => {
+      if (value === undefined) {
+        return [];
+      }
+
+      const parameterSchema = schema[name];
+      if (parameterSchema === undefined) {
+        return [[name, value]];
+      }
+
+      try {
+        if (isPromptParameterSchema(parameterSchema)) {
+          return [[name, validatePromptParameterValue(value)]];
+        }
+
+        if (isModelParameterSchema(parameterSchema)) {
+          if (typeof value !== "string") {
+            throw new Error(
+              `Parameter '${name}' must be a string model identifier`,
+            );
+          }
+          return [[name, value]];
+        }
+
+        return [[name, parameterSchema.parse(value)]];
+      } catch (e) {
+        throw Error(
+          `Invalid parameter value '${name}': ${
+            e instanceof Error ? e.message : String(e)
+          }`,
+        );
+      }
+    }),
+  );
+}
+
+function isPromptParameterSchema(
+  schema: EvalParameter,
+): schema is PromptParameter {
+  return "type" in schema && schema.type === "prompt";
+}
+
+function isModelParameterSchema(
+  schema: EvalParameter,
+): schema is ModelParameter {
+  return "type" in schema && schema.type === "model";
+}
+
+function validatePromptParameterValue(value: unknown): PromptData {
+  if (Prompt.isPrompt(value)) {
+    return value.promptData;
+  }
+
+  const promptDefinitionResult =
+    promptDefinitionWithToolsSchema.safeParse(value);
+  if (promptDefinitionResult.success) {
+    return promptDefinitionToPromptData(
+      promptDefinitionResult.data,
+      promptDefinitionResult.data.tools,
+    );
+  }
+
+  return promptDataSchema.parse(value);
 }
 
 export function serializeEvalParametersToStaticParametersSchema(
@@ -665,7 +756,7 @@ export function serializeEvalParametersToStaticParametersSchema(
 ): StaticParametersSchema {
   return Object.fromEntries(
     Object.entries(parameters).map(([name, value]) => {
-      if ("type" in value && value.type === "prompt") {
+      if (isPromptParameterSchema(value)) {
         return [
           name,
           {
@@ -676,7 +767,7 @@ export function serializeEvalParametersToStaticParametersSchema(
             description: value.description,
           },
         ];
-      } else if ("type" in value && value.type === "model") {
+      } else if (isModelParameterSchema(value)) {
         return [
           name,
           {
@@ -761,20 +852,6 @@ function serializeEvalParameterstoParametersSchema(
     ...(required.length > 0 ? { required } : {}),
     additionalProperties: true,
   };
-}
-
-function getDefaultDataFromParametersSchema(
-  schema: ParametersSchema,
-): Record<string, unknown> {
-  return Object.fromEntries(
-    Object.entries(schema.properties).flatMap(([name, value]) => {
-      if (!("default" in value)) {
-        return [];
-      }
-
-      return [[name, value.default]];
-    }),
-  );
 }
 
 export function serializeRemoteEvalParametersContainer(


### PR DESCRIPTION
When building parameters, this line https://github.com/braintrustdata/braintrust-sdk-javascript/blob/dfb709b80db0a2b48fb36eea7451f0d58b1fce8c/js/src/framework2.ts#L633

Means that the parameter data we upload to braintrust via `bt functions push` will always replace existing parameter data even if the user has made updates to the parameters via the UI or API. That also means setting default values in the parameters schema is the only way to update the underlying parameter data via the sdk. I think default values and actual stored data should be decoupled.

This PR adds `parametersObj.addValues({})` which allows users to use `bt functions push` to update existing fields in a PATCH/merge style update rather than a PUT/replace update.

Aligns with https://github.com/braintrustdata/bt/pull/225. Comments on API/interface welcome 