### PR TITLE
Fix dataset-backed eval origin for copied dataset rows

### DIFF
--- a/.changeset/beige-ducks-sneeze.md
+++ b/.changeset/beige-ducks-sneeze.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+Fix: dataset-backed eval origin for copied dataset rows

--- a/js/src/framework.test.ts
+++ b/js/src/framework.test.ts
@@ -346,7 +346,7 @@ describe("runEvaluator", () => {
     ]);
   });
 
-  test("rejects an invalid inline origin", async () => {
+  test("ignores an invalid inline origin", async () => {
     const origin: {
       object_type: "dataset";
       object_id: string;
@@ -358,22 +358,22 @@ describe("runEvaluator", () => {
     };
     const task = vi.fn(async (input: number) => input * 2);
 
-    await expect(
-      runEvaluator(
-        null,
-        {
-          projectName: "proj",
-          evalName: "eval",
-          data: [{ input: 1, origin }],
-          task,
-          scores: [],
-        },
-        new NoopProgressReporter(),
-        [],
-        undefined,
-      ),
-    ).rejects.toThrow();
-    expect(task).not.toHaveBeenCalled();
+    const out = await runEvaluator(
+      null,
+      {
+        projectName: "proj",
+        evalName: "eval",
+        data: [{ input: 1, origin }],
+        task,
+        scores: [],
+      },
+      new NoopProgressReporter(),
+      [],
+      undefined,
+    );
+
+    expect(task).toHaveBeenCalled();
+    expect(out.results[0].origin).toBeUndefined();
   });
 
   describe("errors", () => {

--- a/js/src/framework.test.ts
+++ b/js/src/framework.test.ts
@@ -268,17 +268,20 @@ describe("runEvaluator", () => {
     });
   });
 
-  test("uses dataset row origin without requiring a transaction id", async () => {
+  test("falls back to source origin when dataset row origin is incomplete", async () => {
     const datasetId = "00000000-0000-0000-0000-000000000001";
+    const sourceOrigin = {
+      object_type: "project_logs" as const,
+      object_id: "00000000-0000-0000-0000-000000000002",
+      id: "source-log-row-1",
+      _xact_id: "source-xact",
+      created: "2026-06-01T00:00:00.000Z",
+    };
     const data = makeDatasetData(datasetId, {
       input: 1,
       id: "dataset-row-1",
       created: "2026-06-02T00:00:00.000Z",
-      origin: {
-        object_type: "project_logs",
-        object_id: "00000000-0000-0000-0000-000000000002",
-        id: "source-log-row-1",
-      },
+      origin: sourceOrigin,
     });
 
     const out = await runEvaluator(
@@ -295,12 +298,7 @@ describe("runEvaluator", () => {
       undefined,
     );
 
-    expect(out.results[0].origin).toEqual({
-      object_type: "dataset",
-      object_id: datasetId,
-      id: "dataset-row-1",
-      created: "2026-06-02T00:00:00.000Z",
-    });
+    expect(out.results[0].origin).toEqual(sourceOrigin);
   });
 
   test("reports progress with dataset row origin for dataset-backed evals", async () => {
@@ -309,6 +307,7 @@ describe("runEvaluator", () => {
       input: 1,
       id: "dataset-row-1",
       _xact_id: "dataset-xact",
+      created: "2026-06-02T00:00:00.000Z",
       origin: {
         object_type: "project_logs",
         object_id: "00000000-0000-0000-0000-000000000002",
@@ -341,6 +340,7 @@ describe("runEvaluator", () => {
           object_id: datasetId,
           id: "dataset-row-1",
           _xact_id: "dataset-xact",
+          created: "2026-06-02T00:00:00.000Z",
         },
       }),
     ]);

--- a/js/src/framework.test.ts
+++ b/js/src/framework.test.ts
@@ -166,6 +166,37 @@ function makeTestScorer(
 }
 
 describe("runEvaluator", () => {
+  function makeDatasetData(
+    datasetId: string,
+    datum: {
+      input: number;
+      id: string;
+      _xact_id?: string;
+      created?: string;
+      origin?: {
+        object_type:
+          | "project_logs"
+          | "experiment"
+          | "dataset"
+          | "prompt"
+          | "function"
+          | "prompt_session";
+        object_id: string;
+        id: string;
+        _xact_id?: string | null;
+        created?: string | null;
+      };
+    },
+  ) {
+    return {
+      __braintrust_dataset_marker: true,
+      id: Promise.resolve(datasetId),
+      async *[Symbol.asyncIterator]() {
+        yield datum;
+      },
+    };
+  }
+
   test("preserves a valid inline origin", async () => {
     const origin: {
       object_type: "dataset";
@@ -196,6 +227,123 @@ describe("runEvaluator", () => {
     );
 
     expect(out.results[0].origin).toEqual(origin);
+  });
+
+  test("prefers dataset row origin over source origin for dataset-backed evals", async () => {
+    const datasetId = "00000000-0000-0000-0000-000000000001";
+    const data = makeDatasetData(datasetId, {
+      input: 1,
+      id: "dataset-row-1",
+      _xact_id: "dataset-xact",
+      created: "2026-06-02T00:00:00.000Z",
+      origin: {
+        object_type: "project_logs",
+        object_id: "00000000-0000-0000-0000-000000000002",
+        id: "source-log-row-1",
+        _xact_id: "source-xact",
+        created: "2026-06-01T00:00:00.000Z",
+      },
+    });
+
+    const out = await runEvaluator(
+      null,
+      {
+        projectName: "proj",
+        evalName: "eval",
+        data,
+        task: async (input: number) => input * 2,
+        scores: [],
+      },
+      new NoopProgressReporter(),
+      [],
+      undefined,
+    );
+
+    expect(out.results[0].origin).toEqual({
+      object_type: "dataset",
+      object_id: datasetId,
+      id: "dataset-row-1",
+      _xact_id: "dataset-xact",
+      created: "2026-06-02T00:00:00.000Z",
+    });
+  });
+
+  test("uses dataset row origin without requiring a transaction id", async () => {
+    const datasetId = "00000000-0000-0000-0000-000000000001";
+    const data = makeDatasetData(datasetId, {
+      input: 1,
+      id: "dataset-row-1",
+      created: "2026-06-02T00:00:00.000Z",
+      origin: {
+        object_type: "project_logs",
+        object_id: "00000000-0000-0000-0000-000000000002",
+        id: "source-log-row-1",
+      },
+    });
+
+    const out = await runEvaluator(
+      null,
+      {
+        projectName: "proj",
+        evalName: "eval",
+        data,
+        task: async (input: number) => input * 2,
+        scores: [],
+      },
+      new NoopProgressReporter(),
+      [],
+      undefined,
+    );
+
+    expect(out.results[0].origin).toEqual({
+      object_type: "dataset",
+      object_id: datasetId,
+      id: "dataset-row-1",
+      created: "2026-06-02T00:00:00.000Z",
+    });
+  });
+
+  test("reports progress with dataset row origin for dataset-backed evals", async () => {
+    const datasetId = "00000000-0000-0000-0000-000000000001";
+    const data = makeDatasetData(datasetId, {
+      input: 1,
+      id: "dataset-row-1",
+      _xact_id: "dataset-xact",
+      origin: {
+        object_type: "project_logs",
+        object_id: "00000000-0000-0000-0000-000000000002",
+        id: "source-log-row-1",
+      },
+    });
+    const streamEvents: unknown[] = [];
+
+    await runEvaluator(
+      null,
+      {
+        projectName: "proj",
+        evalName: "eval",
+        data,
+        task: async (input: number, hooks) => {
+          hooks.reportProgress({ object_type: "progress", progress: 0.5 });
+          return input * 2;
+        },
+        scores: [],
+      },
+      new NoopProgressReporter(),
+      [],
+      (event) => streamEvents.push(event),
+    );
+
+    expect(streamEvents).toEqual([
+      expect.objectContaining({
+        origin: {
+          object_type: "dataset",
+          object_id: datasetId,
+          id: "dataset-row-1",
+          _xact_id: "dataset-xact",
+        },
+      }),
+    ]);
   });
 
   test("rejects an invalid inline origin", async () => {

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -1180,21 +1180,21 @@ async function runEvaluatorInternal(
           : Dataset.isDataset(evaluator.data)
             ? evaluator.data
             : undefined;
-        const datasetOrigin: ObjectReference | undefined =
-          eventDataset && datum.id
+        const inlineDatasetOrigin: ObjectReference | undefined =
+          eventDataset && datum.id && datum._xact_id && datum.created
             ? {
                 object_type: "dataset",
                 object_id: await eventDataset.id,
                 id: datum.id,
                 created: datum.created,
-                ...(datum._xact_id ? { _xact_id: datum._xact_id } : {}),
+                _xact_id: datum._xact_id,
               }
             : undefined;
-        const inlineOrigin =
-          datum.origin === undefined
+        const origin =
+          inlineDatasetOrigin ??
+          (datum.origin === undefined
             ? undefined
-            : ObjectReferenceSchema.parse(datum.origin);
-        const origin = datasetOrigin ?? inlineOrigin;
+            : ObjectReferenceSchema.parse(datum.origin));
 
         const baseEvent: StartSpanArgs = {
           name: "eval",

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -1180,21 +1180,21 @@ async function runEvaluatorInternal(
           : Dataset.isDataset(evaluator.data)
             ? evaluator.data
             : undefined;
-        const inlineOrigin =
-          datum.origin === undefined
-            ? undefined
-            : ObjectReferenceSchema.parse(datum.origin);
-        const origin =
-          inlineOrigin ??
-          (eventDataset && datum.id && datum._xact_id
+        const datasetOrigin: ObjectReference | undefined =
+          eventDataset && datum.id
             ? {
                 object_type: "dataset",
                 object_id: await eventDataset.id,
                 id: datum.id,
                 created: datum.created,
-                _xact_id: datum._xact_id,
+                ...(datum._xact_id ? { _xact_id: datum._xact_id } : {}),
               }
-            : undefined);
+            : undefined;
+        const inlineOrigin =
+          datum.origin === undefined
+            ? undefined
+            : ObjectReferenceSchema.parse(datum.origin);
+        const origin = datasetOrigin ?? inlineOrigin;
 
         const baseEvent: StartSpanArgs = {
           name: "eval",

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -1190,11 +1190,13 @@ async function runEvaluatorInternal(
                 _xact_id: datum._xact_id,
               }
             : undefined;
+        const parsedDatumOrigin =
+          datum.origin === undefined
+            ? undefined
+            : ObjectReferenceSchema.safeParse(datum.origin);
         const origin =
           inlineDatasetOrigin ??
-          (datum.origin === undefined
-            ? undefined
-            : ObjectReferenceSchema.parse(datum.origin));
+          (parsedDatumOrigin?.success ? parsedDatumOrigin.data : undefined);
 
         const baseEvent: StartSpanArgs = {
           name: "eval",

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -1190,10 +1190,7 @@ async function runEvaluatorInternal(
                 _xact_id: datum._xact_id,
               }
             : undefined;
-        const parsedDatumOrigin =
-          datum.origin === undefined
-            ? undefined
-            : ObjectReferenceSchema.safeParse(datum.origin);
+        const parsedDatumOrigin = ObjectReferenceSchema.safeParse(datum.origin);
         const origin =
           inlineDatasetOrigin ??
           (parsedDatumOrigin?.success ? parsedDatumOrigin.data : undefined);

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -1181,7 +1181,7 @@ async function runEvaluatorInternal(
             ? evaluator.data
             : undefined;
         const inlineDatasetOrigin: ObjectReference | undefined =
-          eventDataset && datum.id && datum._xact_id && datum.created
+          eventDataset && datum.id && datum._xact_id
             ? {
                 object_type: "dataset",
                 object_id: await eventDataset.id,


### PR DESCRIPTION
## Summary

  Fix dataset-backed eval/playground origin handling so copied dataset rows use the active dataset row id instead of
  preserved source provenance.

  ## Details

  Dataset rows copied from logs can carry origin pointing at the original project_logs row. runEvaluator previously
  preferred that datum.origin over the synthesized dataset-row origin, causing playground output/progress events to be
  keyed by the source log row id instead of the selected dataset row id.

  This changes dataset-backed evals to prefer the active dataset row origin whenever eventDataset and datum.id are
  present. Inline/non-dataset evals still preserve explicit datum.origin.

  ## Tests

  - Added regression coverage for log-derived dataset rows using dataset row origin
  - Added coverage for dataset rows without _xact_id
  - Added coverage for streamed progress events carrying dataset row origin
  - Ran focused Vitest origin tests successfully via local Vitest binary