### PR TITLE
Allow inline eval cases to carry explicit origin metadata.

### DIFF
--- a/.changeset/late-buses-enjoy.md
+++ b/.changeset/late-buses-enjoy.md
@@ -1,0 +1,5 @@
+---
+"braintrust": minor
+---
+
+Add support for preserving explicit origin metadata on inline eval cases, so evals that run transformed or pre-resolved rows can retain their source-row provenance.

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -1169,6 +1169,17 @@ async function runEvaluatorInternal(
           : Dataset.isDataset(evaluator.data)
             ? evaluator.data
             : undefined;
+        const origin =
+          datum.origin ??
+          (eventDataset && datum.id && datum._xact_id
+            ? {
+                object_type: "dataset",
+                object_id: await eventDataset.id,
+                id: datum.id,
+                created: datum.created,
+                _xact_id: datum._xact_id,
+              }
+            : undefined);
 
         const baseEvent: StartSpanArgs = {
           name: "eval",
@@ -1179,16 +1190,7 @@ async function runEvaluatorInternal(
             input: datum.input,
             expected: "expected" in datum ? datum.expected : undefined,
             tags: datum.tags,
-            origin:
-              eventDataset && datum.id && datum._xact_id
-                ? {
-                    object_type: "dataset",
-                    object_id: await eventDataset.id,
-                    id: datum.id,
-                    created: datum.created,
-                    _xact_id: datum._xact_id,
-                  }
-                : undefined,
+            origin,
             ...(datum.upsert_id ? { id: datum.upsert_id } : {}),
           },
         };

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -77,6 +77,7 @@ import {
   type PromptType as PromptRow,
   type PromptSessionEventType as PromptSessionEvent,
   type RepoInfoType as RepoInfo,
+  type ObjectReferenceType as ObjectReference,
   type PromptBlockDataType as PromptBlockData,
   type ResponseFormatJsonSchemaType as ResponseFormatJsonSchema,
 } from "./generated_types";
@@ -6223,6 +6224,7 @@ export class ObjectFetcher<RecordType> implements AsyncIterable<
 
 export type BaseMetadata = Record<string, unknown> | void;
 export type DefaultMetadataType = void;
+export type EvalCaseOrigin = ObjectReference;
 export type EvalCase<Input, Expected, Metadata> = {
   input: Input;
   tags?: string[];
@@ -6230,6 +6232,7 @@ export type EvalCase<Input, Expected, Metadata> = {
   id?: string;
   _xact_id?: TransactionId;
   created?: string | null;
+  origin?: EvalCaseOrigin;
   // This field is used to help re-run a particular experiment row.
   upsert_id?: string;
   // The number of times to run the evaluator for this specific input.


### PR DESCRIPTION
Previously, eval span origins were inferred only when running directly from a `Dataset`, using the dataset row id/xact metadata on each datum. Callers that resolve or transform rows before invoking `Eval` as inline data had no generic way to preserve the original source-row association.

This change lets an `EvalCase` provide an explicit `origin`, and keeps the existing dataset-derived origin inference as a fallback. That enables batched inline eval flows to preserve per-row provenance without changing behavior for normal dataset-backed evals.