### PR TITLE
Add classifier function push builder

### DIFF
--- a/.changeset/classifier-function-push.md
+++ b/.changeset/classifier-function-push.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+Add project-level classifier builder support for function push.

--- a/js/src/exports.ts
+++ b/js/src/exports.ts
@@ -231,7 +231,6 @@ export {
 export { DatasetPipeline } from "./dataset-pipeline";
 
 export type {
-  ClassifierOpts,
   CodeOpts,
   CreateProjectOpts,
   FunctionEvent,
@@ -240,7 +239,6 @@ export type {
 } from "./framework2";
 
 export {
-  ClassifierBuilder,
   CodeFunction,
   CodePrompt,
   Project,

--- a/js/src/exports.ts
+++ b/js/src/exports.ts
@@ -231,6 +231,7 @@ export {
 export { DatasetPipeline } from "./dataset-pipeline";
 
 export type {
+  ClassifierOpts,
   CodeOpts,
   CreateProjectOpts,
   FunctionEvent,
@@ -239,6 +240,7 @@ export type {
 } from "./framework2";
 
 export {
+  ClassifierBuilder,
   CodeFunction,
   CodePrompt,
   Project,

--- a/js/src/framework.test.ts
+++ b/js/src/framework.test.ts
@@ -1038,6 +1038,62 @@ describe("framework2 metadata support", () => {
 
       expect(tool.tags).toBeUndefined();
     });
+
+    test("classifier registers as a code function", () => {
+      const project = projects.create({ name: "test-project" });
+
+      const classifier = project.classifiers.create({
+        handler: ({ output }: { output: string }) => ({
+          name: "category",
+          id: output,
+        }),
+        name: "test-classifier",
+        parameters: z.object({
+          output: z.string(),
+        }),
+      });
+
+      expect(classifier.type).toBe("classifier");
+      expect(classifier.name).toBe("test-classifier");
+      expect(classifier.slug).toBe("test-classifier");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((project as any)._publishableCodeFunctions).toEqual([classifier]);
+    });
+
+    test("lazy classifier registration uses the functions registry", () => {
+      const previousLazyLoad = globalThis._lazy_load;
+      const previousEvals = globalThis._evals;
+      globalThis._lazy_load = true;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      globalThis._evals = {
+        evaluators: [],
+        functions: [],
+        parameters: [],
+        prompts: [],
+        reporters: [],
+      } as any;
+
+      try {
+        const project = projects.create({ name: "test-project" });
+
+        const classifier = project.classifiers.create({
+          handler: ({ output }: { output: string }) => ({
+            name: "category",
+            id: output,
+          }),
+          name: "test-classifier",
+          parameters: z.object({
+            output: z.string(),
+          }),
+        });
+
+        expect(globalThis._evals.functions).toEqual([classifier]);
+        expect(globalThis._evals.functions[0].type).toBe("classifier");
+      } finally {
+        globalThis._lazy_load = previousLazyLoad;
+        globalThis._evals = previousEvals;
+      }
+    });
   });
 
   describe("CodePrompt metadata", () => {

--- a/js/src/framework2.ts
+++ b/js/src/framework2.ts
@@ -296,7 +296,7 @@ export class ScorerBuilder {
   }
 }
 
-export class ClassifierBuilder {
+class ClassifierBuilder {
   private taskCounter = 0;
   constructor(private readonly project: Project) {}
 
@@ -390,7 +390,7 @@ export type ScorerOpts<
   metadata?: Record<string, unknown>;
 };
 
-export type ClassifierOpts<
+type ClassifierOpts<
   Output,
   Input,
   Params,

--- a/js/src/framework2.ts
+++ b/js/src/framework2.ts
@@ -60,6 +60,7 @@ export class Project {
   public prompts: PromptBuilder;
   public parameters: ParametersBuilder;
   public scorers: ScorerBuilder;
+  public classifiers: ClassifierBuilder;
 
   private _publishableCodeFunctions: CodeFunction<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -80,6 +81,7 @@ export class Project {
     this.prompts = new PromptBuilder(this);
     this.parameters = new ParametersBuilder(this);
     this.scorers = new ScorerBuilder(this);
+    this.classifiers = new ClassifierBuilder(this);
   }
 
   public addPrompt(prompt: CodePrompt) {
@@ -294,6 +296,44 @@ export class ScorerBuilder {
   }
 }
 
+export class ClassifierBuilder {
+  private taskCounter = 0;
+  constructor(private readonly project: Project) {}
+
+  public create<
+    Output,
+    Input,
+    Params,
+    Returns,
+    Fn extends GenericFunction<
+      Exact<Params, ScorerArgs<Output, Input>>,
+      Returns
+    >,
+  >(opts: ClassifierOpts<Output, Input, Params, Returns, Fn>) {
+    this.taskCounter++;
+
+    let resolvedName = opts.name ?? opts.handler.name;
+    if (!resolvedName || resolvedName.trim().length === 0) {
+      resolvedName = `Classifier ${iso.basename(currentFilename)} ${this.taskCounter}`;
+    }
+    const slug =
+      opts.slug ?? slugify(resolvedName, { lower: true, strict: true });
+
+    const classifier: CodeFunction<
+      Exact<Params, ScorerArgs<Output, Input>>,
+      Returns,
+      Fn
+    > = new CodeFunction(this.project, {
+      ...opts,
+      name: resolvedName,
+      slug,
+      type: "classifier",
+    });
+    this.project.addCodeFunction(classifier);
+    return classifier;
+  }
+}
+
 type Schema<Input, Output> = Partial<{
   parameters: z.ZodSchema<Input>;
   returns: z.ZodSchema<Output>;
@@ -347,6 +387,16 @@ export type ScorerOpts<
   Returns,
   Fn extends GenericFunction<Exact<Params, ScorerArgs<Output, Input>>, Returns>,
 > = ScorerOptsUnion<Output, Input, Params, Returns, Fn> & {
+  metadata?: Record<string, unknown>;
+};
+
+export type ClassifierOpts<
+  Output,
+  Input,
+  Params,
+  Returns,
+  Fn extends GenericFunction<Exact<Params, ScorerArgs<Output, Input>>, Returns>,
+> = CodeOpts<Exact<Params, ScorerArgs<Output, Input>>, Returns, Fn> & {
   metadata?: Record<string, unknown>;
 };
 


### PR DESCRIPTION
## Summary
- add a project-level classifier builder for code-backed saved functions
- register classifiers through the existing function push registry with `type: "classifier"`
- add focused coverage for normal and lazy-load function registry registration

## Validation
- `./node_modules/.bin/vitest run src/framework.test.ts -t "classifier registers|lazy classifier"`
- `./node_modules/.bin/tsc --noEmit` was attempted, but the local Node/type environment reports existing `node:util.styleText` and `diagnostics_channel.tracingChannel` type errors unrelated to this change
