### PR TITLE
feat: Add otel compatible distributed tracing

### DIFF
--- a/.changeset/distributed-tracing-w3c.md
+++ b/.changeset/distributed-tracing-w3c.md
@@ -1,0 +1,19 @@
+---
+"braintrust": minor
+---
+
+feat: W3C-compatible distributed tracing
+
+- Add `inject`/`extract` APIs for distributed tracing across service boundaries
+  (`span.inject(carrier)`, `injectTraceContext()`, and `extractTraceContext(headers)`),
+  implementing the [W3C Trace Context](https://www.w3.org/TR/trace-context/) and
+  [W3C Baggage](https://www.w3.org/TR/baggage/) specs. `startSpan({ parent })` now
+  accepts the opaque context returned by `extractTraceContext` in addition to an
+  exported span slug.
+- Default to OpenTelemetry-compatible hex span/trace IDs (and V4 span-component
+  export). Set `BRAINTRUST_LEGACY_IDS` to opt back into legacy UUID IDs (and V3
+  export). `BRAINTRUST_OTEL_COMPAT` continues to force hex IDs and takes
+  precedence over `BRAINTRUST_LEGACY_IDS`.
+
+Note: The deprecated `span.export()` / `startSpan({ parent: <slug> })` path remains
+supported and links correctly across the UUID and hex formats.

--- a/.changeset/distributed-tracing-w3c.md
+++ b/.changeset/distributed-tracing-w3c.md
@@ -5,11 +5,12 @@
 feat: W3C-compatible distributed tracing
 
 - Add `inject`/`extract` APIs for distributed tracing across service boundaries
-  (`span.inject(carrier)`, `injectTraceContext()`, and `extractTraceContext(headers)`),
+  (`span.inject(carrier)`, `injectTraceContext()`, and
+  `extractTraceContextFromHeaders(headers)`),
   implementing the [W3C Trace Context](https://www.w3.org/TR/trace-context/) and
   [W3C Baggage](https://www.w3.org/TR/baggage/) specs. `startSpan({ parent })` now
-  accepts the opaque context returned by `extractTraceContext` in addition to an
-  exported span slug.
+  accepts the opaque context returned by `extractTraceContextFromHeaders` in
+  addition to an exported span slug.
 - Default to OpenTelemetry-compatible hex span/trace IDs (and V4 span-component
   export). Set `BRAINTRUST_LEGACY_IDS` to opt back into legacy UUID IDs (and V3
   export). `BRAINTRUST_OTEL_COMPAT` continues to force hex IDs and takes

--- a/e2e/helpers/normalize.ts
+++ b/e2e/helpers/normalize.ts
@@ -48,6 +48,15 @@ const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const UUID_SUBSTRING_REGEX =
   /[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi;
+// OpenTelemetry-compatible (the SDK default) span ids are 8 random bytes (16
+// lowercase hex chars) and trace ids are 16 random bytes (32 lowercase hex
+// chars). Like UUIDs, these are non-deterministic and show up not only under
+// the span-id keys handled above but also as plain string values (e.g. a span
+// id a scenario captured into its output), so an exact-match normalization
+// keeps such snapshots stable. They share the `tokenMaps.ids` map (and the
+// "span" token prefix) with the span-id keys so the same id resolves to one
+// token wherever it appears.
+const HEX_ID_REGEX = /^(?:[0-9a-f]{16}|[0-9a-f]{32})$/;
 const TIME_KEYS = new Set([
   "completed_at",
   "created",
@@ -426,6 +435,10 @@ function normalizeValue(
 
     if (UUID_REGEX.test(value)) {
       return tokenFor(tokenMaps.ids, value, "uuid");
+    }
+
+    if (HEX_ID_REGEX.test(value)) {
+      return tokenFor(tokenMaps.ids, value, "span");
     }
   }
 

--- a/e2e/helpers/wrapper-contract.ts
+++ b/e2e/helpers/wrapper-contract.ts
@@ -223,16 +223,24 @@ export function summarizeWrapperContract(
 export function payloadRowsForRootSpan(
   payloads: CapturedLogPayload[],
   rootSpanId: string | undefined,
+  traceId: string | undefined = rootSpanId,
 ): CapturedLogRow[] {
   if (!rootSpanId) {
     return [];
   }
 
+  // The whole trace is identified by `root_span_id` (the trace id). With the
+  // default OpenTelemetry-compatible hex ids the root span's own `span_id`
+  // differs from the trace id, so the trace is selected by `traceId` while the
+  // root row is identified by the root span's `span_id`. For legacy UUID ids the
+  // two are equal, which is why `traceId` defaults to `rootSpanId`.
+  const traceRootSpanId = traceId ?? rootSpanId;
+
   const rootRows: CapturedLogRow[] = [];
   const mergedRows = new Map<string, CapturedLogRow>();
 
   for (const row of payloads.flatMap((payload) => payload.rows)) {
-    if (row.root_span_id !== rootSpanId) continue;
+    if (row.root_span_id !== traceRootSpanId) continue;
 
     if (row.span_id === rootSpanId) {
       rootRows.push(...splitTerminalMergeRow(row));

--- a/e2e/scenarios/deno-browser/__snapshots__/request-flow.json
+++ b/e2e/scenarios/deno-browser/__snapshots__/request-flow.json
@@ -45,7 +45,7 @@
           },
           "output": "Paris",
           "project_id": "<project_id>",
-          "root_span_id": "<span:3>",
+          "root_span_id": "<span:4>",
           "span_attributes": {
             "exec_counter": 0,
             "name": "deno browser basic span",
@@ -56,12 +56,12 @@
         {
           "context": {},
           "created": "<timestamp>",
-          "id": "<span:5>",
+          "id": "<span:6>",
           "input": {
             "transcript": {
               "content_type": "application/json",
               "filename": "conversation_transcript.json",
-              "key": "<uuid:6>",
+              "key": "<uuid:7>",
               "type": "braintrust_attachment"
             },
             "type": "chat_completion"
@@ -80,18 +80,18 @@
             "attachment": true
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:7>",
+          "root_span_id": "<span:9>",
           "span_attributes": {
             "exec_counter": 1,
             "name": "deno browser json attachment span",
             "type": "task"
           },
-          "span_id": "<span:7>"
+          "span_id": "<span:8>"
         },
         {
           "context": {},
           "created": "<timestamp>",
-          "id": "<span:8>",
+          "id": "<span:10>",
           "input": {
             "phase": "parent",
             "testRunId": "<run:1>"
@@ -111,18 +111,18 @@
             "phase": "parent"
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:9>",
+          "root_span_id": "<span:12>",
           "span_attributes": {
             "exec_counter": 2,
             "name": "deno browser parent span",
             "type": "task"
           },
-          "span_id": "<span:9>"
+          "span_id": "<span:11>"
         },
         {
           "context": {},
           "created": "<timestamp>",
-          "id": "<span:10>",
+          "id": "<span:13>",
           "input": {
             "step": "child",
             "testRunId": "<run:1>"
@@ -142,18 +142,18 @@
             "phase": "child"
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:11>",
+          "root_span_id": "<span:15>",
           "span_attributes": {
             "exec_counter": 3,
             "name": "deno browser child span",
             "type": "task"
           },
-          "span_id": "<span:11>"
+          "span_id": "<span:14>"
         },
         {
           "context": {},
           "created": "<timestamp>",
-          "id": "<span:12>",
+          "id": "<span:16>",
           "log_id": "g",
           "metadata": {
             "case": "nested-parent",
@@ -165,18 +165,18 @@
             "start": 0
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:13>",
+          "root_span_id": "<span:18>",
           "span_attributes": {
             "exec_counter": 4,
             "name": "deno browser nested parent span",
             "type": "task"
           },
-          "span_id": "<span:13>"
+          "span_id": "<span:17>"
         },
         {
           "context": {},
           "created": "<timestamp>",
-          "id": "<span:14>",
+          "id": "<span:19>",
           "log_id": "g",
           "metadata": {
             "case": "nested-child",
@@ -188,18 +188,18 @@
             "start": 0
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:15>",
+          "root_span_id": "<span:21>",
           "span_attributes": {
             "exec_counter": 5,
             "name": "deno browser nested child span",
             "type": "task"
           },
-          "span_id": "<span:15>"
+          "span_id": "<span:20>"
         },
         {
           "context": {},
           "created": "<timestamp>",
-          "id": "<span:16>",
+          "id": "<span:22>",
           "log_id": "g",
           "metadata": {
             "case": "nested-grandchild",
@@ -211,18 +211,18 @@
             "start": 0
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:17>",
+          "root_span_id": "<span:24>",
           "span_attributes": {
             "exec_counter": 6,
             "name": "deno browser nested grandchild span",
             "type": "task"
           },
-          "span_id": "<span:17>"
+          "span_id": "<span:23>"
         },
         {
           "context": {},
           "created": "<timestamp>",
-          "id": "<span:18>",
+          "id": "<span:25>",
           "log_id": "g",
           "metadata": {
             "case": "current-span",
@@ -234,13 +234,13 @@
             "start": 0
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:19>",
+          "root_span_id": "<span:27>",
           "span_attributes": {
             "exec_counter": 7,
             "name": "deno browser current span",
             "type": "task"
           },
-          "span_id": "<span:19>"
+          "span_id": "<span:26>"
         }
       ]
     },
@@ -269,7 +269,7 @@
           },
           "output": "Paris",
           "project_id": "<project_id>",
-          "root_span_id": "<span:3>",
+          "root_span_id": "<span:4>",
           "span_attributes": {
             "exec_counter": 0,
             "name": "deno browser basic span",
@@ -280,12 +280,12 @@
         {
           "context": {},
           "created": "<timestamp>",
-          "id": "<span:5>",
+          "id": "<span:6>",
           "input": {
             "transcript": {
               "content_type": "application/json",
               "filename": "conversation_transcript.json",
-              "key": "<uuid:6>",
+              "key": "<uuid:7>",
               "type": "braintrust_attachment"
             },
             "type": "chat_completion"
@@ -304,18 +304,18 @@
             "attachment": true
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:7>",
+          "root_span_id": "<span:9>",
           "span_attributes": {
             "exec_counter": 1,
             "name": "deno browser json attachment span",
             "type": "task"
           },
-          "span_id": "<span:7>"
+          "span_id": "<span:8>"
         },
         {
           "context": {},
           "created": "<timestamp>",
-          "id": "<span:8>",
+          "id": "<span:10>",
           "input": {
             "phase": "parent",
             "testRunId": "<run:1>"
@@ -335,18 +335,18 @@
             "phase": "parent"
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:9>",
+          "root_span_id": "<span:12>",
           "span_attributes": {
             "exec_counter": 2,
             "name": "deno browser parent span",
             "type": "task"
           },
-          "span_id": "<span:9>"
+          "span_id": "<span:11>"
         },
         {
           "context": {},
           "created": "<timestamp>",
-          "id": "<span:10>",
+          "id": "<span:13>",
           "input": {
             "step": "child",
             "testRunId": "<run:1>"
@@ -366,18 +366,18 @@
             "phase": "child"
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:11>",
+          "root_span_id": "<span:15>",
           "span_attributes": {
             "exec_counter": 3,
             "name": "deno browser child span",
             "type": "task"
           },
-          "span_id": "<span:11>"
+          "span_id": "<span:14>"
         },
         {
           "context": {},
           "created": "<timestamp>",
-          "id": "<span:12>",
+          "id": "<span:16>",
           "log_id": "g",
           "metadata": {
             "case": "nested-parent",
@@ -389,18 +389,18 @@
             "start": 0
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:13>",
+          "root_span_id": "<span:18>",
           "span_attributes": {
             "exec_counter": 4,
             "name": "deno browser nested parent span",
             "type": "task"
           },
-          "span_id": "<span:13>"
+          "span_id": "<span:17>"
         },
         {
           "context": {},
           "created": "<timestamp>",
-          "id": "<span:14>",
+          "id": "<span:19>",
           "log_id": "g",
           "metadata": {
             "case": "nested-child",
@@ -412,18 +412,18 @@
             "start": 0
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:15>",
+          "root_span_id": "<span:21>",
           "span_attributes": {
             "exec_counter": 5,
             "name": "deno browser nested child span",
             "type": "task"
           },
-          "span_id": "<span:15>"
+          "span_id": "<span:20>"
         },
         {
           "context": {},
           "created": "<timestamp>",
-          "id": "<span:16>",
+          "id": "<span:22>",
           "log_id": "g",
           "metadata": {
             "case": "nested-grandchild",
@@ -435,18 +435,18 @@
             "start": 0
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:17>",
+          "root_span_id": "<span:24>",
           "span_attributes": {
             "exec_counter": 6,
             "name": "deno browser nested grandchild span",
             "type": "task"
           },
-          "span_id": "<span:17>"
+          "span_id": "<span:23>"
         },
         {
           "context": {},
           "created": "<timestamp>",
-          "id": "<span:18>",
+          "id": "<span:25>",
           "log_id": "g",
           "metadata": {
             "case": "current-span",
@@ -458,13 +458,13 @@
             "start": 0
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:19>",
+          "root_span_id": "<span:27>",
           "span_attributes": {
             "exec_counter": 7,
             "name": "deno browser current span",
             "type": "task"
           },
-          "span_id": "<span:19>"
+          "span_id": "<span:26>"
         }
       ]
     }

--- a/e2e/scenarios/deno-node/__snapshots__/request-flow.json
+++ b/e2e/scenarios/deno-node/__snapshots__/request-flow.json
@@ -49,7 +49,7 @@
           },
           "output": "Paris",
           "project_id": "<project_id>",
-          "root_span_id": "<span:3>",
+          "root_span_id": "<span:4>",
           "span_attributes": {
             "exec_counter": 0,
             "name": "deno node basic span",
@@ -64,12 +64,12 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:5>",
+          "id": "<span:6>",
           "input": {
             "transcript": {
               "content_type": "application/json",
               "filename": "conversation_transcript.json",
-              "key": "<uuid:6>",
+              "key": "<uuid:7>",
               "type": "braintrust_attachment"
             },
             "type": "chat_completion"
@@ -88,13 +88,13 @@
             "attachment": true
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:7>",
+          "root_span_id": "<span:9>",
           "span_attributes": {
             "exec_counter": 1,
             "name": "deno node json attachment span",
             "type": "task"
           },
-          "span_id": "<span:7>"
+          "span_id": "<span:8>"
         },
         {
           "context": {
@@ -103,7 +103,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:8>",
+          "id": "<span:10>",
           "input": {
             "phase": "parent",
             "testRunId": "<run:1>"
@@ -123,13 +123,13 @@
             "phase": "parent"
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:9>",
+          "root_span_id": "<span:12>",
           "span_attributes": {
             "exec_counter": 2,
             "name": "deno node parent span",
             "type": "task"
           },
-          "span_id": "<span:9>"
+          "span_id": "<span:11>"
         },
         {
           "context": {
@@ -138,7 +138,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:10>",
+          "id": "<span:13>",
           "input": {
             "step": "child",
             "testRunId": "<run:1>"
@@ -158,14 +158,14 @@
             "phase": "child"
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:9>",
+          "root_span_id": "<span:12>",
           "span_attributes": {
             "exec_counter": 3,
             "name": "deno node child span"
           },
-          "span_id": "<span:11>",
+          "span_id": "<span:14>",
           "span_parents": [
-            "<span:9>"
+            "<span:11>"
           ]
         },
         {
@@ -175,7 +175,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:12>",
+          "id": "<span:15>",
           "log_id": "g",
           "metadata": {
             "case": "nested-parent",
@@ -187,13 +187,13 @@
             "start": 0
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:13>",
+          "root_span_id": "<span:17>",
           "span_attributes": {
             "exec_counter": 4,
             "name": "deno node nested parent span",
             "type": "task"
           },
-          "span_id": "<span:13>"
+          "span_id": "<span:16>"
         },
         {
           "context": {
@@ -202,7 +202,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:14>",
+          "id": "<span:18>",
           "log_id": "g",
           "metadata": {
             "case": "nested-child",
@@ -214,14 +214,14 @@
             "start": 0
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:13>",
+          "root_span_id": "<span:17>",
           "span_attributes": {
             "exec_counter": 5,
             "name": "deno node nested child span"
           },
-          "span_id": "<span:15>",
+          "span_id": "<span:19>",
           "span_parents": [
-            "<span:13>"
+            "<span:16>"
           ]
         },
         {
@@ -231,7 +231,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:16>",
+          "id": "<span:20>",
           "log_id": "g",
           "metadata": {
             "case": "nested-grandchild",
@@ -246,14 +246,14 @@
             "depth": 3
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:13>",
+          "root_span_id": "<span:17>",
           "span_attributes": {
             "exec_counter": 6,
             "name": "deno node nested grandchild span"
           },
-          "span_id": "<span:17>",
+          "span_id": "<span:21>",
           "span_parents": [
-            "<span:15>"
+            "<span:19>"
           ]
         },
         {
@@ -263,7 +263,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:18>",
+          "id": "<span:22>",
           "log_id": "g",
           "metadata": {
             "case": "current-span",
@@ -275,16 +275,16 @@
             "start": 0
           },
           "output": {
-            "observedSpanId": "<uuid:19>"
+            "observedSpanId": "<span:23>"
           },
           "project_id": "<project_id>",
-          "root_span_id": "<uuid:19>",
+          "root_span_id": "<span:24>",
           "span_attributes": {
             "exec_counter": 7,
             "name": "deno node current span",
             "type": "task"
           },
-          "span_id": "<uuid:19>"
+          "span_id": "<span:23>"
         }
       ]
     },
@@ -317,7 +317,7 @@
           },
           "output": "Paris",
           "project_id": "<project_id>",
-          "root_span_id": "<span:3>",
+          "root_span_id": "<span:4>",
           "span_attributes": {
             "exec_counter": 0,
             "name": "deno node basic span",
@@ -332,12 +332,12 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:5>",
+          "id": "<span:6>",
           "input": {
             "transcript": {
               "content_type": "application/json",
               "filename": "conversation_transcript.json",
-              "key": "<uuid:6>",
+              "key": "<uuid:7>",
               "type": "braintrust_attachment"
             },
             "type": "chat_completion"
@@ -356,13 +356,13 @@
             "attachment": true
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:7>",
+          "root_span_id": "<span:9>",
           "span_attributes": {
             "exec_counter": 1,
             "name": "deno node json attachment span",
             "type": "task"
           },
-          "span_id": "<span:7>"
+          "span_id": "<span:8>"
         },
         {
           "context": {
@@ -371,7 +371,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:8>",
+          "id": "<span:10>",
           "input": {
             "phase": "parent",
             "testRunId": "<run:1>"
@@ -391,13 +391,13 @@
             "phase": "parent"
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:9>",
+          "root_span_id": "<span:12>",
           "span_attributes": {
             "exec_counter": 2,
             "name": "deno node parent span",
             "type": "task"
           },
-          "span_id": "<span:9>"
+          "span_id": "<span:11>"
         },
         {
           "context": {
@@ -406,7 +406,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:10>",
+          "id": "<span:13>",
           "input": {
             "step": "child",
             "testRunId": "<run:1>"
@@ -426,14 +426,14 @@
             "phase": "child"
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:9>",
+          "root_span_id": "<span:12>",
           "span_attributes": {
             "exec_counter": 3,
             "name": "deno node child span"
           },
-          "span_id": "<span:11>",
+          "span_id": "<span:14>",
           "span_parents": [
-            "<span:9>"
+            "<span:11>"
           ]
         },
         {
@@ -443,7 +443,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:12>",
+          "id": "<span:15>",
           "log_id": "g",
           "metadata": {
             "case": "nested-parent",
@@ -455,13 +455,13 @@
             "start": 0
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:13>",
+          "root_span_id": "<span:17>",
           "span_attributes": {
             "exec_counter": 4,
             "name": "deno node nested parent span",
             "type": "task"
           },
-          "span_id": "<span:13>"
+          "span_id": "<span:16>"
         },
         {
           "context": {
@@ -470,7 +470,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:14>",
+          "id": "<span:18>",
           "log_id": "g",
           "metadata": {
             "case": "nested-child",
@@ -482,14 +482,14 @@
             "start": 0
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:13>",
+          "root_span_id": "<span:17>",
           "span_attributes": {
             "exec_counter": 5,
             "name": "deno node nested child span"
           },
-          "span_id": "<span:15>",
+          "span_id": "<span:19>",
           "span_parents": [
-            "<span:13>"
+            "<span:16>"
           ]
         },
         {
@@ -499,7 +499,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:16>",
+          "id": "<span:20>",
           "log_id": "g",
           "metadata": {
             "case": "nested-grandchild",
@@ -514,14 +514,14 @@
             "depth": 3
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:13>",
+          "root_span_id": "<span:17>",
           "span_attributes": {
             "exec_counter": 6,
             "name": "deno node nested grandchild span"
           },
-          "span_id": "<span:17>",
+          "span_id": "<span:21>",
           "span_parents": [
-            "<span:15>"
+            "<span:19>"
           ]
         },
         {
@@ -531,7 +531,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:18>",
+          "id": "<span:22>",
           "log_id": "g",
           "metadata": {
             "case": "current-span",
@@ -543,16 +543,16 @@
             "start": 0
           },
           "output": {
-            "observedSpanId": "<uuid:19>"
+            "observedSpanId": "<span:23>"
           },
           "project_id": "<project_id>",
-          "root_span_id": "<uuid:19>",
+          "root_span_id": "<span:24>",
           "span_attributes": {
             "exec_counter": 7,
             "name": "deno node current span",
             "type": "task"
           },
-          "span_id": "<uuid:19>"
+          "span_id": "<span:23>"
         }
       ]
     }

--- a/e2e/scenarios/deno-node/__snapshots__/span-tree.json
+++ b/e2e/scenarios/deno-node/__snapshots__/span-tree.json
@@ -110,7 +110,7 @@
       "type": "task",
       "children": [],
       "output": {
-        "observedSpanId": "<uuid:1>"
+        "observedSpanId": "<span:1>"
       },
       "metadata": {
         "case": "current-span",

--- a/e2e/scenarios/deno-node/__snapshots__/span-tree.txt
+++ b/e2e/scenarios/deno-node/__snapshots__/span-tree.txt
@@ -78,7 +78,7 @@ span_tree:
 │           }
 └── deno node current span [task]
     output: {
-      "observedSpanId": "<uuid:1>"
+      "observedSpanId": "<span:1>"
     }
     metadata: {
       "case": "current-span",

--- a/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/log-payloads.json
+++ b/e2e/scenarios/langgraph-auto-instrumentation/__snapshots__/log-payloads.json
@@ -17,7 +17,7 @@
       "start": 0
     },
     "project_id": "<project_id>",
-    "root_span_id": "<span:2>",
+    "root_span_id": "<span:3>",
     "span_attributes": {
       "exec_counter": 0,
       "name": "langgraph-auto-instrumentation-root",
@@ -33,7 +33,7 @@
       "end": 0
     },
     "project_id": "<project_id>",
-    "root_span_id": "<span:2>",
+    "root_span_id": "<span:3>",
     "span_id": "<span:2>"
   },
   {
@@ -43,7 +43,7 @@
       "caller_lineno": 0
     },
     "created": "<timestamp>",
-    "id": "<span:3>",
+    "id": "<span:4>",
     "input": {},
     "log_id": "g",
     "metadata": {
@@ -53,7 +53,7 @@
       },
       "metadata": {},
       "name": "LangGraph",
-      "run_id": "<uuid:5>",
+      "run_id": "<uuid:6>",
       "serialized": {
         "id": [
           "langgraph",
@@ -73,13 +73,13 @@
       "message": "hello from langgraph"
     },
     "project_id": "<project_id>",
-    "root_span_id": "<span:2>",
+    "root_span_id": "<span:3>",
     "span_attributes": {
       "exec_counter": 1,
       "name": "LangGraph",
       "type": "task"
     },
-    "span_id": "<span:4>",
+    "span_id": "<span:5>",
     "span_parents": [
       "<span:2>"
     ]
@@ -91,7 +91,7 @@
       "caller_lineno": 0
     },
     "created": "<timestamp>",
-    "id": "<span:5>",
+    "id": "<span:6>",
     "input": {
       "message": ""
     },
@@ -102,8 +102,8 @@
         "sdk_language": "javascript"
       },
       "metadata": {
-        "checkpoint_ns": "sayHello:<uuid:8>",
-        "langgraph_checkpoint_ns": "sayHello:<uuid:8>",
+        "checkpoint_ns": "sayHello:<uuid:9>",
+        "langgraph_checkpoint_ns": "sayHello:<uuid:9>",
         "langgraph_node": "sayHello",
         "langgraph_path": [
           "__pregel_pull",
@@ -115,8 +115,8 @@
         ]
       },
       "name": "sayHello",
-      "parent_run_id": "<uuid:5>",
-      "run_id": "<uuid:9>",
+      "parent_run_id": "<uuid:6>",
+      "run_id": "<uuid:10>",
       "serialized": {
         "id": [
           "langchain_core",
@@ -175,15 +175,15 @@
       "message": "hello from langgraph"
     },
     "project_id": "<project_id>",
-    "root_span_id": "<span:2>",
+    "root_span_id": "<span:3>",
     "span_attributes": {
       "exec_counter": 2,
       "name": "sayHello",
       "type": "task"
     },
-    "span_id": "<span:6>",
+    "span_id": "<span:7>",
     "span_parents": [
-      "<span:4>"
+      "<span:5>"
     ]
   },
   {
@@ -193,7 +193,7 @@
       "caller_lineno": 0
     },
     "created": "<timestamp>",
-    "id": "<span:7>",
+    "id": "<span:8>",
     "input": [
       [
         {
@@ -226,8 +226,8 @@
         "temperature": 0
       },
       "metadata": {
-        "checkpoint_ns": "sayHello:<uuid:8>",
-        "langgraph_checkpoint_ns": "sayHello:<uuid:8>",
+        "checkpoint_ns": "sayHello:<uuid:9>",
+        "langgraph_checkpoint_ns": "sayHello:<uuid:9>",
         "langgraph_node": "sayHello",
         "langgraph_path": [
           "__pregel_pull",
@@ -251,8 +251,8 @@
       "options": {
         "signal": {}
       },
-      "parent_run_id": "<uuid:9>",
-      "run_id": "<uuid:12>",
+      "parent_run_id": "<uuid:10>",
+      "run_id": "<uuid:13>",
       "serialized": {
         "id": [
           "langchain",
@@ -301,7 +301,7 @@
               "kwargs": {
                 "additional_kwargs": {},
                 "content": "<llm-response>",
-                "id": "<span:8>",
+                "id": "<span:9>",
                 "invalid_tool_calls": [],
                 "response_metadata": {
                   "finish_reason": "stop",
@@ -361,21 +361,21 @@
       }
     },
     "project_id": "<project_id>",
-    "root_span_id": "<span:2>",
+    "root_span_id": "<span:3>",
     "span_attributes": {
       "exec_counter": 3,
       "name": "ChatOpenAI",
       "type": "llm"
     },
-    "span_id": "<span:9>",
+    "span_id": "<span:10>",
     "span_parents": [
-      "<span:6>"
+      "<span:7>"
     ]
   },
   {
     "context": {},
     "created": "<timestamp>",
-    "id": "<span:10>",
+    "id": "<span:11>",
     "input": [
       {
         "content": "Reply with exactly: hello from langgraph",
@@ -418,13 +418,13 @@
       }
     ],
     "project_id": "<project_id>",
-    "root_span_id": "<span:2>",
+    "root_span_id": "<span:3>",
     "span_attributes": {
       "exec_counter": 4,
       "name": "Chat Completion",
       "type": "llm"
     },
-    "span_id": "<span:11>",
+    "span_id": "<span:12>",
     "span_parents": [
       "<span:2>"
     ]
@@ -436,7 +436,7 @@
       "caller_lineno": 0
     },
     "created": "<timestamp>",
-    "id": "<span:12>",
+    "id": "<span:13>",
     "input": {
       "message": "hello from langgraph"
     },
@@ -447,8 +447,8 @@
         "sdk_language": "javascript"
       },
       "metadata": {
-        "checkpoint_ns": "sayBye:<uuid:18>",
-        "langgraph_checkpoint_ns": "sayBye:<uuid:18>",
+        "checkpoint_ns": "sayBye:<uuid:19>",
+        "langgraph_checkpoint_ns": "sayBye:<uuid:19>",
         "langgraph_node": "sayBye",
         "langgraph_path": [
           "__pregel_pull",
@@ -460,8 +460,8 @@
         ]
       },
       "name": "sayBye",
-      "parent_run_id": "<uuid:5>",
-      "run_id": "<uuid:19>",
+      "parent_run_id": "<uuid:6>",
+      "run_id": "<uuid:20>",
       "serialized": {
         "id": [
           "langchain_core",
@@ -510,15 +510,15 @@
     },
     "output": {},
     "project_id": "<project_id>",
-    "root_span_id": "<span:2>",
+    "root_span_id": "<span:3>",
     "span_attributes": {
       "exec_counter": 5,
       "name": "sayBye",
       "type": "task"
     },
-    "span_id": "<span:13>",
+    "span_id": "<span:14>",
     "span_parents": [
-      "<span:4>"
+      "<span:5>"
     ]
   }
 ]

--- a/e2e/scenarios/langgraph-auto-instrumentation/assertions.ts
+++ b/e2e/scenarios/langgraph-auto-instrumentation/assertions.ts
@@ -257,7 +257,11 @@ export function assertLangGraphAutoInstrumentation(options: {
     spanTree,
     payloadSummary: normalizeForSnapshot(
       normalizeLangGraphPayloadRows(
-        payloadRowsForRootSpan(options.payloads, root?.span.id),
+        payloadRowsForRootSpan(
+          options.payloads,
+          root?.span.id,
+          root?.span.rootId,
+        ),
       ) as Json,
     ),
   };

--- a/e2e/scenarios/nextjs-instrumentation/__snapshots__/request-flow.json
+++ b/e2e/scenarios/nextjs-instrumentation/__snapshots__/request-flow.json
@@ -54,7 +54,7 @@
             "runtime": "nodejs"
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:3>",
+          "root_span_id": "<span:4>",
           "span_attributes": {
             "exec_counter": 0,
             "name": "nextjs nodejs logger span",
@@ -95,7 +95,7 @@
             "runtime": "nodejs"
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:3>",
+          "root_span_id": "<span:4>",
           "span_attributes": {
             "exec_counter": 0,
             "name": "nextjs nodejs logger span",
@@ -127,7 +127,7 @@
         {
           "context": {},
           "created": "<timestamp>",
-          "id": "<span:5>",
+          "id": "<span:6>",
           "input": {
             "route": "/api/smoke-test/edge",
             "runtime": "edge"
@@ -149,13 +149,13 @@
             "runtime": "edge"
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:6>",
+          "root_span_id": "<span:8>",
           "span_attributes": {
             "exec_counter": 0,
             "name": "nextjs edge logger span",
             "type": "task"
           },
-          "span_id": "<span:6>"
+          "span_id": "<span:7>"
         }
       ]
     },
@@ -168,7 +168,7 @@
         {
           "context": {},
           "created": "<timestamp>",
-          "id": "<span:5>",
+          "id": "<span:6>",
           "input": {
             "route": "/api/smoke-test/edge",
             "runtime": "edge"
@@ -190,13 +190,13 @@
             "runtime": "edge"
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:6>",
+          "root_span_id": "<span:8>",
           "span_attributes": {
             "exec_counter": 0,
             "name": "nextjs edge logger span",
             "type": "task"
           },
-          "span_id": "<span:6>"
+          "span_id": "<span:7>"
         }
       ]
     }

--- a/e2e/scenarios/test-framework-evals-jest/__snapshots__/request-flow.json
+++ b/e2e/scenarios/test-framework-evals-jest/__snapshots__/request-flow.json
@@ -49,7 +49,7 @@
           },
           "output": "Paris",
           "project_id": "<project_id>",
-          "root_span_id": "<span:3>",
+          "root_span_id": "<span:4>",
           "span_attributes": {
             "exec_counter": 0,
             "name": "jest basic span",
@@ -88,7 +88,7 @@
           },
           "output": "Paris",
           "project_id": "<project_id>",
-          "root_span_id": "<span:3>",
+          "root_span_id": "<span:4>",
           "span_attributes": {
             "exec_counter": 0,
             "name": "jest basic span",
@@ -125,12 +125,12 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:5>",
+          "id": "<span:6>",
           "input": {
             "transcript": {
               "content_type": "application/json",
               "filename": "conversation_transcript.json",
-              "key": "<uuid:7>",
+              "key": "<uuid:9>",
               "type": "braintrust_attachment"
             },
             "type": "chat_completion"
@@ -149,13 +149,13 @@
             "attachment": true
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:6>",
+          "root_span_id": "<span:8>",
           "span_attributes": {
             "exec_counter": 1,
             "name": "root",
             "type": "task"
           },
-          "span_id": "<span:6>"
+          "span_id": "<span:7>"
         }
       ]
     },
@@ -172,12 +172,12 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:5>",
+          "id": "<span:6>",
           "input": {
             "transcript": {
               "content_type": "application/json",
               "filename": "conversation_transcript.json",
-              "key": "<uuid:7>",
+              "key": "<uuid:9>",
               "type": "braintrust_attachment"
             },
             "type": "chat_completion"
@@ -196,13 +196,13 @@
             "attachment": true
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:6>",
+          "root_span_id": "<span:8>",
           "span_attributes": {
             "exec_counter": 1,
             "name": "root",
             "type": "task"
           },
-          "span_id": "<span:6>"
+          "span_id": "<span:7>"
         }
       ]
     }
@@ -233,7 +233,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:8>",
+          "id": "<span:10>",
           "input": {
             "phase": "parent",
             "testRunId": "<run:1>"
@@ -253,13 +253,13 @@
             "phase": "parent"
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:9>",
+          "root_span_id": "<span:12>",
           "span_attributes": {
             "exec_counter": 2,
             "name": "jest parent span",
             "type": "task"
           },
-          "span_id": "<span:9>"
+          "span_id": "<span:11>"
         },
         {
           "context": {
@@ -268,7 +268,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:10>",
+          "id": "<span:13>",
           "input": {
             "step": "child",
             "testRunId": "<run:1>"
@@ -288,14 +288,14 @@
             "phase": "child"
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:9>",
+          "root_span_id": "<span:12>",
           "span_attributes": {
             "exec_counter": 3,
             "name": "jest child span"
           },
-          "span_id": "<span:11>",
+          "span_id": "<span:14>",
           "span_parents": [
-            "<span:9>"
+            "<span:11>"
           ]
         }
       ]
@@ -313,7 +313,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:8>",
+          "id": "<span:10>",
           "input": {
             "phase": "parent",
             "testRunId": "<run:1>"
@@ -333,13 +333,13 @@
             "phase": "parent"
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:9>",
+          "root_span_id": "<span:12>",
           "span_attributes": {
             "exec_counter": 2,
             "name": "jest parent span",
             "type": "task"
           },
-          "span_id": "<span:9>"
+          "span_id": "<span:11>"
         },
         {
           "context": {
@@ -348,7 +348,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:10>",
+          "id": "<span:13>",
           "input": {
             "step": "child",
             "testRunId": "<run:1>"
@@ -368,14 +368,14 @@
             "phase": "child"
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:9>",
+          "root_span_id": "<span:12>",
           "span_attributes": {
             "exec_counter": 3,
             "name": "jest child span"
           },
-          "span_id": "<span:11>",
+          "span_id": "<span:14>",
           "span_parents": [
-            "<span:9>"
+            "<span:11>"
           ]
         }
       ]
@@ -407,7 +407,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:12>",
+          "id": "<span:15>",
           "log_id": "g",
           "metadata": {
             "case": "nested-parent",
@@ -419,13 +419,13 @@
             "start": 0
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:13>",
+          "root_span_id": "<span:17>",
           "span_attributes": {
             "exec_counter": 4,
             "name": "jest nested parent span",
             "type": "task"
           },
-          "span_id": "<span:13>"
+          "span_id": "<span:16>"
         },
         {
           "context": {
@@ -434,7 +434,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:14>",
+          "id": "<span:18>",
           "log_id": "g",
           "metadata": {
             "case": "nested-child",
@@ -446,14 +446,14 @@
             "start": 0
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:13>",
+          "root_span_id": "<span:17>",
           "span_attributes": {
             "exec_counter": 5,
             "name": "jest nested child span"
           },
-          "span_id": "<span:15>",
+          "span_id": "<span:19>",
           "span_parents": [
-            "<span:13>"
+            "<span:16>"
           ]
         },
         {
@@ -463,7 +463,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:16>",
+          "id": "<span:20>",
           "log_id": "g",
           "metadata": {
             "case": "nested-grandchild",
@@ -478,14 +478,14 @@
             "depth": 3
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:13>",
+          "root_span_id": "<span:17>",
           "span_attributes": {
             "exec_counter": 6,
             "name": "jest nested grandchild span"
           },
-          "span_id": "<span:17>",
+          "span_id": "<span:21>",
           "span_parents": [
-            "<span:15>"
+            "<span:19>"
           ]
         }
       ]
@@ -503,7 +503,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:12>",
+          "id": "<span:15>",
           "log_id": "g",
           "metadata": {
             "case": "nested-parent",
@@ -515,13 +515,13 @@
             "start": 0
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:13>",
+          "root_span_id": "<span:17>",
           "span_attributes": {
             "exec_counter": 4,
             "name": "jest nested parent span",
             "type": "task"
           },
-          "span_id": "<span:13>"
+          "span_id": "<span:16>"
         },
         {
           "context": {
@@ -530,7 +530,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:14>",
+          "id": "<span:18>",
           "log_id": "g",
           "metadata": {
             "case": "nested-child",
@@ -542,14 +542,14 @@
             "start": 0
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:13>",
+          "root_span_id": "<span:17>",
           "span_attributes": {
             "exec_counter": 5,
             "name": "jest nested child span"
           },
-          "span_id": "<span:15>",
+          "span_id": "<span:19>",
           "span_parents": [
-            "<span:13>"
+            "<span:16>"
           ]
         },
         {
@@ -559,7 +559,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:16>",
+          "id": "<span:20>",
           "log_id": "g",
           "metadata": {
             "case": "nested-grandchild",
@@ -574,14 +574,14 @@
             "depth": 3
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:13>",
+          "root_span_id": "<span:17>",
           "span_attributes": {
             "exec_counter": 6,
             "name": "jest nested grandchild span"
           },
-          "span_id": "<span:17>",
+          "span_id": "<span:21>",
           "span_parents": [
-            "<span:15>"
+            "<span:19>"
           ]
         }
       ]
@@ -613,7 +613,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:18>",
+          "id": "<span:22>",
           "log_id": "g",
           "metadata": {
             "case": "current-span",
@@ -625,16 +625,16 @@
             "start": 0
           },
           "output": {
-            "observedSpanId": "<span:19>"
+            "observedSpanId": "<span:23>"
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:19>",
+          "root_span_id": "<span:24>",
           "span_attributes": {
             "exec_counter": 7,
             "name": "jest current span",
             "type": "task"
           },
-          "span_id": "<span:19>"
+          "span_id": "<span:23>"
         }
       ]
     },
@@ -651,7 +651,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:18>",
+          "id": "<span:22>",
           "log_id": "g",
           "metadata": {
             "case": "current-span",
@@ -663,16 +663,16 @@
             "start": 0
           },
           "output": {
-            "observedSpanId": "<span:19>"
+            "observedSpanId": "<span:23>"
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:19>",
+          "root_span_id": "<span:24>",
           "span_attributes": {
             "exec_counter": 7,
             "name": "jest current span",
             "type": "task"
           },
-          "span_id": "<span:19>"
+          "span_id": "<span:23>"
         }
       ]
     }

--- a/e2e/scenarios/test-framework-evals-jest/__snapshots__/span-tree.json
+++ b/e2e/scenarios/test-framework-evals-jest/__snapshots__/span-tree.json
@@ -110,7 +110,7 @@
       "type": "task",
       "children": [],
       "output": {
-        "observedSpanId": "<uuid:1>"
+        "observedSpanId": "<span:1>"
       },
       "metadata": {
         "case": "current-span",

--- a/e2e/scenarios/test-framework-evals-jest/__snapshots__/span-tree.txt
+++ b/e2e/scenarios/test-framework-evals-jest/__snapshots__/span-tree.txt
@@ -78,7 +78,7 @@ span_tree:
 │           }
 └── jest current span [task]
     output: {
-      "observedSpanId": "<uuid:1>"
+      "observedSpanId": "<span:1>"
     }
     metadata: {
       "case": "current-span",

--- a/e2e/scenarios/trace-context-and-continuation/__snapshots__/late-update-payloads.json
+++ b/e2e/scenarios/trace-context-and-continuation/__snapshots__/late-update-payloads.json
@@ -17,7 +17,7 @@
       "start": 0
     },
     "project_id": "<project_id>",
-    "root_span_id": "<span:3>",
+    "root_span_id": "<span:4>",
     "span_attributes": {
       "exec_counter": 3,
       "name": "late-update",
@@ -38,7 +38,7 @@
       "state": "updated"
     },
     "project_id": "<project_id>",
-    "root_span_id": "<span:3>",
+    "root_span_id": "<span:4>",
     "span_id": "<span:3>"
   }
 ]

--- a/e2e/scenarios/trace-primitives-basic/__snapshots__/request-flow.json
+++ b/e2e/scenarios/trace-primitives-basic/__snapshots__/request-flow.json
@@ -59,7 +59,7 @@
             "status": "ok"
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:3>",
+          "root_span_id": "<span:4>",
           "span_attributes": {
             "exec_counter": 0,
             "name": "trace-primitives-root",
@@ -74,7 +74,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:5>",
+          "id": "<span:6>",
           "input": {
             "step": "child",
             "testRunId": "<run:1>"
@@ -92,12 +92,12 @@
             "ok": true
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:3>",
+          "root_span_id": "<span:4>",
           "span_attributes": {
             "exec_counter": 1,
             "name": "basic-child"
           },
-          "span_id": "<span:6>",
+          "span_id": "<span:7>",
           "span_parents": [
             "<span:3>"
           ]
@@ -110,7 +110,7 @@
           },
           "created": "<timestamp>",
           "error": "basic boom\n\nError: basic boom\n    at logger.traced.name (<repo>/e2e/scenarios/trace-primitives-basic/scenario.ts:0:0)\n    at <repo>/js/dist/index.mjs:0:0\n    at AsyncLocalStorage.run (node:<internal>:0:0)\n    at BraintrustContextManager.runInContext (<repo>/js/dist/index.mjs:0:0)\n    at withCurrent (<repo>/js/dist/index.mjs:0:0)\n    at <repo>/js/dist/index.mjs:0:0\n    at runCatchFinally (<repo>/js/dist/index.mjs:0:0)\n    at Logger.traced (<repo>/js/dist/index.mjs:0:0)\n    at main (<repo>/e2e/scenarios/trace-primitives-basic/scenario.ts:0:0)\n    at runMain (<repo>/e2e/helpers/scenario-runtime.ts:0:0)",
-          "id": "<span:7>",
+          "id": "<span:8>",
           "log_id": "g",
           "metadata": {
             "kind": "basic-error",
@@ -121,12 +121,12 @@
             "start": 0
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:3>",
+          "root_span_id": "<span:4>",
           "span_attributes": {
             "exec_counter": 2,
             "name": "basic-error"
           },
-          "span_id": "<span:8>",
+          "span_id": "<span:9>",
           "span_parents": [
             "<span:3>"
           ]
@@ -164,7 +164,7 @@
             "status": "ok"
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:3>",
+          "root_span_id": "<span:4>",
           "span_attributes": {
             "exec_counter": 0,
             "name": "trace-primitives-root",
@@ -179,7 +179,7 @@
             "caller_lineno": 0
           },
           "created": "<timestamp>",
-          "id": "<span:5>",
+          "id": "<span:6>",
           "input": {
             "step": "child",
             "testRunId": "<run:1>"
@@ -197,12 +197,12 @@
             "ok": true
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:3>",
+          "root_span_id": "<span:4>",
           "span_attributes": {
             "exec_counter": 1,
             "name": "basic-child"
           },
-          "span_id": "<span:6>",
+          "span_id": "<span:7>",
           "span_parents": [
             "<span:3>"
           ]
@@ -215,7 +215,7 @@
           },
           "created": "<timestamp>",
           "error": "basic boom\n\nError: basic boom\n    at logger.traced.name (<repo>/e2e/scenarios/trace-primitives-basic/scenario.ts:0:0)\n    at <repo>/js/dist/index.mjs:0:0\n    at AsyncLocalStorage.run (node:<internal>:0:0)\n    at BraintrustContextManager.runInContext (<repo>/js/dist/index.mjs:0:0)\n    at withCurrent (<repo>/js/dist/index.mjs:0:0)\n    at <repo>/js/dist/index.mjs:0:0\n    at runCatchFinally (<repo>/js/dist/index.mjs:0:0)\n    at Logger.traced (<repo>/js/dist/index.mjs:0:0)\n    at main (<repo>/e2e/scenarios/trace-primitives-basic/scenario.ts:0:0)\n    at runMain (<repo>/e2e/helpers/scenario-runtime.ts:0:0)",
-          "id": "<span:7>",
+          "id": "<span:8>",
           "log_id": "g",
           "metadata": {
             "kind": "basic-error",
@@ -226,12 +226,12 @@
             "start": 0
           },
           "project_id": "<project_id>",
-          "root_span_id": "<span:3>",
+          "root_span_id": "<span:4>",
           "span_attributes": {
             "exec_counter": 2,
             "name": "basic-error"
           },
-          "span_id": "<span:8>",
+          "span_id": "<span:9>",
           "span_parents": [
             "<span:3>"
           ]

--- a/e2e/scenarios/trace-primitives-basic/scenario.test.ts
+++ b/e2e/scenarios/trace-primitives-basic/scenario.test.ts
@@ -44,7 +44,11 @@ test("trace-primitives-basic collects a minimal manual trace tree", async () => 
 
       expect(child?.span.parentIds).toEqual([root?.span.id ?? ""]);
       expect(error?.span.parentIds).toEqual([root?.span.id ?? ""]);
-      expect(root?.span.rootId).toBe(root?.span.id);
+      // With the default OTEL-compatible hex ids, root_span_id is a distinct
+      // trace id shared across the whole trace, not the root span's own id.
+      expect(root?.span.rootId).not.toBe(root?.span.id);
+      expect(child?.span.rootId).toBe(root?.span.rootId);
+      expect(error?.span.rootId).toBe(root?.span.rootId);
 
       await matchSpanTreeSnapshot(capturedEvents, spanTreeSnapshotPath);
 

--- a/integrations/otel-js/src/id-gen.test.ts
+++ b/integrations/otel-js/src/id-gen.test.ts
@@ -42,12 +42,57 @@ describe("ID Generation", () => {
   });
 
   describe("getIdGenerator factory function", () => {
-    test("returns UUID generator by default", () => {
+    test("returns hex-id generator by default (after reset)", () => {
+      // The core SDK now defaults to OpenTelemetry-compatible hex ids even
+      // without compat installed, so resetting the compat globals leaves the
+      // hex default in place (BRAINTRUST_LEGACY_IDS opts back into UUIDs).
+      const prevLegacy = process.env.BRAINTRUST_LEGACY_IDS;
+      const prevOtel = process.env.BRAINTRUST_OTEL_COMPAT;
+      delete process.env.BRAINTRUST_LEGACY_IDS;
+      delete process.env.BRAINTRUST_OTEL_COMPAT;
       resetOtelCompat();
 
-      const generator = getIdGenerator();
-      expect(generator).toBeInstanceOf(UUIDGenerator);
-      expect(generator.shareRootSpanId()).toBe(true);
+      try {
+        const generator = getIdGenerator();
+        expect(generator.shareRootSpanId()).toBe(false);
+        expect(/^[0-9a-f]{16}$/.test(generator.getSpanId())).toBe(true);
+      } finally {
+        if (prevLegacy === undefined) {
+          delete process.env.BRAINTRUST_LEGACY_IDS;
+        } else {
+          process.env.BRAINTRUST_LEGACY_IDS = prevLegacy;
+        }
+        if (prevOtel === undefined) {
+          delete process.env.BRAINTRUST_OTEL_COMPAT;
+        } else {
+          process.env.BRAINTRUST_OTEL_COMPAT = prevOtel;
+        }
+      }
+    });
+
+    test("returns UUID generator when BRAINTRUST_LEGACY_IDS is set", () => {
+      const prevLegacy = process.env.BRAINTRUST_LEGACY_IDS;
+      const prevOtel = process.env.BRAINTRUST_OTEL_COMPAT;
+      delete process.env.BRAINTRUST_OTEL_COMPAT;
+      process.env.BRAINTRUST_LEGACY_IDS = "true";
+      resetOtelCompat();
+
+      try {
+        const generator = getIdGenerator();
+        expect(generator).toBeInstanceOf(UUIDGenerator);
+        expect(generator.shareRootSpanId()).toBe(true);
+      } finally {
+        if (prevLegacy === undefined) {
+          delete process.env.BRAINTRUST_LEGACY_IDS;
+        } else {
+          process.env.BRAINTRUST_LEGACY_IDS = prevLegacy;
+        }
+        if (prevOtel === undefined) {
+          delete process.env.BRAINTRUST_OTEL_COMPAT;
+        } else {
+          process.env.BRAINTRUST_OTEL_COMPAT = prevOtel;
+        }
+      }
     });
 
     test("returns OTEL generator when otel is initialized", () => {

--- a/integrations/otel-js/src/otel.test.ts
+++ b/integrations/otel-js/src/otel.test.ts
@@ -1393,26 +1393,38 @@ describe("Otel Compat tests Integration", () => {
   });
 
   test("UUID generator should share span_id as root_span_id for backwards compatibility", async () => {
-    // Ensure UUID generator is used (default behavior)
+    // Legacy UUID mode (hex ids are the default now).
     resetOtelCompat();
+    const prevLegacy = process.env.BRAINTRUST_LEGACY_IDS;
+    process.env.BRAINTRUST_LEGACY_IDS = "true";
+    _exportsForTestingOnly.resetIdGenStateForTests();
 
-    const testLogger = initLogger({
-      projectName: "test-uuid-integration",
-      projectId: "test-project-id",
-    });
+    try {
+      const testLogger = initLogger({
+        projectName: "test-uuid-integration",
+        projectId: "test-project-id",
+      });
 
-    const span = testLogger.startSpan({ name: "test-uuid-span" });
+      const span = testLogger.startSpan({ name: "test-uuid-span" });
 
-    // UUID generators should share span_id as root_span_id for backwards compatibility
-    expect(span.spanId).toBe(span.rootSpanId);
+      // UUID generators should share span_id as root_span_id for backwards compatibility
+      expect(span.spanId).toBe(span.rootSpanId);
 
-    // Verify UUID format (36 characters with dashes)
-    const uuidRegex =
-      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-    expect(span.spanId).toMatch(uuidRegex);
-    expect(span.rootSpanId).toMatch(uuidRegex);
+      // Verify UUID format (36 characters with dashes)
+      const uuidRegex =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+      expect(span.spanId).toMatch(uuidRegex);
+      expect(span.rootSpanId).toMatch(uuidRegex);
 
-    span.end();
+      span.end();
+    } finally {
+      if (prevLegacy === undefined) {
+        delete process.env.BRAINTRUST_LEGACY_IDS;
+      } else {
+        process.env.BRAINTRUST_LEGACY_IDS = prevLegacy;
+      }
+      _exportsForTestingOnly.resetIdGenStateForTests();
+    }
   });
 
   test("OTEL generator should not share span_id as root_span_id", async () => {
@@ -1437,30 +1449,42 @@ describe("Otel Compat tests Integration", () => {
 
   test("parent-child relationships work with UUID generators", async () => {
     resetOtelCompat();
+    const prevLegacy = process.env.BRAINTRUST_LEGACY_IDS;
+    process.env.BRAINTRUST_LEGACY_IDS = "true";
+    _exportsForTestingOnly.resetIdGenStateForTests();
 
-    const testLogger = initLogger({
-      projectName: "test-uuid-parent-child",
-      projectId: "test-project-id",
-    });
+    try {
+      const testLogger = initLogger({
+        projectName: "test-uuid-parent-child",
+        projectId: "test-project-id",
+      });
 
-    const parentSpan = testLogger.startSpan({ name: "uuid-parent" });
+      const parentSpan = testLogger.startSpan({ name: "uuid-parent" });
 
-    // Parent should have span_id === root_span_id
-    expect(parentSpan.spanId).toBe(parentSpan.rootSpanId);
+      // Parent should have span_id === root_span_id
+      expect(parentSpan.spanId).toBe(parentSpan.rootSpanId);
 
-    const childSpan = parentSpan.startSpan({ name: "uuid-child" });
+      const childSpan = parentSpan.startSpan({ name: "uuid-child" });
 
-    // Child should inherit parent's root_span_id
-    expect(childSpan.rootSpanId).toBe(parentSpan.rootSpanId);
+      // Child should inherit parent's root_span_id
+      expect(childSpan.rootSpanId).toBe(parentSpan.rootSpanId);
 
-    // Child should have parent in spanParents
-    expect(childSpan.spanParents).toContain(parentSpan.spanId);
+      // Child should have parent in spanParents
+      expect(childSpan.spanParents).toContain(parentSpan.spanId);
 
-    // Child should have its own span_id (different from parent)
-    expect(childSpan.spanId).not.toBe(parentSpan.spanId);
+      // Child should have its own span_id (different from parent)
+      expect(childSpan.spanId).not.toBe(parentSpan.spanId);
 
-    parentSpan.end();
-    childSpan.end();
+      parentSpan.end();
+      childSpan.end();
+    } finally {
+      if (prevLegacy === undefined) {
+        delete process.env.BRAINTRUST_LEGACY_IDS;
+      } else {
+        process.env.BRAINTRUST_LEGACY_IDS = prevLegacy;
+      }
+      _exportsForTestingOnly.resetIdGenStateForTests();
+    }
   });
 
   test("parent-child relationships work with OTEL generators", async () => {
@@ -1496,51 +1520,62 @@ describe("Otel Compat tests Integration", () => {
   });
 
   test("environment variable switching works correctly", async () => {
-    // Test default (UUID)
-    resetOtelCompat();
+    const prevLegacy = process.env.BRAINTRUST_LEGACY_IDS;
+    const uuidRegex =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    try {
+      // Test legacy UUID mode.
+      resetOtelCompat();
+      process.env.BRAINTRUST_LEGACY_IDS = "true";
+      _exportsForTestingOnly.resetIdGenStateForTests();
 
-    const uuidLogger = initLogger({
-      projectName: "test-env-uuid",
-      projectId: "test-project-id",
-    });
+      const uuidLogger = initLogger({
+        projectName: "test-env-uuid",
+        projectId: "test-project-id",
+      });
 
-    const uuidSpan = uuidLogger.startSpan({ name: "uuid-test" });
-    expect(uuidSpan.spanId).toBe(uuidSpan.rootSpanId);
-    expect(uuidSpan.spanId).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
-    );
-    uuidSpan.end();
+      const uuidSpan = uuidLogger.startSpan({ name: "uuid-test" });
+      expect(uuidSpan.spanId).toBe(uuidSpan.rootSpanId);
+      expect(uuidSpan.spanId).toMatch(uuidRegex);
+      uuidSpan.end();
 
-    // Switch to OTEL
-    setupOtelCompat();
-    _exportsForTestingOnly.resetIdGenStateForTests();
+      // Switch to OTEL compat (hex, wins over legacy).
+      setupOtelCompat();
+      _exportsForTestingOnly.resetIdGenStateForTests();
 
-    const otelLogger = initLogger({
-      projectName: "test-env-otel",
-      projectId: "test-project-id",
-    });
+      const otelLogger = initLogger({
+        projectName: "test-env-otel",
+        projectId: "test-project-id",
+      });
 
-    const otelSpan = otelLogger.startSpan({ name: "otel-test" });
-    expect(otelSpan.spanId).not.toBe(otelSpan.rootSpanId);
-    expect(otelSpan.spanId.length).toBe(16);
-    expect(otelSpan.rootSpanId.length).toBe(32);
-    otelSpan.end();
+      const otelSpan = otelLogger.startSpan({ name: "otel-test" });
+      expect(otelSpan.spanId).not.toBe(otelSpan.rootSpanId);
+      expect(otelSpan.spanId.length).toBe(16);
+      expect(otelSpan.rootSpanId.length).toBe(32);
+      otelSpan.end();
 
-    // Switch back to UUID
-    resetOtelCompat();
-    _exportsForTestingOnly.resetIdGenStateForTests();
+      // Switch back to legacy UUID.
+      resetOtelCompat();
+      process.env.BRAINTRUST_LEGACY_IDS = "true";
+      _exportsForTestingOnly.resetIdGenStateForTests();
 
-    const uuidLogger2 = initLogger({
-      projectName: "test-env-uuid2",
-      apiKey: "test-key",
-    });
+      const uuidLogger2 = initLogger({
+        projectName: "test-env-uuid2",
+        apiKey: "test-key",
+      });
 
-    const uuidSpan2 = uuidLogger2.startSpan({ name: "uuid-test2" });
-    expect(uuidSpan2.spanId).toBe(uuidSpan2.rootSpanId);
-    expect(uuidSpan2.spanId).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
-    );
-    uuidSpan2.end();
+      const uuidSpan2 = uuidLogger2.startSpan({ name: "uuid-test2" });
+      expect(uuidSpan2.spanId).toBe(uuidSpan2.rootSpanId);
+      expect(uuidSpan2.spanId).toMatch(uuidRegex);
+      uuidSpan2.end();
+    } finally {
+      if (prevLegacy === undefined) {
+        delete process.env.BRAINTRUST_LEGACY_IDS;
+      } else {
+        process.env.BRAINTRUST_LEGACY_IDS = prevLegacy;
+      }
+      _exportsForTestingOnly.resetIdGenStateForTests();
+    }
   });
 
   test("case insensitive environment variable", async () => {
@@ -1587,31 +1622,65 @@ describe("export() format selection based on if otel is initialized", () => {
     _exportsForTestingOnly.resetIdGenStateForTests();
   });
 
-  test("uses SpanComponentsV3 when otel is not initialized", async () => {
+  test("uses SpanComponentsV3 in legacy mode when otel is not initialized", async () => {
     resetOtelCompat();
+    const prevLegacy = process.env.BRAINTRUST_LEGACY_IDS;
+    process.env.BRAINTRUST_LEGACY_IDS = "true";
+    _exportsForTestingOnly.resetIdGenStateForTests();
+
+    try {
+      const testLogger = initLogger({
+        projectName: "test-export-v3",
+        projectId: "test-project-id",
+      });
+      const span = testLogger.startSpan({ name: "test-span" });
+
+      const exported = await span.export();
+      expect(typeof exported).toBe("string");
+      expect(exported.length).toBeGreaterThan(0);
+
+      // Verify version byte is 3 (legacy UUID mode -> V3 export)
+      expect(getExportVersion(exported)).toBe(3);
+
+      // The exported string should be parseable by both V3 and V4 (V4 can read V3)
+      const v3Components = SpanComponentsV3.fromStr(exported);
+      expect(v3Components.data.row_id).toBe(span.id);
+      expect(v3Components.data.span_id).toBe(span.spanId);
+      expect(v3Components.data.root_span_id).toBe(span.rootSpanId);
+
+      // V4 should also be able to read V3 format
+      const v4Components = SpanComponentsV4.fromStr(exported);
+      expect(v4Components.data.row_id).toBe(span.id);
+
+      span.end();
+    } finally {
+      if (prevLegacy === undefined) {
+        delete process.env.BRAINTRUST_LEGACY_IDS;
+      } else {
+        process.env.BRAINTRUST_LEGACY_IDS = prevLegacy;
+      }
+    }
+  });
+
+  test("uses SpanComponentsV4 by default when otel is not initialized", async () => {
+    resetOtelCompat();
+    _exportsForTestingOnly.resetIdGenStateForTests();
 
     const testLogger = initLogger({
-      projectName: "test-export-v3",
+      projectName: "test-export-v4-default",
       projectId: "test-project-id",
     });
     const span = testLogger.startSpan({ name: "test-span" });
 
     const exported = await span.export();
-    expect(typeof exported).toBe("string");
-    expect(exported.length).toBeGreaterThan(0);
+    // The core SDK now defaults to V4 (OTEL-compatible hex ids) even without
+    // compat installed.
+    expect(getExportVersion(exported)).toBe(4);
 
-    // Verify version byte is 3
-    expect(getExportVersion(exported)).toBe(3);
-
-    // The exported string should be parseable by both V3 and V4 (V4 can read V3)
-    const v3Components = SpanComponentsV3.fromStr(exported);
-    expect(v3Components.data.row_id).toBe(span.id);
-    expect(v3Components.data.span_id).toBe(span.spanId);
-    expect(v3Components.data.root_span_id).toBe(span.rootSpanId);
-
-    // V4 should also be able to read V3 format
     const v4Components = SpanComponentsV4.fromStr(exported);
     expect(v4Components.data.row_id).toBe(span.id);
+    expect(v4Components.data.span_id).toBe(span.spanId);
+    expect(v4Components.data.root_span_id).toBe(span.rootSpanId);
 
     span.end();
   });
@@ -1640,8 +1709,11 @@ describe("export() format selection based on if otel is initialized", () => {
   });
 
   test("Logger.export() uses correct format based on env var", async () => {
-    // Test V3
+    // Test V3 (legacy UUID mode)
     resetOtelCompat();
+    const prevLegacy = process.env.BRAINTRUST_LEGACY_IDS;
+    process.env.BRAINTRUST_LEGACY_IDS = "true";
+    _exportsForTestingOnly.resetIdGenStateForTests();
 
     const loggerV3 = initLogger({
       projectName: "test-logger-export-v3",
@@ -1652,6 +1724,13 @@ describe("export() format selection based on if otel is initialized", () => {
 
     const v3Parsed = SpanComponentsV3.fromStr(exportedV3);
     expect(v3Parsed.data.object_type).toBeDefined();
+
+    if (prevLegacy === undefined) {
+      delete process.env.BRAINTRUST_LEGACY_IDS;
+    } else {
+      process.env.BRAINTRUST_LEGACY_IDS = prevLegacy;
+    }
+    _exportsForTestingOnly.resetIdGenStateForTests();
 
     // Test V4
     setupOtelCompat();
@@ -1727,40 +1806,50 @@ describe("export() format selection based on if otel is initialized", () => {
     span.end();
   });
 
-  test("V3 format uses UUIDs when otel is not initialized", async () => {
+  test("V3 format uses UUIDs in legacy mode when otel is not initialized", async () => {
     resetOtelCompat();
-
+    const prevLegacy = process.env.BRAINTRUST_LEGACY_IDS;
+    process.env.BRAINTRUST_LEGACY_IDS = "true";
     _exportsForTestingOnly.resetIdGenStateForTests();
 
-    const testLogger = initLogger({
-      projectName: "test-uuid-ids",
-      projectId: "test-project-id",
-    });
+    try {
+      const testLogger = initLogger({
+        projectName: "test-uuid-ids",
+        projectId: "test-project-id",
+      });
 
-    const span = testLogger.startSpan({ name: "test-span-uuid" });
+      const span = testLogger.startSpan({ name: "test-span-uuid" });
 
-    // Verify the span has UUID format (with dashes)
-    expect(span.spanId.length).toBe(36); // UUID format
-    expect(span.spanId).toContain("-");
-    const uuidRegex =
-      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-    expect(span.spanId).toMatch(uuidRegex);
+      // Verify the span has UUID format (with dashes)
+      expect(span.spanId.length).toBe(36); // UUID format
+      expect(span.spanId).toContain("-");
+      const uuidRegex =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+      expect(span.spanId).toMatch(uuidRegex);
 
-    // Export the span
-    const exported = await span.export();
+      // Export the span
+      const exported = await span.export();
 
-    // Parse the exported data with V3
-    const parsed = SpanComponentsV3.fromStr(exported);
+      // Parse the exported data with V3
+      const parsed = SpanComponentsV3.fromStr(exported);
 
-    // Verify the parsed data has the same UUID
-    expect(parsed.data.span_id).toBe(span.spanId);
+      // Verify the parsed data has the same UUID
+      expect(parsed.data.span_id).toBe(span.spanId);
 
-    // V3 uses UUID compression in binary format
-    const rawBytes = base64ToUint8Array(exported);
+      // V3 uses UUID compression in binary format
+      const rawBytes = base64ToUint8Array(exported);
 
-    // Check that version byte is 3
-    expect(rawBytes[0]).toBe(3);
+      // Check that version byte is 3
+      expect(rawBytes[0]).toBe(3);
 
-    span.end();
+      span.end();
+    } finally {
+      if (prevLegacy === undefined) {
+        delete process.env.BRAINTRUST_LEGACY_IDS;
+      } else {
+        process.env.BRAINTRUST_LEGACY_IDS = prevLegacy;
+      }
+      _exportsForTestingOnly.resetIdGenStateForTests();
+    }
   });
 });

--- a/integrations/temporal-js/src/interceptors.ts
+++ b/integrations/temporal-js/src/interceptors.ts
@@ -8,7 +8,7 @@ import type {
 import type { WorkflowClientInterceptor } from "@temporalio/client";
 import { defaultPayloadConverter } from "@temporalio/common";
 import * as braintrust from "braintrust";
-import { SpanComponentsV3 } from "braintrust/util";
+import { SpanComponentsV4 } from "braintrust/util";
 import { getWorkflowSpanExport } from "./sinks";
 import {
   BRAINTRUST_SPAN_HEADER,
@@ -103,7 +103,7 @@ class BraintrustActivityInterceptor implements ActivityInboundCallsInterceptor {
 
       if (workflowSpanId && clientContext) {
         try {
-          const clientComponents = SpanComponentsV3.fromStr(clientContext);
+          const clientComponents = SpanComponentsV4.fromStr(clientContext);
           const clientData = clientComponents.data;
 
           // We can only construct a workflow parent if we have:
@@ -125,11 +125,11 @@ class BraintrustActivityInterceptor implements ActivityInboundCallsInterceptor {
               root_span_id: clientData.root_span_id, // Keep same trace
             };
             const workflowComponents = clientData.object_id
-              ? new SpanComponentsV3({
+              ? new SpanComponentsV4({
                   ...workflowParentBase,
                   object_id: clientData.object_id,
                 })
-              : new SpanComponentsV3({
+              : new SpanComponentsV4({
                   ...workflowParentBase,
                   compute_object_metadata_args:
                     clientData.compute_object_metadata_args!,

--- a/integrations/temporal-js/src/temporal.test.ts
+++ b/integrations/temporal-js/src/temporal.test.ts
@@ -6,7 +6,11 @@ import {
   BRAINTRUST_WORKFLOW_SPAN_HEADER,
   BRAINTRUST_WORKFLOW_SPAN_ID_HEADER,
 } from "./utils";
-import { SpanComponentsV3, SpanObjectTypeV3 } from "braintrust/util";
+import {
+  SpanComponentsV3,
+  SpanComponentsV4,
+  SpanObjectTypeV3,
+} from "braintrust/util";
 import {
   BraintrustTemporalPlugin,
   createBraintrustTemporalPlugin,
@@ -74,8 +78,49 @@ describe("temporal header utilities", () => {
   });
 });
 
-describe("SpanComponentsV3 cross-worker reconstruction", () => {
-  test("can parse and reconstruct span components with new span_id", () => {
+describe("SpanComponentsV4 cross-worker reconstruction", () => {
+  test("can parse and reconstruct V4 span components with new span_id", () => {
+    const clientComponents = new SpanComponentsV4({
+      object_type: SpanObjectTypeV3.PROJECT_LOGS,
+      object_id: "project-123",
+      row_id: "row-456",
+      span_id: "1234567890abcdef",
+      root_span_id: "1234567890abcdef1234567890abcdef",
+    });
+
+    const clientContext = clientComponents.toStr();
+    const workflowSpanId = "workflow-span-id";
+
+    const parsed = SpanComponentsV4.fromStr(clientContext);
+    const data = parsed.data;
+
+    expect(data.row_id).toBe("row-456");
+    expect(data.root_span_id).toBe("1234567890abcdef1234567890abcdef");
+    expect(data.span_id).toBe("1234567890abcdef");
+
+    if (data.row_id && data.root_span_id) {
+      const workflowComponents = new SpanComponentsV4({
+        object_type: data.object_type,
+        object_id: data.object_id,
+        propagated_event: data.propagated_event,
+        row_id: workflowSpanId,
+        root_span_id: data.root_span_id,
+        span_id: workflowSpanId,
+      });
+
+      const reconstructed = SpanComponentsV4.fromStr(
+        workflowComponents.toStr(),
+      );
+      expect(reconstructed.data.span_id).toBe(workflowSpanId);
+      expect(reconstructed.data.row_id).toBe(workflowSpanId);
+      expect(reconstructed.data.root_span_id).toBe(
+        "1234567890abcdef1234567890abcdef",
+      );
+      expect(reconstructed.data.object_id).toBe("project-123");
+    }
+  });
+
+  test("can parse legacy V3 client context and reconstruct V4 parent", () => {
     const clientComponents = new SpanComponentsV3({
       object_type: SpanObjectTypeV3.PROJECT_LOGS,
       object_id: "project-123",
@@ -84,34 +129,21 @@ describe("SpanComponentsV3 cross-worker reconstruction", () => {
       root_span_id: "root-span-id",
     });
 
-    const clientContext = clientComponents.toStr();
-    const workflowSpanId = "workflow-span-id";
+    const parsed = SpanComponentsV4.fromStr(clientComponents.toStr());
+    const workflowComponents = new SpanComponentsV4({
+      object_type: parsed.data.object_type,
+      object_id: parsed.data.object_id,
+      propagated_event: parsed.data.propagated_event,
+      row_id: "workflow-span-id",
+      root_span_id: parsed.data.root_span_id!,
+      span_id: "workflow-span-id",
+    });
 
-    const parsed = SpanComponentsV3.fromStr(clientContext);
-    const data = parsed.data;
-
-    expect(data.row_id).toBe("row-456");
-    expect(data.root_span_id).toBe("root-span-id");
-    expect(data.span_id).toBe("client-span-id");
-
-    if (data.row_id && data.root_span_id) {
-      const workflowComponents = new SpanComponentsV3({
-        object_type: data.object_type,
-        object_id: data.object_id,
-        propagated_event: data.propagated_event,
-        row_id: data.row_id,
-        root_span_id: data.root_span_id,
-        span_id: workflowSpanId,
-      });
-
-      const reconstructed = SpanComponentsV3.fromStr(
-        workflowComponents.toStr(),
-      );
-      expect(reconstructed.data.span_id).toBe(workflowSpanId);
-      expect(reconstructed.data.row_id).toBe("row-456");
-      expect(reconstructed.data.root_span_id).toBe("root-span-id");
-      expect(reconstructed.data.object_id).toBe("project-123");
-    }
+    const reconstructed = SpanComponentsV4.fromStr(workflowComponents.toStr());
+    expect(reconstructed.data.span_id).toBe("workflow-span-id");
+    expect(reconstructed.data.row_id).toBe("workflow-span-id");
+    expect(reconstructed.data.root_span_id).toBe("root-span-id");
+    expect(reconstructed.data.object_id).toBe("project-123");
   });
 
   test("preserves object_type when reconstructing", () => {
@@ -122,7 +154,7 @@ describe("SpanComponentsV3 cross-worker reconstruction", () => {
     ];
 
     for (const objectType of objectTypes) {
-      const original = new SpanComponentsV3({
+      const original = new SpanComponentsV4({
         object_type: objectType,
         object_id: "test-id",
         row_id: "row-id",
@@ -130,9 +162,9 @@ describe("SpanComponentsV3 cross-worker reconstruction", () => {
         root_span_id: "root-span-id",
       });
 
-      const parsed = SpanComponentsV3.fromStr(original.toStr());
+      const parsed = SpanComponentsV4.fromStr(original.toStr());
 
-      const reconstructed = new SpanComponentsV3({
+      const reconstructed = new SpanComponentsV4({
         object_type: parsed.data.object_type,
         object_id: parsed.data.object_id,
         propagated_event: parsed.data.propagated_event,
@@ -146,12 +178,12 @@ describe("SpanComponentsV3 cross-worker reconstruction", () => {
   });
 
   test("handles span components without row_id fields", () => {
-    const componentsWithoutRowId = new SpanComponentsV3({
+    const componentsWithoutRowId = new SpanComponentsV4({
       object_type: SpanObjectTypeV3.PROJECT_LOGS,
       object_id: "test-id",
     });
 
-    const parsed = SpanComponentsV3.fromStr(componentsWithoutRowId.toStr());
+    const parsed = SpanComponentsV4.fromStr(componentsWithoutRowId.toStr());
 
     expect(parsed.data.row_id).toBeUndefined();
     expect(parsed.data.span_id).toBeUndefined();
@@ -161,7 +193,7 @@ describe("SpanComponentsV3 cross-worker reconstruction", () => {
   test("preserves propagated_event when reconstructing", () => {
     const propagatedEvent = { key: "value", nested: { inner: 123 } };
 
-    const original = new SpanComponentsV3({
+    const original = new SpanComponentsV4({
       object_type: SpanObjectTypeV3.PROJECT_LOGS,
       object_id: "test-id",
       propagated_event: propagatedEvent,
@@ -170,9 +202,9 @@ describe("SpanComponentsV3 cross-worker reconstruction", () => {
       root_span_id: "root-span-id",
     });
 
-    const parsed = SpanComponentsV3.fromStr(original.toStr());
+    const parsed = SpanComponentsV4.fromStr(original.toStr());
 
-    const reconstructed = new SpanComponentsV3({
+    const reconstructed = new SpanComponentsV4({
       object_type: parsed.data.object_type,
       object_id: parsed.data.object_id,
       propagated_event: parsed.data.propagated_event,

--- a/js/src/edge-runtime-bootstrap.test.ts
+++ b/js/src/edge-runtime-bootstrap.test.ts
@@ -105,7 +105,9 @@ describe.each([
       expect(result.isNoop).toBe(false);
       expect(result.sameObject).toBe(true);
       expect(result.childParents).toHaveLength(1);
-      expect(result.childRootSpanId).toBe(root.spanId);
+      // With the default hex (OTEL-compatible) ids, root_span_id is the trace
+      // id shared across the trace, not the root span's own span id.
+      expect(result.childRootSpanId).toBe(root.rootSpanId);
       expect(await backgroundLogger.drain()).toHaveLength(3);
     });
 

--- a/js/src/exports.ts
+++ b/js/src/exports.ts
@@ -174,7 +174,12 @@ export {
   BAGGAGE_HEADER,
   BRAINTRUST_PARENT_KEY,
 } from "./propagation";
-export type { ParsedTraceparent, PropagatedState } from "./propagation";
+export type {
+  ParsedTraceparent,
+  PropagatedState,
+  TraceContextCarrier,
+  TraceContextHeaders,
+} from "./propagation";
 
 export {
   LEGACY_CACHED_HEADER,

--- a/js/src/exports.ts
+++ b/js/src/exports.ts
@@ -34,6 +34,7 @@ export type {
   MetricSummary,
   ObjectMetadata,
   PromiseUnless,
+  PropagationContext,
   PromptRowWithId,
   ScoreSummary,
   SerializedBraintrustState,
@@ -85,11 +86,13 @@ export {
   currentSpan,
   deepCopyEvent,
   deserializePlainStringAsJSON,
+  extractTraceContext,
   flush,
   getContextManager,
   getPromptVersions,
   getSpanParentObject,
   init,
+  injectTraceContext,
   initDataset,
   initExperiment,
   initLogger,
@@ -158,7 +161,20 @@ export {
   devNullWritableStream,
 } from "./functions/stream";
 
-export { IDGenerator, UUIDGenerator, getIdGenerator } from "./id-gen";
+export {
+  IDGenerator,
+  UUIDGenerator,
+  OTELIDGenerator,
+  getIdGenerator,
+} from "./id-gen";
+
+export {
+  TRACEPARENT_HEADER,
+  TRACESTATE_HEADER,
+  BAGGAGE_HEADER,
+  BRAINTRUST_PARENT_KEY,
+} from "./propagation";
+export type { ParsedTraceparent, PropagatedState } from "./propagation";
 
 export {
   LEGACY_CACHED_HEADER,

--- a/js/src/exports.ts
+++ b/js/src/exports.ts
@@ -86,7 +86,7 @@ export {
   currentSpan,
   deepCopyEvent,
   deserializePlainStringAsJSON,
-  extractTraceContext,
+  extractTraceContextFromHeaders,
   flush,
   getContextManager,
   getPromptVersions,

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -1225,8 +1225,8 @@ async function runEvaluatorInternal(
 
           const parentStr = state.currentParent.getStore();
           // The eval framework only ever sets a slug string here; a W3C
-          // trace-context object (from extractTraceContext) is not expected in
-          // this path, so it is treated as no parent.
+          // trace-context object (from extractTraceContextFromHeaders) is not
+          // expected in this path, so it is treated as no parent.
           // SpanComponentsV4.fromStr decodes both V4 (default) and older V3
           // slugs, so it works regardless of the active export version.
           const parentComponents =

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -4,7 +4,7 @@ import {
   Classification,
   ClassificationItem,
   Score,
-  SpanComponentsV3,
+  SpanComponentsV4,
   SpanTypeAttribute,
   spanObjectTypeV3ToTypedString,
 } from "../util/index";
@@ -1224,9 +1224,15 @@ async function runEvaluatorInternal(
           };
 
           const parentStr = state.currentParent.getStore();
-          const parentComponents = parentStr
-            ? SpanComponentsV3.fromStr(parentStr)
-            : null;
+          // The eval framework only ever sets a slug string here; a W3C
+          // trace-context object (from extractTraceContext) is not expected in
+          // this path, so it is treated as no parent.
+          // SpanComponentsV4.fromStr decodes both V4 (default) and older V3
+          // slugs, so it works regardless of the active export version.
+          const parentComponents =
+            typeof parentStr === "string"
+              ? SpanComponentsV4.fromStr(parentStr)
+              : null;
 
           const trace = state
             ? new LocalTrace({

--- a/js/src/id-gen.test.ts
+++ b/js/src/id-gen.test.ts
@@ -1,37 +1,117 @@
-import { expect, test, describe } from "vitest";
-import { UUIDGenerator } from "braintrust";
+import { expect, test, describe, beforeEach, afterEach } from "vitest";
+import { UUIDGenerator, OTELIDGenerator, getIdGenerator } from "./id-gen";
+import { configureNode } from "./node/config";
+
+configureNode();
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function isHex(s: string): boolean {
+  return /^[0-9a-f]+$/.test(s);
+}
 
 describe("ID Generation", () => {
   describe("UUIDGenerator", () => {
     test("implements IDGenerator interface and generates valid UUIDs", () => {
       const generator = new UUIDGenerator();
 
-      // Test that UUID generators should share root_span_id for backwards compatibility
+      // UUID generators should share root_span_id for backwards compatibility
       expect(generator.shareRootSpanId()).toBe(true);
 
-      // Test span ID generation
       const spanId1 = generator.getSpanId();
       const spanId2 = generator.getSpanId();
-
       expect(spanId1).not.toBe(spanId2);
-      expect(typeof spanId1).toBe("string");
-      expect(typeof spanId2).toBe("string");
+      expect(spanId1).toMatch(UUID_RE);
+      expect(spanId2).toMatch(UUID_RE);
 
-      // Validate UUID format (36 characters with dashes)
-      const uuidRegex =
-        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-      expect(spanId1).toMatch(uuidRegex);
-      expect(spanId2).toMatch(uuidRegex);
-
-      // Test trace ID generation
       const traceId1 = generator.getTraceId();
       const traceId2 = generator.getTraceId();
-
       expect(traceId1).not.toBe(traceId2);
-      expect(typeof traceId1).toBe("string");
-      expect(typeof traceId2).toBe("string");
-      expect(traceId1).toMatch(uuidRegex);
-      expect(traceId2).toMatch(uuidRegex);
+      expect(traceId1).toMatch(UUID_RE);
+      expect(traceId2).toMatch(UUID_RE);
+    });
+  });
+
+  describe("OTELIDGenerator", () => {
+    test("generates W3C-shaped hex ids and does not share root span id", () => {
+      const generator = new OTELIDGenerator();
+
+      expect(generator.shareRootSpanId()).toBe(false);
+
+      const spanId = generator.getSpanId();
+      expect(spanId.length).toBe(16); // 8 bytes hex
+      expect(isHex(spanId)).toBe(true);
+
+      const traceId = generator.getTraceId();
+      expect(traceId.length).toBe(32); // 16 bytes hex
+      expect(isHex(traceId)).toBe(true);
+    });
+  });
+
+  describe("getIdGenerator env selection", () => {
+    let prevLegacy: string | undefined;
+    let prevOtel: string | undefined;
+
+    beforeEach(() => {
+      prevLegacy = process.env.BRAINTRUST_LEGACY_IDS;
+      prevOtel = process.env.BRAINTRUST_OTEL_COMPAT;
+      delete process.env.BRAINTRUST_LEGACY_IDS;
+      delete process.env.BRAINTRUST_OTEL_COMPAT;
+    });
+
+    afterEach(() => {
+      if (prevLegacy === undefined) {
+        delete process.env.BRAINTRUST_LEGACY_IDS;
+      } else {
+        process.env.BRAINTRUST_LEGACY_IDS = prevLegacy;
+      }
+      if (prevOtel === undefined) {
+        delete process.env.BRAINTRUST_OTEL_COMPAT;
+      } else {
+        process.env.BRAINTRUST_OTEL_COMPAT = prevOtel;
+      }
+    });
+
+    test("defaults to hex ids (no env vars)", () => {
+      const generator = getIdGenerator();
+      expect(generator.shareRootSpanId()).toBe(false);
+      expect(isHex(generator.getSpanId())).toBe(true);
+      expect(isHex(generator.getTraceId())).toBe(true);
+    });
+
+    test.each(["true", "True", "TRUE", "1", "yes", "on"])(
+      "BRAINTRUST_OTEL_COMPAT=%s -> hex",
+      (value) => {
+        process.env.BRAINTRUST_OTEL_COMPAT = value;
+        const generator = getIdGenerator();
+        expect(isHex(generator.getSpanId())).toBe(true);
+        expect(generator.shareRootSpanId()).toBe(false);
+      },
+    );
+
+    test.each(["true", "True", "1"])(
+      "BRAINTRUST_LEGACY_IDS=%s -> UUID",
+      (value) => {
+        process.env.BRAINTRUST_LEGACY_IDS = value;
+        const generator = getIdGenerator();
+        expect(generator.getSpanId()).toMatch(UUID_RE);
+        expect(generator.shareRootSpanId()).toBe(true);
+      },
+    );
+
+    test("BRAINTRUST_LEGACY_IDS=false -> hex", () => {
+      process.env.BRAINTRUST_LEGACY_IDS = "false";
+      const generator = getIdGenerator();
+      expect(isHex(generator.getSpanId())).toBe(true);
+    });
+
+    test("OTEL_COMPAT wins over LEGACY_IDS when both set", () => {
+      process.env.BRAINTRUST_OTEL_COMPAT = "true";
+      process.env.BRAINTRUST_LEGACY_IDS = "true";
+      const generator = getIdGenerator();
+      expect(generator.shareRootSpanId()).toBe(false);
+      expect(isHex(generator.getSpanId())).toBe(true);
     });
   });
 });

--- a/js/src/id-gen.ts
+++ b/js/src/id-gen.ts
@@ -48,6 +48,8 @@ export class UUIDGenerator extends IDGenerator {
 
 function generateHexId(bytes: number): string {
   let result = "";
+  // Math.random() is intentional here: these ids only correlate telemetry and
+  // are not auth tokens or mission-critical identifiers.
   for (let i = 0; i < bytes; i++) {
     result += Math.floor(Math.random() * 256)
       .toString(16)

--- a/js/src/id-gen.ts
+++ b/js/src/id-gen.ts
@@ -1,7 +1,13 @@
 // ID generation system for Braintrust spans
-// Supports both UUID and OpenTelemetry-compatible ID formats
+// Supports both UUID and OpenTelemetry-compatible (hex) ID formats.
+//
+// By default the SDK generates OpenTelemetry-compatible hex IDs (16-byte trace
+// id / 8-byte span id) which can be propagated via W3C Trace Context. Setting
+// BRAINTRUST_LEGACY_IDS opts back into the legacy UUID-based IDs.
 
 import { v4 as uuidv4 } from "uuid";
+import { debugLogger } from "./debug-logger";
+import iso from "./isomorph";
 
 /**
  * Abstract base class for ID generators
@@ -40,14 +46,104 @@ export class UUIDGenerator extends IDGenerator {
   }
 }
 
+function generateHexId(bytes: number): string {
+  let result = "";
+  for (let i = 0; i < bytes; i++) {
+    result += Math.floor(Math.random() * 256)
+      .toString(16)
+      .padStart(2, "0");
+  }
+  return result;
+}
+
+/**
+ * ID generator that produces OpenTelemetry-compatible hex IDs.
+ *
+ * Span IDs are 8 random bytes (16 hex chars) and trace IDs are 16 random bytes
+ * (32 hex chars), matching the W3C Trace Context / OpenTelemetry shape. Trace
+ * ids are distinct from span ids (root_span_id is a separate trace id, not the
+ * root span's id), so `shareRootSpanId()` returns false.
+ */
+export class OTELIDGenerator extends IDGenerator {
+  getSpanId(): string {
+    // Generate 8 random bytes and convert to hex (16 characters)
+    return generateHexId(8);
+  }
+
+  getTraceId(): string {
+    // Generate 16 random bytes and convert to hex (32 characters)
+    return generateHexId(16);
+  }
+
+  shareRootSpanId(): boolean {
+    return false;
+  }
+}
+
+/**
+ * Parse a boolean environment variable. Accepts common truthy/falsey spellings;
+ * unset or unrecognized values are treated as false.
+ */
+function parseEnvBool(name: string): boolean {
+  const raw = iso.getEnv(name);
+  if (raw === undefined || raw === null) {
+    return false;
+  }
+  const normalized = raw.trim().toLowerCase();
+  return (
+    normalized === "true" ||
+    normalized === "1" ||
+    normalized === "yes" ||
+    normalized === "y" ||
+    normalized === "on"
+  );
+}
+
+let _warnedLegacyUuidConflict = false;
+
+/**
+ * Resolve whether the SDK should generate legacy UUID-based span/trace IDs.
+ *
+ * The default is OpenTelemetry-compatible hex IDs (16-byte trace id / 8-byte
+ * span id) with V4 span-component export. Setting BRAINTRUST_LEGACY_IDS opts
+ * back into UUID IDs with V3 export.
+ *
+ * BRAINTRUST_OTEL_COMPAT (which selects the OpenTelemetry context manager)
+ * requires hex IDs, so it always wins: if both it and BRAINTRUST_LEGACY_IDS are
+ * set, legacy IDs are disabled and a warning is logged (at most once per
+ * process, even though this is re-resolved lazily on each access).
+ */
+export function resolveUseLegacyUuidIds(): boolean {
+  const legacy = parseEnvBool("BRAINTRUST_LEGACY_IDS");
+  if (parseEnvBool("BRAINTRUST_OTEL_COMPAT")) {
+    if (legacy && !_warnedLegacyUuidConflict) {
+      _warnedLegacyUuidConflict = true;
+      debugLogger.warn(
+        "BRAINTRUST_LEGACY_IDS is ignored because BRAINTRUST_OTEL_COMPAT " +
+          "requires OpenTelemetry-compatible hex span IDs. Using hex IDs.",
+      );
+    }
+    return false;
+  }
+  return legacy;
+}
+
 /**
  * Factory function that creates a new ID generator instance each time.
  *
  * This eliminates global state and makes tests parallelizable.
  * Each caller gets their own generator instance.
+ *
+ * Honors an explicitly-installed `globalThis.BRAINTRUST_ID_GENERATOR` (e.g. set
+ * by `@braintrust/otel`'s `setupOtelCompat()`). Otherwise it defaults to
+ * OpenTelemetry-compatible hex IDs, falling back to legacy UUID IDs when
+ * BRAINTRUST_LEGACY_IDS is set.
  */
 export function getIdGenerator(): IDGenerator {
-  return globalThis.BRAINTRUST_ID_GENERATOR !== undefined
-    ? new globalThis.BRAINTRUST_ID_GENERATOR()
-    : new UUIDGenerator();
+  if (globalThis.BRAINTRUST_ID_GENERATOR !== undefined) {
+    return new globalThis.BRAINTRUST_ID_GENERATOR();
+  }
+  return resolveUseLegacyUuidIds()
+    ? new UUIDGenerator()
+    : new OTELIDGenerator();
 }

--- a/js/src/logger.test.ts
+++ b/js/src/logger.test.ts
@@ -17,6 +17,7 @@ import {
   updateSpan,
   Attachment,
   deepCopyEvent,
+  ReadonlyExperiment,
   renderMessageImpl,
 } from "./logger";
 
@@ -26,6 +27,7 @@ import { writeFile, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { SpanComponentsV4 } from "../util/span_identifier_v4";
+import { SpanCache } from "./span-cache";
 
 configureNode();
 
@@ -2941,6 +2943,81 @@ describe("parent precedence", () => {
     expect(byName.child.experiment_id).toBe("experiment-b");
     expect(byName.child.root_span_id).toBe(byName.root.root_span_id);
     expect(byName.child.span_parents).toContain(byName.root.span_id);
+  });
+
+  test("ReadonlyExperiment.asDataset keeps root rows when trace id differs from span id", async () => {
+    const experiment = Object.create(ReadonlyExperiment.prototype) as any;
+    experiment.fetch = async function* () {
+      yield {
+        root_span_id: "trace-id",
+        span_id: "root-span-id",
+        is_root: true,
+        input: "root-input",
+        output: "root-output",
+      };
+      yield {
+        root_span_id: "trace-id",
+        span_id: "child-span-id",
+        is_root: false,
+        input: "child-input",
+        output: "child-output",
+      };
+      yield {
+        root_span_id: "legacy-root-id",
+        span_id: "legacy-root-id",
+        input: "legacy-input",
+        output: "legacy-output",
+      };
+    };
+
+    const rows = [];
+    for await (const row of experiment.asDataset()) {
+      rows.push(row);
+    }
+
+    expect(rows).toEqual([
+      {
+        input: "root-input",
+        expected: "root-output",
+        metadata: undefined,
+        tags: undefined,
+      },
+      {
+        input: "legacy-input",
+        expected: "legacy-output",
+        metadata: undefined,
+        tags: undefined,
+      },
+    ]);
+  });
+
+  test("span cache marks root spans by parent list", () => {
+    const experiment = _exportsForTestingOnly.initTestExperiment(
+      "cache-root",
+      "project",
+    );
+    const state = experiment.loggingState;
+    const previousSpanCache = state.spanCache;
+    state.spanCache = new SpanCache();
+    state.spanCache.start();
+    try {
+      const root = experiment.startSpan({ name: "root" });
+      const child = root.startSpan({ name: "child" });
+      child.end();
+      root.end();
+
+      const rows = state.spanCache.getByRootSpanId(root.rootSpanId) ?? [];
+      const rootRow = rows.find((row) => row.span_id === root.spanId);
+      const childRow = rows.find((row) => row.span_id === child.spanId);
+
+      expect(root.spanId).not.toBe(root.rootSpanId);
+      expect(rootRow?.is_root).toBe(true);
+      expect(childRow?.is_root).toBe(false);
+    } finally {
+      state.spanCache.stop();
+      state.spanCache.clearAll();
+      state.spanCache = previousSpanCache;
+    }
   });
 });
 

--- a/js/src/logger.test.ts
+++ b/js/src/logger.test.ts
@@ -25,7 +25,7 @@ import { type GitMetadataSettingsType as GitMetadataSettings } from "./generated
 import { writeFile, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { SpanComponentsV3 } from "../util/span_identifier_v3";
+import { SpanComponentsV4 } from "../util/span_identifier_v4";
 
 configureNode();
 
@@ -2273,7 +2273,10 @@ test("startSpan support ids without parent", () => {
   const logger = initLogger({});
   const span = logger.startSpan({ name: "test-span", spanId: "123" });
   expect(span.spanId).toBe("123");
-  expect(span.rootSpanId).toBe("123");
+  // With the default hex (OTEL-compatible) ids, a root span gets a distinct
+  // trace id rather than reusing its span id, so root_span_id !== span_id.
+  expect(span.rootSpanId).not.toBe("123");
+  expect(span.rootSpanId.length).toBe(32); // 16-byte hex trace id
   expect(span.spanParents).toEqual([]);
   span.end();
 });
@@ -3128,8 +3131,8 @@ describe("sensitive data redaction", () => {
     expect(typeof exported).toBe("string");
     expect(exported.length).toBeGreaterThan(0);
 
-    // The exported string should be parseable by SpanComponentsV3
-    const components = SpanComponentsV3.fromStr(exported);
+    // The default export is now V4 (OTEL-compatible hex ids).
+    const components = SpanComponentsV4.fromStr(exported);
     expect(components.data.row_id).toBe(span.id);
     expect(components.data.span_id).toBe(span.spanId);
     expect(components.data.root_span_id).toBe(span.rootSpanId);

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -5530,6 +5530,45 @@ function setHeader(
   headerBag[name] = value;
 }
 
+function deleteHeader(carrier: TraceContextCarrier, name: string): void {
+  const lowered = name.toLowerCase();
+  if (isMutableHeaderTupleArray(carrier)) {
+    for (let i = carrier.length - 1; i >= 0; i--) {
+      if (carrier[i][0].toLowerCase() === lowered) {
+        carrier.splice(i, 1);
+      }
+    }
+    return;
+  }
+
+  const deleter = (carrier as { delete?: unknown }).delete;
+  if (typeof deleter === "function") {
+    try {
+      deleter.call(carrier, name);
+      return;
+    } catch {
+      // Fall through to other header carrier styles.
+    }
+  }
+
+  const remover = (carrier as { removeHeader?: unknown }).removeHeader;
+  if (typeof remover === "function") {
+    try {
+      remover.call(carrier, name);
+      return;
+    } catch {
+      // Fall through to plain object cleanup.
+    }
+  }
+
+  const headerBag = carrier as { [name: string]: string };
+  for (const key of Object.keys(headerBag)) {
+    if (key.toLowerCase() === lowered) {
+      delete headerBag[key];
+    }
+  }
+}
+
 /**
  * Inject W3C trace-context headers into a carrier (in place).
  *
@@ -5573,6 +5612,13 @@ export function _injectIntoCarrier(
   const baggageValue = mergeBaggage(existing, args.braintrustParent);
   if (baggageValue !== undefined) {
     setHeader(carrier, BAGGAGE_HEADER, baggageValue);
+  } else if (existing !== undefined) {
+    // mergeBaggage returns undefined when the existing header only had a stale
+    // braintrust.parent (or otherwise no members worth forwarding), so remove
+    // the old header instead of letting a reused carrier propagate bad routing.
+    // If left in place, a downstream service could attach this trace to the
+    // previous project/experiment, or leak that parent to an unrelated request.
+    deleteHeader(carrier, BAGGAGE_HEADER);
   }
 }
 

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -2359,6 +2359,12 @@ function startSpanParentArgs(args: {
       );
     }
 
+    // For logger/span method calls that receive a W3C parent, the inbound
+    // context links this span to the upstream trace ids, but the span still
+    // belongs to the current Braintrust project/experiment and should propagate
+    // that current parent onward. Keep the receiver's object id/metadata and
+    // only forward opaque W3C state (trace-flags/tracestate), not the inbound
+    // braintrust.parent fallback.
     argParentObjectId = args.parentObjectId;
     if (
       parentComponents.data.row_id &&
@@ -2377,7 +2383,12 @@ function startSpanParentArgs(args: {
       ((parentComponents.data.propagated_event ?? undefined) as
         | StartSpanEventArgs
         | undefined);
-    argPropagatedState = args.propagatedState ?? parentPropagatedState;
+    const propagatedState = args.propagatedState ?? parentPropagatedState;
+    if (propagatedState) {
+      const { braintrustParent: _ignoredBraintrustParent, ...w3cState } =
+        propagatedState;
+      argPropagatedState = w3cState;
+    }
   } else {
     argParentObjectId = args.parentObjectId;
     argParentSpanIds = args.parentSpanIds;
@@ -5773,7 +5784,7 @@ function resolveW3cParent(
   } as SpanComponentsV4Data).toStr();
   return {
     parentSlug: slug,
-    propagatedState: { tracestate, traceFlags },
+    propagatedState: { tracestate, traceFlags, braintrustParent },
   };
 }
 
@@ -7790,7 +7801,8 @@ export class SpanImpl implements Span {
       _injectIntoCarrier(resolvedCarrier, {
         traceId: this._rootSpanId,
         spanId: this._spanId,
-        braintrustParent: this._getOtelParent(),
+        braintrustParent:
+          this._getOtelParent() ?? this._propagatedState?.braintrustParent,
         propagatedState: this._propagatedState,
       });
     } catch (e) {

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -24,6 +24,7 @@ import {
   TRACESTATE_HEADER,
   formatTraceparent,
   getHeader,
+  isValidTracestate,
   mergeBaggage,
   parseBaggage,
   parseTraceparent,
@@ -5654,7 +5655,7 @@ export function extractTraceContextFromHeaders(
     context[BAGGAGE_HEADER] = baggageValue;
   }
   const tracestate = getHeader(headers, TRACESTATE_HEADER);
-  if (tracestate) {
+  if (tracestate && isValidTracestate(tracestate)) {
     context[TRACESTATE_HEADER] = tracestate;
   }
   return context;
@@ -5710,7 +5711,11 @@ function resolveW3cParent(
   }
   const { objectType, objectId, computeArgs } = parsedParent;
 
-  const tracestate = getHeader(context, TRACESTATE_HEADER) || undefined;
+  const tracestateValue = getHeader(context, TRACESTATE_HEADER);
+  const tracestate =
+    tracestateValue && isValidTracestate(tracestateValue)
+      ? tracestateValue
+      : undefined;
 
   const slug = new SpanComponentsV4({
     object_type: objectType,

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -24,7 +24,6 @@ import {
   TRACESTATE_HEADER,
   formatTraceparent,
   getHeader,
-  isValidTracestate,
   mergeBaggage,
   parseBaggage,
   parseTraceparent,
@@ -5701,7 +5700,10 @@ export function extractTraceContextFromHeaders(
     context[BAGGAGE_HEADER] = baggageValue;
   }
   const tracestate = getHeader(headers, TRACESTATE_HEADER);
-  if (tracestate && isValidTracestate(tracestate)) {
+  if (tracestate) {
+    // `tracestate` is opaque vendor state. Once `traceparent` is valid, keep the
+    // raw value even if our local grammar check would reject it; dropping or
+    // rewriting another vendor's state can break an otherwise usable trace.
     context[TRACESTATE_HEADER] = tracestate;
   }
   return context;
@@ -5757,11 +5759,7 @@ function resolveW3cParent(
   }
   const { objectType, objectId, computeArgs } = parsedParent;
 
-  const tracestateValue = getHeader(context, TRACESTATE_HEADER);
-  const tracestate =
-    tracestateValue && isValidTracestate(tracestateValue)
-      ? tracestateValue
-      : undefined;
+  const tracestate = getHeader(context, TRACESTATE_HEADER);
 
   const slug = new SpanComponentsV4({
     object_type: objectType,
@@ -7324,7 +7322,8 @@ export class ReadonlyExperiment extends ObjectFetcher<ExperimentEvent> {
     const records = this.fetch(options);
 
     for await (const record of records) {
-      if (record.root_span_id !== record.span_id) {
+      const isRoot = record.is_root ?? record.root_span_id === record.span_id;
+      if (!isRoot) {
         continue;
       }
 
@@ -7620,7 +7619,7 @@ export class SpanImpl implements Span {
         tags: partialRecord.tags,
         span_id: this._spanId,
         span_parents: this._spanParents,
-        is_root: this._spanId === this._rootSpanId,
+        is_root: !this._spanParents || this._spanParents.length === 0,
         span_attributes: partialRecord.span_attributes,
       };
       this._state.spanCache.queueWrite(

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -13,7 +13,19 @@ import {
   setDebugLogStateResolver,
   setGlobalDebugLogLevel,
 } from "./debug-logger";
-import { IDGenerator, getIdGenerator } from "./id-gen";
+import { IDGenerator, getIdGenerator, resolveUseLegacyUuidIds } from "./id-gen";
+import {
+  BAGGAGE_HEADER,
+  BRAINTRUST_PARENT_KEY,
+  PropagatedState,
+  TRACEPARENT_HEADER,
+  TRACESTATE_HEADER,
+  formatTraceparent,
+  getHeader,
+  mergeBaggage,
+  parseBaggage,
+  parseTraceparent,
+} from "./propagation";
 import {
   _urljoin,
   AnyDatasetRecord,
@@ -39,6 +51,7 @@ import {
   SanitizedExperimentLogPartialArgs,
   SpanComponentsV3,
   SpanComponentsV4,
+  SpanComponentsV4Data,
   SpanObjectTypeV3,
   spanObjectTypeV3ToString,
   SpanType,
@@ -253,7 +266,12 @@ export type StartSpanArgs = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   spanAttributes?: Record<any, any>;
   startTime?: number;
-  parent?: string;
+  /**
+   * The parent to start this span under. May be an exported span slug string
+   * (from `span.export()`) or an opaque W3C trace-context (from
+   * {@link extractTraceContext}).
+   */
+  parent?: string | PropagationContext;
   event?: StartSpanEventArgs;
   propagatedEvent?: StartSpanEventArgs;
   spanId?: string;
@@ -373,6 +391,22 @@ export interface Span extends Exportable {
    * @returns Serialized representation of this span's identifiers.
    */
   export(): Promise<string>;
+
+  /**
+   * Inject W3C trace-context headers (`traceparent` and `baggage`) for this span
+   * into a carrier, for distributed tracing across service boundaries.
+   *
+   * Adds `traceparent` (trace identity) and, when this span's Braintrust parent
+   * is known, a `baggage` entry `braintrust.parent=<parent>` (merged with any
+   * pre-existing baggage). Propagation is best-effort and never throws; if the
+   * span's ids are not W3C-shaped hex (e.g. legacy UUID mode), `traceparent` is
+   * omitted.
+   *
+   * @param carrier Optional existing carrier (e.g. outbound HTTP headers) to
+   *   mutate and return. A new object is created if not provided.
+   * @returns The carrier with propagation headers injected.
+   */
+  inject(carrier?: Record<string, string>): Record<string, string>;
 
   /**
    * Format a permalink to the Braintrust application for viewing this span.
@@ -508,10 +542,18 @@ declare global {
 
 type SpanComponent = typeof SpanComponentsV3 | typeof SpanComponentsV4;
 
+// Return the active span-component exporter class.
+//
+// The export version is coupled to the active ID format: hex IDs (the default)
+// serialize as V4, legacy UUID IDs serialize as V3. These must move together --
+// serializing hex IDs via V3 would lose the compact encoding and risk
+// corrupting hex values that happen to parse as UUIDs. An explicit
+// `globalThis.BRAINTRUST_SPAN_COMPONENT` (e.g. from `@braintrust/otel`) wins.
 function getSpanComponentsClass(): SpanComponent {
-  return globalThis.BRAINTRUST_SPAN_COMPONENT
-    ? globalThis.BRAINTRUST_SPAN_COMPONENT
-    : SpanComponentsV3;
+  if (globalThis.BRAINTRUST_SPAN_COMPONENT) {
+    return globalThis.BRAINTRUST_SPAN_COMPONENT;
+  }
+  return resolveUseLegacyUuidIds() ? SpanComponentsV3 : SpanComponentsV4;
 }
 
 export function getContextManager(): ContextManager {
@@ -563,6 +605,10 @@ export class NoopSpan implements Span {
 
   public async export(): Promise<string> {
     return "";
+  }
+
+  public inject(carrier?: Record<string, string>): Record<string, string> {
+    return carrier ?? {};
   }
 
   public async permalink(): Promise<string> {
@@ -657,7 +703,7 @@ export class BraintrustState {
   // Note: the value of IsAsyncFlush doesn't really matter here, since we
   // (safely) dynamically cast it whenever retrieving the logger.
   public currentLogger: Logger<false> | undefined;
-  public currentParent: IsoAsyncLocalStorage<string>;
+  public currentParent: IsoAsyncLocalStorage<string | PropagationContext>;
   public currentSpan: IsoAsyncLocalStorage<Span>;
   // Any time we re-log in, we directly update the apiConn inside the logger.
   // This is preferable to replacing the whole logger, which would create the
@@ -694,7 +740,9 @@ export class BraintrustState {
     this.id = `${new Date().toLocaleString()}-${stateNonce++}`; // This is for debugging. uuidv4() breaks on platforms like Cloudflare.
     this.currentExperiment = undefined;
     this.currentLogger = undefined;
-    this.currentParent = iso.newAsyncLocalStorage();
+    this.currentParent = iso.newAsyncLocalStorage<
+      string | PropagationContext
+    >();
     this.currentSpan = iso.newAsyncLocalStorage();
 
     if (loginParams.fetch) {
@@ -2062,7 +2110,7 @@ export function updateSpan({
 > &
   OptionalStateArg): void {
   const resolvedState = state ?? _globalState;
-  const components = getSpanComponentsClass().fromStr(exported);
+  const components = SpanComponentsV4.fromStr(exported);
 
   if (!components.data.row_id) {
     throw new Error("Exported span must have a row id");
@@ -2080,6 +2128,15 @@ export function updateSpan({
     event,
   });
 }
+
+/**
+ * An opaque W3C trace-context, as returned by {@link extractTraceContext}.
+ *
+ * Carries the relevant W3C headers (`traceparent`, `baggage`, `tracestate`).
+ * Callers MUST treat it as opaque and pass it straight to
+ * `startSpan({ parent })`.
+ */
+export type PropagationContext = Record<string, string>;
 
 interface ParentSpanIds {
   spanId: string;
@@ -2230,7 +2287,7 @@ export async function permalink(
   };
 
   try {
-    const components = getSpanComponentsClass().fromStr(slug);
+    const components = SpanComponentsV4.fromStr(slug);
     const object_type = spanObjectTypeV3ToString(components.data.object_type);
     const [orgName, appUrl, object_id] = await Promise.all([
       getOrgName(),
@@ -2257,28 +2314,35 @@ export async function permalink(
 // the original argument set.
 function startSpanParentArgs(args: {
   state: BraintrustState;
-  parent: string | undefined;
+  // `parent` may be an exported slug string or an opaque W3C trace-context
+  // (from `extractTraceContext`).
+  parent: string | PropagationContext | undefined;
   parentObjectType: SpanObjectTypeV3;
   parentObjectId: LazyValue<string>;
   parentComputeObjectMetadataArgs: Record<string, any> | undefined;
   parentSpanIds: ParentSpanIds | MultiParentSpanIds | undefined;
   propagatedEvent: StartSpanEventArgs | undefined;
+  propagatedState?: PropagatedState | undefined;
 }): {
   parentObjectType: SpanObjectTypeV3;
   parentObjectId: LazyValue<string>;
   parentComputeObjectMetadataArgs: Record<string, any> | undefined;
   parentSpanIds: ParentSpanIds | MultiParentSpanIds | undefined;
   propagatedEvent: StartSpanEventArgs | undefined;
+  propagatedState: PropagatedState | undefined;
 } {
   let argParentObjectId: LazyValue<string> | undefined = undefined;
   let argParentSpanIds: ParentSpanIds | MultiParentSpanIds | undefined =
     undefined;
   let argPropagatedEvent: StartSpanEventArgs | undefined = undefined;
-  if (args.parent) {
+  let argPropagatedState: PropagatedState | undefined = undefined;
+  const { parentSlug, propagatedState: parentPropagatedState } =
+    normalizeParent(args.parent, args.state);
+  if (parentSlug) {
     if (args.parentSpanIds) {
       throw new Error("Cannot specify both parent and parentSpanIds");
     }
-    const parentComponents = getSpanComponentsClass().fromStr(args.parent);
+    const parentComponents = SpanComponentsV4.fromStr(parentSlug);
     if (args.parentObjectType !== parentComponents.data.object_type) {
       throw new Error(
         `Mismatch between expected span parent object type ${args.parentObjectType} and provided type ${parentComponents.data.object_type}`,
@@ -2286,7 +2350,13 @@ function startSpanParentArgs(args: {
     }
 
     argParentObjectId = args.parentObjectId;
-    if (parentComponents.data.row_id) {
+    if (
+      parentComponents.data.row_id &&
+      parentSpanIdsUsable(
+        parentComponents.data.span_id,
+        parentComponents.data.root_span_id,
+      )
+    ) {
       argParentSpanIds = {
         spanId: parentComponents.data.span_id,
         rootSpanId: parentComponents.data.root_span_id,
@@ -2297,10 +2367,12 @@ function startSpanParentArgs(args: {
       ((parentComponents.data.propagated_event ?? undefined) as
         | StartSpanEventArgs
         | undefined);
+    argPropagatedState = args.propagatedState ?? parentPropagatedState;
   } else {
     argParentObjectId = args.parentObjectId;
     argParentSpanIds = args.parentSpanIds;
     argPropagatedEvent = args.propagatedEvent;
+    argPropagatedState = args.propagatedState;
   }
 
   return {
@@ -2309,6 +2381,7 @@ function startSpanParentArgs(args: {
     parentComputeObjectMetadataArgs: args.parentComputeObjectMetadataArgs,
     parentSpanIds: argParentSpanIds,
     propagatedEvent: argPropagatedEvent,
+    propagatedState: argPropagatedState,
   };
 }
 
@@ -2550,6 +2623,24 @@ export class Logger<IsAsyncFlush extends boolean> implements Exportable {
    */
   public _getLinkBaseUrl(): string | null {
     return _getLinkBaseUrl(this.state, this._linkArgs);
+  }
+
+  /**
+   * Return this logger's Braintrust parent string (`project_id:<id>` or
+   * `project_name:<name>`) for the `braintrust.parent` baggage entry, or
+   * undefined when it cannot be determined synchronously.
+   */
+  public _getOtelParent(): string | undefined {
+    const id =
+      this.computeMetadataArgs?.project_id || this.lazyId.getSync().value;
+    if (id) {
+      return `project_id:${id}`;
+    }
+    const name = this.computeMetadataArgs?.project_name;
+    if (name) {
+      return `project_name:${name}`;
+    }
+    return undefined;
   }
 }
 
@@ -5186,37 +5277,409 @@ export function currentSpan(options?: OptionalStateArg): Span {
 }
 
 /**
+ * Resolve the parent object and any forwarded W3C state in a single pass.
+ *
+ * Same precedence as {@link getSpanParentObject}, but also returns the W3C state
+ * (tracestate + raw traceparent flags) recovered while normalizing the `parent`
+ * argument, so callers don't have to re-run `normalizeParent` (which would
+ * re-parse baggage and re-resolve the active logger/experiment, potentially
+ * disagreeing if state changed between calls). The state is only meaningful when
+ * a parent slug was resolved; otherwise it is undefined.
+ */
+function getSpanParentObjectAndPropagatedState<IsAsyncFlush extends boolean>(
+  options?: AsyncFlushArg<IsAsyncFlush> &
+    OptionalStateArg & { parent?: string | PropagationContext },
+): {
+  parentObject:
+    | SpanComponentsV3
+    | SpanComponentsV4
+    | Span
+    | Experiment
+    | Logger<IsAsyncFlush>;
+  propagatedState: PropagatedState | undefined;
+} {
+  const state = options?.state ?? _globalState;
+
+  const parentSpan = currentSpan({ state });
+  if (!Object.is(parentSpan, NOOP_SPAN)) {
+    return { parentObject: parentSpan, propagatedState: undefined };
+  }
+
+  const parent = options?.parent ?? state.currentParent.getStore();
+  const { parentSlug, propagatedState } = normalizeParent(parent, state);
+  if (parentSlug) {
+    return {
+      parentObject: SpanComponentsV4.fromStr(parentSlug),
+      propagatedState,
+    };
+  }
+
+  const experiment = currentExperiment();
+  if (experiment) {
+    return { parentObject: experiment, propagatedState: undefined };
+  }
+  const logger = currentLogger<IsAsyncFlush>(options);
+  if (logger) {
+    return { parentObject: logger, propagatedState: undefined };
+  }
+  return { parentObject: NOOP_SPAN, propagatedState: undefined };
+}
+
+/**
  * Mainly for internal use. Return the parent object for starting a span in a global context.
- * Applies precedence: current span > propagated parent string > experiment > logger.
+ * Applies precedence: current span > propagated parent > experiment > logger.
+ *
+ * `parent` may be an exported slug string or an opaque W3C trace-context (from
+ * {@link extractTraceContext}).
  */
 export function getSpanParentObject<IsAsyncFlush extends boolean>(
   options?: AsyncFlushArg<IsAsyncFlush> &
-    OptionalStateArg & { parent?: string },
+    OptionalStateArg & { parent?: string | PropagationContext },
 ):
   | SpanComponentsV3
   | SpanComponentsV4
   | Span
   | Experiment
   | Logger<IsAsyncFlush> {
-  const state = options?.state ?? _globalState;
+  return getSpanParentObjectAndPropagatedState(options).parentObject;
+}
 
-  const parentSpan = currentSpan({ state });
-  if (!Object.is(parentSpan, NOOP_SPAN)) {
-    return parentSpan;
-  }
+/**
+ * Return the Braintrust parent string for the current logger/experiment, if any.
+ *
+ * Used as the fallback Braintrust parent on receive, when an inbound request
+ * carries trace identity (`traceparent`) but no `braintrust.parent` baggage.
+ */
+function currentBraintrustParent(state?: BraintrustState): string | undefined {
+  const resolvedState = state ?? _globalState;
 
-  const parentStr = options?.parent ?? state.currentParent.getStore();
-  if (parentStr) return getSpanComponentsClass().fromStr(parentStr);
-
-  const experiment = currentExperiment();
+  const experiment = currentExperiment({ state: resolvedState });
   if (experiment) {
-    return experiment;
+    try {
+      return experiment._getOtelParent() ?? undefined;
+    } catch {
+      return undefined;
+    }
   }
-  const logger = currentLogger<IsAsyncFlush>(options);
+
+  const logger = currentLogger({ state: resolvedState });
   if (logger) {
-    return logger;
+    try {
+      return logger._getOtelParent() ?? undefined;
+    } catch {
+      return undefined;
+    }
   }
-  return NOOP_SPAN;
+
+  return undefined;
+}
+
+interface BraintrustParentComponents {
+  objectType: SpanObjectTypeV3;
+  objectId: string | undefined;
+  computeArgs: Record<string, any> | undefined;
+}
+
+/**
+ * Parse a `braintrust.parent` string into object type / id / compute args.
+ *
+ * Accepts `project_id:<id>`, `project_name:<name>`, or `experiment_id:<id>`.
+ * Returns undefined if the value is empty or malformed.
+ */
+function braintrustParentToComponents(
+  braintrustParent: string | undefined | null,
+): BraintrustParentComponents | undefined {
+  if (!braintrustParent) {
+    return undefined;
+  }
+  if (braintrustParent.startsWith("project_id:")) {
+    const objectId = braintrustParent.slice("project_id:".length);
+    return objectId
+      ? {
+          objectType: SpanObjectTypeV3.PROJECT_LOGS,
+          objectId,
+          computeArgs: undefined,
+        }
+      : undefined;
+  }
+  if (braintrustParent.startsWith("project_name:")) {
+    const name = braintrustParent.slice("project_name:".length);
+    return name
+      ? {
+          objectType: SpanObjectTypeV3.PROJECT_LOGS,
+          objectId: undefined,
+          computeArgs: { project_name: name },
+        }
+      : undefined;
+  }
+  if (braintrustParent.startsWith("experiment_id:")) {
+    const objectId = braintrustParent.slice("experiment_id:".length);
+    return objectId
+      ? {
+          objectType: SpanObjectTypeV3.EXPERIMENT,
+          objectId,
+          computeArgs: undefined,
+        }
+      : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Set a W3C trace-context header on a carrier, sending the lowercase name.
+ *
+ * Per the W3C Trace Context spec (§3.2.1 / §3.3.1), vendors SHOULD send these
+ * header names in lowercase. `name` is always the canonical lowercase key. A
+ * plain object carrier is case-sensitive, so any pre-existing case-variant (e.g.
+ * `Baggage` from a framework that title-cases headers) must be removed first,
+ * otherwise the carrier would end up with two conflicting headers.
+ */
+function setHeader(
+  carrier: Record<string, string>,
+  name: string,
+  value: string,
+): void {
+  const lowered = name.toLowerCase();
+  for (const key of Object.keys(carrier)) {
+    if (key !== name && key.toLowerCase() === lowered) {
+      delete carrier[key];
+    }
+  }
+  carrier[name] = value;
+}
+
+/**
+ * Inject W3C trace-context headers into a carrier (in place).
+ *
+ * Emits `traceparent` from the hex trace/span ids, merges `braintrust.parent`
+ * into existing `baggage` when known, and forwards any inbound W3C state
+ * (`tracestate` plus the original `traceparent` trace-flags) carried in
+ * `propagatedState`. Pre-existing, non-Braintrust baggage entries are preserved.
+ */
+export function _injectIntoCarrier(
+  carrier: Record<string, string>,
+  args: {
+    traceId: string | undefined;
+    spanId: string | undefined;
+    braintrustParent: string | undefined | null;
+    propagatedState?: PropagatedState | undefined;
+  },
+): void {
+  // Re-emit the inbound trace-flags verbatim so the upstream sampling decision
+  // (and any future flag bits) is preserved; defaults to sampled when we
+  // originated the trace (no inbound flags).
+  const traceFlags = args.propagatedState?.traceFlags;
+  const traceparent = traceFlags
+    ? formatTraceparent(args.traceId, args.spanId, traceFlags)
+    : formatTraceparent(args.traceId, args.spanId);
+  if (traceparent === undefined) {
+    // Ids aren't W3C-shaped (e.g. legacy UUID mode); nothing to propagate.
+    return;
+  }
+  setHeader(carrier, TRACEPARENT_HEADER, traceparent);
+
+  // Forward upstream tracestate (per W3C, only alongside a valid traceparent).
+  const tracestate = args.propagatedState?.tracestate;
+  if (tracestate) {
+    setHeader(carrier, TRACESTATE_HEADER, tracestate);
+  }
+
+  // Merge braintrust.parent into any existing baggage. Other vendors' members
+  // are forwarded byte-for-byte (see mergeBaggage) so we never rewrite their
+  // percent-encoding.
+  const existing = getHeader(carrier, BAGGAGE_HEADER);
+  const baggageValue = mergeBaggage(existing, args.braintrustParent);
+  if (baggageValue !== undefined) {
+    setHeader(carrier, BAGGAGE_HEADER, baggageValue);
+  }
+}
+
+/**
+ * Inject W3C trace-context headers for the current (or given) span into a
+ * carrier.
+ *
+ * This is the free-function form of {@link Span.inject}, and the send-side
+ * counterpart of {@link extractTraceContext}. If no span is provided, the
+ * currently-active span is used. Propagation is best-effort and never throws.
+ *
+ * @param carrier Optional carrier (e.g. outbound HTTP headers) to mutate.
+ * @param options.span Optional span to inject. Defaults to the current span.
+ * @returns The carrier with propagation headers injected.
+ */
+export function injectTraceContext(
+  carrier?: Record<string, string>,
+  options?: OptionalStateArg & { span?: Span },
+): Record<string, string> {
+  const resolvedCarrier = carrier ?? {};
+  const span = options?.span ?? currentSpan({ state: options?.state });
+  try {
+    return span.inject(resolvedCarrier);
+  } catch (e) {
+    debugLogger.warn(`Error injecting trace context: ${e}`);
+    return resolvedCarrier;
+  }
+}
+
+/**
+ * Extract an opaque W3C trace-context from inbound request headers.
+ *
+ * This is the receive-side counterpart of {@link Span.inject} /
+ * {@link injectTraceContext}. The return value is an opaque propagation context
+ * that can be passed as `parent` to `startSpan`:
+ *
+ * ```ts
+ * const ctx = extractTraceContext(request.headers);
+ * traced((span) => { ... }, { name: "handler", parent: ctx });
+ * ```
+ *
+ * Only the W3C Trace Context headers are interpreted (`traceparent`, `baggage`,
+ * `tracestate`); header lookups are case-insensitive. If no valid `traceparent`
+ * is present, returns undefined (the caller starts a fresh root span). The
+ * Braintrust container the trace is routed under is resolved when the span is
+ * created: from the `braintrust.parent` baggage entry, or else the
+ * currently-active logger/experiment.
+ *
+ * Callers should treat the return value as opaque.
+ *
+ * @param headers Inbound request headers (e.g. an HTTP framework's headers).
+ * @returns An opaque context for `startSpan({ parent })`, or undefined.
+ */
+export function extractTraceContext(
+  headers: Record<string, unknown> | null | undefined,
+): PropagationContext | undefined {
+  if (!headers) {
+    return undefined;
+  }
+
+  const traceparent = getHeader(headers, TRACEPARENT_HEADER);
+  if (!traceparent || parseTraceparent(traceparent) === undefined) {
+    return undefined;
+  }
+
+  const context: PropagationContext = { [TRACEPARENT_HEADER]: traceparent };
+  const baggageValue = getHeader(headers, BAGGAGE_HEADER);
+  if (baggageValue) {
+    context[BAGGAGE_HEADER] = baggageValue;
+  }
+  const tracestate = getHeader(headers, TRACESTATE_HEADER);
+  if (tracestate) {
+    context[TRACESTATE_HEADER] = tracestate;
+  }
+  return context;
+}
+
+/**
+ * Resolve a W3C trace-context into `{ parentSlug, propagatedState }`.
+ *
+ * Reads `traceparent` for trace identity and `braintrust.parent` from `baggage`
+ * (falling back to the currently-active logger/experiment) for routing, and
+ * builds an internal Braintrust parent slug. Captures the `tracestate` and raw
+ * `traceparent` flags to forward onward. Returns `{ undefined, undefined }` if
+ * the context cannot be resolved into a usable parent (so the caller falls back
+ * to local precedence / a fresh root).
+ */
+function resolveW3cParent(
+  context: PropagationContext,
+  state?: BraintrustState,
+): {
+  parentSlug: string | undefined;
+  propagatedState: PropagatedState | undefined;
+} {
+  const traceparent = getHeader(context, TRACEPARENT_HEADER);
+  const parsed = traceparent ? parseTraceparent(traceparent) : undefined;
+  if (parsed === undefined) {
+    return { parentSlug: undefined, propagatedState: undefined };
+  }
+  const { traceId, spanId, traceFlags } = parsed;
+
+  // Determine the Braintrust container: baggage -> current logger/experiment.
+  let braintrustParent: string | undefined = undefined;
+  const baggageValue = getHeader(context, BAGGAGE_HEADER);
+  if (baggageValue) {
+    braintrustParent = parseBaggage(baggageValue)[BRAINTRUST_PARENT_KEY];
+  }
+  if (!braintrustParent) {
+    braintrustParent = currentBraintrustParent(state);
+  }
+  if (!braintrustParent) {
+    debugLogger.warn(
+      "Received traceparent without a braintrust.parent and no active logger/experiment; " +
+        "cannot route the trace. Starting a fresh local span instead.",
+    );
+    return { parentSlug: undefined, propagatedState: undefined };
+  }
+
+  const parsedParent = braintrustParentToComponents(braintrustParent);
+  if (parsedParent === undefined) {
+    debugLogger.warn(
+      `Invalid braintrust.parent: ${JSON.stringify(braintrustParent)}`,
+    );
+    return { parentSlug: undefined, propagatedState: undefined };
+  }
+  const { objectType, objectId, computeArgs } = parsedParent;
+
+  const tracestate = getHeader(context, TRACESTATE_HEADER) || undefined;
+
+  const slug = new SpanComponentsV4({
+    object_type: objectType,
+    ...(computeArgs
+      ? { compute_object_metadata_args: computeArgs }
+      : { object_id: objectId }),
+    row_id: "bt-propagation", // non-empty to enable span_id/root_span_id
+    span_id: spanId,
+    root_span_id: traceId,
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  } as SpanComponentsV4Data).toStr();
+  return {
+    parentSlug: slug,
+    propagatedState: { tracestate, traceFlags },
+  };
+}
+
+/**
+ * Normalize a `parent` argument into `{ parentSlug, propagatedState }`.
+ *
+ * - object -> interpreted as a W3C trace-context (from `extractTraceContext`)
+ * - string -> an exported span slug (passed through unchanged)
+ * - undefined -> no parent
+ *
+ * `propagatedState` carries any inbound W3C state (tracestate + raw flags) to
+ * forward on the next `inject`; it is undefined when there is no inbound W3C
+ * context.
+ */
+function normalizeParent(
+  parent: string | PropagationContext | undefined | null,
+  state?: BraintrustState,
+): {
+  parentSlug: string | undefined;
+  propagatedState: PropagatedState | undefined;
+} {
+  if (parent && typeof parent === "object") {
+    return resolveW3cParent(parent, state);
+  }
+  return {
+    parentSlug: parent ?? undefined,
+    propagatedState: undefined,
+  };
+}
+
+/**
+ * Return true if a parent slug carries span ids the child can link to.
+ *
+ * A child links to any parent slug that carries both a span id and a root span
+ * id, regardless of whether those ids are hex (the default) or legacy UUID. This
+ * keeps the deprecated `startSpan({ parent: <slug> })` path backwards
+ * compatible: a slug exported by an older (UUID) sender still links into a trace
+ * on a newer (hex) receiver, and vice versa. The child's own freshly generated
+ * span id stays in the active format; the backend supports traces whose nodes
+ * mix id formats across a propagation boundary. Empty ids (no row) are handled
+ * by the caller.
+ */
+function parentSpanIdsUsable(
+  spanId: string | undefined | null,
+  rootSpanId: string | undefined | null,
+): boolean {
+  return Boolean(spanId) && Boolean(rootSpanId);
 }
 
 export function logError(span: Span, error: unknown) {
@@ -5593,25 +6056,37 @@ function startSpanAndIsLogger<IsAsyncFlush extends boolean = true>(
 ): { span: Span; isSyncFlushLogger: boolean } {
   const state = args?.state ?? _globalState;
 
-  const parentObject = getSpanParentObject<IsAsyncFlush>({
-    asyncFlush: args?.asyncFlush,
-    parent: args?.parent,
-    state,
-  });
+  // Resolve the parent object and any forwarded W3C state in one pass, so we
+  // don't re-normalize `parent` (which could disagree if the active
+  // logger/experiment changed between calls).
+  const { parentObject, propagatedState } =
+    getSpanParentObjectAndPropagatedState<IsAsyncFlush>({
+      asyncFlush: args?.asyncFlush,
+      parent: args?.parent,
+      state,
+    });
 
   if (
     parentObject instanceof SpanComponentsV3 ||
     parentObject instanceof SpanComponentsV4
   ) {
-    const parentSpanIds: ParentSpanIds | undefined = parentObject.data.row_id
-      ? {
-          spanId: parentObject.data.span_id,
-          rootSpanId: parentObject.data.root_span_id,
-        }
-      : undefined;
+    const parentSpanIds: ParentSpanIds | undefined =
+      parentObject.data.row_id &&
+      parentSpanIdsUsable(
+        parentObject.data.span_id,
+        parentObject.data.root_span_id,
+      )
+        ? {
+            spanId: parentObject.data.span_id,
+            rootSpanId: parentObject.data.root_span_id,
+          }
+        : undefined;
+    // The parent object/state are already resolved from `parent` above; drop
+    // the raw `parent` so it isn't re-normalized.
+    const { parent: _ignoredParent, ...spanArgs } = args ?? {};
     const span = new SpanImpl({
       state,
-      ...args,
+      ...spanArgs,
       parentObjectType: parentObject.data.object_type,
       parentObjectId: new LazyValue(
         spanComponentsToObjectIdLambda(state, parentObject),
@@ -5625,6 +6100,7 @@ function startSpanAndIsLogger<IsAsyncFlush extends boolean = true>(
         ((parentObject.data.propagated_event ?? undefined) as
           | StartSpanEventArgs
           | undefined),
+      propagatedState,
     });
     return {
       span,
@@ -5727,7 +6203,7 @@ async function* asyncGeneratorWithCurrent<T>(
 }
 
 export function withParent<R>(
-  parent: string,
+  parent: string | PropagationContext,
   callback: () => R,
   state: BraintrustState | undefined = undefined,
 ): R {
@@ -6632,6 +7108,16 @@ export class Experiment
   }
 
   /**
+   * Return this experiment's Braintrust parent string (`experiment_id:<id>`) for
+   * the `braintrust.parent` baggage entry, or undefined when it cannot be
+   * determined synchronously.
+   */
+  public _getOtelParent(): string | undefined {
+    const id = this.lazyId.getSync().value;
+    return id ? `experiment_id:${id}` : undefined;
+  }
+
+  /**
    * Flush any pending rows to the server.
    */
   async flush(): Promise<void> {
@@ -6816,6 +7302,13 @@ export class SpanImpl implements Span {
   private _rootSpanId: string;
   private _spanParents: string[] | undefined;
 
+  // Inbound W3C trace-context state (tracestate + raw traceparent flags) to
+  // forward on outbound propagation. Captured at the span that received it (via
+  // extractTraceContext) and inherited by all subspans, so that any inject()
+  // within the trace re-emits the upstream state unchanged, per the W3C Trace
+  // Context spec. Not interpreted.
+  private _propagatedState: PropagatedState | undefined;
+
   public kind = "span" as const;
 
   constructor(
@@ -6827,9 +7320,11 @@ export class SpanImpl implements Span {
       parentSpanIds: ParentSpanIds | MultiParentSpanIds | undefined;
       defaultRootType?: SpanType;
       spanId?: string;
+      propagatedState?: PropagatedState | undefined;
     } & Omit<StartSpanArgs, "parent">,
   ) {
     this._state = args.state;
+    this._propagatedState = args.propagatedState;
 
     const spanAttributes = args.spanAttributes ?? {};
     const rawEvent = args.event ?? {};
@@ -7053,6 +7548,7 @@ export class SpanImpl implements Span {
         parentComputeObjectMetadataArgs: this.parentComputeObjectMetadataArgs,
         parentSpanIds,
         propagatedEvent: args?.propagatedEvent ?? this.propagatedEvent,
+        propagatedState: this._propagatedState,
       }),
     });
   }
@@ -7077,6 +7573,7 @@ export class SpanImpl implements Span {
         parentComputeObjectMetadataArgs: this.parentComputeObjectMetadataArgs,
         parentSpanIds,
         propagatedEvent: args?.propagatedEvent ?? this.propagatedEvent,
+        propagatedState: this._propagatedState,
       }),
       spanId,
     });
@@ -7111,6 +7608,49 @@ export class SpanImpl implements Span {
       root_span_id: this._rootSpanId,
       propagated_event: this.propagatedEvent,
     }).toStr();
+  }
+
+  /**
+   * Return this span's Braintrust parent string (`project_id:<id>`,
+   * `project_name:<name>`, or `experiment_id:<id>`) for the `braintrust.parent`
+   * baggage entry, or undefined when it cannot be determined synchronously.
+   */
+  public _getOtelParent(): string | undefined {
+    if (this.parentObjectType === SpanObjectTypeV3.PROJECT_LOGS) {
+      const id =
+        this.parentComputeObjectMetadataArgs?.project_id ||
+        this.parentObjectId.getSync().value;
+      const name = this.parentComputeObjectMetadataArgs?.project_name;
+      if (id) {
+        return `project_id:${id}`;
+      } else if (name) {
+        return `project_name:${name}`;
+      }
+    } else if (this.parentObjectType === SpanObjectTypeV3.EXPERIMENT) {
+      const id =
+        this.parentComputeObjectMetadataArgs?.experiment_id ||
+        this.parentObjectId.getSync().value;
+      if (id) {
+        return `experiment_id:${id}`;
+      }
+    }
+    return undefined;
+  }
+
+  public inject(carrier?: Record<string, string>): Record<string, string> {
+    const resolvedCarrier = carrier ?? {};
+    try {
+      _injectIntoCarrier(resolvedCarrier, {
+        traceId: this._rootSpanId,
+        spanId: this._spanId,
+        braintrustParent: this._getOtelParent(),
+        propagatedState: this._propagatedState,
+      });
+    } catch (e) {
+      // best-effort: never break the caller
+      debugLogger.warn(`Error injecting trace context: ${e}`);
+    }
+    return resolvedCarrier;
   }
 
   public async permalink(): Promise<string> {

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -24,7 +24,6 @@ import {
   TRACESTATE_HEADER,
   formatTraceparent,
   getHeader,
-  isValidTracestate,
   mergeBaggage,
   parseBaggage,
   parseTraceparent,
@@ -5712,10 +5711,10 @@ export function extractTraceContextFromHeaders(
     context[BAGGAGE_HEADER] = baggageValue;
   }
   const tracestate = getHeader(headers, TRACESTATE_HEADER);
-  if (tracestate && isValidTracestate(tracestate)) {
-    // `tracestate` is opaque vendor state that we forward but never author. We
-    // only adopt it when it conforms to the W3C grammar/limits, so a malformed
-    // or oversized inbound value is dropped rather than propagated onward.
+  if (tracestate) {
+    // `tracestate` is opaque vendor state that we forward but never author or
+    // interpret. It is passed along unchanged; receivers that want to use it
+    // validate it themselves, per the W3C Trace Context spec.
     context[TRACESTATE_HEADER] = tracestate;
   }
   return context;
@@ -5771,13 +5770,9 @@ function resolveW3cParent(
   }
   const { objectType, objectId, computeArgs } = parsedParent;
 
-  // Only carry forward `tracestate` that conforms to the W3C grammar/limits; a
-  // malformed or oversized value is dropped rather than propagated onward.
-  const tracestateValue = getHeader(context, TRACESTATE_HEADER);
-  const tracestate =
-    tracestateValue && isValidTracestate(tracestateValue)
-      ? tracestateValue
-      : undefined;
+  // `tracestate` is opaque vendor state, forwarded unchanged and never
+  // authored or interpreted by Braintrust.
+  const tracestate = getHeader(context, TRACESTATE_HEADER);
 
   const slug = new SpanComponentsV4({
     object_type: objectType,

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -19,6 +19,7 @@ import {
   BRAINTRUST_PARENT_KEY,
   PropagatedState,
   TRACEPARENT_HEADER,
+  TraceContextHeaders,
   TRACESTATE_HEADER,
   formatTraceparent,
   getHeader,
@@ -269,7 +270,7 @@ export type StartSpanArgs = {
   /**
    * The parent to start this span under. May be an exported span slug string
    * (from `span.export()`) or an opaque W3C trace-context (from
-   * {@link extractTraceContext}).
+   * {@link extractTraceContextFromHeaders}).
    */
   parent?: string | PropagationContext;
   event?: StartSpanEventArgs;
@@ -2130,7 +2131,8 @@ export function updateSpan({
 }
 
 /**
- * An opaque W3C trace-context, as returned by {@link extractTraceContext}.
+ * An opaque W3C trace-context, as returned by
+ * {@link extractTraceContextFromHeaders}.
  *
  * Carries the relevant W3C headers (`traceparent`, `baggage`, `tracestate`).
  * Callers MUST treat it as opaque and pass it straight to
@@ -2315,7 +2317,7 @@ export async function permalink(
 function startSpanParentArgs(args: {
   state: BraintrustState;
   // `parent` may be an exported slug string or an opaque W3C trace-context
-  // (from `extractTraceContext`).
+  // (from `extractTraceContextFromHeaders`).
   parent: string | PropagationContext | undefined;
   parentObjectType: SpanObjectTypeV3;
   parentObjectId: LazyValue<string>;
@@ -5330,7 +5332,7 @@ function getSpanParentObjectAndPropagatedState<IsAsyncFlush extends boolean>(
  * Applies precedence: current span > propagated parent > experiment > logger.
  *
  * `parent` may be an exported slug string or an opaque W3C trace-context (from
- * {@link extractTraceContext}).
+ * {@link extractTraceContextFromHeaders}).
  */
 export function getSpanParentObject<IsAsyncFlush extends boolean>(
   options?: AsyncFlushArg<IsAsyncFlush> &
@@ -5499,8 +5501,9 @@ export function _injectIntoCarrier(
  * carrier.
  *
  * This is the free-function form of {@link Span.inject}, and the send-side
- * counterpart of {@link extractTraceContext}. If no span is provided, the
- * currently-active span is used. Propagation is best-effort and never throws.
+ * counterpart of {@link extractTraceContextFromHeaders}. If no span is
+ * provided, the currently-active span is used. Propagation is best-effort and
+ * never throws.
  *
  * @param carrier Optional carrier (e.g. outbound HTTP headers) to mutate.
  * @param options.span Optional span to inject. Defaults to the current span.
@@ -5528,7 +5531,7 @@ export function injectTraceContext(
  * that can be passed as `parent` to `startSpan`:
  *
  * ```ts
- * const ctx = extractTraceContext(request.headers);
+ * const ctx = extractTraceContextFromHeaders(request.headers);
  * traced((span) => { ... }, { name: "handler", parent: ctx });
  * ```
  *
@@ -5544,8 +5547,8 @@ export function injectTraceContext(
  * @param headers Inbound request headers (e.g. an HTTP framework's headers).
  * @returns An opaque context for `startSpan({ parent })`, or undefined.
  */
-export function extractTraceContext(
-  headers: Record<string, unknown> | null | undefined,
+export function extractTraceContextFromHeaders(
+  headers: TraceContextHeaders | null | undefined,
 ): PropagationContext | undefined {
   if (!headers) {
     return undefined;
@@ -5639,7 +5642,8 @@ function resolveW3cParent(
 /**
  * Normalize a `parent` argument into `{ parentSlug, propagatedState }`.
  *
- * - object -> interpreted as a W3C trace-context (from `extractTraceContext`)
+ * - object -> interpreted as a W3C trace-context (from
+ *   `extractTraceContextFromHeaders`)
  * - string -> an exported span slug (passed through unchanged)
  * - undefined -> no parent
  *
@@ -7304,9 +7308,9 @@ export class SpanImpl implements Span {
 
   // Inbound W3C trace-context state (tracestate + raw traceparent flags) to
   // forward on outbound propagation. Captured at the span that received it (via
-  // extractTraceContext) and inherited by all subspans, so that any inject()
-  // within the trace re-emits the upstream state unchanged, per the W3C Trace
-  // Context spec. Not interpreted.
+  // extractTraceContextFromHeaders) and inherited by all subspans, so that any
+  // inject() within the trace re-emits the upstream state unchanged, per the W3C
+  // Trace Context spec. Not interpreted.
   private _propagatedState: PropagatedState | undefined;
 
   public kind = "span" as const;

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -19,6 +19,7 @@ import {
   BRAINTRUST_PARENT_KEY,
   PropagatedState,
   TRACEPARENT_HEADER,
+  TraceContextCarrier,
   TraceContextHeaders,
   TRACESTATE_HEADER,
   formatTraceparent,
@@ -404,10 +405,13 @@ export interface Span extends Exportable {
    * omitted.
    *
    * @param carrier Optional existing carrier (e.g. outbound HTTP headers) to
-   *   mutate and return. A new object is created if not provided.
+   *   mutate and return. Supports plain objects, Web `Headers`, Node-style
+   *   `setHeader` carriers, framework `header` carriers, and mutable
+   *   `HeadersInit` tuple arrays. A new object is created if not provided.
    * @returns The carrier with propagation headers injected.
    */
-  inject(carrier?: Record<string, string>): Record<string, string>;
+  inject(): Record<string, string>;
+  inject<T extends TraceContextCarrier>(carrier: T): T;
 
   /**
    * Format a permalink to the Braintrust application for viewing this span.
@@ -608,7 +612,11 @@ export class NoopSpan implements Span {
     return "";
   }
 
-  public inject(carrier?: Record<string, string>): Record<string, string> {
+  public inject(): Record<string, string>;
+  public inject<T extends TraceContextCarrier>(carrier: T): T;
+  public inject<T extends TraceContextCarrier>(
+    carrier?: T,
+  ): T | Record<string, string> {
     return carrier ?? {};
   }
 
@@ -5436,18 +5444,89 @@ function braintrustParentToComponents(
  * `Baggage` from a framework that title-cases headers) must be removed first,
  * otherwise the carrier would end up with two conflicting headers.
  */
+function isMutableHeaderTupleArray(
+  carrier: TraceContextCarrier,
+): carrier is [string, string][] {
+  return (
+    Array.isArray(carrier) &&
+    carrier.every((item) => Array.isArray(item) && typeof item[0] === "string")
+  );
+}
+
 function setHeader(
-  carrier: Record<string, string>,
+  carrier: TraceContextCarrier,
   name: string,
   value: string,
 ): void {
+  if (isMutableHeaderTupleArray(carrier)) {
+    const lowered = name.toLowerCase();
+    for (let i = carrier.length - 1; i >= 0; i--) {
+      if (carrier[i][0].toLowerCase() === lowered) {
+        carrier.splice(i, 1);
+      }
+    }
+    carrier.push([name, value]);
+    return;
+  }
+
+  const setter = (carrier as { set?: unknown }).set;
+  if (typeof setter === "function") {
+    const deleter = (carrier as { delete?: unknown }).delete;
+    if (typeof deleter === "function") {
+      try {
+        deleter.call(carrier, name);
+      } catch {
+        // Setting below may still succeed for custom header-like objects.
+      }
+    }
+    setter.call(carrier, name, value);
+    return;
+  }
+
+  const nodeSetter = (carrier as { setHeader?: unknown }).setHeader;
+  if (typeof nodeSetter === "function") {
+    const remover = (carrier as { removeHeader?: unknown }).removeHeader;
+    if (typeof remover === "function") {
+      try {
+        remover.call(carrier, name);
+      } catch {
+        // Setting below may still succeed for custom header-like objects.
+      }
+    }
+    nodeSetter.call(carrier, name, value);
+    return;
+  }
+
+  const headerSetter = (carrier as { header?: unknown }).header;
+  if (typeof headerSetter === "function") {
+    const deleter = (carrier as { delete?: unknown }).delete;
+    if (typeof deleter === "function") {
+      try {
+        deleter.call(carrier, name);
+      } catch {
+        // Setting below may still succeed for custom header-like objects.
+      }
+    }
+    const remover = (carrier as { removeHeader?: unknown }).removeHeader;
+    if (typeof remover === "function") {
+      try {
+        remover.call(carrier, name);
+      } catch {
+        // Setting below may still succeed for custom header-like objects.
+      }
+    }
+    headerSetter.call(carrier, name, value);
+    return;
+  }
+
+  const headerBag = carrier as { [name: string]: string };
   const lowered = name.toLowerCase();
-  for (const key of Object.keys(carrier)) {
+  for (const key of Object.keys(headerBag)) {
     if (key !== name && key.toLowerCase() === lowered) {
-      delete carrier[key];
+      delete headerBag[key];
     }
   }
-  carrier[name] = value;
+  headerBag[name] = value;
 }
 
 /**
@@ -5459,7 +5538,7 @@ function setHeader(
  * `propagatedState`. Pre-existing, non-Braintrust baggage entries are preserved.
  */
 export function _injectIntoCarrier(
-  carrier: Record<string, string>,
+  carrier: TraceContextCarrier,
   args: {
     traceId: string | undefined;
     spanId: string | undefined;
@@ -5506,13 +5585,23 @@ export function _injectIntoCarrier(
  * never throws.
  *
  * @param carrier Optional carrier (e.g. outbound HTTP headers) to mutate.
+ *   Supports plain objects, Web `Headers`, Node-style `setHeader` carriers,
+ *   framework `header` carriers, and mutable `HeadersInit` tuple arrays.
  * @param options.span Optional span to inject. Defaults to the current span.
  * @returns The carrier with propagation headers injected.
  */
 export function injectTraceContext(
-  carrier?: Record<string, string>,
+  carrier?: undefined,
   options?: OptionalStateArg & { span?: Span },
-): Record<string, string> {
+): Record<string, string>;
+export function injectTraceContext<T extends TraceContextCarrier>(
+  carrier: T,
+  options?: OptionalStateArg & { span?: Span },
+): T;
+export function injectTraceContext<T extends TraceContextCarrier>(
+  carrier?: T,
+  options?: OptionalStateArg & { span?: Span },
+): T | Record<string, string> {
   const resolvedCarrier = carrier ?? {};
   const span = options?.span ?? currentSpan({ state: options?.state });
   try {
@@ -7641,7 +7730,11 @@ export class SpanImpl implements Span {
     return undefined;
   }
 
-  public inject(carrier?: Record<string, string>): Record<string, string> {
+  public inject(): Record<string, string>;
+  public inject<T extends TraceContextCarrier>(carrier: T): T;
+  public inject<T extends TraceContextCarrier>(
+    carrier?: T,
+  ): T | Record<string, string> {
     const resolvedCarrier = carrier ?? {};
     try {
       _injectIntoCarrier(resolvedCarrier, {

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -24,6 +24,7 @@ import {
   TRACESTATE_HEADER,
   formatTraceparent,
   getHeader,
+  isValidTracestate,
   mergeBaggage,
   parseBaggage,
   parseTraceparent,
@@ -5711,10 +5712,10 @@ export function extractTraceContextFromHeaders(
     context[BAGGAGE_HEADER] = baggageValue;
   }
   const tracestate = getHeader(headers, TRACESTATE_HEADER);
-  if (tracestate) {
-    // `tracestate` is opaque vendor state. Once `traceparent` is valid, keep the
-    // raw value even if our local grammar check would reject it; dropping or
-    // rewriting another vendor's state can break an otherwise usable trace.
+  if (tracestate && isValidTracestate(tracestate)) {
+    // `tracestate` is opaque vendor state that we forward but never author. We
+    // only adopt it when it conforms to the W3C grammar/limits, so a malformed
+    // or oversized inbound value is dropped rather than propagated onward.
     context[TRACESTATE_HEADER] = tracestate;
   }
   return context;
@@ -5770,7 +5771,13 @@ function resolveW3cParent(
   }
   const { objectType, objectId, computeArgs } = parsedParent;
 
-  const tracestate = getHeader(context, TRACESTATE_HEADER);
+  // Only carry forward `tracestate` that conforms to the W3C grammar/limits; a
+  // malformed or oversized value is dropped rather than propagated onward.
+  const tracestateValue = getHeader(context, TRACESTATE_HEADER);
+  const tracestate =
+    tracestateValue && isValidTracestate(tracestateValue)
+      ? tracestateValue
+      : undefined;
 
   const slug = new SpanComponentsV4({
     object_type: objectType,

--- a/js/src/propagation.test.ts
+++ b/js/src/propagation.test.ts
@@ -742,6 +742,21 @@ describe("inject / extract / round-trip", () => {
       expect(BRAINTRUST_PARENT_KEY in parsed).toBe(false);
     });
 
+    test("no braintrust parent removes stale braintrust baggage", () => {
+      const carrier: Record<string, string> = {
+        Baggage: `${BRAINTRUST_PARENT_KEY}=project_id%3Aold`,
+      };
+      _injectIntoCarrier(carrier, {
+        traceId: VALID_TRACE_ID,
+        spanId: VALID_SPAN_ID,
+        braintrustParent: undefined,
+      });
+      expect(carrier[TRACEPARENT_HEADER]).toMatch(TRACEPARENT_RE);
+      expect(
+        Object.keys(carrier).map((key) => key.toLowerCase()),
+      ).not.toContain(BAGGAGE_HEADER);
+    });
+
     test("injectTraceContext free function", () => {
       const logger = makeLogger();
       let captured: { root: string; span: string } | undefined;

--- a/js/src/propagation.test.ts
+++ b/js/src/propagation.test.ts
@@ -935,6 +935,56 @@ describe("inject / extract / round-trip", () => {
     spanB.end();
   });
 
+  test("top-level propagated project_id parent is re-injected before lazy id resolves", () => {
+    makeLogger();
+    const parent = extractTraceContextFromHeaders({
+      traceparent: VALID_TRACEPARENT,
+      baggage: `${BRAINTRUST_PARENT_KEY}=project_id:remote-project-id`,
+    });
+    const span = startSpan({ name: "svc_b", parent });
+    const carrier = span.inject({});
+    span.end();
+
+    expect(parseBaggage(carrier[BAGGAGE_HEADER])).toEqual({
+      [BRAINTRUST_PARENT_KEY]: "project_id:remote-project-id",
+    });
+  });
+
+  test("top-level propagated experiment_id parent is re-injected before lazy id resolves", () => {
+    makeLogger();
+    const parent = extractTraceContextFromHeaders({
+      traceparent: VALID_TRACEPARENT,
+      baggage: `${BRAINTRUST_PARENT_KEY}=experiment_id:remote-experiment-id`,
+    });
+    const span = startSpan({ name: "svc_b", parent });
+    const carrier = span.inject({});
+    span.end();
+
+    expect(parseBaggage(carrier[BAGGAGE_HEADER])).toEqual({
+      [BRAINTRUST_PARENT_KEY]: "experiment_id:remote-experiment-id",
+    });
+  });
+
+  test("logger method links inbound trace but propagates current project", () => {
+    const logger = initLogger({
+      projectName: PROJECT_NAME,
+      projectId: "current-project-id",
+    });
+    const parent = extractTraceContextFromHeaders({
+      traceparent: VALID_TRACEPARENT,
+      baggage: `${BRAINTRUST_PARENT_KEY}=project_id:remote-project-id`,
+    });
+    const span = logger.startSpan({ name: "svc_b", parent });
+    const carrier = span.inject({});
+    span.end();
+
+    expect(span.rootSpanId).toBe(VALID_TRACE_ID);
+    expect(span.spanParents).toEqual([VALID_SPAN_ID]);
+    expect(parseBaggage(carrier[BAGGAGE_HEADER])).toEqual({
+      [BRAINTRUST_PARENT_KEY]: "project_id:current-project-id",
+    });
+  });
+
   test("inject does not break span emission without parent", async () => {
     // inject is best-effort and must never drop the span. Use a projectId so
     // draining doesn't require a metadata round-trip.

--- a/js/src/propagation.test.ts
+++ b/js/src/propagation.test.ts
@@ -404,16 +404,42 @@ test("getHeader case insensitive", () => {
   expect(getHeader(headers, "missing")).toBeUndefined();
 });
 
-test("getHeader reduces array-valued headers to the first element", () => {
-  // Node's IncomingHttpHeaders can expose multi-valued headers as arrays; the
-  // W3C trace-context headers are single-valued, so we take the first element.
+test("getHeader handles array-valued headers", () => {
+  // Node's IncomingHttpHeaders can expose multi-valued headers as arrays.
+  // traceparent is single-valued, while baggage and tracestate are list headers.
   const headers = {
     traceparent: [VALID_TRACEPARENT, "00-extra"],
-    baggage: ["foo=bar"],
+    baggage: ["foo=bar", "team=eng"],
+    tracestate: ["congo=t61", "rojo=00f"],
+  };
+  expect(getHeader(headers, "traceparent")).toBe(VALID_TRACEPARENT);
+  expect(getHeader(headers, "baggage")).toBe("foo=bar,team=eng");
+  expect(getHeader(headers, "tracestate")).toBe("congo=t61,rojo=00f");
+  expect(getHeader({ traceparent: [] }, "traceparent")).toBeUndefined();
+});
+
+test("getHeader reads tuple-array headers", () => {
+  const headers: [string, string][] = [
+    ["TraceParent", VALID_TRACEPARENT],
+    ["baggage", "foo=bar"],
+    ["Baggage", "team=eng"],
+  ];
+  expect(getHeader(headers, "traceparent")).toBe(VALID_TRACEPARENT);
+  expect(getHeader(headers, "baggage")).toBe("foo=bar,team=eng");
+});
+
+test("getHeader reads Node setHeader-style objects", () => {
+  const headers = {
+    getHeader(name: string) {
+      const values: Record<string, string> = {
+        traceparent: VALID_TRACEPARENT,
+        baggage: "foo=bar",
+      };
+      return values[name.toLowerCase()];
+    },
   };
   expect(getHeader(headers, "traceparent")).toBe(VALID_TRACEPARENT);
   expect(getHeader(headers, "baggage")).toBe("foo=bar");
-  expect(getHeader({ traceparent: [] }, "traceparent")).toBeUndefined();
 });
 
 test("getHeader skips a null case-variant and keeps searching", () => {
@@ -499,6 +525,22 @@ describe("inject / extract / round-trip", () => {
       );
     });
 
+    test("array-valued baggage is joined before merge", () => {
+      const logger = makeLogger();
+      const span = logger.startSpan({ name: "svc_a" });
+      const carrier = span.inject({
+        [BAGGAGE_HEADER]: ["user=alice", "team=eng"],
+      });
+      span.end();
+
+      const parsed = parseBaggage(carrier[BAGGAGE_HEADER]);
+      expect(parsed["user"]).toBe("alice");
+      expect(parsed["team"]).toBe("eng");
+      expect(parsed[BRAINTRUST_PARENT_KEY]).toBe(
+        `project_name:${PROJECT_NAME}`,
+      );
+    });
+
     test("title-cased baggage emits single lowercase header", () => {
       const logger = makeLogger();
       const span = logger.startSpan({ name: "svc_a" });
@@ -539,6 +581,128 @@ describe("inject / extract / round-trip", () => {
       expect(Object.keys(carrier).map((k) => k.toLowerCase())).not.toContain(
         "x-bt-parent",
       );
+    });
+
+    test("injects into Web Headers-style objects", () => {
+      const HeadersCtor = (
+        globalThis as unknown as {
+          Headers?: new (init?: Record<string, string>) => {
+            get(name: string): string | null;
+            set(name: string, value: string): void;
+          };
+        }
+      ).Headers;
+      if (!HeadersCtor) {
+        return;
+      }
+
+      const logger = makeLogger();
+      const span = logger.startSpan({ name: "svc_a" });
+      const carrier = new HeadersCtor({ Baggage: "user=alice" });
+      const returned = span.inject(carrier);
+      span.end();
+
+      expect(returned).toBe(carrier);
+      expect(carrier.get(TRACEPARENT_HEADER)).toMatch(TRACEPARENT_RE);
+      expect(parseBaggage(carrier.get(BAGGAGE_HEADER))).toEqual({
+        user: "alice",
+        [BRAINTRUST_PARENT_KEY]: `project_name:${PROJECT_NAME}`,
+      });
+    });
+
+    test("injects into tuple-array headers", () => {
+      const logger = makeLogger();
+      const span = logger.startSpan({ name: "svc_a" });
+      const carrier: [string, string][] = [["Baggage", "user=alice"]];
+      const returned = span.inject(carrier);
+      span.end();
+
+      expect(returned).toBe(carrier);
+      expect(getHeader(carrier, TRACEPARENT_HEADER)).toMatch(TRACEPARENT_RE);
+      expect(getHeader(carrier, BAGGAGE_HEADER)).not.toBeUndefined();
+      expect(
+        carrier.filter(([key]) => key.toLowerCase() === BAGGAGE_HEADER),
+      ).toHaveLength(1);
+      expect(parseBaggage(getHeader(carrier, BAGGAGE_HEADER))).toEqual({
+        user: "alice",
+        [BRAINTRUST_PARENT_KEY]: `project_name:${PROJECT_NAME}`,
+      });
+    });
+
+    test("injects into Node setHeader-style objects", () => {
+      const logger = makeLogger();
+      const span = logger.startSpan({ name: "svc_a" });
+      const carrier = {
+        values: { Baggage: "user=alice" } as Record<string, string>,
+        getHeader(name: string) {
+          const lowered = name.toLowerCase();
+          for (const key of Object.keys(this.values)) {
+            if (key.toLowerCase() === lowered) {
+              return this.values[key];
+            }
+          }
+          return undefined;
+        },
+        setHeader(name: string, value: string) {
+          this.values[name] = value;
+        },
+        removeHeader(name: string) {
+          const lowered = name.toLowerCase();
+          for (const key of Object.keys(this.values)) {
+            if (key.toLowerCase() === lowered) {
+              delete this.values[key];
+            }
+          }
+        },
+      };
+      const returned = span.inject(carrier);
+      span.end();
+
+      expect(returned).toBe(carrier);
+      expect(carrier.values[TRACEPARENT_HEADER]).toMatch(TRACEPARENT_RE);
+      expect("Baggage" in carrier.values).toBe(false);
+      expect(parseBaggage(carrier.values[BAGGAGE_HEADER])).toEqual({
+        user: "alice",
+        [BRAINTRUST_PARENT_KEY]: `project_name:${PROJECT_NAME}`,
+      });
+    });
+
+    test("injects into header-style response objects", () => {
+      const logger = makeLogger();
+      const span = logger.startSpan({ name: "svc_a" });
+      const carrier = {
+        values: { Baggage: "user=alice" } as Record<string, string>,
+        getHeader(name: string) {
+          const lowered = name.toLowerCase();
+          for (const key of Object.keys(this.values)) {
+            if (key.toLowerCase() === lowered) {
+              return this.values[key];
+            }
+          }
+          return undefined;
+        },
+        header(name: string, value: string) {
+          this.values[name] = value;
+        },
+        removeHeader(name: string) {
+          const lowered = name.toLowerCase();
+          for (const key of Object.keys(this.values)) {
+            if (key.toLowerCase() === lowered) {
+              delete this.values[key];
+            }
+          }
+        },
+      };
+      const returned = span.inject(carrier);
+      span.end();
+
+      expect(returned).toBe(carrier);
+      expect(carrier.values[TRACEPARENT_HEADER]).toMatch(TRACEPARENT_RE);
+      expect("Baggage" in carrier.values).toBe(false);
+      expect(parseBaggage(carrier.values[BAGGAGE_HEADER])).toEqual({
+        user: "alice",
+        [BRAINTRUST_PARENT_KEY]: `project_name:${PROJECT_NAME}`,
+      });
     });
 
     test("no braintrust parent injects traceparent without baggage", () => {

--- a/js/src/propagation.test.ts
+++ b/js/src/propagation.test.ts
@@ -11,7 +11,7 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
   _exportsForTestingOnly,
   _injectIntoCarrier,
-  extractTraceContext,
+  extractTraceContextFromHeaders,
   initLogger,
   injectTraceContext,
   startSpan,
@@ -423,6 +423,16 @@ test("getHeader skips a null case-variant and keeps searching", () => {
   expect(getHeader(headers, "traceparent")).toBe(VALID_TRACEPARENT);
 });
 
+test("getHeader reads Web Headers-style objects", () => {
+  const headers = {
+    get(name: string) {
+      return name === "traceparent" ? VALID_TRACEPARENT : null;
+    },
+  };
+  expect(getHeader(headers, "traceparent")).toBe(VALID_TRACEPARENT);
+  expect(getHeader(headers, "missing")).toBeUndefined();
+});
+
 // --------------------------------------------------------------------------- //
 // Send / receive / round-trip against a live logger
 // --------------------------------------------------------------------------- //
@@ -581,7 +591,7 @@ describe("inject / extract / round-trip", () => {
   describe("extract", () => {
     test("traceparent with baggage parent", () => {
       const logger = makeLogger();
-      const ctx = extractTraceContext({
+      const ctx = extractTraceContextFromHeaders({
         traceparent: VALID_TRACEPARENT,
         baggage: `${BRAINTRUST_PARENT_KEY}=project_id:abc123`,
       });
@@ -593,7 +603,7 @@ describe("inject / extract / round-trip", () => {
 
     test("traceparent baggage with unrelated keys", () => {
       const logger = makeLogger();
-      const ctx = extractTraceContext({
+      const ctx = extractTraceContextFromHeaders({
         traceparent: VALID_TRACEPARENT,
         baggage: `user=alice,${BRAINTRUST_PARENT_KEY}=project_id:abc,team=eng`,
       });
@@ -605,7 +615,9 @@ describe("inject / extract / round-trip", () => {
 
     test("traceparent no baggage uses current logger", () => {
       const logger = makeLogger();
-      const ctx = extractTraceContext({ traceparent: VALID_TRACEPARENT });
+      const ctx = extractTraceContextFromHeaders({
+        traceparent: VALID_TRACEPARENT,
+      });
       expect(ctx).not.toBeUndefined();
       const span = logger.startSpan({ name: "h", parent: ctx });
       expect(span.rootSpanId).toBe(VALID_TRACE_ID);
@@ -614,14 +626,14 @@ describe("inject / extract / round-trip", () => {
     });
 
     test("no headers returns undefined", () => {
-      expect(extractTraceContext({})).toBeUndefined();
-      expect(extractTraceContext(null)).toBeUndefined();
-      expect(extractTraceContext(undefined)).toBeUndefined();
+      expect(extractTraceContextFromHeaders({})).toBeUndefined();
+      expect(extractTraceContextFromHeaders(null)).toBeUndefined();
+      expect(extractTraceContextFromHeaders(undefined)).toBeUndefined();
     });
 
     test("malformed traceparent returns undefined", () => {
       expect(
-        extractTraceContext({
+        extractTraceContextFromHeaders({
           traceparent: "garbage",
           baggage: `${BRAINTRUST_PARENT_KEY}=project_id:abc`,
         }),
@@ -630,7 +642,7 @@ describe("inject / extract / round-trip", () => {
 
     test("case insensitive headers", () => {
       const logger = makeLogger();
-      const ctx = extractTraceContext({
+      const ctx = extractTraceContextFromHeaders({
         TraceParent: VALID_TRACEPARENT,
         Baggage: `${BRAINTRUST_PARENT_KEY}=project_id:abc`,
       });
@@ -640,8 +652,64 @@ describe("inject / extract / round-trip", () => {
       span.end();
     });
 
+    test("Node-style array headers", () => {
+      const logger = makeLogger();
+      const ctx = extractTraceContextFromHeaders({
+        traceparent: [VALID_TRACEPARENT, "00-extra"],
+        baggage: [`${BRAINTRUST_PARENT_KEY}=project_id:abc`],
+        tracestate: ["congo=t61"],
+      });
+      const span = logger.startSpan({ name: "h", parent: ctx });
+      expect(span.rootSpanId).toBe(VALID_TRACE_ID);
+      expect(span.spanParents).toEqual([VALID_SPAN_ID]);
+      span.end();
+    });
+
+    test("Web Headers-style getter object", () => {
+      const logger = makeLogger();
+      const headers = {
+        get(name: string) {
+          const values: Record<string, string> = {
+            traceparent: VALID_TRACEPARENT,
+            baggage: `${BRAINTRUST_PARENT_KEY}=project_id:abc`,
+          };
+          return values[name] ?? null;
+        },
+      };
+      const ctx = extractTraceContextFromHeaders(headers);
+      const span = logger.startSpan({ name: "h", parent: ctx });
+      expect(span.rootSpanId).toBe(VALID_TRACE_ID);
+      expect(span.spanParents).toEqual([VALID_SPAN_ID]);
+      span.end();
+    });
+
+    test("native Headers object when available", () => {
+      const HeadersCtor = (
+        globalThis as unknown as {
+          Headers?: new (init?: Record<string, string>) => {
+            get(name: string): string | null;
+          };
+        }
+      ).Headers;
+      if (!HeadersCtor) {
+        return;
+      }
+
+      const logger = makeLogger();
+      const ctx = extractTraceContextFromHeaders(
+        new HeadersCtor({
+          traceparent: VALID_TRACEPARENT,
+          baggage: `${BRAINTRUST_PARENT_KEY}=project_id:abc`,
+        }),
+      );
+      const span = logger.startSpan({ name: "h", parent: ctx });
+      expect(span.rootSpanId).toBe(VALID_TRACE_ID);
+      expect(span.spanParents).toEqual([VALID_SPAN_ID]);
+      span.end();
+    });
+
     test("extract returns opaque dict", () => {
-      const ctx = extractTraceContext({
+      const ctx = extractTraceContextFromHeaders({
         traceparent: VALID_TRACEPARENT,
         baggage: `${BRAINTRUST_PARENT_KEY}=project_id:abc`,
         tracestate: "congo=t61",
@@ -652,7 +720,9 @@ describe("inject / extract / round-trip", () => {
 
     test("no parent and logger present starts span without throwing", () => {
       const logger = makeLogger();
-      const ctx = extractTraceContext({ traceparent: VALID_TRACEPARENT });
+      const ctx = extractTraceContextFromHeaders({
+        traceparent: VALID_TRACEPARENT,
+      });
       const span = logger.startSpan({ name: "h", parent: ctx });
       expect(span.spanId).not.toBeUndefined();
       span.end();
@@ -667,7 +737,7 @@ describe("inject / extract / round-trip", () => {
     const aSpan = spanA.spanId;
     spanA.end();
 
-    const parent = extractTraceContext(carrier);
+    const parent = extractTraceContextFromHeaders(carrier);
     const spanB = logger.startSpan({ name: "svc_b", parent });
     expect(spanB.rootSpanId).toBe(aRoot);
     expect(spanB.spanParents).toEqual([aSpan]);
@@ -780,7 +850,7 @@ describe("tracestate / flags pass-through", () => {
 
   test("extract then inject forwards tracestate", () => {
     const logger = makeLogger();
-    const parent = extractTraceContext({
+    const parent = extractTraceContextFromHeaders({
       traceparent: VALID_TRACEPARENT,
       baggage: `${BRAINTRUST_PARENT_KEY}=project_id:abc`,
       tracestate: UPSTREAM_TRACESTATE,
@@ -803,7 +873,7 @@ describe("tracestate / flags pass-through", () => {
   test("extract then inject preserves unsampled flag", () => {
     const logger = makeLogger();
     const unsampled = `00-${VALID_TRACE_ID}-${VALID_SPAN_ID}-00`;
-    const parent = extractTraceContext({
+    const parent = extractTraceContextFromHeaders({
       traceparent: unsampled,
       baggage: `${BRAINTRUST_PARENT_KEY}=project_id:abc`,
     });
@@ -815,7 +885,7 @@ describe("tracestate / flags pass-through", () => {
 
   test("extract then inject preserves sampled flag", () => {
     const logger = makeLogger();
-    const parent = extractTraceContext({
+    const parent = extractTraceContextFromHeaders({
       traceparent: VALID_TRACEPARENT, // ...-01
       baggage: `${BRAINTRUST_PARENT_KEY}=project_id:abc`,
     });

--- a/js/src/propagation.test.ts
+++ b/js/src/propagation.test.ts
@@ -23,6 +23,7 @@ import {
   TRACESTATE_HEADER,
   formatTraceparent,
   getHeader,
+  isValidTracestate,
   mergeBaggage,
   parseBaggage,
   parseTraceparent,
@@ -204,6 +205,41 @@ describe("baggage", () => {
     expect(
       parseBaggage(`${BRAINTRUST_PARENT_KEY}=project_id%3Aabc123`),
     ).toEqual({ [BRAINTRUST_PARENT_KEY]: "project_id:abc123" });
+  });
+});
+
+describe("isValidTracestate", () => {
+  test.each([
+    "congo=t61rcWkgMzE",
+    "congo=t61rcWkgMzE,rojo=00f067aa0ba902b7",
+    "vendor@system=value",
+    "a=b", // minimal single member
+    `k=${"a".repeat(256)}`, // max value length
+    "k=a b c", // spaces allowed mid-value
+    Array.from({ length: 32 }, (_, i) => `k${i}=v`).join(","), // max members
+  ])("accepts valid tracestate: %s", (value) => {
+    expect(isValidTracestate(value)).toBe(true);
+  });
+
+  test.each([
+    ["", "empty"],
+    [null, "null"],
+    [undefined, "undefined"],
+    ["ConGo=t61", "uppercase key"],
+    ["1congo=t61", "key must start with a letter"],
+    ["congo=", "empty value"],
+    ["congo=bad=value", "value cannot contain equals"],
+    ["congo,rojo=v", "member missing equals"],
+    ["congo=\u00e9", "non-ASCII value"],
+    ["congo=a,congo=b", "duplicate key"],
+    [`k=${"a".repeat(257)}`, "value too long"],
+    [
+      Array.from({ length: 33 }, (_, i) => `k${i}=v`).join(","),
+      "too many members",
+    ],
+    [`congo=${"a".repeat(513)}`, "over 512 chars total"],
+  ])("rejects invalid tracestate (%s): %s", (value) => {
+    expect(isValidTracestate(value as string)).toBe(false);
   });
 });
 
@@ -1126,7 +1162,10 @@ describe("tracestate / flags pass-through", () => {
     "congo=\u00e9", // non-ASCII value
     Array.from({ length: 33 }, (_, i) => `k${i}=v`).join(","), // too many members
     `congo=${"a".repeat(513)}`, // too long overall
-  ])("invalid tracestate is forwarded unchanged: %s", (tracestate) => {
+  ])("invalid tracestate is not forwarded: %s", (tracestate) => {
+    // `tracestate` we forward but never author, so an inbound value that does
+    // not conform to the W3C grammar/limits is dropped on extract rather than
+    // relayed onward.
     const logger = makeLogger();
     const parent = extractTraceContextFromHeaders({
       traceparent: VALID_TRACEPARENT,
@@ -1136,7 +1175,7 @@ describe("tracestate / flags pass-through", () => {
     const span = logger.startSpan({ name: "mid", parent });
     const outbound = span.inject({});
     span.end();
-    expect(outbound[TRACESTATE_HEADER]).toBe(tracestate);
+    expect(TRACESTATE_HEADER in outbound).toBe(false);
   });
 
   test("extract then inject preserves unsampled flag", () => {

--- a/js/src/propagation.test.ts
+++ b/js/src/propagation.test.ts
@@ -1061,6 +1061,14 @@ describe("tracestate / flags pass-through", () => {
     expect(TRACESTATE_HEADER in outbound).toBe(false);
   });
 
+  test("inject leaves existing tracestate untouched when none inbound", () => {
+    const logger = makeLogger();
+    const span = logger.startSpan({ name: "root" });
+    const outbound = span.inject({ [TRACESTATE_HEADER]: UPSTREAM_TRACESTATE });
+    span.end();
+    expect(outbound[TRACESTATE_HEADER]).toBe(UPSTREAM_TRACESTATE);
+  });
+
   test.each([
     "ConGo=t61rcWkgMzE", // uppercase key
     "congo=", // empty value
@@ -1068,7 +1076,7 @@ describe("tracestate / flags pass-through", () => {
     "congo=\u00e9", // non-ASCII value
     Array.from({ length: 33 }, (_, i) => `k${i}=v`).join(","), // too many members
     `congo=${"a".repeat(513)}`, // too long overall
-  ])("invalid tracestate is not forwarded: %s", (tracestate) => {
+  ])("invalid tracestate is forwarded unchanged: %s", (tracestate) => {
     const logger = makeLogger();
     const parent = extractTraceContextFromHeaders({
       traceparent: VALID_TRACEPARENT,
@@ -1078,7 +1086,7 @@ describe("tracestate / flags pass-through", () => {
     const span = logger.startSpan({ name: "mid", parent });
     const outbound = span.inject({});
     span.end();
-    expect(TRACESTATE_HEADER in outbound).toBe(false);
+    expect(outbound[TRACESTATE_HEADER]).toBe(tracestate);
   });
 
   test("extract then inject preserves unsampled flag", () => {

--- a/js/src/propagation.test.ts
+++ b/js/src/propagation.test.ts
@@ -23,7 +23,6 @@ import {
   TRACESTATE_HEADER,
   formatTraceparent,
   getHeader,
-  isValidTracestate,
   mergeBaggage,
   parseBaggage,
   parseTraceparent,
@@ -205,41 +204,6 @@ describe("baggage", () => {
     expect(
       parseBaggage(`${BRAINTRUST_PARENT_KEY}=project_id%3Aabc123`),
     ).toEqual({ [BRAINTRUST_PARENT_KEY]: "project_id:abc123" });
-  });
-});
-
-describe("isValidTracestate", () => {
-  test.each([
-    "congo=t61rcWkgMzE",
-    "congo=t61rcWkgMzE,rojo=00f067aa0ba902b7",
-    "vendor@system=value",
-    "a=b", // minimal single member
-    `k=${"a".repeat(256)}`, // max value length
-    "k=a b c", // spaces allowed mid-value
-    Array.from({ length: 32 }, (_, i) => `k${i}=v`).join(","), // max members
-  ])("accepts valid tracestate: %s", (value) => {
-    expect(isValidTracestate(value)).toBe(true);
-  });
-
-  test.each([
-    ["", "empty"],
-    [null, "null"],
-    [undefined, "undefined"],
-    ["ConGo=t61", "uppercase key"],
-    ["1congo=t61", "key must start with a letter"],
-    ["congo=", "empty value"],
-    ["congo=bad=value", "value cannot contain equals"],
-    ["congo,rojo=v", "member missing equals"],
-    ["congo=\u00e9", "non-ASCII value"],
-    ["congo=a,congo=b", "duplicate key"],
-    [`k=${"a".repeat(257)}`, "value too long"],
-    [
-      Array.from({ length: 33 }, (_, i) => `k${i}=v`).join(","),
-      "too many members",
-    ],
-    [`congo=${"a".repeat(513)}`, "over 512 chars total"],
-  ])("rejects invalid tracestate (%s): %s", (value) => {
-    expect(isValidTracestate(value as string)).toBe(false);
   });
 });
 
@@ -537,7 +501,7 @@ describe("inject / extract / round-trip", () => {
     test("traceparent well-formed and matches span", () => {
       const logger = makeLogger();
       const span = logger.startSpan({ name: "svc_a" });
-      const carrier = span.inject({});
+      const carrier = span.inject<Record<string, string>>({});
       span.end();
 
       const tp = carrier[TRACEPARENT_HEADER];
@@ -550,7 +514,7 @@ describe("inject / extract / round-trip", () => {
     test("baggage contains braintrust parent", () => {
       const logger = makeLogger();
       const span = logger.startSpan({ name: "svc_a" });
-      const carrier = span.inject({});
+      const carrier = span.inject<Record<string, string>>({});
       span.end();
 
       const parsed = parseBaggage(carrier[BAGGAGE_HEADER]);
@@ -576,12 +540,13 @@ describe("inject / extract / round-trip", () => {
     test("array-valued baggage is joined before merge", () => {
       const logger = makeLogger();
       const span = logger.startSpan({ name: "svc_a" });
-      const carrier = span.inject({
+      const carrier = span.inject<Record<string, string | string[]>>({
         [BAGGAGE_HEADER]: ["user=alice", "team=eng"],
       });
       span.end();
 
-      const parsed = parseBaggage(carrier[BAGGAGE_HEADER]);
+      // inject() joins and replaces the array value with a single string.
+      const parsed = parseBaggage(String(carrier[BAGGAGE_HEADER]));
       expect(parsed["user"]).toBe("alice");
       expect(parsed["team"]).toBe("eng");
       expect(parsed[BRAINTRUST_PARENT_KEY]).toBe(
@@ -592,7 +557,9 @@ describe("inject / extract / round-trip", () => {
     test("title-cased baggage emits single lowercase header", () => {
       const logger = makeLogger();
       const span = logger.startSpan({ name: "svc_a" });
-      const carrier = span.inject({ Baggage: "user=alice" });
+      const carrier = span.inject<Record<string, string>>({
+        Baggage: "user=alice",
+      });
       span.end();
 
       const baggageKeys = Object.keys(carrier).filter(
@@ -609,7 +576,9 @@ describe("inject / extract / round-trip", () => {
     test("title-cased traceparent emits single lowercase header", () => {
       const logger = makeLogger();
       const span = logger.startSpan({ name: "svc_a" });
-      const carrier = span.inject({ Traceparent: "stale" });
+      const carrier = span.inject<Record<string, string>>({
+        Traceparent: "stale",
+      });
       span.end();
 
       const traceparentKeys = Object.keys(carrier).filter(
@@ -624,7 +593,7 @@ describe("inject / extract / round-trip", () => {
     test("never emits x-bt-parent", () => {
       const logger = makeLogger();
       const span = logger.startSpan({ name: "svc_a" });
-      const carrier = span.inject({});
+      const carrier = span.inject<Record<string, string>>({});
       span.end();
       expect(Object.keys(carrier).map((k) => k.toLowerCase())).not.toContain(
         "x-bt-parent",
@@ -978,7 +947,7 @@ describe("inject / extract / round-trip", () => {
       baggage: `${BRAINTRUST_PARENT_KEY}=project_id:remote-project-id`,
     });
     const span = startSpan({ name: "svc_b", parent });
-    const carrier = span.inject({});
+    const carrier = span.inject<Record<string, string>>({});
     span.end();
 
     expect(parseBaggage(carrier[BAGGAGE_HEADER])).toEqual({
@@ -993,7 +962,7 @@ describe("inject / extract / round-trip", () => {
       baggage: `${BRAINTRUST_PARENT_KEY}=experiment_id:remote-experiment-id`,
     });
     const span = startSpan({ name: "svc_b", parent });
-    const carrier = span.inject({});
+    const carrier = span.inject<Record<string, string>>({});
     span.end();
 
     expect(parseBaggage(carrier[BAGGAGE_HEADER])).toEqual({
@@ -1011,7 +980,7 @@ describe("inject / extract / round-trip", () => {
       baggage: `${BRAINTRUST_PARENT_KEY}=project_id:remote-project-id`,
     });
     const span = logger.startSpan({ name: "svc_b", parent });
-    const carrier = span.inject({});
+    const carrier = span.inject<Record<string, string>>({});
     span.end();
 
     expect(span.rootSpanId).toBe(VALID_TRACE_ID);
@@ -1133,7 +1102,7 @@ describe("tracestate / flags pass-through", () => {
       tracestate: UPSTREAM_TRACESTATE,
     });
     const span = logger.startSpan({ name: "mid", parent });
-    const outbound = span.inject({});
+    const outbound = span.inject<Record<string, string>>({});
     span.end();
     expect(outbound[TRACESTATE_HEADER]).toBe(UPSTREAM_TRACESTATE);
     expect(outbound[TRACEPARENT_HEADER]).toMatch(TRACEPARENT_RE);
@@ -1142,7 +1111,7 @@ describe("tracestate / flags pass-through", () => {
   test("no tracestate emitted when none inbound", () => {
     const logger = makeLogger();
     const span = logger.startSpan({ name: "root" });
-    const outbound = span.inject({});
+    const outbound = span.inject<Record<string, string>>({});
     span.end();
     expect(TRACESTATE_HEADER in outbound).toBe(false);
   });
@@ -1162,10 +1131,10 @@ describe("tracestate / flags pass-through", () => {
     "congo=\u00e9", // non-ASCII value
     Array.from({ length: 33 }, (_, i) => `k${i}=v`).join(","), // too many members
     `congo=${"a".repeat(513)}`, // too long overall
-  ])("invalid tracestate is not forwarded: %s", (tracestate) => {
-    // `tracestate` we forward but never author, so an inbound value that does
-    // not conform to the W3C grammar/limits is dropped on extract rather than
-    // relayed onward.
+  ])("invalid tracestate is forwarded unchanged: %s", (tracestate) => {
+    // `tracestate` is opaque vendor state that Braintrust forwards but never
+    // authors or interprets, so even a value our local grammar would reject is
+    // relayed unchanged; receivers validate it themselves per the W3C spec.
     const logger = makeLogger();
     const parent = extractTraceContextFromHeaders({
       traceparent: VALID_TRACEPARENT,
@@ -1173,9 +1142,9 @@ describe("tracestate / flags pass-through", () => {
       tracestate,
     });
     const span = logger.startSpan({ name: "mid", parent });
-    const outbound = span.inject({});
+    const outbound = span.inject<Record<string, string>>({});
     span.end();
-    expect(TRACESTATE_HEADER in outbound).toBe(false);
+    expect(outbound[TRACESTATE_HEADER]).toBe(tracestate);
   });
 
   test("extract then inject preserves unsampled flag", () => {
@@ -1186,7 +1155,7 @@ describe("tracestate / flags pass-through", () => {
       baggage: `${BRAINTRUST_PARENT_KEY}=project_id:abc`,
     });
     const span = logger.startSpan({ name: "mid", parent });
-    const outbound = span.inject({});
+    const outbound = span.inject<Record<string, string>>({});
     span.end();
     expect(outbound[TRACEPARENT_HEADER].endsWith("-00")).toBe(true);
   });
@@ -1198,7 +1167,7 @@ describe("tracestate / flags pass-through", () => {
       baggage: `${BRAINTRUST_PARENT_KEY}=project_id:abc`,
     });
     const span = logger.startSpan({ name: "mid", parent });
-    const outbound = span.inject({});
+    const outbound = span.inject<Record<string, string>>({});
     span.end();
     expect(outbound[TRACEPARENT_HEADER].endsWith("-01")).toBe(true);
   });

--- a/js/src/propagation.test.ts
+++ b/js/src/propagation.test.ts
@@ -294,6 +294,18 @@ describe("mergeBaggage", () => {
     });
   });
 
+  test("omits oversized braintrust parent", () => {
+    const oversizedParent = `project_name:${"a".repeat(9000)}`;
+    expect(mergeBaggage(null, oversizedParent)).toBeUndefined();
+    expect(mergeBaggage("vendor=x", oversizedParent)).toBe("vendor=x");
+    expect(
+      mergeBaggage(
+        `${BRAINTRUST_PARENT_KEY}=project_id%3Aold,vendor=x`,
+        oversizedParent,
+      ),
+    ).toBe("vendor=x");
+  });
+
   // The braintrust.parent value embeds a user-controlled project/experiment
   // name. Per W3C Baggage §3.3.1.3 a value's unencoded bytes are restricted to
   // baggage-octet; everything else MUST be percent-encoded.
@@ -1029,6 +1041,26 @@ describe("tracestate / flags pass-through", () => {
   test("no tracestate emitted when none inbound", () => {
     const logger = makeLogger();
     const span = logger.startSpan({ name: "root" });
+    const outbound = span.inject({});
+    span.end();
+    expect(TRACESTATE_HEADER in outbound).toBe(false);
+  });
+
+  test.each([
+    "ConGo=t61rcWkgMzE", // uppercase key
+    "congo=", // empty value
+    "congo=bad=value", // value cannot contain equals
+    "congo=\u00e9", // non-ASCII value
+    Array.from({ length: 33 }, (_, i) => `k${i}=v`).join(","), // too many members
+    `congo=${"a".repeat(513)}`, // too long overall
+  ])("invalid tracestate is not forwarded: %s", (tracestate) => {
+    const logger = makeLogger();
+    const parent = extractTraceContextFromHeaders({
+      traceparent: VALID_TRACEPARENT,
+      baggage: `${BRAINTRUST_PARENT_KEY}=project_id:abc`,
+      tracestate,
+    });
+    const span = logger.startSpan({ name: "mid", parent });
     const outbound = span.inject({});
     span.end();
     expect(TRACESTATE_HEADER in outbound).toBe(false);

--- a/js/src/propagation.test.ts
+++ b/js/src/propagation.test.ts
@@ -1,0 +1,913 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+
+/**
+ * Tests for native W3C trace-context propagation.
+ *
+ * Mirrors the Braintrust distributed-tracing spec's test matrix using the pure
+ * propagation path (no `@opentelemetry/api` dependency).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  _exportsForTestingOnly,
+  _injectIntoCarrier,
+  extractTraceContext,
+  initLogger,
+  injectTraceContext,
+  startSpan,
+} from "./logger";
+import {
+  BAGGAGE_HEADER,
+  BRAINTRUST_PARENT_KEY,
+  TRACEPARENT_HEADER,
+  TRACESTATE_HEADER,
+  formatTraceparent,
+  getHeader,
+  mergeBaggage,
+  parseBaggage,
+  parseTraceparent,
+} from "./propagation";
+import { SpanComponentsV3 } from "../util/span_identifier_v3";
+import { SpanComponentsV4 } from "../util/span_identifier_v4";
+import { SpanObjectTypeV3 } from "../util/index";
+import { configureNode } from "./node/config";
+import { v4 as uuidv4 } from "uuid";
+
+configureNode();
+
+const TRACEPARENT_RE = /^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/;
+
+const VALID_TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736";
+const VALID_SPAN_ID = "00f067aa0ba902b7";
+const VALID_TRACEPARENT = `00-${VALID_TRACE_ID}-${VALID_SPAN_ID}-01`;
+
+// --------------------------------------------------------------------------- //
+// Primitives: traceparent / baggage parse + format
+// --------------------------------------------------------------------------- //
+
+describe("traceparent", () => {
+  test("parse valid", () => {
+    expect(parseTraceparent(VALID_TRACEPARENT)).toEqual({
+      traceId: VALID_TRACE_ID,
+      spanId: VALID_SPAN_ID,
+      traceFlags: "01",
+    });
+  });
+
+  test("parse strips whitespace", () => {
+    expect(parseTraceparent(`  ${VALID_TRACEPARENT}  `)).toEqual({
+      traceId: VALID_TRACE_ID,
+      spanId: VALID_SPAN_ID,
+      traceFlags: "01",
+    });
+  });
+
+  test.each([
+    "",
+    null,
+    undefined,
+    "invalid",
+    "00-tooshort-00f067aa0ba902b7-01",
+    `00-${VALID_TRACE_ID}-00f067aa-01`, // short span id
+    `99-${VALID_TRACE_ID}-${VALID_SPAN_ID}-01`, // bad version
+    `00-${"0".repeat(32)}-${VALID_SPAN_ID}-01`, // zero trace id
+    `00-${VALID_TRACE_ID}-${"0".repeat(16)}-01`, // zero span id
+    `00-${VALID_TRACE_ID.toUpperCase()}-${VALID_SPAN_ID}-01`, // uppercase hex
+  ])("parse invalid: %s", (value) => {
+    expect(parseTraceparent(value as string)).toBeUndefined();
+  });
+
+  test("format round trip", () => {
+    const tp = formatTraceparent(VALID_TRACE_ID, VALID_SPAN_ID)!;
+    expect(tp).toMatch(TRACEPARENT_RE);
+    expect(parseTraceparent(tp)).toEqual({
+      traceId: VALID_TRACE_ID,
+      spanId: VALID_SPAN_ID,
+      traceFlags: "01",
+    });
+  });
+
+  test("format rejects non-hex", () => {
+    expect(formatTraceparent("not-hex", VALID_SPAN_ID)).toBeUndefined();
+    expect(formatTraceparent(VALID_TRACE_ID, "00000000-0000")).toBeUndefined();
+    expect(formatTraceparent("0".repeat(32), VALID_SPAN_ID)).toBeUndefined();
+  });
+
+  test("parse reports trace flags", () => {
+    // The raw trace-flags byte must be recoverable so it can be carried through
+    // extract -> inject. A not-sampled (`-00`) inbound trace must not be
+    // silently upgraded to sampled.
+    expect(
+      parseTraceparent(`00-${VALID_TRACE_ID}-${VALID_SPAN_ID}-01`)?.traceFlags,
+    ).toBe("01");
+    expect(
+      parseTraceparent(`00-${VALID_TRACE_ID}-${VALID_SPAN_ID}-00`)?.traceFlags,
+    ).toBe("00");
+  });
+
+  test("format preserves flags round trip", () => {
+    const parsed = parseTraceparent(
+      `00-${VALID_TRACE_ID}-${VALID_SPAN_ID}-00`,
+    )!;
+    const tp = formatTraceparent(
+      VALID_TRACE_ID,
+      VALID_SPAN_ID,
+      parsed.traceFlags,
+    )!;
+    expect(tp.endsWith("-00")).toBe(true);
+    expect(parseTraceparent(tp)?.traceFlags).toBe("00");
+  });
+
+  test("format defaults to sampled", () => {
+    expect(
+      formatTraceparent(VALID_TRACE_ID, VALID_SPAN_ID)?.endsWith("-01"),
+    ).toBe(true);
+  });
+
+  test("format falls back on bad flags", () => {
+    expect(
+      formatTraceparent(VALID_TRACE_ID, VALID_SPAN_ID, "zz")?.endsWith("-01"),
+    ).toBe(true);
+  });
+});
+
+describe("baggage", () => {
+  test("parse simple", () => {
+    expect(parseBaggage("braintrust.parent=project_id:abc")).toEqual({
+      "braintrust.parent": "project_id:abc",
+    });
+  });
+
+  test("parse preserves unrelated keys", () => {
+    const parsed = parseBaggage(
+      "foo=bar,braintrust.parent=project_id:abc,baz=qux",
+    );
+    expect(parsed["foo"]).toBe("bar");
+    expect(parsed["baz"]).toBe("qux");
+    expect(parsed["braintrust.parent"]).toBe("project_id:abc");
+  });
+
+  test("parse ignores properties", () => {
+    expect(parseBaggage("k=v;prop=1")).toEqual({ k: "v" });
+  });
+
+  test.each(["", null, undefined, "no-equals", ",,,"])(
+    "parse malformed does not throw: %s",
+    (value) => {
+      expect(parseBaggage(value as string)).toEqual({});
+    },
+  );
+
+  test("parse oversized does not throw", () => {
+    const big = "x=" + "a".repeat(100000);
+    // A single member larger than the limit has no complete member to keep, so
+    // it is dropped entirely (we never decode a partial value).
+    expect(parseBaggage(big)).toEqual({});
+  });
+
+  test("parse oversized keeps whole members only", () => {
+    const members = Array.from(
+      { length: 200 },
+      (_, i) => `k${i}=${"v".repeat(100)}`,
+    );
+    const header = members.join(",");
+    const parsed = parseBaggage(header);
+    expect(Object.keys(parsed).length).toBeGreaterThan(0);
+    expect(Object.values(parsed).every((v) => v === "v".repeat(100))).toBe(
+      true,
+    );
+    const keptKeys = Object.keys(parsed);
+    expect(keptKeys).toEqual(keptKeys.map((_, i) => `k${i}`));
+  });
+
+  test("parse caps member count", () => {
+    const header = Array.from({ length: 200 }, (_, i) => `k${i}=v`).join(",");
+    const parsed = parseBaggage(header);
+    expect(Object.keys(parsed).length).toBe(64);
+    expect(Object.keys(parsed)).toEqual(
+      Array.from({ length: 64 }, (_, i) => `k${i}`),
+    );
+  });
+
+  test.each([
+    [64, 64],
+    [65, 64],
+    [10, 10],
+  ])("parse member count boundary: %i -> %i", (count, expected) => {
+    const header = Array.from({ length: count }, (_, i) => `k${i}=v`).join(",");
+    expect(Object.keys(parseBaggage(header)).length).toBe(expected);
+  });
+
+  test("parse decodes standard encoder values", () => {
+    // Standard encoders (e.g. OpenTelemetry's propagator) percent-encode `:` as
+    // `%3A`. We must fully decode inbound values to interoperate.
+    expect(
+      parseBaggage(`${BRAINTRUST_PARENT_KEY}=project_id%3Aabc123`),
+    ).toEqual({ [BRAINTRUST_PARENT_KEY]: "project_id:abc123" });
+  });
+});
+
+describe("mergeBaggage", () => {
+  test("adds braintrust parent when no existing", () => {
+    const merged = mergeBaggage(null, "project_id:abc");
+    expect(parseBaggage(merged)).toEqual({
+      [BRAINTRUST_PARENT_KEY]: "project_id:abc",
+    });
+  });
+
+  test("none parent and no existing returns undefined", () => {
+    expect(mergeBaggage(null, null)).toBeUndefined();
+    expect(mergeBaggage("", null)).toBeUndefined();
+  });
+
+  test("preserves unrelated baggage byte for byte", () => {
+    const merged = mergeBaggage("path=a%2Fb,user=alice", "project_id:abc")!;
+    expect(merged).toContain("path=a%2Fb");
+    expect(merged).toContain("user=alice");
+    // Our own value is percent-encoded for spec compliance (`:` -> `%3A`).
+    expect(merged).toContain(`${BRAINTRUST_PARENT_KEY}=project_id%3Aabc`);
+    expect(parseBaggage(merged)[BRAINTRUST_PARENT_KEY]).toBe("project_id:abc");
+  });
+
+  test("does not decode unowned percent sequences", () => {
+    // `%41` is the percent-encoding of `A`. A transparent relay must not
+    // collapse `a%41b` to `aAb`.
+    expect(mergeBaggage("k=a%41b", null)).toBe("k=a%41b");
+  });
+
+  test.each([
+    "a%2Fb", // `/` outside our encode set
+    "x%3Ay", // `:` (what OTel encodes)
+    "c%2Cd", // encoded comma
+    "a%3Db", // encoded `=`
+    "%C3%A9", // multi-byte UTF-8 (é) already percent-encoded
+    "%2520", // a literal `%20` the upstream double-encoded
+  ])("unowned value encodings pass through verbatim: %s", (value) => {
+    expect(mergeBaggage(`vendor=${value}`, null)).toBe(`vendor=${value}`);
+  });
+
+  test("multiple unowned members pass through verbatim", () => {
+    const inbound = "p1=a%2Fb,p2=x%3Ay,p3=c%2Cd";
+    const merged = mergeBaggage(inbound, "project_id:p");
+    expect(merged).toBe(`${inbound},${BRAINTRUST_PARENT_KEY}=project_id%3Ap`);
+  });
+
+  test("preserves member properties", () => {
+    const merged = mergeBaggage("k=v;meta=1;ttl=30,vendor=y", null);
+    expect(merged).toBe("k=v;meta=1;ttl=30,vendor=y");
+  });
+
+  test("empty value member is preserved", () => {
+    expect(mergeBaggage("k=,vendor=y", null)).toBe("k=,vendor=y");
+  });
+
+  test("optional whitespace is trimmed", () => {
+    const merged = mergeBaggage(" a=1 , b=2 ", "project_id:p");
+    expect(merged).toBe(`a=1,b=2,${BRAINTRUST_PARENT_KEY}=project_id%3Ap`);
+  });
+
+  test("replaces existing braintrust parent", () => {
+    const merged = mergeBaggage(
+      `${BRAINTRUST_PARENT_KEY}=project_id:old,vendor=x`,
+      "project_id:new",
+    )!;
+    const parsed = parseBaggage(merged);
+    expect(parsed[BRAINTRUST_PARENT_KEY]).toBe("project_id:new");
+    expect(parsed["vendor"]).toBe("x");
+    expect(
+      (merged.match(new RegExp(`${BRAINTRUST_PARENT_KEY}=`, "g")) || []).length,
+    ).toBe(1);
+  });
+
+  test("drops existing braintrust parent when no new value", () => {
+    const merged = mergeBaggage(
+      `${BRAINTRUST_PARENT_KEY}=project_id:old,vendor=x`,
+      null,
+    );
+    expect(merged).toBe("vendor=x");
+  });
+
+  test("encodes braintrust parent with reserved chars", () => {
+    const merged = mergeBaggage(null, "project_name:a,b c");
+    expect(parseBaggage(merged)).toEqual({
+      [BRAINTRUST_PARENT_KEY]: "project_name:a,b c",
+    });
+  });
+
+  // The braintrust.parent value embeds a user-controlled project/experiment
+  // name. Per W3C Baggage §3.3.1.3 a value's unencoded bytes are restricted to
+  // baggage-octet; everything else MUST be percent-encoded.
+  test.each([
+    'a"b', // DQUOTE
+    "a\\b", // backslash
+    "a\tb", // tab
+    "a\nb", // newline
+    "abcd\u00e9", // non-ASCII (é)
+    "emoji\u{1f600}", // astral plane
+    "a+b", // literal plus must stay a plus
+    "a%b", // literal percent MUST be encoded
+    "a,b c", // comma + space
+    "a;b=c", // semicolon + equals
+  ])("braintrust parent value round trips spec-compliant: %s", (name) => {
+    const value = `project_name:${name}`;
+    const merged = mergeBaggage(null, value)!;
+
+    // Round-trip through the same decode path the SDK uses on receive.
+    expect(parseBaggage(merged)).toEqual({ [BRAINTRUST_PARENT_KEY]: value });
+
+    // ASCII only, and the braintrust.parent member carries no raw
+    // baggage-octet violators.
+    // eslint-disable-next-line no-control-regex
+    expect(/^[\x00-\x7f]*$/.test(merged)).toBe(true);
+    const member = merged
+      .split(",")
+      .find((m) => m.startsWith(`${BRAINTRUST_PARENT_KEY}=`))!;
+    const encodedVal = member.slice(member.indexOf("=") + 1);
+    for (const ch of encodedVal) {
+      const cp = ch.codePointAt(0)!;
+      const allowed =
+        cp === 0x21 ||
+        (cp >= 0x23 && cp <= 0x2b) ||
+        (cp >= 0x2d && cp <= 0x3a) ||
+        (cp >= 0x3c && cp <= 0x5b) ||
+        (cp >= 0x5d && cp <= 0x7e);
+      expect(allowed).toBe(true);
+    }
+  });
+
+  test("skips malformed existing members", () => {
+    const merged = mergeBaggage("garbage,,k=v,no-equals", "project_id:abc")!;
+    const parsed = parseBaggage(merged);
+    expect(parsed["k"]).toBe("v");
+    expect(parsed[BRAINTRUST_PARENT_KEY]).toBe("project_id:abc");
+  });
+
+  test("oversized existing relays whole members only", () => {
+    const members = Array.from(
+      { length: 200 },
+      (_, i) => `k${i}=${"v".repeat(100)}`,
+    );
+    const existing = members.join(",");
+    const merged = mergeBaggage(existing, "project_id:abc")!;
+    const parsed = parseBaggage(merged);
+    expect(new TextEncoder().encode(merged).length).toBeLessThanOrEqual(8192);
+    expect(parsed[BRAINTRUST_PARENT_KEY]).toBe("project_id:abc");
+    const relayed = Object.entries(parsed).filter(
+      ([k]) => k !== BRAINTRUST_PARENT_KEY,
+    );
+    expect(relayed.length).toBeGreaterThan(0);
+    expect(relayed.every(([, v]) => v === "v".repeat(100))).toBe(true);
+    for (const member of merged.split(",")) {
+      if (member.startsWith(`${BRAINTRUST_PARENT_KEY}=`)) {
+        continue;
+      }
+      expect(member.endsWith("v".repeat(100))).toBe(true);
+    }
+  });
+
+  test("caps member count and reserves slot for braintrust parent", () => {
+    const existing = Array.from({ length: 200 }, (_, i) => `k${i}=v`).join(",");
+    const merged = mergeBaggage(existing, "project_id:abc")!;
+    const parsed = parseBaggage(merged);
+    expect((merged.match(/,/g) || []).length + 1).toBe(64);
+    expect(Object.keys(parsed).length).toBe(64);
+    expect(parsed[BRAINTRUST_PARENT_KEY]).toBe("project_id:abc");
+    const relayedKeys = Object.keys(parsed).filter(
+      (k) => k !== BRAINTRUST_PARENT_KEY,
+    );
+    expect(relayedKeys).toEqual(Array.from({ length: 63 }, (_, i) => `k${i}`));
+  });
+
+  test("member count cap without braintrust parent", () => {
+    const existing = Array.from({ length: 200 }, (_, i) => `k${i}=v`).join(",");
+    const merged = mergeBaggage(existing, null)!;
+    const parsed = parseBaggage(merged);
+    expect(Object.keys(parsed).length).toBe(64);
+    expect(Object.keys(parsed)).toEqual(
+      Array.from({ length: 64 }, (_, i) => `k${i}`),
+    );
+  });
+
+  test("under member limit keeps all", () => {
+    const existing = Array.from({ length: 10 }, (_, i) => `k${i}=v`).join(",");
+    const merged = mergeBaggage(existing, "project_id:abc")!;
+    const parsed = parseBaggage(merged);
+    expect(Object.keys(parsed).length).toBe(11);
+    expect(parsed[BRAINTRUST_PARENT_KEY]).toBe("project_id:abc");
+  });
+});
+
+test("getHeader case insensitive", () => {
+  const headers = { TraceParent: VALID_TRACEPARENT, BAGGAGE: "foo=bar" };
+  expect(getHeader(headers, "traceparent")).toBe(VALID_TRACEPARENT);
+  expect(getHeader(headers, "baggage")).toBe("foo=bar");
+  expect(getHeader(headers, "missing")).toBeUndefined();
+});
+
+test("getHeader reduces array-valued headers to the first element", () => {
+  // Node's IncomingHttpHeaders can expose multi-valued headers as arrays; the
+  // W3C trace-context headers are single-valued, so we take the first element.
+  const headers = {
+    traceparent: [VALID_TRACEPARENT, "00-extra"],
+    baggage: ["foo=bar"],
+  };
+  expect(getHeader(headers, "traceparent")).toBe(VALID_TRACEPARENT);
+  expect(getHeader(headers, "baggage")).toBe("foo=bar");
+  expect(getHeader({ traceparent: [] }, "traceparent")).toBeUndefined();
+});
+
+test("getHeader skips a null case-variant and keeps searching", () => {
+  // A null/absent value under one case must not stop the lookup from finding a
+  // valid value under a different case-variant of the same header.
+  const headers = { traceparent: null, Traceparent: VALID_TRACEPARENT };
+  expect(getHeader(headers, "traceparent")).toBe(VALID_TRACEPARENT);
+});
+
+// --------------------------------------------------------------------------- //
+// Send / receive / round-trip against a live logger
+// --------------------------------------------------------------------------- //
+
+const PROJECT_NAME = "propagation-test";
+
+describe("inject / extract / round-trip", () => {
+  let memoryLogger: ReturnType<
+    typeof _exportsForTestingOnly.useTestBackgroundLogger
+  >;
+
+  beforeEach(() => {
+    _exportsForTestingOnly.simulateLoginForTests();
+    _exportsForTestingOnly.resetIdGenStateForTests();
+    memoryLogger = _exportsForTestingOnly.useTestBackgroundLogger();
+  });
+
+  afterEach(() => {
+    _exportsForTestingOnly.clearTestBackgroundLogger();
+    _exportsForTestingOnly.simulateLogoutForTests();
+  });
+
+  function makeLogger() {
+    return initLogger({ projectName: PROJECT_NAME });
+  }
+
+  describe("inject", () => {
+    test("traceparent well-formed and matches span", () => {
+      const logger = makeLogger();
+      const span = logger.startSpan({ name: "svc_a" });
+      const carrier = span.inject({});
+      span.end();
+
+      const tp = carrier[TRACEPARENT_HEADER];
+      expect(tp).toMatch(TRACEPARENT_RE);
+      const parsed = parseTraceparent(tp)!;
+      expect(parsed.traceId).toBe(span.rootSpanId);
+      expect(parsed.spanId).toBe(span.spanId);
+    });
+
+    test("baggage contains braintrust parent", () => {
+      const logger = makeLogger();
+      const span = logger.startSpan({ name: "svc_a" });
+      const carrier = span.inject({});
+      span.end();
+
+      const parsed = parseBaggage(carrier[BAGGAGE_HEADER]);
+      expect(parsed[BRAINTRUST_PARENT_KEY]).toBe(
+        `project_name:${PROJECT_NAME}`,
+      );
+    });
+
+    test("preexisting baggage preserved", () => {
+      const logger = makeLogger();
+      const span = logger.startSpan({ name: "svc_a" });
+      const carrier = span.inject({ [BAGGAGE_HEADER]: "user=alice,team=eng" });
+      span.end();
+
+      const parsed = parseBaggage(carrier[BAGGAGE_HEADER]);
+      expect(parsed["user"]).toBe("alice");
+      expect(parsed["team"]).toBe("eng");
+      expect(parsed[BRAINTRUST_PARENT_KEY]).toBe(
+        `project_name:${PROJECT_NAME}`,
+      );
+    });
+
+    test("title-cased baggage emits single lowercase header", () => {
+      const logger = makeLogger();
+      const span = logger.startSpan({ name: "svc_a" });
+      const carrier = span.inject({ Baggage: "user=alice" });
+      span.end();
+
+      const baggageKeys = Object.keys(carrier).filter(
+        (k) => k.toLowerCase() === BAGGAGE_HEADER,
+      );
+      expect(baggageKeys).toEqual([BAGGAGE_HEADER]);
+      const parsed = parseBaggage(carrier[BAGGAGE_HEADER]);
+      expect(parsed["user"]).toBe("alice");
+      expect(parsed[BRAINTRUST_PARENT_KEY]).toBe(
+        `project_name:${PROJECT_NAME}`,
+      );
+    });
+
+    test("title-cased traceparent emits single lowercase header", () => {
+      const logger = makeLogger();
+      const span = logger.startSpan({ name: "svc_a" });
+      const carrier = span.inject({ Traceparent: "stale" });
+      span.end();
+
+      const traceparentKeys = Object.keys(carrier).filter(
+        (k) => k.toLowerCase() === TRACEPARENT_HEADER,
+      );
+      expect(traceparentKeys).toEqual([TRACEPARENT_HEADER]);
+      const parsed = parseTraceparent(carrier[TRACEPARENT_HEADER])!;
+      expect(parsed.traceId).toBe(span.rootSpanId);
+      expect(parsed.spanId).toBe(span.spanId);
+    });
+
+    test("never emits x-bt-parent", () => {
+      const logger = makeLogger();
+      const span = logger.startSpan({ name: "svc_a" });
+      const carrier = span.inject({});
+      span.end();
+      expect(Object.keys(carrier).map((k) => k.toLowerCase())).not.toContain(
+        "x-bt-parent",
+      );
+    });
+
+    test("no braintrust parent injects traceparent without baggage", () => {
+      const carrier: Record<string, string> = {};
+      _injectIntoCarrier(carrier, {
+        traceId: VALID_TRACE_ID,
+        spanId: VALID_SPAN_ID,
+        braintrustParent: undefined,
+      });
+      expect(carrier[TRACEPARENT_HEADER]).toMatch(TRACEPARENT_RE);
+      expect(BAGGAGE_HEADER in carrier).toBe(false);
+    });
+
+    test("no braintrust parent preserves existing baggage without bt key", () => {
+      const carrier: Record<string, string> = {
+        [BAGGAGE_HEADER]: "user=alice",
+      };
+      _injectIntoCarrier(carrier, {
+        traceId: VALID_TRACE_ID,
+        spanId: VALID_SPAN_ID,
+        braintrustParent: undefined,
+      });
+      const parsed = parseBaggage(carrier[BAGGAGE_HEADER]);
+      expect(parsed["user"]).toBe("alice");
+      expect(BRAINTRUST_PARENT_KEY in parsed).toBe(false);
+    });
+
+    test("injectTraceContext free function", () => {
+      const logger = makeLogger();
+      let captured: { root: string; span: string } | undefined;
+      let carrier: Record<string, string> = {};
+      logger.traced(
+        (span) => {
+          carrier = injectTraceContext();
+          captured = { root: span.rootSpanId, span: span.spanId };
+        },
+        { name: "svc_a" },
+      );
+      const parsed = parseTraceparent(carrier[TRACEPARENT_HEADER])!;
+      expect(parsed.traceId).toBe(captured!.root);
+      expect(parsed.spanId).toBe(captured!.span);
+    });
+
+    test("inject no current span is safe", () => {
+      const carrier = injectTraceContext({});
+      expect(TRACEPARENT_HEADER in carrier).toBe(false);
+    });
+  });
+
+  describe("extract", () => {
+    test("traceparent with baggage parent", () => {
+      const logger = makeLogger();
+      const ctx = extractTraceContext({
+        traceparent: VALID_TRACEPARENT,
+        baggage: `${BRAINTRUST_PARENT_KEY}=project_id:abc123`,
+      });
+      const span = logger.startSpan({ name: "h", parent: ctx });
+      expect(span.rootSpanId).toBe(VALID_TRACE_ID);
+      expect(span.spanParents).toEqual([VALID_SPAN_ID]);
+      span.end();
+    });
+
+    test("traceparent baggage with unrelated keys", () => {
+      const logger = makeLogger();
+      const ctx = extractTraceContext({
+        traceparent: VALID_TRACEPARENT,
+        baggage: `user=alice,${BRAINTRUST_PARENT_KEY}=project_id:abc,team=eng`,
+      });
+      const span = logger.startSpan({ name: "h", parent: ctx });
+      expect(span.rootSpanId).toBe(VALID_TRACE_ID);
+      expect(span.spanParents).toEqual([VALID_SPAN_ID]);
+      span.end();
+    });
+
+    test("traceparent no baggage uses current logger", () => {
+      const logger = makeLogger();
+      const ctx = extractTraceContext({ traceparent: VALID_TRACEPARENT });
+      expect(ctx).not.toBeUndefined();
+      const span = logger.startSpan({ name: "h", parent: ctx });
+      expect(span.rootSpanId).toBe(VALID_TRACE_ID);
+      expect(span.spanParents).toEqual([VALID_SPAN_ID]);
+      span.end();
+    });
+
+    test("no headers returns undefined", () => {
+      expect(extractTraceContext({})).toBeUndefined();
+      expect(extractTraceContext(null)).toBeUndefined();
+      expect(extractTraceContext(undefined)).toBeUndefined();
+    });
+
+    test("malformed traceparent returns undefined", () => {
+      expect(
+        extractTraceContext({
+          traceparent: "garbage",
+          baggage: `${BRAINTRUST_PARENT_KEY}=project_id:abc`,
+        }),
+      ).toBeUndefined();
+    });
+
+    test("case insensitive headers", () => {
+      const logger = makeLogger();
+      const ctx = extractTraceContext({
+        TraceParent: VALID_TRACEPARENT,
+        Baggage: `${BRAINTRUST_PARENT_KEY}=project_id:abc`,
+      });
+      const span = logger.startSpan({ name: "h", parent: ctx });
+      expect(span.rootSpanId).toBe(VALID_TRACE_ID);
+      expect(span.spanParents).toEqual([VALID_SPAN_ID]);
+      span.end();
+    });
+
+    test("extract returns opaque dict", () => {
+      const ctx = extractTraceContext({
+        traceparent: VALID_TRACEPARENT,
+        baggage: `${BRAINTRUST_PARENT_KEY}=project_id:abc`,
+        tracestate: "congo=t61",
+      })!;
+      expect(typeof ctx).toBe("object");
+      expect(ctx[TRACEPARENT_HEADER]).toBe(VALID_TRACEPARENT);
+    });
+
+    test("no parent and logger present starts span without throwing", () => {
+      const logger = makeLogger();
+      const ctx = extractTraceContext({ traceparent: VALID_TRACEPARENT });
+      const span = logger.startSpan({ name: "h", parent: ctx });
+      expect(span.spanId).not.toBeUndefined();
+      span.end();
+    });
+  });
+
+  test("round trip inject extract", () => {
+    const logger = makeLogger();
+    const spanA = logger.startSpan({ name: "svc_a" });
+    const carrier = spanA.inject({});
+    const aRoot = spanA.rootSpanId;
+    const aSpan = spanA.spanId;
+    spanA.end();
+
+    const parent = extractTraceContext(carrier);
+    const spanB = logger.startSpan({ name: "svc_b", parent });
+    expect(spanB.rootSpanId).toBe(aRoot);
+    expect(spanB.spanParents).toEqual([aSpan]);
+    spanB.end();
+  });
+
+  test("inject does not break span emission without parent", async () => {
+    // inject is best-effort and must never drop the span. Use a projectId so
+    // draining doesn't require a metadata round-trip.
+    const logger = initLogger({
+      projectName: "emit-test",
+      projectId: "emit-test-project-id",
+    });
+    const span = logger.startSpan({ name: "svc_a" });
+    span.inject({});
+    span.log({ output: "hello" });
+    span.end();
+    await memoryLogger.flush();
+    const events = (await memoryLogger.drain()) as any[];
+    expect(events.some((e) => e["output"] === "hello")).toBe(true);
+  });
+
+  test("legacy export slug round trips with hex ids", () => {
+    const logger = makeLogger();
+    const parent = logger.startSpan({ name: "parent" });
+    const pRoot = parent.rootSpanId;
+    const pSpan = parent.spanId;
+    parent.end();
+
+    // Ids are OTEL-shaped hex by default.
+    expect(pSpan.length).toBe(16);
+    expect(pRoot.length).toBe(32);
+
+    // Build a slug synchronously from the hex ids (mirrors span.export()).
+    const slug = new SpanComponentsV4({
+      object_type: SpanObjectTypeV3.PROJECT_LOGS,
+      compute_object_metadata_args: { project_name: PROJECT_NAME },
+      row_id: "bt-row",
+      span_id: pSpan,
+      root_span_id: pRoot,
+    }).toStr();
+
+    const child = logger.startSpan({ name: "child", parent: slug });
+    expect(child.rootSpanId).toBe(pRoot);
+    expect(child.spanParents).toEqual([pSpan]);
+    child.end();
+  });
+
+  test("legacy parent slug (UUID) linked in hex mode", () => {
+    const logger = makeLogger();
+    const pSpan = uuidv4();
+    const pRoot = uuidv4();
+    const legacySlug = new SpanComponentsV3({
+      object_type: SpanObjectTypeV3.PROJECT_LOGS,
+      object_id: "legacy-proj",
+      row_id: uuidv4(),
+      span_id: pSpan,
+      root_span_id: pRoot,
+    }).toStr();
+
+    const child = logger.startSpan({ name: "child", parent: legacySlug });
+    // Links to the slug's UUID ids; the child's own span id stays hex.
+    expect(child.rootSpanId).toBe(pRoot);
+    expect(child.spanParents).toEqual([pSpan]);
+    expect(child.spanId.length).toBe(16);
+    child.end();
+  });
+
+  test("legacy parent slug linked via top-level startSpan", () => {
+    makeLogger();
+    const pSpan = uuidv4();
+    const pRoot = uuidv4();
+    const legacySlug = new SpanComponentsV3({
+      object_type: SpanObjectTypeV3.PROJECT_LOGS,
+      object_id: "legacy-proj",
+      row_id: uuidv4(),
+      span_id: pSpan,
+      root_span_id: pRoot,
+    }).toStr();
+
+    const child = startSpan({ name: "child", parent: legacySlug });
+    expect(child.rootSpanId).toBe(pRoot);
+    expect(child.spanParents).toEqual([pSpan]);
+    expect(child.spanId.length).toBe(16);
+    child.end();
+  });
+});
+
+// --------------------------------------------------------------------------- //
+// tracestate / trace-flags pass-through
+// --------------------------------------------------------------------------- //
+
+const UPSTREAM_TRACESTATE = "congo=t61rcWkgMzE,rojo=00f067aa0ba902b7";
+
+describe("tracestate / flags pass-through", () => {
+  beforeEach(() => {
+    _exportsForTestingOnly.simulateLoginForTests();
+    _exportsForTestingOnly.resetIdGenStateForTests();
+    _exportsForTestingOnly.useTestBackgroundLogger();
+  });
+
+  afterEach(() => {
+    _exportsForTestingOnly.clearTestBackgroundLogger();
+    _exportsForTestingOnly.simulateLogoutForTests();
+  });
+
+  function makeLogger() {
+    return initLogger({ projectName: PROJECT_NAME });
+  }
+
+  test("extract then inject forwards tracestate", () => {
+    const logger = makeLogger();
+    const parent = extractTraceContext({
+      traceparent: VALID_TRACEPARENT,
+      baggage: `${BRAINTRUST_PARENT_KEY}=project_id:abc`,
+      tracestate: UPSTREAM_TRACESTATE,
+    });
+    const span = logger.startSpan({ name: "mid", parent });
+    const outbound = span.inject({});
+    span.end();
+    expect(outbound[TRACESTATE_HEADER]).toBe(UPSTREAM_TRACESTATE);
+    expect(outbound[TRACEPARENT_HEADER]).toMatch(TRACEPARENT_RE);
+  });
+
+  test("no tracestate emitted when none inbound", () => {
+    const logger = makeLogger();
+    const span = logger.startSpan({ name: "root" });
+    const outbound = span.inject({});
+    span.end();
+    expect(TRACESTATE_HEADER in outbound).toBe(false);
+  });
+
+  test("extract then inject preserves unsampled flag", () => {
+    const logger = makeLogger();
+    const unsampled = `00-${VALID_TRACE_ID}-${VALID_SPAN_ID}-00`;
+    const parent = extractTraceContext({
+      traceparent: unsampled,
+      baggage: `${BRAINTRUST_PARENT_KEY}=project_id:abc`,
+    });
+    const span = logger.startSpan({ name: "mid", parent });
+    const outbound = span.inject({});
+    span.end();
+    expect(outbound[TRACEPARENT_HEADER].endsWith("-00")).toBe(true);
+  });
+
+  test("extract then inject preserves sampled flag", () => {
+    const logger = makeLogger();
+    const parent = extractTraceContext({
+      traceparent: VALID_TRACEPARENT, // ...-01
+      baggage: `${BRAINTRUST_PARENT_KEY}=project_id:abc`,
+    });
+    const span = logger.startSpan({ name: "mid", parent });
+    const outbound = span.inject({});
+    span.end();
+    expect(outbound[TRACEPARENT_HEADER].endsWith("-01")).toBe(true);
+  });
+});
+
+// --------------------------------------------------------------------------- //
+// Legacy UUID mode
+// --------------------------------------------------------------------------- //
+
+describe("legacy UUID mode", () => {
+  let prevLegacy: string | undefined;
+  let prevOtel: string | undefined;
+
+  beforeEach(() => {
+    prevLegacy = process.env.BRAINTRUST_LEGACY_IDS;
+    prevOtel = process.env.BRAINTRUST_OTEL_COMPAT;
+    delete process.env.BRAINTRUST_OTEL_COMPAT;
+    process.env.BRAINTRUST_LEGACY_IDS = "true";
+    _exportsForTestingOnly.simulateLoginForTests();
+    _exportsForTestingOnly.resetIdGenStateForTests();
+    _exportsForTestingOnly.useTestBackgroundLogger();
+  });
+
+  afterEach(() => {
+    _exportsForTestingOnly.clearTestBackgroundLogger();
+    _exportsForTestingOnly.simulateLogoutForTests();
+    if (prevLegacy === undefined) {
+      delete process.env.BRAINTRUST_LEGACY_IDS;
+    } else {
+      process.env.BRAINTRUST_LEGACY_IDS = prevLegacy;
+    }
+    if (prevOtel === undefined) {
+      delete process.env.BRAINTRUST_OTEL_COMPAT;
+    } else {
+      process.env.BRAINTRUST_OTEL_COMPAT = prevOtel;
+    }
+    _exportsForTestingOnly.resetIdGenStateForTests();
+  });
+
+  test("inject no-ops in legacy UUID mode", () => {
+    const logger = initLogger({ projectName: "legacy-inject" });
+    const span = logger.startSpan({ name: "p" });
+    // Legacy spans use UUID ids (share root == span).
+    expect(span.spanId.length).toBe(36);
+    const carrier = span.inject({ existing: "header" });
+    span.end();
+
+    expect(carrier).toEqual({ existing: "header" });
+    expect(TRACEPARENT_HEADER in carrier).toBe(false);
+    expect(BAGGAGE_HEADER in carrier).toBe(false);
+  });
+
+  test("legacy parent slug (UUID) linked in legacy mode", () => {
+    const logger = initLogger({ projectName: "legacy-proj" });
+    const pSpan = uuidv4();
+    const pRoot = uuidv4();
+    const legacySlug = new SpanComponentsV3({
+      object_type: SpanObjectTypeV3.PROJECT_LOGS,
+      object_id: "legacy-proj",
+      row_id: uuidv4(),
+      span_id: pSpan,
+      root_span_id: pRoot,
+    }).toStr();
+
+    const child = logger.startSpan({ name: "child", parent: legacySlug });
+    expect(child.rootSpanId).toBe(pRoot);
+    expect(child.spanParents).toEqual([pSpan]);
+    child.end();
+  });
+
+  test("hex parent slug linked in legacy mode", () => {
+    const logger = initLogger({ projectName: "legacy-proj" });
+    const pSpan = "00f067aa0ba902b7"; // 8-byte hex
+    const pRoot = "4bf92f3577b34da6a3ce929d0e0e4736"; // 16-byte hex
+    const hexSlug = new SpanComponentsV4({
+      object_type: SpanObjectTypeV3.PROJECT_LOGS,
+      object_id: "legacy-proj",
+      row_id: "bt-row",
+      span_id: pSpan,
+      root_span_id: pRoot,
+    }).toStr();
+
+    const child = logger.startSpan({ name: "child", parent: hexSlug });
+    // Links to the slug's hex ids; the child's own span id stays UUID.
+    expect(child.rootSpanId).toBe(pRoot);
+    expect(child.spanParents).toEqual([pSpan]);
+    expect(child.spanId.length).toBe(36);
+    child.end();
+  });
+});

--- a/js/src/propagation.ts
+++ b/js/src/propagation.ts
@@ -117,6 +117,12 @@ const ZERO_SPAN_ID = "0".repeat(16);
 const MAX_BAGGAGE_LENGTH = 8192;
 const MAX_BAGGAGE_MEMBERS = 64;
 
+// W3C Trace Context §3.3.1.5 limits tracestate to 32 list-members and 512
+// characters total. The grammar is ASCII-only, so character count and byte count
+// are equivalent after validation.
+const MAX_TRACESTATE_LENGTH = 512;
+const MAX_TRACESTATE_MEMBERS = 32;
+
 const _utf8Encoder = new TextEncoder();
 
 function utf8ByteLength(value: string): number {
@@ -213,6 +219,57 @@ function headerValueToString(value: unknown, name: string): string | undefined {
     return isListHeader(name) ? stringValues.join(",") : stringValues[0];
   }
   return typeof value === "string" ? value : String(value);
+}
+
+export function isValidTracestate(value: string | undefined | null): boolean {
+  if (!value || value.length > MAX_TRACESTATE_LENGTH) {
+    return false;
+  }
+
+  const members = value.split(",");
+  if (members.length > MAX_TRACESTATE_MEMBERS) {
+    return false;
+  }
+
+  const seenKeys = new Set<string>();
+  for (const rawMember of members) {
+    const member = rawMember.trim();
+    const eq = member.indexOf("=");
+    if (eq <= 0 || member.indexOf("=", eq + 1) !== -1) {
+      return false;
+    }
+
+    const key = member.slice(0, eq);
+    const valuePart = member.slice(eq + 1);
+    const keyIsValid =
+      /^[a-z][a-z0-9_\-*/]{0,255}$/.test(key) ||
+      /^[a-z][a-z0-9_\-*/]{0,240}@[a-z][a-z0-9_\-*/]{0,13}$/.test(key);
+    if (
+      !keyIsValid ||
+      seenKeys.has(key) ||
+      valuePart.length === 0 ||
+      valuePart.length > 256 ||
+      valuePart.charCodeAt(valuePart.length - 1) === 0x20
+    ) {
+      return false;
+    }
+    seenKeys.add(key);
+
+    for (let i = 0; i < valuePart.length; i++) {
+      const c = valuePart.charCodeAt(i);
+      const valid =
+        c === 0x20 ||
+        c === 0x21 ||
+        (c >= 0x23 && c <= 0x2b) ||
+        (c >= 0x2d && c <= 0x3c) ||
+        (c >= 0x3e && c <= 0x7e);
+      if (!valid) {
+        return false;
+      }
+    }
+  }
+
+  return true;
 }
 
 /**
@@ -439,11 +496,12 @@ export function parseBaggage(
  * `existing` is dropped in favor of the supplied value.
  *
  * The result is bounded to both W3C limits (§3.3.2): at most 64 list-members and
- * at most 8192 bytes. Our own `braintrust.parent` member is prioritized: its
- * byte cost and one member slot are reserved first, then relayed members are
- * appended in order until either budget is exhausted, always on whole-member
- * boundaries (never a partial list-member). Relayed members that do not fit are
- * dropped.
+ * at most 8192 bytes. Our own `braintrust.parent` member is prioritized when it
+ * fits: its byte cost and one member slot are reserved first, then relayed
+ * members are appended in order until either budget is exhausted, always on
+ * whole-member boundaries (never a partial list-member). Relayed members that do
+ * not fit are dropped. If the encoded `braintrust.parent` member is itself too
+ * large to fit in a valid baggage header, it is omitted.
  *
  * Returns the merged header value, or undefined if there is nothing to emit (so
  * callers omit the header rather than emit an empty one).
@@ -457,10 +515,13 @@ export function mergeBaggage(
     const encodedKey = percentEncode(BRAINTRUST_PARENT_KEY);
     const encodedVal = percentEncode(String(braintrustParent));
     btMember = `${encodedKey}=${encodedVal}`;
+    if (utf8ByteLength(btMember) > MAX_BAGGAGE_LENGTH) {
+      btMember = undefined;
+    }
   }
 
-  // Reserve both budgets for our own member first so it always survives; relayed
-  // members fill whatever space remains.
+  // Reserve both budgets for our own member first when it fits; relayed members
+  // fill whatever space remains.
   let byteBudget = MAX_BAGGAGE_LENGTH;
   let memberBudget = MAX_BAGGAGE_MEMBERS;
   if (btMember !== undefined) {

--- a/js/src/propagation.ts
+++ b/js/src/propagation.ts
@@ -1,0 +1,395 @@
+/**
+ * Native W3C Trace Context propagation for Braintrust.
+ *
+ * This module implements the propagation wire format described in the Braintrust
+ * distributed-tracing spec, in pure TypeScript with no dependency on
+ * `@opentelemetry/api`. It parses and serializes the W3C `traceparent` and
+ * `baggage` headers and the Braintrust `braintrust.parent` baggage entry.
+ *
+ * Trace identity (trace id + parent span id) is carried in `traceparent`; the
+ * Braintrust container the trace belongs to (project/experiment) is carried in
+ * `baggage` under the `braintrust.parent` key.
+ */
+
+export const TRACEPARENT_HEADER = "traceparent";
+export const TRACESTATE_HEADER = "tracestate";
+export const BAGGAGE_HEADER = "baggage";
+export const BRAINTRUST_PARENT_KEY = "braintrust.parent";
+
+// Trace-flags byte we emit for traces we originate: sampled (low bit set).
+const DEFAULT_TRACE_FLAGS = "01";
+
+/**
+ * Parsed W3C `traceparent` fields.
+ *
+ * `traceFlags` is the raw 2-hex trace-flags byte (e.g. `"01"` sampled, `"00"`
+ * not sampled), kept raw so any future flag bits survive a parse -> format
+ * round trip without per-bit handling.
+ */
+export interface ParsedTraceparent {
+  traceId: string;
+  spanId: string;
+  traceFlags: string;
+}
+
+/**
+ * Inbound W3C trace-context state that Braintrust forwards but never interprets.
+ *
+ * Captured at the span created from inbound headers (via `extractTraceContext`)
+ * and inherited by every subspan, so that any `inject()` within the trace
+ * re-emits the upstream state unchanged, per the W3C Trace Context spec.
+ *
+ * - `tracestate`: the W3C `tracestate` header (opaque vendor state).
+ * - `traceFlags`: the raw 2-hex `traceparent` trace-flags byte. Stored raw so
+ *   future flag bits are preserved without per-bit handling.
+ */
+export interface PropagatedState {
+  tracestate?: string;
+  traceFlags?: string;
+}
+
+// W3C traceparent: version-traceid-parentid-flags, version 00, lowercase hex.
+const TRACEPARENT_RE = /^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/;
+const ZERO_TRACE_ID = "0".repeat(32);
+const ZERO_SPAN_ID = "0".repeat(16);
+
+// W3C Baggage limits (§3.3.2): a conformant baggage-string must satisfy *both*
+// of these conditions. https://www.w3.org/TR/baggage/#limits
+//   - Condition 1: at most 64 list-members.
+//   - Condition 2: at most 8192 bytes total.
+//
+// We reuse these as a defensive bound on parsing/relaying untrusted inbound
+// headers: the header arrives from the network and is attacker-controllable, so
+// we never split or decode an unbounded string. When an inbound header exceeds
+// either limit we drop trailing list-members rather than truncate one mid-value:
+// the spec says a platform that cannot propagate all list-members "MUST NOT
+// propagate any partial list-members", so we keep only the leading whole members
+// that fit within both limits.
+const MAX_BAGGAGE_LENGTH = 8192;
+const MAX_BAGGAGE_MEMBERS = 64;
+
+const _utf8Encoder = new TextEncoder();
+
+function utf8ByteLength(value: string): number {
+  return _utf8Encoder.encode(value).length;
+}
+
+/**
+ * Return `value` bounded to the W3C limits, never splitting a list-member
+ * mid-value.
+ *
+ * Enforces both §3.3.2 limits: at most `MAX_BAGGAGE_MEMBERS` list-members and at
+ * most `MAX_BAGGAGE_LENGTH` UTF-8 bytes (the spec limit is a byte count, not
+ * code points). If the header is within both limits it is returned unchanged.
+ * Otherwise we keep the leading whole members that fit and drop the rest -- a
+ * trailing member that would be partial is never kept. If even the first member
+ * exceeds the byte limit there is no complete member to keep, so we return an
+ * empty string.
+ */
+function capBaggageToMemberBoundary(value: string): string {
+  const totalBytes = utf8ByteLength(value);
+  const withinBytes = totalBytes <= MAX_BAGGAGE_LENGTH;
+  // Cheap structural cap on member count: actual members are <= comma count + 1.
+  let commaCount = 0;
+  for (let i = 0; i < value.length; i++) {
+    if (value.charCodeAt(i) === 0x2c) {
+      commaCount++;
+    }
+  }
+  const withinMembers = commaCount < MAX_BAGGAGE_MEMBERS;
+  if (withinBytes && withinMembers) {
+    return value;
+  }
+
+  // Walk members in order, keeping whole ones until either limit is reached. We
+  // account on UTF-8 byte length so the byte budget is exact, and we only ever
+  // cut on comma boundaries so partial code points are never split.
+  const kept: string[] = [];
+  let length = 0;
+  for (const rawMember of value.split(",")) {
+    if (kept.length >= MAX_BAGGAGE_MEMBERS) {
+      break;
+    }
+    const cost = utf8ByteLength(rawMember) + (kept.length ? 1 : 0);
+    if (length + cost > MAX_BAGGAGE_LENGTH) {
+      break;
+    }
+    kept.push(rawMember);
+    length += cost;
+  }
+  if (!kept.length) {
+    // The first member alone already exceeds the byte limit.
+    return "";
+  }
+  return kept.join(",");
+}
+
+/**
+ * Normalize a raw header value to a single string.
+ *
+ * Node's `IncomingHttpHeaders` and some frameworks expose multi-valued headers
+ * as a string array; the W3C trace-context headers are single-valued, so we take
+ * the first element. Returns undefined for missing/empty values.
+ */
+function headerValueToString(value: unknown): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    const first = value[0];
+    return typeof first === "string" ? first : undefined;
+  }
+  return typeof value === "string" ? value : String(value);
+}
+
+/**
+ * Case-insensitive header lookup.
+ *
+ * Some frameworks normalize header names to title case (e.g. `Traceparent`)
+ * while the W3C keys are lowercase. Returns the first matching value or
+ * undefined. Array-valued headers (e.g. Node's `IncomingHttpHeaders`) are
+ * reduced to their first element, since these headers are single-valued.
+ */
+export function getHeader(
+  headers: Record<string, unknown> | null | undefined,
+  name: string,
+): string | undefined {
+  if (!headers) {
+    return undefined;
+  }
+  // Fast path: exact (lowercase) match.
+  const exact = headerValueToString(headers[name]);
+  if (exact !== undefined) {
+    return exact;
+  }
+  const lowered = name.toLowerCase();
+  for (const key of Object.keys(headers)) {
+    if (key !== name && key.toLowerCase() === lowered) {
+      const value = headerValueToString(headers[key]);
+      if (value !== undefined) {
+        return value;
+      }
+    }
+  }
+  return undefined;
+}
+
+function isHex(value: string | undefined | null, length: number): boolean {
+  if (typeof value !== "string" || value.length !== length) {
+    return false;
+  }
+  for (let i = 0; i < value.length; i++) {
+    const c = value[i];
+    const isDigit = c >= "0" && c <= "9";
+    const isLowerHex = c >= "a" && c <= "f";
+    if (!isDigit && !isLowerHex) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Parse a W3C `traceparent` value into a {@link ParsedTraceparent}.
+ *
+ * Returns `{ traceId, spanId, traceFlags }`, where `traceFlags` is the raw
+ * 2-hex trace-flags byte. Returns undefined for any malformed value (bad
+ * version, wrong length, non-hex, or all-zero ids). Never throws.
+ */
+export function parseTraceparent(
+  value: string | undefined | null,
+): ParsedTraceparent | undefined {
+  if (!value || typeof value !== "string") {
+    return undefined;
+  }
+  const match = TRACEPARENT_RE.exec(value.trim());
+  if (!match) {
+    return undefined;
+  }
+  const traceId = match[1];
+  const spanId = match[2];
+  const traceFlags = match[3];
+  if (traceId === ZERO_TRACE_ID || spanId === ZERO_SPAN_ID) {
+    return undefined;
+  }
+  return { traceId, spanId, traceFlags };
+}
+
+/**
+ * Serialize a W3C `traceparent` value from hex trace/span ids.
+ *
+ * `traceFlags` is the raw 2-hex trace-flags byte to emit; it is forwarded
+ * verbatim so any upstream/future flag bits survive. Falls back to
+ * `DEFAULT_TRACE_FLAGS` (sampled) when not a valid 2-hex byte. Returns undefined
+ * if the ids are not valid W3C-shaped hex (so callers can omit the header rather
+ * than emit something malformed).
+ */
+export function formatTraceparent(
+  traceId: string | undefined | null,
+  spanId: string | undefined | null,
+  traceFlags: string = DEFAULT_TRACE_FLAGS,
+): string | undefined {
+  if (!isHex(traceId, 32) || traceId === ZERO_TRACE_ID) {
+    return undefined;
+  }
+  if (!isHex(spanId, 16) || spanId === ZERO_SPAN_ID) {
+    return undefined;
+  }
+  const flags = isHex(traceFlags, 2) ? traceFlags : DEFAULT_TRACE_FLAGS;
+  return `00-${traceId}-${spanId}-${flags}`;
+}
+
+// Per W3C Baggage (§3.3.1.3), a value's unencoded bytes are restricted to the
+// `baggage-octet` set:
+//
+//   baggage-octet = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
+//
+// i.e. US-ASCII excluding CTLs, whitespace, DQUOTE, comma, semicolon, and
+// backslash; the percent sign MUST be encoded; and any non-ASCII code point MUST
+// be percent-encoded (as UTF-8 octets). We only ever encode our own
+// `braintrust.parent` member, whose value embeds an arbitrary, user-controlled
+// project/experiment name -- so it can contain any of those characters.
+//
+// `encodeURIComponent` percent-encodes every byte outside the set
+// `A-Z a-z 0-9 - _ . ! ~ * ' ( )`. Every char it leaves unencoded is within
+// `baggage-octet`, so the result is always spec-compliant: we may over-encode
+// some characters that are technically legal unencoded (the spec explicitly
+// permits this), but we never emit a byte that violates the grammar. Space is
+// emitted as `%20`, not the form-urlencoded `+`.
+//
+// On receive we decode with `decodeURIComponent`, the inverse of
+// `encodeURIComponent` (`%20` -> space, multi-byte UTF-8 reassembled). A literal
+// `+` in a value is encoded to `%2B` and decoded back to `+`, so it survives.
+//
+// Byte-for-byte pass-through of *other* vendors' baggage is handled separately
+// by `mergeBaggage`, which forwards their raw member strings unchanged rather
+// than round-tripping them through this codec.
+
+function percentEncode(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function percentDecode(value: string): string {
+  if (!value.includes("%")) {
+    return value;
+  }
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Parse a W3C `baggage` header into an ordered map of key -> value.
+ *
+ * Tolerates malformed/oversized input by skipping bad entries; never throws.
+ * Property metadata (after ';') is ignored. Keys and values are percent-decoded.
+ */
+export function parseBaggage(
+  value: string | undefined | null,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  if (!value || typeof value !== "string") {
+    return result;
+  }
+  // Oversized header: bound the work to whole list-members (never mid-value).
+  const bounded = capBaggageToMemberBoundary(value);
+  for (let member of bounded.split(",")) {
+    member = member.trim();
+    if (!member || !member.includes("=")) {
+      continue;
+    }
+    // Strip any ';'-delimited properties.
+    member = member.split(";", 1)[0];
+    const eq = member.indexOf("=");
+    const key = percentDecode(member.slice(0, eq).trim());
+    const val = member.slice(eq + 1).trim();
+    if (!key) {
+      continue;
+    }
+    result[key] = percentDecode(val);
+  }
+  return result;
+}
+
+/**
+ * Merge a `braintrust.parent` value into an existing `baggage` header.
+ *
+ * This preserves every other vendor's baggage member byte-for-byte: their raw
+ * `key=value` substrings (properties included) are forwarded exactly as received
+ * rather than decoded and re-encoded. Decoding then re-encoding would silently
+ * rewrite another vendor's percent-encoding (e.g. `path=a%2Fb` -> `path=a/b`),
+ * so we keep Braintrust a transparent relay. Whitespace around list members is
+ * insignificant per W3C and is trimmed.
+ *
+ * Only the `braintrust.parent` member is (re)serialized, by us, from the
+ * `braintrustParent` argument. Any pre-existing `braintrust.parent` member in
+ * `existing` is dropped in favor of the supplied value.
+ *
+ * The result is bounded to both W3C limits (§3.3.2): at most 64 list-members and
+ * at most 8192 bytes. Our own `braintrust.parent` member is prioritized: its
+ * byte cost and one member slot are reserved first, then relayed members are
+ * appended in order until either budget is exhausted, always on whole-member
+ * boundaries (never a partial list-member). Relayed members that do not fit are
+ * dropped.
+ *
+ * Returns the merged header value, or undefined if there is nothing to emit (so
+ * callers omit the header rather than emit an empty one).
+ */
+export function mergeBaggage(
+  existing: string | undefined | null,
+  braintrustParent: string | undefined | null,
+): string | undefined {
+  let btMember: string | undefined = undefined;
+  if (braintrustParent) {
+    const encodedKey = percentEncode(BRAINTRUST_PARENT_KEY);
+    const encodedVal = percentEncode(String(braintrustParent));
+    btMember = `${encodedKey}=${encodedVal}`;
+  }
+
+  // Reserve both budgets for our own member first so it always survives; relayed
+  // members fill whatever space remains.
+  let byteBudget = MAX_BAGGAGE_LENGTH;
+  let memberBudget = MAX_BAGGAGE_MEMBERS;
+  if (btMember !== undefined) {
+    // +1 for the comma joining our member to any preceding relayed member.
+    byteBudget -= utf8ByteLength(btMember) + 1;
+    memberBudget -= 1;
+  }
+
+  const relayed: string[] = [];
+  let length = 0;
+  if (existing && typeof existing === "string") {
+    for (const rawMember of existing.split(",")) {
+      const member = rawMember.trim();
+      if (!member || !member.includes("=")) {
+        continue;
+      }
+      // Identify the key (ignoring ';'-delimited properties) only to skip any
+      // inbound braintrust.parent; everything else is forwarded raw.
+      const keyPart = member.split(";", 1)[0].split("=", 1)[0];
+      const key = percentDecode(keyPart.trim());
+      if (key === BRAINTRUST_PARENT_KEY) {
+        continue;
+      }
+      // Stop at whole-member boundaries once either budget is exhausted; we
+      // never forward a partial member (W3C §3.3.2).
+      if (relayed.length >= memberBudget) {
+        break;
+      }
+      const cost = utf8ByteLength(member) + (relayed.length ? 1 : 0);
+      if (length + cost > byteBudget) {
+        break;
+      }
+      relayed.push(member);
+      length += cost;
+    }
+  }
+
+  const members = btMember !== undefined ? [...relayed, btMember] : relayed;
+  if (!members.length) {
+    return undefined;
+  }
+  return members.join(",");
+}

--- a/js/src/propagation.ts
+++ b/js/src/propagation.ts
@@ -49,7 +49,14 @@ export interface PropagatedState {
   traceFlags?: string;
 }
 
-type TraceContextHeaderValue = string | readonly string[] | null | undefined;
+type TraceContextHeaderValue =
+  | string
+  | number
+  | readonly string[]
+  | null
+  | undefined;
+
+export type TraceContextHeaderTuple = readonly [name: string, value: string];
 
 /**
  * Minimal structural interface for inbound HTTP headers.
@@ -59,7 +66,36 @@ type TraceContextHeaderValue = string | readonly string[] | null | undefined;
  */
 export type TraceContextHeaders =
   | { [name: string]: TraceContextHeaderValue }
-  | { get(name: string): TraceContextHeaderValue };
+  | { get(name: string): TraceContextHeaderValue }
+  | { getHeader(name: string): TraceContextHeaderValue }
+  | readonly TraceContextHeaderTuple[];
+
+/**
+ * Minimal structural interface for outbound HTTP header carriers.
+ *
+ * Supports plain objects, Web/Fetch-compatible `Headers`, Node/Fastify-style
+ * response carriers, and mutable `HeadersInit` tuple arrays.
+ */
+export type TraceContextCarrier =
+  | { [name: string]: TraceContextHeaderValue }
+  | {
+      get(name: string): TraceContextHeaderValue;
+      set(name: string, value: string): void;
+      delete?(name: string): void;
+    }
+  | {
+      getHeader(name: string): TraceContextHeaderValue;
+      setHeader(name: string, value: string): void;
+      removeHeader?(name: string): void;
+    }
+  | {
+      get?(name: string): TraceContextHeaderValue;
+      getHeader?(name: string): TraceContextHeaderValue;
+      header(name: string, value: string): void;
+      delete?(name: string): void;
+      removeHeader?(name: string): void;
+    }
+  | [string, string][];
 
 // W3C traceparent: version-traceid-parentid-flags, version 00, lowercase hex.
 const TRACEPARENT_RE = /^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/;
@@ -144,13 +180,37 @@ function capBaggageToMemberBoundary(value: string): string {
  * as a string array; the W3C trace-context headers are single-valued, so we take
  * the first element. Returns undefined for missing/empty values.
  */
-function headerValueToString(value: unknown): string | undefined {
+function isTraceContextHeaderTupleArray(
+  value: unknown,
+): value is readonly TraceContextHeaderTuple[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (item) =>
+        Array.isArray(item) &&
+        typeof item[0] === "string" &&
+        typeof item[1] === "string",
+    )
+  );
+}
+
+function isListHeader(name: string): boolean {
+  const lowered = name.toLowerCase();
+  return lowered === BAGGAGE_HEADER || lowered === TRACESTATE_HEADER;
+}
+
+function headerValueToString(value: unknown, name: string): string | undefined {
   if (value === undefined || value === null) {
     return undefined;
   }
   if (Array.isArray(value)) {
-    const first = value[0];
-    return typeof first === "string" ? first : undefined;
+    const stringValues = value.filter((item): item is string => {
+      return typeof item === "string";
+    });
+    if (!stringValues.length) {
+      return undefined;
+    }
+    return isListHeader(name) ? stringValues.join(",") : stringValues[0];
   }
   return typeof value === "string" ? value : String(value);
 }
@@ -161,21 +221,44 @@ function headerValueToString(value: unknown): string | undefined {
  * Some frameworks normalize header names to title case (e.g. `Traceparent`)
  * while the W3C keys are lowercase; Web `Headers` objects expose a
  * case-insensitive `.get(name)` method. Returns the first matching value or
- * undefined. Array-valued headers are reduced to their first element, since
- * these headers are single-valued.
+ * undefined. Array-valued `baggage` and `tracestate` headers are comma-joined;
+ * other array-valued headers are reduced to their first element.
  */
 export function getHeader(
-  headers: TraceContextHeaders | null | undefined,
+  headers: TraceContextHeaders | TraceContextCarrier | null | undefined,
   name: string,
 ): string | undefined {
   if (!headers) {
     return undefined;
   }
 
+  if (isTraceContextHeaderTupleArray(headers)) {
+    const lowered = name.toLowerCase();
+    const matches = headers
+      .filter(([key]) => key.toLowerCase() === lowered)
+      .map(([, value]) => value);
+    if (!matches.length) {
+      return undefined;
+    }
+    return headerValueToString(matches, name);
+  }
+
   const getter = (headers as { get?: unknown }).get;
   if (typeof getter === "function") {
     try {
-      const value = headerValueToString(getter.call(headers, name));
+      const value = headerValueToString(getter.call(headers, name), name);
+      if (value !== undefined) {
+        return value;
+      }
+    } catch {
+      // Fall back to other lookup styles for custom header-like objects.
+    }
+  }
+
+  const nodeGetter = (headers as { getHeader?: unknown }).getHeader;
+  if (typeof nodeGetter === "function") {
+    try {
+      const value = headerValueToString(nodeGetter.call(headers, name), name);
       if (value !== undefined) {
         return value;
       }
@@ -186,14 +269,14 @@ export function getHeader(
 
   const headerBag = headers as { [name: string]: TraceContextHeaderValue };
   // Fast path: exact (lowercase) match.
-  const exact = headerValueToString(headerBag[name]);
+  const exact = headerValueToString(headerBag[name], name);
   if (exact !== undefined) {
     return exact;
   }
   const lowered = name.toLowerCase();
   for (const key of Object.keys(headers)) {
     if (key !== name && key.toLowerCase() === lowered) {
-      const value = headerValueToString(headerBag[key]);
+      const value = headerValueToString(headerBag[key], name);
       if (value !== undefined) {
         return value;
       }

--- a/js/src/propagation.ts
+++ b/js/src/propagation.ts
@@ -35,9 +35,10 @@ export interface ParsedTraceparent {
 /**
  * Inbound W3C trace-context state that Braintrust forwards but never interprets.
  *
- * Captured at the span created from inbound headers (via `extractTraceContext`)
- * and inherited by every subspan, so that any `inject()` within the trace
- * re-emits the upstream state unchanged, per the W3C Trace Context spec.
+ * Captured at the span created from inbound headers (via
+ * `extractTraceContextFromHeaders`) and inherited by every subspan, so that any
+ * `inject()` within the trace re-emits the upstream state unchanged, per the W3C
+ * Trace Context spec.
  *
  * - `tracestate`: the W3C `tracestate` header (opaque vendor state).
  * - `traceFlags`: the raw 2-hex `traceparent` trace-flags byte. Stored raw so
@@ -47,6 +48,18 @@ export interface PropagatedState {
   tracestate?: string;
   traceFlags?: string;
 }
+
+type TraceContextHeaderValue = string | readonly string[] | null | undefined;
+
+/**
+ * Minimal structural interface for inbound HTTP headers.
+ *
+ * Covers Node/framework header bags and Web/Fetch-compatible `Headers` objects
+ * without depending on Node or DOM platform typings.
+ */
+export type TraceContextHeaders =
+  | { [name: string]: TraceContextHeaderValue }
+  | { get(name: string): TraceContextHeaderValue };
 
 // W3C traceparent: version-traceid-parentid-flags, version 00, lowercase hex.
 const TRACEPARENT_RE = /^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/;
@@ -146,26 +159,41 @@ function headerValueToString(value: unknown): string | undefined {
  * Case-insensitive header lookup.
  *
  * Some frameworks normalize header names to title case (e.g. `Traceparent`)
- * while the W3C keys are lowercase. Returns the first matching value or
- * undefined. Array-valued headers (e.g. Node's `IncomingHttpHeaders`) are
- * reduced to their first element, since these headers are single-valued.
+ * while the W3C keys are lowercase; Web `Headers` objects expose a
+ * case-insensitive `.get(name)` method. Returns the first matching value or
+ * undefined. Array-valued headers are reduced to their first element, since
+ * these headers are single-valued.
  */
 export function getHeader(
-  headers: Record<string, unknown> | null | undefined,
+  headers: TraceContextHeaders | null | undefined,
   name: string,
 ): string | undefined {
   if (!headers) {
     return undefined;
   }
+
+  const getter = (headers as { get?: unknown }).get;
+  if (typeof getter === "function") {
+    try {
+      const value = headerValueToString(getter.call(headers, name));
+      if (value !== undefined) {
+        return value;
+      }
+    } catch {
+      // Fall back to object lookup for custom header-like objects.
+    }
+  }
+
+  const headerBag = headers as { [name: string]: TraceContextHeaderValue };
   // Fast path: exact (lowercase) match.
-  const exact = headerValueToString(headers[name]);
+  const exact = headerValueToString(headerBag[name]);
   if (exact !== undefined) {
     return exact;
   }
   const lowered = name.toLowerCase();
   for (const key of Object.keys(headers)) {
     if (key !== name && key.toLowerCase() === lowered) {
-      const value = headerValueToString(headers[key]);
+      const value = headerValueToString(headerBag[key]);
       if (value !== undefined) {
         return value;
       }

--- a/js/src/propagation.ts
+++ b/js/src/propagation.ts
@@ -121,12 +121,6 @@ const ZERO_SPAN_ID = "0".repeat(16);
 const MAX_BAGGAGE_LENGTH = 8192;
 const MAX_BAGGAGE_MEMBERS = 64;
 
-// W3C Trace Context §3.3.1.5 limits tracestate to 32 list-members and 512
-// characters total. The grammar is ASCII-only, so character count and byte count
-// are equivalent after validation.
-const MAX_TRACESTATE_LENGTH = 512;
-const MAX_TRACESTATE_MEMBERS = 32;
-
 const _utf8Encoder = new TextEncoder();
 
 function utf8ByteLength(value: string): number {
@@ -223,57 +217,6 @@ function headerValueToString(value: unknown, name: string): string | undefined {
     return isListHeader(name) ? stringValues.join(",") : stringValues[0];
   }
   return typeof value === "string" ? value : String(value);
-}
-
-export function isValidTracestate(value: string | undefined | null): boolean {
-  if (!value || value.length > MAX_TRACESTATE_LENGTH) {
-    return false;
-  }
-
-  const members = value.split(",");
-  if (members.length > MAX_TRACESTATE_MEMBERS) {
-    return false;
-  }
-
-  const seenKeys = new Set<string>();
-  for (const rawMember of members) {
-    const member = rawMember.trim();
-    const eq = member.indexOf("=");
-    if (eq <= 0 || member.indexOf("=", eq + 1) !== -1) {
-      return false;
-    }
-
-    const key = member.slice(0, eq);
-    const valuePart = member.slice(eq + 1);
-    const keyIsValid =
-      /^[a-z][a-z0-9_\-*/]{0,255}$/.test(key) ||
-      /^[a-z][a-z0-9_\-*/]{0,240}@[a-z][a-z0-9_\-*/]{0,13}$/.test(key);
-    if (
-      !keyIsValid ||
-      seenKeys.has(key) ||
-      valuePart.length === 0 ||
-      valuePart.length > 256 ||
-      valuePart.charCodeAt(valuePart.length - 1) === 0x20
-    ) {
-      return false;
-    }
-    seenKeys.add(key);
-
-    for (let i = 0; i < valuePart.length; i++) {
-      const c = valuePart.charCodeAt(i);
-      const valid =
-        c === 0x20 ||
-        c === 0x21 ||
-        (c >= 0x23 && c <= 0x2b) ||
-        (c >= 0x2d && c <= 0x3c) ||
-        (c >= 0x3e && c <= 0x7e);
-      if (!valid) {
-        return false;
-      }
-    }
-  }
-
-  return true;
 }
 
 /**

--- a/js/src/propagation.ts
+++ b/js/src/propagation.ts
@@ -43,10 +43,14 @@ export interface ParsedTraceparent {
  * - `tracestate`: the W3C `tracestate` header (opaque vendor state).
  * - `traceFlags`: the raw 2-hex `traceparent` trace-flags byte. Stored raw so
  *   future flag bits are preserved without per-bit handling.
+ * - `braintrustParent`: the resolved `braintrust.parent` value, kept so
+ *   id-based propagated parents can be re-injected synchronously before their
+ *   lazy object id has been awaited.
  */
 export interface PropagatedState {
   tracestate?: string;
   traceFlags?: string;
+  braintrustParent?: string;
 }
 
 type TraceContextHeaderValue =

--- a/js/tests/api-compatibility/api-compatibility.test.ts
+++ b/js/tests/api-compatibility/api-compatibility.test.ts
@@ -630,18 +630,43 @@ function areFunctionSignaturesCompatible(
   oldFn: string,
   newFn: string,
 ): boolean {
-  // Extract function name and parameters
+  // Extract function name and parameters. The parameter list is extracted by
+  // balancing parentheses (rather than a `[^)]*` regex) so that parameters whose
+  // types contain their own parentheses -- e.g. a `callback: () => R` arrow type
+  // -- are captured in full instead of truncating the signature.
   const parseFunctionSig = (sig: string) => {
-    // Match: export function name(params): returnType OR function name(params): returnType (for re-exports)
-    const match = sig.match(
-      /(?:export\s+)?(?:declare\s+)?function\s+(\w+)\s*\(([^)]*)\)\s*:\s*(.+)$/,
+    const headerMatch = sig.match(
+      /(?:export\s+)?(?:declare\s+)?function\s+(\w+)\s*(?:<[^(]*>)?\s*\(/,
     );
-    if (!match) return null;
+    if (!headerMatch || headerMatch.index === undefined) return null;
+    const name = headerMatch[1];
+
+    const openParenIndex = headerMatch.index + headerMatch[0].length - 1;
+    let depth = 0;
+    let closeParenIndex = -1;
+    for (let i = openParenIndex; i < sig.length; i++) {
+      const char = sig[i];
+      if (char === "(") {
+        depth++;
+      } else if (char === ")") {
+        depth--;
+        if (depth === 0) {
+          closeParenIndex = i;
+          break;
+        }
+      }
+    }
+    if (closeParenIndex === -1) return null;
+
+    const params = sig.slice(openParenIndex + 1, closeParenIndex).trim();
+    const afterParams = sig.slice(closeParenIndex + 1).trim();
+    if (!afterParams.startsWith(":")) return null;
+    const returnType = afterParams.slice(1).trim();
 
     return {
-      name: match[1],
-      params: match[2].trim(),
-      returnType: match[3].trim(),
+      name,
+      params,
+      returnType,
     };
   };
 
@@ -733,8 +758,11 @@ function areFunctionSignaturesCompatible(
       return false;
     }
 
-    if (oldParam.type !== newParam.type) {
-      // Parameter type changed - breaking change
+    if (
+      oldParam.type !== newParam.type &&
+      !areParamTypesCompatible(oldParam.type, newParam.type)
+    ) {
+      // Parameter type changed incompatibly - breaking change
       return false;
     }
 
@@ -788,6 +816,38 @@ function normalizeTypeReference(type: string): string {
 function isObjectLiteralType(def: string): boolean {
   const trimmed = def.trim();
   return trimmed.startsWith("{") && trimmed.endsWith("}");
+}
+
+// True if the type text contains an inline object literal (e.g. an options
+// object, possibly inside an intersection like `A & B & { ... }`).
+function containsObjectLiteralType(def: string): boolean {
+  return def.includes("{") && def.includes("}");
+}
+
+/**
+ * True if a parameter type changed from `oldType` to `newType` in a
+ * backwards-compatible way: identical, widened to a union that still accepts the
+ * old type (`T` -> `T | U`), or an object-literal/options type whose fields were
+ * only added (optional) or widened (e.g. an inline `{ parent?: string }` ->
+ * `{ parent?: string | Context }`, including inside an intersection).
+ */
+function areParamTypesCompatible(oldType: string, newType: string): boolean {
+  const oldNorm = normalizeTypeReference(oldType.replace(/\s+/g, " ").trim());
+  const newNorm = normalizeTypeReference(newType.replace(/\s+/g, " ").trim());
+  if (oldNorm === newNorm) {
+    return true;
+  }
+  if (isUnionTypeWidening(oldNorm, newNorm)) {
+    return true;
+  }
+  if (
+    containsObjectLiteralType(oldType) &&
+    containsObjectLiteralType(newType) &&
+    areObjectTypeDefinitionsCompatible(oldType, newType)
+  ) {
+    return true;
+  }
+  return false;
 }
 
 function parseObjectTypeProps(
@@ -1283,6 +1343,12 @@ function areInterfaceSignaturesCompatible(
   oldInterface: string,
   newInterface: string,
 ): boolean {
+  type InterfaceMethod = {
+    params: Array<{ type: string; optional: boolean }>;
+    returnType: string;
+    optional: boolean;
+  };
+
   const parseInterface = (interfaceSig: string) => {
     const sourceFile = ts.createSourceFile(
       "interface.ts",
@@ -1304,20 +1370,35 @@ function areInterfaceSignaturesCompatible(
     }
 
     const fields = new Map<string, { type: string; optional: boolean }>();
+    const methods = new Map<string, InterfaceMethod>();
     for (const member of declaration.members) {
-      if (!ts.isPropertySignature(member) || !member.type) {
+      if (ts.isPropertySignature(member) && member.type) {
+        fields.set(member.name.getText(sourceFile), {
+          type: member.type.getText(sourceFile),
+          optional: !!member.questionToken,
+        });
+      } else if (ts.isMethodSignature(member)) {
+        // Method members (e.g. `inject(carrier?): ...`) are captured so that
+        // adding a method, or widening a method's parameters, can be recognized
+        // as backwards compatible rather than treated as unparseable.
+        methods.set(member.name.getText(sourceFile), {
+          params: member.parameters.map((param) => ({
+            type: param.type ? param.type.getText(sourceFile) : "any",
+            optional: !!param.questionToken || !!param.initializer,
+          })),
+          returnType: member.type ? member.type.getText(sourceFile) : "any",
+          optional: !!member.questionToken,
+        });
+      } else {
+        // Unknown member kind (e.g. index/call signatures) - be conservative.
         return null;
       }
-
-      fields.set(member.name.getText(sourceFile), {
-        type: member.type.getText(sourceFile),
-        optional: !!member.questionToken,
-      });
     }
 
     return {
       name: declaration.name.text,
       fields,
+      methods,
     };
   };
 
@@ -1330,6 +1411,8 @@ function areInterfaceSignaturesCompatible(
 
   const oldFields = oldParsed.fields;
   const newFields = newParsed.fields;
+  const oldMethods = oldParsed.methods;
+  const newMethods = newParsed.methods;
 
   // Check that all old fields exist in new interface with compatible types
   for (const [fieldName, oldField] of oldFields) {
@@ -1384,6 +1467,55 @@ function areInterfaceSignaturesCompatible(
       // New optional field - compatible
     }
   }
+
+  // Existing methods must still exist with a compatible signature.
+  const normalizeType = (type: string) =>
+    normalizeTypeReference(type.replace(/\s+/g, " ").trim());
+  for (const [methodName, oldMethod] of oldMethods) {
+    const newMethod = newMethods.get(methodName);
+    if (!newMethod) {
+      // Method removed - breaking change
+      return false;
+    }
+
+    if (
+      normalizeType(oldMethod.returnType) !==
+      normalizeType(newMethod.returnType)
+    ) {
+      // Return type changed - breaking change
+      return false;
+    }
+
+    // Each previously-existing parameter must remain, with a compatible type
+    // (identical or widened to a union that still accepts the old type) and may
+    // not become required if it was optional.
+    for (let i = 0; i < oldMethod.params.length; i++) {
+      const oldParam = oldMethod.params[i];
+      const newParam = newMethod.params[i];
+      if (!newParam) {
+        return false;
+      }
+      if (
+        oldParam.type !== newParam.type &&
+        !areParamTypesCompatible(oldParam.type, newParam.type)
+      ) {
+        return false;
+      }
+      if (oldParam.optional && !newParam.optional) {
+        return false;
+      }
+    }
+
+    // Any added parameters must be optional.
+    for (let i = oldMethod.params.length; i < newMethod.params.length; i++) {
+      if (!newMethod.params[i].optional) {
+        return false;
+      }
+    }
+  }
+
+  // Newly-added methods are additive (existing callers are unaffected), matching
+  // how new optional fields are treated above.
 
   // All checks passed - interfaces are compatible
   return true;
@@ -2189,6 +2321,63 @@ describe("areInterfaceSignaturesCompatible", () => {
     const result = areInterfaceSignaturesCompatible(oldInterface, newInterface);
     expect(result).toBe(true);
   });
+
+  test("should allow adding a new method to an interface", () => {
+    // Real-world case: adding `inject(carrier?)` to the Span interface.
+    const oldInterface = `export interface Span { export(): Promise<string>; link(): string; }`;
+    const newInterface = `export interface Span { export(): Promise<string>; inject(carrier?: Record<string, string>): Record<string, string>; link(): string; }`;
+
+    const result = areInterfaceSignaturesCompatible(oldInterface, newInterface);
+    expect(result).toBe(true);
+  });
+
+  test("should reject removing a method from an interface", () => {
+    const oldInterface = `export interface Span { export(): Promise<string>; link(): string; }`;
+    const newInterface = `export interface Span { export(): Promise<string>; }`;
+
+    const result = areInterfaceSignaturesCompatible(oldInterface, newInterface);
+    expect(result).toBe(false);
+  });
+
+  test("should allow widening a method parameter type to a union", () => {
+    const oldInterface = `export interface Api { run(parent: string): void; }`;
+    const newInterface = `export interface Api { run(parent: string | PropagationContext): void; }`;
+
+    const result = areInterfaceSignaturesCompatible(oldInterface, newInterface);
+    expect(result).toBe(true);
+  });
+
+  test("should reject narrowing a method parameter type", () => {
+    const oldInterface = `export interface Api { run(parent: string | PropagationContext): void; }`;
+    const newInterface = `export interface Api { run(parent: string): void; }`;
+
+    const result = areInterfaceSignaturesCompatible(oldInterface, newInterface);
+    expect(result).toBe(false);
+  });
+
+  test("should reject changing a method return type", () => {
+    const oldInterface = `export interface Api { run(): void; }`;
+    const newInterface = `export interface Api { run(): string; }`;
+
+    const result = areInterfaceSignaturesCompatible(oldInterface, newInterface);
+    expect(result).toBe(false);
+  });
+
+  test("should allow adding an optional parameter to a method", () => {
+    const oldInterface = `export interface Api { run(): void; }`;
+    const newInterface = `export interface Api { run(opts?: Options): void; }`;
+
+    const result = areInterfaceSignaturesCompatible(oldInterface, newInterface);
+    expect(result).toBe(true);
+  });
+
+  test("should reject adding a required parameter to a method", () => {
+    const oldInterface = `export interface Api { run(): void; }`;
+    const newInterface = `export interface Api { run(opts: Options): void; }`;
+
+    const result = areInterfaceSignaturesCompatible(oldInterface, newInterface);
+    expect(result).toBe(false);
+  });
 });
 
 describe("areClassSignaturesCompatible", () => {
@@ -2331,6 +2520,40 @@ describe("areFunctionSignaturesCompatible", () => {
     const oldFn = `export function foo(a: string): void`;
     const newFn = `export function foo(a: string): number`;
     expect(areFunctionSignaturesCompatible(oldFn, newFn)).toBe(false);
+  });
+
+  test("should allow widening a parameter type to a union", () => {
+    // Real-world case: `withParent(parent: string)` ->
+    // `withParent(parent: string | PropagationContext)`.
+    const oldFn = `export function withParent<R>(parent: string, callback: () => R): R`;
+    const newFn = `export function withParent<R>(parent: string | PropagationContext, callback: () => R): R`;
+    expect(areFunctionSignaturesCompatible(oldFn, newFn)).toBe(true);
+  });
+
+  test("should reject narrowing a parameter type from a union", () => {
+    const oldFn = `export function foo(a: string | number): void`;
+    const newFn = `export function foo(a: string): void`;
+    expect(areFunctionSignaturesCompatible(oldFn, newFn)).toBe(false);
+  });
+
+  test("should allow widening a field inside an options-object parameter", () => {
+    // Real-world case: getSpanParentObject's options param widens its nested
+    // `parent?` field from `string` to `string | PropagationContext`.
+    const oldFn = `export function getSpanParentObject<IsAsyncFlush extends boolean>(options?: AsyncFlushArg<IsAsyncFlush> & OptionalStateArg & { parent?: string; }): Span`;
+    const newFn = `export function getSpanParentObject<IsAsyncFlush extends boolean>(options?: AsyncFlushArg<IsAsyncFlush> & OptionalStateArg & { parent?: string | PropagationContext; }): Span`;
+    expect(areFunctionSignaturesCompatible(oldFn, newFn)).toBe(true);
+  });
+
+  test("should reject adding a required field to an options-object parameter", () => {
+    const oldFn = `export function foo(options?: { a?: string; }): void`;
+    const newFn = `export function foo(options?: { a?: string; b: number; }): void`;
+    expect(areFunctionSignaturesCompatible(oldFn, newFn)).toBe(false);
+  });
+
+  test("should handle a parameter whose type is an arrow function", () => {
+    const oldFn = `export function withParent<R>(parent: string, callback: () => R, state?: BraintrustState | undefined): R`;
+    const newFn = `export function withParent<R>(parent: string | PropagationContext, callback: () => R, state?: BraintrustState | undefined): R`;
+    expect(areFunctionSignaturesCompatible(oldFn, newFn)).toBe(true);
   });
 });
 

--- a/js/util/object.ts
+++ b/js/util/object.ts
@@ -90,6 +90,9 @@ export type ExperimentEvent = Partial<InputField> &
     span_parents: string[];
     span_attributes: Record<string, unknown>;
     context: Record<string, unknown>;
+    // Server-populated on read: whether this row is the root span of its trace.
+    // a root span id may differ from its trace id so `is_root` is the authoritative root marker.
+    is_root: boolean | null;
     [AUDIT_SOURCE_FIELD]: Source;
     [AUDIT_METADATA_FIELD]?: Record<string, unknown>;
   }>;


### PR DESCRIPTION
implements: https://github.com/braintrustdata/braintrust-spec/blob/main/docs/features/distributed-tracing.md

- use otel-friendly IDs by default in the SDK
- add inject/extract methods for distributed tracing instead of parent slug methods
    - implements: https://www.w3.org/TR/trace-context/

OLD WAY: https://www.braintrust.dev/docs/instrument/advanced-tracing#trace-distributed-systems
```typescript
import { currentSpan, initLogger, startSpan, traced } from "braintrust";

const logger = initLogger({ projectName: "my-project" });

// Client: Export the span
const processRequest = (request: Request) =>
  traced(
    async (span) =>
      fetch("/api/process", {
        method: "POST",
        body: JSON.stringify(request),
        headers: { "X-Trace-ID": await currentSpan().export() },
      }),
  );

// Server: Resume the trace
async function handleRequest(req: Request) {
  const traceId = req.headers.get("X-Trace-ID") ?? undefined;

  return traced(
    async (span) => {
      const result = await processData(req.body);
      span.log({ input: req.body, output: result });
      return result;
    },
    { parent: traceId },
  );
}
```

NOTE: the "old way" is still supported and backwards-compatible. Native SDKs can continue to link to each other in the manner, even if one is upgraded and the other is not. However if users with to link to otel sdks, they will have to change their code to use the new apis.

NEW WAY:
```typescript
import {
  currentSpan,
  extractTraceContext,
  initLogger,
  startSpan,
  traced,
} from "braintrust";

const logger = initLogger({ projectName: "my-project" });

// Client: Export the span
const processRequest = (request: Request) =>
  traced(
    async (span) =>
      fetch("/api/process", {
        method: "POST",
        body: JSON.stringify(request),
        headers: currentSpan().inject({}), // <--- new inject api
      }),
  );

// Server: Resume the trace
async function handleRequest(req: Request) {
  return traced(
    async (span) => {
      const result = await processData(req.body);
      span.log({ input: req.body, output: result });
      return result;
    },
    { parent: extractTraceContext(req.headers) }, // <--- new extract api
  );
}
```

# Other notes

- confusing naming: this has the unfortunate effect of the `root_span_id` field essentially becoming the trace id rather than the id of the root span (i.e. `root_span_id` != `rootSpan.id`). This sucks, but it's already the case for otel sdks and py otel compat mode. So at least we're consistent.
- legacy id flag: the sdk currently maintains two paths for id generation. it defaults to UUIDs and does hex IDs when we're in in otel compat mode. This changes the default to use hex IDs and has a flag to revert to the old behavior (`BRAINTRUST_LEGACY_IDS`). We could just rip out the old uuid logic entirely, but this approach seems like the least risky
- to support passing through tracestate and flags, an additional field was added to SpanImpl (propagatedState)

# examples

- https://www.braintrust.dev/app/Braintrust%20SDKs/p/distributed-tracing-test/trace?object_type=project_logs&object_id=d010dc4b-b4f2-421e-a165-232a8e6f062f&r=c7681ae1d7754e3fd27a06fb53c6fc29&s=decc9abf92ddeae5
- https://www.braintrust.dev/app/Braintrust%20SDKs/p/distributed-tracing-test/logs?r=6449255f3c9a8f7121cf9ce04c6d73f6&s=4180f4889809461e