### PR TITLE
feat: Add support for `@anthropic-ai/bedrock-sdk`

### DIFF
--- a/.changeset/moody-houses-like.md
+++ b/.changeset/moody-houses-like.md
@@ -1,0 +1,5 @@
+---
+"braintrust": minor
+---
+
+feat: Add support for `@anthropic-ai/bedrock-sdk`

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -100,6 +100,7 @@ Provider credentials are only required when recording or explicitly running live
 
 - `OPENAI_API_KEY`
 - `ANTHROPIC_API_KEY`
+- `AWS_BEARER_TOKEN_BEDROCK`
 - `GEMINI_API_KEY` or `GOOGLE_API_KEY`
 - `CURSOR_API_KEY`
 - `OPENROUTER_API_KEY`
@@ -109,6 +110,8 @@ Provider credentials are only required when recording or explicitly running live
 - `GROQ_API_KEY`
 
 `claude-agent-sdk-instrumentation` also uses `ANTHROPIC_API_KEY`, because it runs the real Claude Agent SDK against Anthropic in the same style as the existing live Anthropic wrapper coverage.
+
+`anthropic-bedrock-instrumentation` uses `AWS_BEARER_TOKEN_BEDROCK`; when recording, its region resolves from `AWS_REGION`, then `AWS_DEFAULT_REGION`, then `us-east-1`, and its model can be overridden with `BRAINTRUST_ANTHROPIC_BEDROCK_MODEL`.
 
 `test:e2e:canary` runs inside Docker because it installs packages on the latest versions and those packages may contain malicious code (supply-chain attacks).
 
@@ -134,7 +137,7 @@ The mock Braintrust server captures **outbound** SDK→Braintrust traffic and sn
 
 The cassette layer is backed by the internal `@braintrust/seinfeld` workspace package. For e2e tests, the harness starts a local cassette HTTP server and points provider SDK base URLs at that server.
 
-- **Layer:** `withScenarioHarness(...)` starts a `createCassetteServer()` instance for cassette-enabled scenario runs. Provider base URL env vars (for OpenAI, Anthropic, Google, Cohere, Cursor, Groq, HuggingFace, Mistral, OpenRouter, and the GitHub Copilot SDK's OpenAI provider mode) point at route prefixes on that server, so subprocesses and SDK-launched binaries can be captured too.
+- **Layer:** `withScenarioHarness(...)` starts a `createCassetteServer()` instance for cassette-enabled scenario runs. Provider base URL env vars (for OpenAI, Anthropic, Anthropic Bedrock, Google, Cohere, Cursor, Groq, HuggingFace, Mistral, OpenRouter, and the GitHub Copilot SDK's OpenAI provider mode) point at route prefixes on that server, so subprocesses and SDK-launched binaries can be captured too.
 - **Auto-engage:** the harness automatically engages the cassette layer when (a) a scenario run has `runContext.variantKey`, (b) a cassette JSON exists for the scenario+variant on disk, OR (c) `BRAINTRUST_E2E_CASSETTE_MODE` is `record` / `record-missing`. Scenarios just need to thread `runContext: { variantKey, originalScenarioDir }` into their runner calls — no other code change required.
 - **Provider replay failures:** provider scenarios are not skipped when a cassette is missing. In replay mode, the cassette server still starts from `runContext.variantKey`, injects placeholder provider keys, and fails on cassette misses instead of silently calling a live provider.
 - **Mode** is set by `BRAINTRUST_E2E_CASSETTE_MODE`:
@@ -157,7 +160,8 @@ pnpm run test:e2e:record -- <name>
 pnpm --filter=@braintrust/js-e2e-tests run test:e2e:record -- <name>
 
 # Or via shell env:
-ANTHROPIC_API_KEY=... OPENAI_API_KEY=... GEMINI_API_KEY=... \
+ANTHROPIC_API_KEY=... AWS_BEARER_TOKEN_BEDROCK=... \
+OPENAI_API_KEY=... GEMINI_API_KEY=... \
 COHERE_API_KEY=... GROQ_API_KEY=... HUGGINGFACE_API_KEY=... \
 MISTRAL_API_KEY=... OPENROUTER_API_KEY=... \
 CURSOR_API_KEY=... \
@@ -167,7 +171,7 @@ CURSOR_API_KEY=... \
 After recording, run again **without any provider keys** to confirm the cassette is sufficient:
 
 ```bash
-unset ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY GOOGLE_API_KEY GOOGLE_GENAI_API_KEY COHERE_API_KEY GROQ_API_KEY HUGGINGFACE_API_KEY MISTRAL_API_KEY OPENROUTER_API_KEY CURSOR_API_KEY
+unset ANTHROPIC_API_KEY AWS_BEARER_TOKEN_BEDROCK OPENAI_API_KEY GEMINI_API_KEY GOOGLE_API_KEY GOOGLE_GENAI_API_KEY COHERE_API_KEY GROQ_API_KEY HUGGINGFACE_API_KEY MISTRAL_API_KEY OPENROUTER_API_KEY CURSOR_API_KEY
 pnpm --filter=@braintrust/js-e2e-tests run test:e2e
 ```
 
@@ -179,7 +183,7 @@ After any successful record run, stale cassette variants are cleaned only inside
 
 These scenarios have cassette wiring in place and will use cassettes once they're recorded:
 
-`anthropic-instrumentation`, `openai-instrumentation`, `openai-codex-instrumentation`, `ai-sdk-instrumentation`, `ai-sdk-otel-export`, `claude-agent-sdk-instrumentation`, `cohere-instrumentation`, `cursor-sdk-instrumentation`, `github-copilot-instrumentation`, `google-adk-instrumentation`, `google-genai-instrumentation`, `groq-instrumentation`, `huggingface-instrumentation`, `mistral-instrumentation`, `openrouter-agent-instrumentation`, `openrouter-instrumentation`, `wrap-langchain-js-traces`.
+`anthropic-bedrock-instrumentation`, `anthropic-instrumentation`, `openai-instrumentation`, `openai-codex-instrumentation`, `ai-sdk-instrumentation`, `ai-sdk-otel-export`, `claude-agent-sdk-instrumentation`, `cohere-instrumentation`, `cursor-sdk-instrumentation`, `github-copilot-instrumentation`, `google-adk-instrumentation`, `google-genai-instrumentation`, `groq-instrumentation`, `huggingface-instrumentation`, `mistral-instrumentation`, `openrouter-agent-instrumentation`, `openrouter-instrumentation`, `wrap-langchain-js-traces`.
 
 ### Cassette format
 

--- a/e2e/config/pr-comment-scenarios.json
+++ b/e2e/config/pr-comment-scenarios.json
@@ -49,6 +49,25 @@
     ]
   },
   {
+    "scenarioDirName": "anthropic-bedrock-instrumentation",
+    "label": "Anthropic Bedrock Instrumentation",
+    "metadataScenario": "anthropic-bedrock-instrumentation",
+    "variants": [
+      {
+        "variantKey": "anthropic-bedrock-v0302-wrapped",
+        "label": "v0.30.2 wrapped"
+      },
+      {
+        "variantKey": "anthropic-bedrock-v0302-auto-esm",
+        "label": "v0.30.2 auto ESM"
+      },
+      {
+        "variantKey": "anthropic-bedrock-v0302-auto-cjs",
+        "label": "v0.30.2 auto CJS"
+      }
+    ]
+  },
+  {
     "scenarioDirName": "google-adk-instrumentation",
     "label": "Google ADK Instrumentation",
     "metadataScenario": "google-adk-instrumentation",

--- a/e2e/helpers/scenario-harness.ts
+++ b/e2e/helpers/scenario-harness.ts
@@ -47,6 +47,7 @@ const HELPERS_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HELPERS_DIR, "../..");
 const RUN_CONTEXT_DIR_ENV = "BRAINTRUST_E2E_RUN_CONTEXT_DIR";
 const CASSETTE_MODE_ENV = "BRAINTRUST_E2E_CASSETTE_MODE";
+const DEFAULT_ANTHROPIC_BEDROCK_REGION = "us-east-1";
 
 type ScenarioRunner = "deno" | "node" | "tsx";
 
@@ -282,25 +283,39 @@ interface ActiveCassetteWiring extends CassetteWiring {
   serverUrl: string;
 }
 
-const CASSETTE_SERVER_ROUTES: CassetteServerRoute[] = [
-  { prefix: "/anthropic", upstreamOrigin: "https://api.anthropic.com" },
-  { prefix: "/cohere", upstreamOrigin: "https://api.cohere.com" },
-  { prefix: "/cursor/v1", upstreamOrigin: "https://api.cursor.com/v1" },
-  { prefix: "/cursor", upstreamOrigin: "https://api2.cursor.sh" },
-  {
-    prefix: "/google-generative-language",
-    upstreamOrigin: "https://generativelanguage.googleapis.com",
-  },
-  { prefix: "/groq", upstreamOrigin: "https://api.groq.com" },
-  { prefix: "/huggingface", upstreamOrigin: "https://huggingface.co" },
-  {
-    prefix: "/huggingface-router",
-    upstreamOrigin: "https://router.huggingface.co",
-  },
-  { prefix: "/mistral", upstreamOrigin: "https://api.mistral.ai" },
-  { prefix: "/openai", upstreamOrigin: "https://api.openai.com" },
-  { prefix: "/openrouter", upstreamOrigin: "https://openrouter.ai" },
-];
+function getAnthropicBedrockRegion(): string {
+  return (
+    process.env.AWS_REGION ||
+    process.env.AWS_DEFAULT_REGION ||
+    DEFAULT_ANTHROPIC_BEDROCK_REGION
+  );
+}
+
+function getCassetteServerRoutes(): CassetteServerRoute[] {
+  return [
+    { prefix: "/anthropic", upstreamOrigin: "https://api.anthropic.com" },
+    {
+      prefix: "/anthropic-bedrock",
+      upstreamOrigin: `https://bedrock-runtime.${getAnthropicBedrockRegion()}.amazonaws.com`,
+    },
+    { prefix: "/cohere", upstreamOrigin: "https://api.cohere.com" },
+    { prefix: "/cursor/v1", upstreamOrigin: "https://api.cursor.com/v1" },
+    { prefix: "/cursor", upstreamOrigin: "https://api2.cursor.sh" },
+    {
+      prefix: "/google-generative-language",
+      upstreamOrigin: "https://generativelanguage.googleapis.com",
+    },
+    { prefix: "/groq", upstreamOrigin: "https://api.groq.com" },
+    { prefix: "/huggingface", upstreamOrigin: "https://huggingface.co" },
+    {
+      prefix: "/huggingface-router",
+      upstreamOrigin: "https://router.huggingface.co",
+    },
+    { prefix: "/mistral", upstreamOrigin: "https://api.mistral.ai" },
+    { prefix: "/openai", upstreamOrigin: "https://api.openai.com" },
+    { prefix: "/openrouter", upstreamOrigin: "https://openrouter.ai" },
+  ];
+}
 
 const CASSETTE_IGNORED_REQUESTS = [
   /^https:\/\/api2\.cursor\.sh\/aiserver\.v1\.AnalyticsService\/TrackEvents$/,
@@ -315,6 +330,7 @@ function getCassetteEnv(wiring: ActiveCassetteWiring): Record<string, string> {
     BRAINTRUST_E2E_CASSETTE_VARIANT: wiring.variantKey,
     BRAINTRUST_E2E_MODEL_BASE_URL: `${serverUrl}/openai/v1`,
     ANTHROPIC_BASE_URL: `${serverUrl}/anthropic`,
+    ANTHROPIC_BEDROCK_BASE_URL: `${serverUrl}/anthropic-bedrock`,
     COHERE_BASE_URL: `${serverUrl}/cohere`,
     COHERE_API_URL: `${serverUrl}/cohere`,
     CURSOR_BACKEND_URL: `${serverUrl}/cursor`,
@@ -361,6 +377,10 @@ const CASSETTE_PROVIDER_KEYS: Array<{
   {
     envVars: ["ANTHROPIC_API_KEY"],
     placeholder: "sk-ant-cassette-placeholder",
+  },
+  {
+    envVars: ["AWS_BEARER_TOKEN_BEDROCK"],
+    placeholder: "cassette-placeholder",
   },
   {
     envVars: ["COHERE_API_KEY", "CO_API_KEY"],
@@ -760,7 +780,7 @@ export async function withScenarioHarness(
       redact: cassetteOptions.redact,
       streamingRequests: cassetteOptions.streamingRequests,
       ignoredRequests: CASSETTE_IGNORED_REQUESTS,
-      routes: CASSETTE_SERVER_ROUTES,
+      routes: getCassetteServerRoutes(),
       onMiss: (req) => {
         process.stderr.write(`[cassette] MISS: ${req.method} ${req.url}\n`);
       },

--- a/e2e/scenarios/anthropic-bedrock-instrumentation/__cassettes__/anthropic-bedrock-v0302-auto-cjs.cassette.json
+++ b/e2e/scenarios/anthropic-bedrock-instrumentation/__cassettes__/anthropic-bedrock-v0302-auto-cjs.cassette.json
@@ -1,0 +1,117 @@
+{
+  "entries": [
+    {
+      "callIndex": 0,
+      "id": "e6926053c025e8b6",
+      "matchKey": "POST bedrock-runtime.aws-region.amazonaws.com/model/us.anthropic.claude-sonnet-4-5-20250929-v1:0/invoke",
+      "recordedAt": "2026-06-18T15:28:20.701Z",
+      "request": {
+        "body": {
+          "kind": "json",
+          "value": {
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": 24,
+            "messages": [
+              {
+                "content": "Reply with exactly OK.",
+                "role": "user"
+              }
+            ],
+            "temperature": 0
+          }
+        },
+        "headers": {},
+        "method": "POST",
+        "url": "https://bedrock-runtime.us-east-2.amazonaws.com/model/us.anthropic.claude-sonnet-4-5-20250929-v1:0/invoke"
+      },
+      "response": {
+        "body": {
+          "kind": "json",
+          "value": {
+            "content": [
+              {
+                "text": "OK",
+                "type": "text"
+              }
+            ],
+            "id": "msg_bdrk_01XSYMmj9bzHPs8PLnhLZMH8",
+            "model": "claude-sonnet-4-5-20250929",
+            "role": "assistant",
+            "stop_reason": "end_turn",
+            "stop_sequence": null,
+            "type": "message",
+            "usage": {
+              "cache_creation": {
+                "ephemeral_1h_input_tokens": 0,
+                "ephemeral_5m_input_tokens": 0
+              },
+              "cache_creation_input_tokens": 0,
+              "cache_read_input_tokens": 0,
+              "input_tokens": 12,
+              "output_tokens": 4
+            }
+          }
+        },
+        "headers": {
+          "connection": "keep-alive",
+          "content-length": "386",
+          "content-type": "application/json",
+          "date": "Thu, 18 Jun 2026 15:28:20 GMT",
+          "x-amzn-bedrock-cache-read-input-token-count": "0",
+          "x-amzn-bedrock-cache-write-input-token-count": "0",
+          "x-amzn-bedrock-input-token-count": "12",
+          "x-amzn-bedrock-invocation-latency": "3400",
+          "x-amzn-bedrock-output-token-count": "4",
+          "x-amzn-requestid": "2d35ac39-c9df-4ec1-8e3d-d4aae8a434d8"
+        },
+        "status": 200,
+        "statusText": "OK"
+      }
+    },
+    {
+      "callIndex": 0,
+      "id": "5dd8e64febed30e6",
+      "matchKey": "POST bedrock-runtime.aws-region.amazonaws.com/model/us.anthropic.claude-sonnet-4-5-20250929-v1:0/invoke-with-response-stream",
+      "recordedAt": "2026-06-18T15:28:22.507Z",
+      "request": {
+        "body": {
+          "kind": "json",
+          "value": {
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": 32,
+            "messages": [
+              {
+                "content": "Count from 1 to 3 and include the words one two three.",
+                "role": "user"
+              }
+            ],
+            "temperature": 0
+          }
+        },
+        "headers": {},
+        "method": "POST",
+        "url": "https://bedrock-runtime.us-east-2.amazonaws.com/model/us.anthropic.claude-sonnet-4-5-20250929-v1:0/invoke-with-response-stream"
+      },
+      "response": {
+        "body": {
+          "contentType": "application/vnd.amazon.eventstream",
+          "kind": "base64",
+          "value": "AAACqwAAAEvOE0j9CzpldmVudC10eXBlBwAFY2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpvaWJXVnpjMkZuWlY5emRHRnlkQ0lzSW0xbGMzTmhaMlVpT25zaWJXOWtaV3dpT2lKamJHRjFaR1V0YzI5dWJtVjBMVFF0TlMweU1ESTFNRGt5T1NJc0ltbGtJam9pYlhOblgySmtjbXRmTURFeVpHMTZRbEZ4WmtSNGRISlZkWGRaYW5WemRsQkVJaXdpZEhsd1pTSTZJbTFsYzNOaFoyVWlMQ0p5YjJ4bElqb2lZWE56YVhOMFlXNTBJaXdpWTI5dWRHVnVkQ0k2VzEwc0luTjBiM0JmY21WaGMyOXVJanB1ZFd4c0xDSnpkRzl3WDNObGNYVmxibU5sSWpwdWRXeHNMQ0oxYzJGblpTSTZleUpwYm5CMWRGOTBiMnRsYm5NaU9qSTBMQ0pqWVdOb1pWOWpjbVZoZEdsdmJsOXBibkIxZEY5MGIydGxibk1pT2pBc0ltTmhZMmhsWDNKbFlXUmZhVzV3ZFhSZmRHOXJaVzV6SWpvd0xDSmpZV05vWlY5amNtVmhkR2x2YmlJNmV5SmxjR2hsYldWeVlXeGZOVzFmYVc1d2RYUmZkRzlyWlc1eklqb3dMQ0psY0dobGJXVnlZV3hmTVdoZmFXNXdkWFJmZEc5clpXNXpJam93ZlN3aWIzVjBjSFYwWDNSdmEyVnVjeUk2TVgxOWZRPT0iLCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWjAifSR2CAAAAAEBAAAAS3IQvWQLOmV2ZW50LXR5cGUHAAVjaHVuaw06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImJ5dGVzIjoiZXlKMGVYQmxJam9pWTI5dWRHVnVkRjlpYkc5amExOXpkR0Z5ZENJc0ltbHVaR1Y0SWpvd0xDSmpiMjUwWlc1MFgySnNiMk5ySWpwN0luUjVjR1VpT2lKMFpYaDBJaXdpZEdWNGRDSTZJaUo5ZlE9PSIsInAiOiJhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ekFCQ0RFRkdISSJ960LhrAAAAPIAAABLtthETAs6ZXZlbnQtdHlwZQcABWNodW5rDTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiYnl0ZXMiOiJleUowZVhCbElqb2lZMjl1ZEdWdWRGOWliRzlqYTE5a1pXeDBZU0lzSW1sdVpHVjRJam93TENKa1pXeDBZU0k2ZXlKMGVYQmxJam9pZEdWNGRGOWtaV3gwWVNJc0luUmxlSFFpT2lJeElDSjlmUT09IiwicCI6ImFiY2RlZmdoaWprbG1ub3BxcnN0In17ZMMjAAAA+AAAAEv8aFztCzpldmVudC10eXBlBwAFY2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpvaVkyOXVkR1Z1ZEY5aWJHOWphMTlrWld4MFlTSXNJbWx1WkdWNElqb3dMQ0prWld4MFlTSTZleUowZVhCbElqb2lkR1Y0ZEY5a1pXeDBZU0lzSW5SbGVIUWlPaUl0SW4xOSIsInAiOiJhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ekFCQ0QifZAv90QAAAEiAAAAS/Rx6LALOmV2ZW50LXR5cGUHAAVjaHVuaw06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImJ5dGVzIjoiZXlKMGVYQmxJam9pWTI5dWRHVnVkRjlpYkc5amExOWtaV3gwWVNJc0ltbHVaR1Y0SWpvd0xDSmtaV3gwWVNJNmV5SjBlWEJsSWpvaWRHVjRkRjlrWld4MFlTSXNJblJsZUhRaU9pSWdiMjVsWEc0eUlDMGdkSGR2WEc0ekluMTkiLCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWiJ9dxjdSgAAAOkAAABLoeji3ws6ZXZlbnQtdHlwZQcABWNodW5rDTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiYnl0ZXMiOiJleUowZVhCbElqb2lZMjl1ZEdWdWRGOWliRzlqYTE5a1pXeDBZU0lzSW1sdVpHVjRJam93TENKa1pXeDBZU0k2ZXlKMGVYQmxJam9pZEdWNGRGOWtaV3gwWVNJc0luUmxlSFFpT2lJZ0xTQjBhSEpsWlNKOWZRPT0iLCJwIjoiYWJjIn0ozul3AAAAxAAAAEuYuQlqCzpldmVudC10eXBlBwAFY2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpvaVkyOXVkR1Z1ZEY5aWJHOWphMTl6ZEc5d0lpd2lhVzVrWlhnaU9qQjkiLCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSCJ9/DIv/gAAAXcAAABLBIKoCws6ZXZlbnQtdHlwZQcABWNodW5rDTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiYnl0ZXMiOiJleUowZVhCbElqb2liV1Z6YzJGblpWOWtaV3gwWVNJc0ltUmxiSFJoSWpwN0luTjBiM0JmY21WaGMyOXVJam9pWlc1a1gzUjFjbTRpTENKemRHOXdYM05sY1hWbGJtTmxJanB1ZFd4c2ZTd2lkWE5oWjJVaU9uc2lhVzV3ZFhSZmRHOXJaVzV6SWpveU5Dd2lZMkZqYUdWZlkzSmxZWFJwYjI1ZmFXNXdkWFJmZEc5clpXNXpJam93TENKallXTm9aVjl5WldGa1gybHVjSFYwWDNSdmEyVnVjeUk2TUN3aWIzVjBjSFYwWDNSdmEyVnVjeUk2TVRoOWZRPT0iLCJwIjoiYWJjZGVmZ2hpamtsbSJ9NJ8tfwAAAWcAAABLZGI/iQs6ZXZlbnQtdHlwZQcABWNodW5rDTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiYnl0ZXMiOiJleUowZVhCbElqb2liV1Z6YzJGblpWOXpkRzl3SWl3aVlXMWhlbTl1TFdKbFpISnZZMnN0YVc1MmIyTmhkR2x2YmsxbGRISnBZM01pT25zaWFXNXdkWFJVYjJ0bGJrTnZkVzUwSWpveU5Dd2liM1YwY0hWMFZHOXJaVzVEYjNWdWRDSTZNVGdzSW1sdWRtOWpZWFJwYjI1TVlYUmxibU41SWpveE5UZ3hMQ0ptYVhKemRFSjVkR1ZNWVhSbGJtTjVJam94TWprNWZYMD0iLCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk9QUVJTIn1xx9PT"
+        },
+        "headers": {
+          "connection": "keep-alive",
+          "content-type": "application/vnd.amazon.eventstream",
+          "date": "Thu, 18 Jun 2026 15:28:22 GMT",
+          "transfer-encoding": "chunked",
+          "x-amzn-bedrock-content-type": "application/json",
+          "x-amzn-requestid": "d3cf2c6a-342a-4773-a5e7-5e80cd824d32"
+        },
+        "status": 200,
+        "statusText": "OK"
+      }
+    }
+  ],
+  "meta": {
+    "createdAt": "2026-06-18T15:26:57.285Z"
+  }
+}

--- a/e2e/scenarios/anthropic-bedrock-instrumentation/__cassettes__/anthropic-bedrock-v0302-auto-esm.cassette.json
+++ b/e2e/scenarios/anthropic-bedrock-instrumentation/__cassettes__/anthropic-bedrock-v0302-auto-esm.cassette.json
@@ -1,0 +1,117 @@
+{
+  "entries": [
+    {
+      "callIndex": 0,
+      "id": "e6926053c025e8b6",
+      "matchKey": "POST bedrock-runtime.aws-region.amazonaws.com/model/us.anthropic.claude-sonnet-4-5-20250929-v1:0/invoke",
+      "recordedAt": "2026-06-18T15:28:14.064Z",
+      "request": {
+        "body": {
+          "kind": "json",
+          "value": {
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": 24,
+            "messages": [
+              {
+                "content": "Reply with exactly OK.",
+                "role": "user"
+              }
+            ],
+            "temperature": 0
+          }
+        },
+        "headers": {},
+        "method": "POST",
+        "url": "https://bedrock-runtime.us-east-2.amazonaws.com/model/us.anthropic.claude-sonnet-4-5-20250929-v1:0/invoke"
+      },
+      "response": {
+        "body": {
+          "kind": "json",
+          "value": {
+            "content": [
+              {
+                "text": "OK",
+                "type": "text"
+              }
+            ],
+            "id": "msg_bdrk_01PDHMbVh1e3wfda8w6duQxt",
+            "model": "claude-sonnet-4-5-20250929",
+            "role": "assistant",
+            "stop_reason": "end_turn",
+            "stop_sequence": null,
+            "type": "message",
+            "usage": {
+              "cache_creation": {
+                "ephemeral_1h_input_tokens": 0,
+                "ephemeral_5m_input_tokens": 0
+              },
+              "cache_creation_input_tokens": 0,
+              "cache_read_input_tokens": 0,
+              "input_tokens": 12,
+              "output_tokens": 4
+            }
+          }
+        },
+        "headers": {
+          "connection": "keep-alive",
+          "content-length": "386",
+          "content-type": "application/json",
+          "date": "Thu, 18 Jun 2026 15:28:13 GMT",
+          "x-amzn-bedrock-cache-read-input-token-count": "0",
+          "x-amzn-bedrock-cache-write-input-token-count": "0",
+          "x-amzn-bedrock-input-token-count": "12",
+          "x-amzn-bedrock-invocation-latency": "2096",
+          "x-amzn-bedrock-output-token-count": "4",
+          "x-amzn-requestid": "2df5aa6b-0e5c-4e34-b684-c9b88c700d76"
+        },
+        "status": 200,
+        "statusText": "OK"
+      }
+    },
+    {
+      "callIndex": 0,
+      "id": "5dd8e64febed30e6",
+      "matchKey": "POST bedrock-runtime.aws-region.amazonaws.com/model/us.anthropic.claude-sonnet-4-5-20250929-v1:0/invoke-with-response-stream",
+      "recordedAt": "2026-06-18T15:28:16.226Z",
+      "request": {
+        "body": {
+          "kind": "json",
+          "value": {
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": 32,
+            "messages": [
+              {
+                "content": "Count from 1 to 3 and include the words one two three.",
+                "role": "user"
+              }
+            ],
+            "temperature": 0
+          }
+        },
+        "headers": {},
+        "method": "POST",
+        "url": "https://bedrock-runtime.us-east-2.amazonaws.com/model/us.anthropic.claude-sonnet-4-5-20250929-v1:0/invoke-with-response-stream"
+      },
+      "response": {
+        "body": {
+          "contentType": "application/vnd.amazon.eventstream",
+          "kind": "base64",
+          "value": "AAACqQAAAEu00xudCzpldmVudC10eXBlBwAFY2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpvaWJXVnpjMkZuWlY5emRHRnlkQ0lzSW0xbGMzTmhaMlVpT25zaWJXOWtaV3dpT2lKamJHRjFaR1V0YzI5dWJtVjBMVFF0TlMweU1ESTFNRGt5T1NJc0ltbGtJam9pYlhOblgySmtjbXRmTURFelUyNTRZblkyV1ZGWlZYbzNablpZZVhVM1RtMW5JaXdpZEhsd1pTSTZJbTFsYzNOaFoyVWlMQ0p5YjJ4bElqb2lZWE56YVhOMFlXNTBJaXdpWTI5dWRHVnVkQ0k2VzEwc0luTjBiM0JmY21WaGMyOXVJanB1ZFd4c0xDSnpkRzl3WDNObGNYVmxibU5sSWpwdWRXeHNMQ0oxYzJGblpTSTZleUpwYm5CMWRGOTBiMnRsYm5NaU9qSTBMQ0pqWVdOb1pWOWpjbVZoZEdsdmJsOXBibkIxZEY5MGIydGxibk1pT2pBc0ltTmhZMmhsWDNKbFlXUmZhVzV3ZFhSZmRHOXJaVzV6SWpvd0xDSmpZV05vWlY5amNtVmhkR2x2YmlJNmV5SmxjR2hsYldWeVlXeGZOVzFmYVc1d2RYUmZkRzlyWlc1eklqb3dMQ0psY0dobGJXVnlZV3hmTVdoZmFXNXdkWFJmZEc5clpXNXpJam93ZlN3aWIzVjBjSFYwWDNSdmEyVnVjeUk2TVgxOWZRPT0iLCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZIn0p73BIAAAA9QAAAEsE+JhcCzpldmVudC10eXBlBwAFY2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpvaVkyOXVkR1Z1ZEY5aWJHOWphMTl6ZEdGeWRDSXNJbWx1WkdWNElqb3dMQ0pqYjI1MFpXNTBYMkpzYjJOcklqcDdJblI1Y0dVaU9pSjBaWGgwSWl3aWRHVjRkQ0k2SWlKOWZRPT0iLCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnciffZcoq0AAADwAAAAS8wYFywLOmV2ZW50LXR5cGUHAAVjaHVuaw06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImJ5dGVzIjoiZXlKMGVYQmxJam9pWTI5dWRHVnVkRjlpYkc5amExOWtaV3gwWVNJc0ltbHVaR1Y0SWpvd0xDSmtaV3gwWVNJNmV5SjBlWEJsSWpvaWRHVjRkRjlrWld4MFlTSXNJblJsZUhRaU9pSXhJQ0o5ZlE9PSIsInAiOiJhYmNkZWZnaGlqa2xtbm9wcXIifdPdQuIAAADgAAAAS6z4gK4LOmV2ZW50LXR5cGUHAAVjaHVuaw06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImJ5dGVzIjoiZXlKMGVYQmxJam9pWTI5dWRHVnVkRjlpYkc5amExOWtaV3gwWVNJc0ltbHVaR1Y0SWpvd0xDSmtaV3gwWVNJNmV5SjBlWEJsSWpvaWRHVjRkRjlrWld4MFlTSXNJblJsZUhRaU9pSXRJbjE5IiwicCI6ImFiY2RlZiJ9917xMQAAASYAAABLAfFOcAs6ZXZlbnQtdHlwZQcABWNodW5rDTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiYnl0ZXMiOiJleUowZVhCbElqb2lZMjl1ZEdWdWRGOWliRzlqYTE5a1pXeDBZU0lzSW1sdVpHVjRJam93TENKa1pXeDBZU0k2ZXlKMGVYQmxJam9pZEdWNGRGOWtaV3gwWVNJc0luUmxlSFFpT2lJZ2IyNWxYRzR5SUMwZ2RIZHZYRzR6SW4xOSIsInAiOiJhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ekFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaMDEyMyJ9m7l8pwAAAOgAAABLnIjLbws6ZXZlbnQtdHlwZQcABWNodW5rDTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiYnl0ZXMiOiJleUowZVhCbElqb2lZMjl1ZEdWdWRGOWliRzlqYTE5a1pXeDBZU0lzSW1sdVpHVjRJam93TENKa1pXeDBZU0k2ZXlKMGVYQmxJam9pZEdWNGRGOWtaV3gwWVNJc0luUmxlSFFpT2lJZ0xTQjBhSEpsWlNKOWZRPT0iLCJwIjoiYWIifSId/ioAAADHAAAAS98Zc7oLOmV2ZW50LXR5cGUHAAVjaHVuaw06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImJ5dGVzIjoiZXlKMGVYQmxJam9pWTI5dWRHVnVkRjlpYkc5amExOXpkRzl3SWl3aWFXNWtaWGdpT2pCOSIsInAiOiJhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ekFCQ0RFRkdISUpLIn289g6LAAABbQAAAEsu0icoCzpldmVudC10eXBlBwAFY2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpvaWJXVnpjMkZuWlY5a1pXeDBZU0lzSW1SbGJIUmhJanA3SW5OMGIzQmZjbVZoYzI5dUlqb2laVzVrWDNSMWNtNGlMQ0p6ZEc5d1gzTmxjWFZsYm1ObElqcHVkV3hzZlN3aWRYTmhaMlVpT25zaWFXNXdkWFJmZEc5clpXNXpJam95TkN3aVkyRmphR1ZmWTNKbFlYUnBiMjVmYVc1d2RYUmZkRzlyWlc1eklqb3dMQ0pqWVdOb1pWOXlaV0ZrWDJsdWNIVjBYM1J2YTJWdWN5STZNQ3dpYjNWMGNIVjBYM1J2YTJWdWN5STZNVGg5ZlE9PSIsInAiOiJhYmMifYVrvyYAAAFKAAAAS10z1DwLOmV2ZW50LXR5cGUHAAVjaHVuaw06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImJ5dGVzIjoiZXlKMGVYQmxJam9pYldWemMyRm5aVjl6ZEc5d0lpd2lZVzFoZW05dUxXSmxaSEp2WTJzdGFXNTJiMk5oZEdsdmJrMWxkSEpwWTNNaU9uc2lhVzV3ZFhSVWIydGxia052ZFc1MElqb3lOQ3dpYjNWMGNIVjBWRzlyWlc1RGIzVnVkQ0k2TVRnc0ltbHVkbTlqWVhScGIyNU1ZWFJsYm1ONUlqb3lNREF6TENKbWFYSnpkRUo1ZEdWTVlYUmxibU41SWpveE56SXhmWDA9IiwicCI6ImFiY2RlZmdoaWprbG1ub3AifVcUnoY="
+        },
+        "headers": {
+          "connection": "keep-alive",
+          "content-type": "application/vnd.amazon.eventstream",
+          "date": "Thu, 18 Jun 2026 15:28:15 GMT",
+          "transfer-encoding": "chunked",
+          "x-amzn-bedrock-content-type": "application/json",
+          "x-amzn-requestid": "a395b9be-8719-49a4-a721-f532db6e5650"
+        },
+        "status": 200,
+        "statusText": "OK"
+      }
+    }
+  ],
+  "meta": {
+    "createdAt": "2026-06-18T15:26:52.832Z"
+  }
+}

--- a/e2e/scenarios/anthropic-bedrock-instrumentation/__cassettes__/anthropic-bedrock-v0302-wrapped.cassette.json
+++ b/e2e/scenarios/anthropic-bedrock-instrumentation/__cassettes__/anthropic-bedrock-v0302-wrapped.cassette.json
@@ -1,0 +1,117 @@
+{
+  "entries": [
+    {
+      "callIndex": 0,
+      "id": "e6926053c025e8b6",
+      "matchKey": "POST bedrock-runtime.aws-region.amazonaws.com/model/us.anthropic.claude-sonnet-4-5-20250929-v1:0/invoke",
+      "recordedAt": "2026-06-18T15:28:09.153Z",
+      "request": {
+        "body": {
+          "kind": "json",
+          "value": {
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": 24,
+            "messages": [
+              {
+                "content": "Reply with exactly OK.",
+                "role": "user"
+              }
+            ],
+            "temperature": 0
+          }
+        },
+        "headers": {},
+        "method": "POST",
+        "url": "https://bedrock-runtime.us-east-2.amazonaws.com/model/us.anthropic.claude-sonnet-4-5-20250929-v1:0/invoke"
+      },
+      "response": {
+        "body": {
+          "kind": "json",
+          "value": {
+            "content": [
+              {
+                "text": "OK",
+                "type": "text"
+              }
+            ],
+            "id": "msg_bdrk_01KJPf3KeruwxuLuEPbmVi7k",
+            "model": "claude-sonnet-4-5-20250929",
+            "role": "assistant",
+            "stop_reason": "end_turn",
+            "stop_sequence": null,
+            "type": "message",
+            "usage": {
+              "cache_creation": {
+                "ephemeral_1h_input_tokens": 0,
+                "ephemeral_5m_input_tokens": 0
+              },
+              "cache_creation_input_tokens": 0,
+              "cache_read_input_tokens": 0,
+              "input_tokens": 12,
+              "output_tokens": 4
+            }
+          }
+        },
+        "headers": {
+          "connection": "keep-alive",
+          "content-length": "386",
+          "content-type": "application/json",
+          "date": "Thu, 18 Jun 2026 15:28:08 GMT",
+          "x-amzn-bedrock-cache-read-input-token-count": "0",
+          "x-amzn-bedrock-cache-write-input-token-count": "0",
+          "x-amzn-bedrock-input-token-count": "12",
+          "x-amzn-bedrock-invocation-latency": "1973",
+          "x-amzn-bedrock-output-token-count": "4",
+          "x-amzn-requestid": "f5db199f-7566-4834-8837-b6555fae81f8"
+        },
+        "status": 200,
+        "statusText": "OK"
+      }
+    },
+    {
+      "callIndex": 0,
+      "id": "5dd8e64febed30e6",
+      "matchKey": "POST bedrock-runtime.aws-region.amazonaws.com/model/us.anthropic.claude-sonnet-4-5-20250929-v1:0/invoke-with-response-stream",
+      "recordedAt": "2026-06-18T15:28:10.776Z",
+      "request": {
+        "body": {
+          "kind": "json",
+          "value": {
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": 32,
+            "messages": [
+              {
+                "content": "Count from 1 to 3 and include the words one two three.",
+                "role": "user"
+              }
+            ],
+            "temperature": 0
+          }
+        },
+        "headers": {},
+        "method": "POST",
+        "url": "https://bedrock-runtime.us-east-2.amazonaws.com/model/us.anthropic.claude-sonnet-4-5-20250929-v1:0/invoke-with-response-stream"
+      },
+      "response": {
+        "body": {
+          "contentType": "application/vnd.amazon.eventstream",
+          "kind": "base64",
+          "value": "AAACkwAAAEtfQru6CzpldmVudC10eXBlBwAFY2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpvaWJXVnpjMkZuWlY5emRHRnlkQ0lzSW0xbGMzTmhaMlVpT25zaWJXOWtaV3dpT2lKamJHRjFaR1V0YzI5dWJtVjBMVFF0TlMweU1ESTFNRGt5T1NJc0ltbGtJam9pYlhOblgySmtjbXRmTURFM1VYTmhNVE5WVVZVMldtdG1hVUozVGtKdmFqaFZJaXdpZEhsd1pTSTZJbTFsYzNOaFoyVWlMQ0p5YjJ4bElqb2lZWE56YVhOMFlXNTBJaXdpWTI5dWRHVnVkQ0k2VzEwc0luTjBiM0JmY21WaGMyOXVJanB1ZFd4c0xDSnpkRzl3WDNObGNYVmxibU5sSWpwdWRXeHNMQ0oxYzJGblpTSTZleUpwYm5CMWRGOTBiMnRsYm5NaU9qSTBMQ0pqWVdOb1pWOWpjbVZoZEdsdmJsOXBibkIxZEY5MGIydGxibk1pT2pBc0ltTmhZMmhsWDNKbFlXUmZhVzV3ZFhSZmRHOXJaVzV6SWpvd0xDSmpZV05vWlY5amNtVmhkR2x2YmlJNmV5SmxjR2hsYldWeVlXeGZOVzFmYVc1d2RYUmZkRzlyWlc1eklqb3dMQ0psY0dobGJXVnlZV3hmTVdoZmFXNXdkWFJmZEc5clpXNXpJam93ZlN3aWIzVjBjSFYwWDNSdmEyVnVjeUk2TVgxOWZRPT0iLCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkMifZcKeBoAAADtAAAAS1RoRB8LOmV2ZW50LXR5cGUHAAVjaHVuaw06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImJ5dGVzIjoiZXlKMGVYQmxJam9pWTI5dWRHVnVkRjlpYkc5amExOXpkR0Z5ZENJc0ltbHVaR1Y0SWpvd0xDSmpiMjUwWlc1MFgySnNiMk5ySWpwN0luUjVjR1VpT2lKMFpYaDBJaXdpZEdWNGRDSTZJaUo5ZlE9PSIsInAiOiJhYmNkZWZnaGlqa2xtbm8ifaLt8+IAAAEQAAAASy+QA1YLOmV2ZW50LXR5cGUHAAVjaHVuaw06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImJ5dGVzIjoiZXlKMGVYQmxJam9pWTI5dWRHVnVkRjlpYkc5amExOWtaV3gwWVNJc0ltbHVaR1Y0SWpvd0xDSmtaV3gwWVNJNmV5SjBlWEJsSWpvaWRHVjRkRjlrWld4MFlTSXNJblJsZUhRaU9pSXhJQ0o5ZlE9PSIsInAiOiJhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ekFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWCJ9ASOIewAAAN8AAABLj4mv+Qs6ZXZlbnQtdHlwZQcABWNodW5rDTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiYnl0ZXMiOiJleUowZVhCbElqb2lZMjl1ZEdWdWRGOWliRzlqYTE5a1pXeDBZU0lzSW1sdVpHVjRJam93TENKa1pXeDBZU0k2ZXlKMGVYQmxJam9pZEdWNGRGOWtaV3gwWVNJc0luUmxlSFFpT2lJdEluMTkiLCJwIjoiYWJjZGUifYfYX2IAAAEWAAAAS6DQ9vYLOmV2ZW50LXR5cGUHAAVjaHVuaw06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImJ5dGVzIjoiZXlKMGVYQmxJam9pWTI5dWRHVnVkRjlpYkc5amExOWtaV3gwWVNJc0ltbHVaR1Y0SWpvd0xDSmtaV3gwWVNJNmV5SjBlWEJsSWpvaWRHVjRkRjlrWld4MFlTSXNJblJsZUhRaU9pSWdiMjVsWEc0eUlDMGdkSGR2WEc0ekluMTkiLCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTiJ9n3fvKgAAAPIAAABLtthETAs6ZXZlbnQtdHlwZQcABWNodW5rDTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiYnl0ZXMiOiJleUowZVhCbElqb2lZMjl1ZEdWdWRGOWliRzlqYTE5a1pXeDBZU0lzSW1sdVpHVjRJam93TENKa1pXeDBZU0k2ZXlKMGVYQmxJam9pZEdWNGRGOWtaV3gwWVNJc0luUmxlSFFpT2lJZ0xTQjBhSEpsWlNKOWZRPT0iLCJwIjoiYWJjZGVmZ2hpamtsIn3LaLclAAAAywAAAEsa6Z67CzpldmVudC10eXBlBwAFY2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpvaVkyOXVkR1Z1ZEY5aWJHOWphMTl6ZEc5d0lpd2lhVzVrWlhnaU9qQjkiLCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk8ifWlb3xAAAAGCAAAAS4RWdyYLOmV2ZW50LXR5cGUHAAVjaHVuaw06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImJ5dGVzIjoiZXlKMGVYQmxJam9pYldWemMyRm5aVjlrWld4MFlTSXNJbVJsYkhSaElqcDdJbk4wYjNCZmNtVmhjMjl1SWpvaVpXNWtYM1IxY200aUxDSnpkRzl3WDNObGNYVmxibU5sSWpwdWRXeHNmU3dpZFhOaFoyVWlPbnNpYVc1d2RYUmZkRzlyWlc1eklqb3lOQ3dpWTJGamFHVmZZM0psWVhScGIyNWZhVzV3ZFhSZmRHOXJaVzV6SWpvd0xDSmpZV05vWlY5eVpXRmtYMmx1Y0hWMFgzUnZhMlZ1Y3lJNk1Dd2liM1YwY0hWMFgzUnZhMlZ1Y3lJNk1UaDlmUT09IiwicCI6ImFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eCJ9zhznGgAAAWEAAABL6yLKKQs6ZXZlbnQtdHlwZQcABWNodW5rDTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiYnl0ZXMiOiJleUowZVhCbElqb2liV1Z6YzJGblpWOXpkRzl3SWl3aVlXMWhlbTl1TFdKbFpISnZZMnN0YVc1MmIyTmhkR2x2YmsxbGRISnBZM01pT25zaWFXNXdkWFJVYjJ0bGJrTnZkVzUwSWpveU5Dd2liM1YwY0hWMFZHOXJaVzVEYjNWdWRDSTZNVGdzSW1sdWRtOWpZWFJwYjI1TVlYUmxibU41SWpveE5EUXlMQ0ptYVhKemRFSjVkR1ZNWVhSbGJtTjVJam94TVRVNWZYMD0iLCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNIn2YP/uu"
+        },
+        "headers": {
+          "connection": "keep-alive",
+          "content-type": "application/vnd.amazon.eventstream",
+          "date": "Thu, 18 Jun 2026 15:28:10 GMT",
+          "transfer-encoding": "chunked",
+          "x-amzn-bedrock-content-type": "application/json",
+          "x-amzn-requestid": "dc0a5154-c10e-4799-8001-c7dd2d3b7e3a"
+        },
+        "status": 200,
+        "statusText": "OK"
+      }
+    }
+  ],
+  "meta": {
+    "createdAt": "2026-06-18T15:26:45.766Z"
+  }
+}

--- a/e2e/scenarios/anthropic-bedrock-instrumentation/__snapshots__/anthropic-bedrock-v0302-auto-cjs.span-tree.json
+++ b/e2e/scenarios/anthropic-bedrock-instrumentation/__snapshots__/anthropic-bedrock-v0302-auto-cjs.span-tree.json
@@ -1,0 +1,97 @@
+{
+  "span_tree": [
+    {
+      "name": "anthropic-bedrock-instrumentation-root",
+      "type": "task",
+      "children": [
+        {
+          "name": "anthropic-bedrock-create-operation",
+          "children": [
+            {
+              "name": "anthropic.messages.create",
+              "type": "llm",
+              "children": [],
+              "input": [
+                {
+                  "content": "Reply with exactly OK.",
+                  "role": "user"
+                }
+              ],
+              "output": {
+                "content": [
+                  {
+                    "text": "OK",
+                    "type": "text"
+                  }
+                ],
+                "role": "assistant"
+              },
+              "metadata": {
+                "max_tokens": 24,
+                "model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+                "provider": "anthropic",
+                "stop_reason": "end_turn",
+                "stop_sequence": null,
+                "temperature": 0
+              },
+              "metrics": {
+                "completion_tokens": 4,
+                "prompt_cache_creation_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 16
+              }
+            }
+          ],
+          "metadata": {
+            "operation": "create",
+            "testRunId": "<run:1>"
+          }
+        },
+        {
+          "name": "anthropic-bedrock-stream-operation",
+          "children": [
+            {
+              "name": "anthropic.messages.create",
+              "type": "llm",
+              "children": [],
+              "input": [
+                {
+                  "content": "Count from 1 to 3 and include the words one two three.",
+                  "role": "user"
+                }
+              ],
+              "output": "1 - one\n2 - two\n3 - three",
+              "metadata": {
+                "max_tokens": 32,
+                "model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+                "provider": "anthropic",
+                "stop_reason": "end_turn",
+                "stop_sequence": null,
+                "stream": true,
+                "temperature": 0
+              },
+              "metrics": {
+                "completion_tokens": 18,
+                "prompt_cache_creation_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 24,
+                "time_to_first_token": 0,
+                "tokens": 42
+              }
+            }
+          ],
+          "metadata": {
+            "operation": "stream",
+            "testRunId": "<run:1>"
+          }
+        }
+      ],
+      "metadata": {
+        "scenario": "anthropic-bedrock-instrumentation",
+        "testRunId": "<run:1>"
+      }
+    }
+  ]
+}

--- a/e2e/scenarios/anthropic-bedrock-instrumentation/__snapshots__/anthropic-bedrock-v0302-auto-cjs.span-tree.txt
+++ b/e2e/scenarios/anthropic-bedrock-instrumentation/__snapshots__/anthropic-bedrock-v0302-auto-cjs.span-tree.txt
@@ -1,0 +1,73 @@
+span_tree:
+└── anthropic-bedrock-instrumentation-root [task]
+    metadata: {
+      "scenario": "anthropic-bedrock-instrumentation",
+      "testRunId": "<run:1>"
+    }
+    ├── anthropic-bedrock-create-operation
+    │   metadata: {
+    │     "operation": "create",
+    │     "testRunId": "<run:1>"
+    │   }
+    │   └── anthropic.messages.create [llm]
+    │       input: [
+    │         {
+    │           "content": "Reply with exactly OK.",
+    │           "role": "user"
+    │         }
+    │       ]
+    │       output: {
+    │         "content": [
+    │           {
+    │             "text": "OK",
+    │             "type": "text"
+    │           }
+    │         ],
+    │         "role": "assistant"
+    │       }
+    │       metadata: {
+    │         "max_tokens": 24,
+    │         "model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    │         "provider": "anthropic",
+    │         "stop_reason": "end_turn",
+    │         "stop_sequence": null,
+    │         "temperature": 0
+    │       }
+    │       metrics: {
+    │         "completion_tokens": 4,
+    │         "prompt_cache_creation_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
+    │       }
+    └── anthropic-bedrock-stream-operation
+        metadata: {
+          "operation": "stream",
+          "testRunId": "<run:1>"
+        }
+        └── anthropic.messages.create [llm]
+            input: [
+              {
+                "content": "Count from 1 to 3 and include the words one two three.",
+                "role": "user"
+              }
+            ]
+            output: "1 - one\n2 - two\n3 - three"
+            metadata: {
+              "max_tokens": 32,
+              "model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+              "provider": "anthropic",
+              "stop_reason": "end_turn",
+              "stop_sequence": null,
+              "stream": true,
+              "temperature": 0
+            }
+            metrics: {
+              "completion_tokens": 18,
+              "prompt_cache_creation_tokens": 0,
+              "prompt_cached_tokens": 0,
+              "prompt_tokens": 24,
+              "time_to_first_token": 0,
+              "tokens": 42
+            }

--- a/e2e/scenarios/anthropic-bedrock-instrumentation/__snapshots__/anthropic-bedrock-v0302-auto-esm.span-tree.json
+++ b/e2e/scenarios/anthropic-bedrock-instrumentation/__snapshots__/anthropic-bedrock-v0302-auto-esm.span-tree.json
@@ -1,0 +1,97 @@
+{
+  "span_tree": [
+    {
+      "name": "anthropic-bedrock-instrumentation-root",
+      "type": "task",
+      "children": [
+        {
+          "name": "anthropic-bedrock-create-operation",
+          "children": [
+            {
+              "name": "anthropic.messages.create",
+              "type": "llm",
+              "children": [],
+              "input": [
+                {
+                  "content": "Reply with exactly OK.",
+                  "role": "user"
+                }
+              ],
+              "output": {
+                "content": [
+                  {
+                    "text": "OK",
+                    "type": "text"
+                  }
+                ],
+                "role": "assistant"
+              },
+              "metadata": {
+                "max_tokens": 24,
+                "model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+                "provider": "anthropic",
+                "stop_reason": "end_turn",
+                "stop_sequence": null,
+                "temperature": 0
+              },
+              "metrics": {
+                "completion_tokens": 4,
+                "prompt_cache_creation_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 16
+              }
+            }
+          ],
+          "metadata": {
+            "operation": "create",
+            "testRunId": "<run:1>"
+          }
+        },
+        {
+          "name": "anthropic-bedrock-stream-operation",
+          "children": [
+            {
+              "name": "anthropic.messages.create",
+              "type": "llm",
+              "children": [],
+              "input": [
+                {
+                  "content": "Count from 1 to 3 and include the words one two three.",
+                  "role": "user"
+                }
+              ],
+              "output": "1 - one\n2 - two\n3 - three",
+              "metadata": {
+                "max_tokens": 32,
+                "model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+                "provider": "anthropic",
+                "stop_reason": "end_turn",
+                "stop_sequence": null,
+                "stream": true,
+                "temperature": 0
+              },
+              "metrics": {
+                "completion_tokens": 18,
+                "prompt_cache_creation_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 24,
+                "time_to_first_token": 0,
+                "tokens": 42
+              }
+            }
+          ],
+          "metadata": {
+            "operation": "stream",
+            "testRunId": "<run:1>"
+          }
+        }
+      ],
+      "metadata": {
+        "scenario": "anthropic-bedrock-instrumentation",
+        "testRunId": "<run:1>"
+      }
+    }
+  ]
+}

--- a/e2e/scenarios/anthropic-bedrock-instrumentation/__snapshots__/anthropic-bedrock-v0302-auto-esm.span-tree.txt
+++ b/e2e/scenarios/anthropic-bedrock-instrumentation/__snapshots__/anthropic-bedrock-v0302-auto-esm.span-tree.txt
@@ -1,0 +1,73 @@
+span_tree:
+└── anthropic-bedrock-instrumentation-root [task]
+    metadata: {
+      "scenario": "anthropic-bedrock-instrumentation",
+      "testRunId": "<run:1>"
+    }
+    ├── anthropic-bedrock-create-operation
+    │   metadata: {
+    │     "operation": "create",
+    │     "testRunId": "<run:1>"
+    │   }
+    │   └── anthropic.messages.create [llm]
+    │       input: [
+    │         {
+    │           "content": "Reply with exactly OK.",
+    │           "role": "user"
+    │         }
+    │       ]
+    │       output: {
+    │         "content": [
+    │           {
+    │             "text": "OK",
+    │             "type": "text"
+    │           }
+    │         ],
+    │         "role": "assistant"
+    │       }
+    │       metadata: {
+    │         "max_tokens": 24,
+    │         "model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    │         "provider": "anthropic",
+    │         "stop_reason": "end_turn",
+    │         "stop_sequence": null,
+    │         "temperature": 0
+    │       }
+    │       metrics: {
+    │         "completion_tokens": 4,
+    │         "prompt_cache_creation_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
+    │       }
+    └── anthropic-bedrock-stream-operation
+        metadata: {
+          "operation": "stream",
+          "testRunId": "<run:1>"
+        }
+        └── anthropic.messages.create [llm]
+            input: [
+              {
+                "content": "Count from 1 to 3 and include the words one two three.",
+                "role": "user"
+              }
+            ]
+            output: "1 - one\n2 - two\n3 - three"
+            metadata: {
+              "max_tokens": 32,
+              "model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+              "provider": "anthropic",
+              "stop_reason": "end_turn",
+              "stop_sequence": null,
+              "stream": true,
+              "temperature": 0
+            }
+            metrics: {
+              "completion_tokens": 18,
+              "prompt_cache_creation_tokens": 0,
+              "prompt_cached_tokens": 0,
+              "prompt_tokens": 24,
+              "time_to_first_token": 0,
+              "tokens": 42
+            }

--- a/e2e/scenarios/anthropic-bedrock-instrumentation/__snapshots__/anthropic-bedrock-v0302-wrapped.span-tree.json
+++ b/e2e/scenarios/anthropic-bedrock-instrumentation/__snapshots__/anthropic-bedrock-v0302-wrapped.span-tree.json
@@ -1,0 +1,97 @@
+{
+  "span_tree": [
+    {
+      "name": "anthropic-bedrock-instrumentation-root",
+      "type": "task",
+      "children": [
+        {
+          "name": "anthropic-bedrock-create-operation",
+          "children": [
+            {
+              "name": "anthropic.messages.create",
+              "type": "llm",
+              "children": [],
+              "input": [
+                {
+                  "content": "Reply with exactly OK.",
+                  "role": "user"
+                }
+              ],
+              "output": {
+                "content": [
+                  {
+                    "text": "OK",
+                    "type": "text"
+                  }
+                ],
+                "role": "assistant"
+              },
+              "metadata": {
+                "max_tokens": 24,
+                "model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+                "provider": "anthropic",
+                "stop_reason": "end_turn",
+                "stop_sequence": null,
+                "temperature": 0
+              },
+              "metrics": {
+                "completion_tokens": 4,
+                "prompt_cache_creation_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 16
+              }
+            }
+          ],
+          "metadata": {
+            "operation": "create",
+            "testRunId": "<run:1>"
+          }
+        },
+        {
+          "name": "anthropic-bedrock-stream-operation",
+          "children": [
+            {
+              "name": "anthropic.messages.create",
+              "type": "llm",
+              "children": [],
+              "input": [
+                {
+                  "content": "Count from 1 to 3 and include the words one two three.",
+                  "role": "user"
+                }
+              ],
+              "output": "1 - one\n2 - two\n3 - three",
+              "metadata": {
+                "max_tokens": 32,
+                "model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+                "provider": "anthropic",
+                "stop_reason": "end_turn",
+                "stop_sequence": null,
+                "stream": true,
+                "temperature": 0
+              },
+              "metrics": {
+                "completion_tokens": 18,
+                "prompt_cache_creation_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 24,
+                "time_to_first_token": 0,
+                "tokens": 42
+              }
+            }
+          ],
+          "metadata": {
+            "operation": "stream",
+            "testRunId": "<run:1>"
+          }
+        }
+      ],
+      "metadata": {
+        "scenario": "anthropic-bedrock-instrumentation",
+        "testRunId": "<run:1>"
+      }
+    }
+  ]
+}

--- a/e2e/scenarios/anthropic-bedrock-instrumentation/__snapshots__/anthropic-bedrock-v0302-wrapped.span-tree.txt
+++ b/e2e/scenarios/anthropic-bedrock-instrumentation/__snapshots__/anthropic-bedrock-v0302-wrapped.span-tree.txt
@@ -1,0 +1,73 @@
+span_tree:
+└── anthropic-bedrock-instrumentation-root [task]
+    metadata: {
+      "scenario": "anthropic-bedrock-instrumentation",
+      "testRunId": "<run:1>"
+    }
+    ├── anthropic-bedrock-create-operation
+    │   metadata: {
+    │     "operation": "create",
+    │     "testRunId": "<run:1>"
+    │   }
+    │   └── anthropic.messages.create [llm]
+    │       input: [
+    │         {
+    │           "content": "Reply with exactly OK.",
+    │           "role": "user"
+    │         }
+    │       ]
+    │       output: {
+    │         "content": [
+    │           {
+    │             "text": "OK",
+    │             "type": "text"
+    │           }
+    │         ],
+    │         "role": "assistant"
+    │       }
+    │       metadata: {
+    │         "max_tokens": 24,
+    │         "model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    │         "provider": "anthropic",
+    │         "stop_reason": "end_turn",
+    │         "stop_sequence": null,
+    │         "temperature": 0
+    │       }
+    │       metrics: {
+    │         "completion_tokens": 4,
+    │         "prompt_cache_creation_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
+    │       }
+    └── anthropic-bedrock-stream-operation
+        metadata: {
+          "operation": "stream",
+          "testRunId": "<run:1>"
+        }
+        └── anthropic.messages.create [llm]
+            input: [
+              {
+                "content": "Count from 1 to 3 and include the words one two three.",
+                "role": "user"
+              }
+            ]
+            output: "1 - one\n2 - two\n3 - three"
+            metadata: {
+              "max_tokens": 32,
+              "model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+              "provider": "anthropic",
+              "stop_reason": "end_turn",
+              "stop_sequence": null,
+              "stream": true,
+              "temperature": 0
+            }
+            metrics: {
+              "completion_tokens": 18,
+              "prompt_cache_creation_tokens": 0,
+              "prompt_cached_tokens": 0,
+              "prompt_tokens": 24,
+              "time_to_first_token": 0,
+              "tokens": 42
+            }

--- a/e2e/scenarios/anthropic-bedrock-instrumentation/assertions.ts
+++ b/e2e/scenarios/anthropic-bedrock-instrumentation/assertions.ts
@@ -1,0 +1,147 @@
+import { beforeAll, describe, expect, test } from "vitest";
+import type { CapturedLogEvent } from "../../helpers/mock-braintrust-server";
+import { resolveFileSnapshotPath } from "../../helpers/file-snapshot";
+import {
+  withScenarioHarness,
+  type ScenarioRunContext,
+} from "../../helpers/scenario-harness";
+import { matchSpanTreeSnapshot } from "../../helpers/span-tree";
+import { findChildSpans, findLatestSpan } from "../../helpers/trace-selectors";
+
+import { ROOT_NAME, SCENARIO_NAME } from "./scenario.impl.mjs";
+
+type RunAnthropicBedrockScenario = (harness: {
+  runNodeScenarioDir: (options: {
+    entry: string;
+    nodeArgs: string[];
+    runContext?: ScenarioRunContext;
+    scenarioDir: string;
+    timeoutMs: number;
+  }) => Promise<unknown>;
+  runScenarioDir: (options: {
+    entry: string;
+    runContext?: ScenarioRunContext;
+    scenarioDir: string;
+    timeoutMs: number;
+  }) => Promise<unknown>;
+}) => Promise<void>;
+
+function findAnthropicSpan(
+  events: CapturedLogEvent[],
+  parentId: string | undefined,
+) {
+  const spans = findChildSpans(events, "anthropic.messages.create", parentId);
+  return spans.find((candidate) => candidate.output !== undefined) ?? spans[0];
+}
+
+function expectAnthropicMetadata(
+  metadata: Record<string, unknown> | undefined,
+) {
+  expect(metadata).toMatchObject({
+    provider: "anthropic",
+  });
+  expect(typeof metadata?.model).toBe("string");
+  expect(metadata).not.toHaveProperty("bedrock");
+  expect(metadata).not.toHaveProperty("awsRegion");
+  expect(metadata).not.toHaveProperty("aws_region");
+  expect(metadata).not.toHaveProperty("region");
+}
+
+function spanTreeEvents(events: CapturedLogEvent[]): CapturedLogEvent[] {
+  const createOperation = findLatestSpan(
+    events,
+    "anthropic-bedrock-create-operation",
+  );
+  const streamOperation = findLatestSpan(
+    events,
+    "anthropic-bedrock-stream-operation",
+  );
+
+  return [
+    findLatestSpan(events, ROOT_NAME),
+    createOperation,
+    findAnthropicSpan(events, createOperation?.span.id),
+    streamOperation,
+    findAnthropicSpan(events, streamOperation?.span.id),
+  ].map((event) => event!);
+}
+
+export function defineAnthropicBedrockInstrumentationAssertions(options: {
+  name: string;
+  runScenario: RunAnthropicBedrockScenario;
+  snapshotName: string;
+  testFileUrl: string;
+  timeoutMs: number;
+}): void {
+  const spanSnapshotPath = resolveFileSnapshotPath(
+    options.testFileUrl,
+    `${options.snapshotName}.span-tree.json`,
+  );
+  const testConfig = {
+    timeout: options.timeoutMs,
+  };
+
+  describe(options.name, () => {
+    let events: CapturedLogEvent[] = [];
+
+    beforeAll(async () => {
+      await withScenarioHarness(async (harness) => {
+        await options.runScenario(harness);
+        events = harness.events();
+      });
+    }, options.timeoutMs);
+
+    test("captures the scenario root span", testConfig, () => {
+      const root = findLatestSpan(events, ROOT_NAME);
+
+      expect(root).toBeDefined();
+      expect(root?.row.metadata).toMatchObject({
+        scenario: SCENARIO_NAME,
+      });
+    });
+
+    test(
+      "captures create and stream spans through the Anthropic contract",
+      testConfig,
+      () => {
+        const root = findLatestSpan(events, ROOT_NAME);
+        const createOperation = findLatestSpan(
+          events,
+          "anthropic-bedrock-create-operation",
+        );
+        const createSpan = findAnthropicSpan(events, createOperation?.span.id);
+        const streamOperation = findLatestSpan(
+          events,
+          "anthropic-bedrock-stream-operation",
+        );
+        const streamSpan = findAnthropicSpan(events, streamOperation?.span.id);
+
+        expect(createOperation).toBeDefined();
+        expect(createSpan).toBeDefined();
+        expect(streamOperation).toBeDefined();
+        expect(streamSpan).toBeDefined();
+        expect(createOperation?.span.parentIds).toEqual([root?.span.id ?? ""]);
+        expect(streamOperation?.span.parentIds).toEqual([root?.span.id ?? ""]);
+
+        expectAnthropicMetadata(
+          createSpan?.row.metadata as Record<string, unknown> | undefined,
+        );
+        expect(createSpan?.output).toBeDefined();
+
+        expectAnthropicMetadata(
+          streamSpan?.row.metadata as Record<string, unknown> | undefined,
+        );
+        expect(streamSpan?.output).toBeDefined();
+        expect(streamSpan?.metrics).toMatchObject({
+          completion_tokens: expect.any(Number),
+          prompt_tokens: expect.any(Number),
+          time_to_first_token: expect.any(Number),
+        });
+      },
+    );
+
+    test("matches span tree snapshot", testConfig, async () => {
+      await matchSpanTreeSnapshot(spanTreeEvents(events), spanSnapshotPath);
+    });
+  });
+}

--- a/e2e/scenarios/anthropic-bedrock-instrumentation/cassette-filter.mjs
+++ b/e2e/scenarios/anthropic-bedrock-instrumentation/cassette-filter.mjs
@@ -1,0 +1,21 @@
+export const filter = [
+  "default",
+  {
+    normalizeRequest(req) {
+      try {
+        const url = new URL(req.url);
+        if (/^bedrock-runtime\.[^.]+\.amazonaws\.com$/.test(url.hostname)) {
+          url.hostname = "bedrock-runtime.aws-region.amazonaws.com";
+          return {
+            ...req,
+            url: url.toString(),
+          };
+        }
+      } catch {
+        // Keep the default-normalized request unchanged.
+      }
+
+      return req;
+    },
+  },
+];

--- a/e2e/scenarios/anthropic-bedrock-instrumentation/package.json
+++ b/e2e/scenarios/anthropic-bedrock-instrumentation/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@braintrust/e2e-anthropic-bedrock-instrumentation",
+  "private": true,
+  "braintrustScenario": {
+    "canary": {
+      "dependencies": {
+        "@anthropic-ai/bedrock-sdk": "latest"
+      }
+    }
+  },
+  "dependencies": {
+    "@anthropic-ai/bedrock-sdk": "0.30.2"
+  }
+}

--- a/e2e/scenarios/anthropic-bedrock-instrumentation/pnpm-lock.yaml
+++ b/e2e/scenarios/anthropic-bedrock-instrumentation/pnpm-lock.yaml
@@ -1,0 +1,946 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@anthropic-ai/bedrock-sdk':
+        specifier: 0.30.2
+        version: 0.30.2
+
+packages:
+
+  '@anthropic-ai/bedrock-sdk@0.30.2':
+    resolution: {integrity: sha512-4CSqbJN9UfKxPCut2y8PyNP32Pj2omUE6//lVVpiVRgYgml8QRm/Q+HknOSJgcr7b+YKXW8/+oVuKA93f08ShQ==}
+
+  '@anthropic-ai/sdk@0.104.2':
+    resolution: {integrity: sha512-s1wEVDAtEwkS7Ajgep6PZKJLFqybRkmD3Byz+iVVsSpbDY0gjROXE9aOft6V3PMqynn3NTcycV5whga9tCzmKA==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@aws-crypto/crc32@3.0.0':
+    resolution: {integrity: sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==}
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@4.0.0':
+    resolution: {integrity: sha512-MHGJyjE7TX9aaqXj7zk2ppnFUOhaDs5sP+HtNS0evOxn72c+5njUmyJmpGd7TfyoDznZlHMmdo/xGUdu2NIjNQ==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@3.0.0':
+    resolution: {integrity: sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==}
+
+  '@aws-crypto/util@4.0.0':
+    resolution: {integrity: sha512-2EnmPy2gsFZ6m8bwUQN4jq+IyXV3quHAcwPOS6ZA3k+geujiqI8aRokO2kFJe+idJ/P3v4qWI186rVMo0+zLDQ==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-bedrock-runtime@3.1071.0':
+    resolution: {integrity: sha512-1Sa7UTC98Wy+M+zYbbXEqhcL5WUE3VnAmO1Y2RikmYjWx/8nCHudjSj1bVovk6Obfrrsir9Q1AbrmKbgxwI90g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-cognito-identity@3.1071.0':
+    resolution: {integrity: sha512-DIzsM+S/jLcTu+gRHy/luPGkqjiXIQFQTe8zCADE1SX4QXw05bUJNoF2yI0z3HUEMC4wIJsVhDpgKt6jeUr/eA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.22':
+    resolution: {integrity: sha512-YofH63shc6YRdXjz80BJkpJW+Bkn0Cuu2dn4Rv7s9G2Idt58tgtzQEWxrR2xVljlVfIBeUjPuULnSVYLke3sUQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.47':
+    resolution: {integrity: sha512-IEW+q7yXgTT6+TFgJlOW+K5FK7kj1pBFW7oc04J/jlitMxq+vOJpmU42j+xaQlhwPx2JR805ryi73aLRWicXjQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.48':
+    resolution: {integrity: sha512-h6FEC95fbexUd6zxm4PdgS82bTcI2PRtUb2ZwMipb/Xr8bPwtf0G8rBo2jp7NA24Mbx2JA8/WingiYpA9RCCyw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.50':
+    resolution: {integrity: sha512-lJO3OLpjvz5m/RSBQmsG/CEUGsvCy5ruxKwPQaOCqxqCMuyYT2BZwQUTDZVVwqQ9LrZKuK24JSa6r31hL/tvkg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.55':
+    resolution: {integrity: sha512-TBoF4buBGYhXjdZAryayY2TrkQj2B2KfE/msG4V53XCt+w0EhEwM2JRjx8p2grJ2C6gtH5++SAwEvGMRdi0yyw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.54':
+    resolution: {integrity: sha512-hBWI3wZTdTGiuMfmPts6AWbAjFfRniOQnqx68tc2cQvRKWawFbN9wkLOVPWM1FAOyowZU73mC6Fi+rHSHNyLFw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.57':
+    resolution: {integrity: sha512-u6dClpzNdWf1HGWz4wwhdXi1wiOofCLniM9S4BQQGlLAN9TW7VB+ld5V533GdKrYMaFeBGFqKnj0JCYvynLqwQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.48':
+    resolution: {integrity: sha512-w6VZwojPt12WnEkAUy6Nu4K6sWCbBmR7QX390b0nE6vRvkXbrYr9Lq9VySGkfjiMjpUA87op+J4EgvRmtWIDoQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.54':
+    resolution: {integrity: sha512-23uZpIpF2SIFDCa1fcWa202tK4gGeyvX6GIIAjiB8WBsvsVRBMnJ/7dCxHzxf7eZT7GToJg837LDIBnZsl/VUg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.54':
+    resolution: {integrity: sha512-0Iv5QttS6wcATlodYKgvQj6B9Db51rx7NU9fqu0PoLeS4BIgdYMc/QK4smwLwpm5RFrs02V/eLyEFp3FklvlNQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-providers@3.1071.0':
+    resolution: {integrity: sha512-CyujYtNK0EoKgxwkqlz3UGADDgXVhOsGudqau/tlxzLAt25cYi5o9wImIVwbO5NwGy3CqjYC/2bQp1z2lW0XfQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.22':
+    resolution: {integrity: sha512-tqPJv0dz4+O0hWGm1a6YekcMZyPhDFs/zH73Von7icaVT5n0Jqvm86typ3jRrG+qoUdPhALOnboRLTmnWQTlYQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.18':
+    resolution: {integrity: sha512-OHpk8YoZi3yexPq8aFt1vN1IxA2zLKvsIR5GpWYylX/ve6kQmY7wxHNSFy/D3t2apMZ16rs76Co4dJWcDyIk3A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.30':
+    resolution: {integrity: sha512-kH6N4f/Fzi9r/dYap8EQ+Zk4NOz8pl4AtWKhzAoG2C1/4YkIHok9APp/e+75woreWQq264n+LkrJsJVZ0Q+M1Q==}
+    engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.22':
+    resolution: {integrity: sha512-4IwtcYSxEIVw5hcp8ogq0CMbFNZFw7jJUetpfFUhFFeqsa1K8j2Ihg2hnxLyOp3stMZnXda6VzOmPi1AFZQXcg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.35':
+    resolution: {integrity: sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1071.0':
+    resolution: {integrity: sha512-4LDW2Qob6LoLFuqYSYZq2AyTE9koSE9+i+n5UZcm10GpmQOK0zRD9L4uYlzItiTKksIWgC/qMFChAi3RvKYtMg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.13':
+    resolution: {integrity: sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    resolution: {integrity: sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-utf8-browser@3.259.0':
+    resolution: {integrity: sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==}
+
+  '@aws-sdk/xml-builder@3.972.30':
+    resolution: {integrity: sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@nodable/entities@2.2.0':
+    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
+
+  '@smithy/abort-controller@2.2.0':
+    resolution: {integrity: sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/core@3.25.1':
+    resolution: {integrity: sha512-zpDbpXBCBsxfLtG2GEUyfgvHvSFrw5CwDZSNzL0v52gx/c3oPlPbm+7W7num8xs6vyiUBn+bvYPHcQDOXZynCQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.1':
+    resolution: {integrity: sha512-TSAF5NHgxEsllbErYWbK8aLnl5L601NGc5VYJlSPsKnf3YlkhdoBN+geGcaU00oiw2OK3QO5LA3QNXiiWhCidQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-codec@2.2.0':
+    resolution: {integrity: sha512-8janZoJw85nJmQZc4L8TuePp2pk1nxLgkxIR0TUjKJ5Dkj5oelB9WtiSSGXCQvNsJl0VSTvK/2ueMXxvpa9GVw==}
+
+  '@smithy/eventstream-serde-node@2.2.0':
+    resolution: {integrity: sha512-zpQMtJVqCUMn+pCSFcl9K/RPNtQE0NuMh8sKpCdEHafhwRsjP50Oq/4kMmvxSRy6d8Jslqd8BLvDngrUtmN9iA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/eventstream-serde-universal@2.2.0':
+    resolution: {integrity: sha512-pvoe/vvJY0mOpuF84BEtyZoYfbehiFj8KKWk1ds2AT0mTLYFVs+7sBJZmioOFdBXKd48lfrx1vumdPdmGlCLxA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/fetch-http-handler@2.5.0':
+    resolution: {integrity: sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==}
+
+  '@smithy/fetch-http-handler@5.5.1':
+    resolution: {integrity: sha512-96JrD1q71anokymx9Iblb+zKmNQYNstlV/25A9ZYIJ2A0rp1r7/GZAIm0bDWSmVvz3DpNOCZuabzsiL+w0UHhw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@3.0.0':
+    resolution: {integrity: sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@smithy/middleware-endpoint@2.5.1':
+    resolution: {integrity: sha512-1/8kFp6Fl4OsSIVTWHnNjLnTL8IqpIb/D3sTSczrKFnrE9VMNWxnrRKNvpUHOJ6zpGD5f62TPm7+17ilTJpiCQ==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/middleware-serde@2.3.0':
+    resolution: {integrity: sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/middleware-stack@2.2.0':
+    resolution: {integrity: sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-config-provider@2.3.0':
+    resolution: {integrity: sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@2.5.0':
+    resolution: {integrity: sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.8.1':
+    resolution: {integrity: sha512-emtXvoky671puri18ETf64AFIQUGIEA093F2drXpBgB0OGnBLjcwNR3CA2mYu62IAqNsS56xa5lnTxAgPq7cjw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@2.2.0':
+    resolution: {integrity: sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/protocol-http@3.3.0':
+    resolution: {integrity: sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/querystring-builder@2.2.0':
+    resolution: {integrity: sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/querystring-parser@2.2.0':
+    resolution: {integrity: sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/shared-ini-file-loader@2.4.0':
+    resolution: {integrity: sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/signature-v4@3.1.2':
+    resolution: {integrity: sha512-3BcPylEsYtD0esM4Hoyml/+s7WP2LFhcM3J2AGdcL2vx9O60TtfpDOL72gjb4lU8NeRPeKAwR77YNyyGvMbuEA==}
+    engines: {node: '>=16.0.0'}
+
+  '@smithy/signature-v4@5.5.1':
+    resolution: {integrity: sha512-X9rVls3En0z3NtrmguTmpRM0/NqtWUxBjal6fcAkwtsub+gOdLZ6kD+V7xhUgFMGdG14bHbZ7M5QjaRI1+DatQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@2.5.1':
+    resolution: {integrity: sha512-jrbSQrYCho0yDaaf92qWgd+7nAeap5LtHTI51KXqmpIFCceKU3K9+vIVTUH72bOJngBMqa4kyu1VJhRcSrk/CQ==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/types@2.12.0':
+    resolution: {integrity: sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/types@3.7.2':
+    resolution: {integrity: sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==}
+    engines: {node: '>=16.0.0'}
+
+  '@smithy/types@4.15.0':
+    resolution: {integrity: sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@2.2.0':
+    resolution: {integrity: sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==}
+
+  '@smithy/util-base64@2.3.0':
+    resolution: {integrity: sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@3.0.0':
+    resolution: {integrity: sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==}
+    engines: {node: '>=16.0.0'}
+
+  '@smithy/util-hex-encoding@2.2.0':
+    resolution: {integrity: sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-hex-encoding@3.0.0':
+    resolution: {integrity: sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@smithy/util-middleware@2.2.0':
+    resolution: {integrity: sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-middleware@3.0.11':
+    resolution: {integrity: sha512-dWpyc1e1R6VoXrwLoLDd57U1z6CwNSdkM69Ie4+6uYh2GC7Vg51Qtan7ITzczuVpqezdDTKJGJB95fFvvjU/ow==}
+    engines: {node: '>=16.0.0'}
+
+  '@smithy/util-stream@2.2.0':
+    resolution: {integrity: sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-uri-escape@2.2.0':
+    resolution: {integrity: sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-uri-escape@3.0.0':
+    resolution: {integrity: sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==}
+    engines: {node: '>=16.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@3.0.0':
+    resolution: {integrity: sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==}
+    engines: {node: '>=16.0.0'}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
+    hasBin: true
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
+  strnum@2.4.1:
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
+snapshots:
+
+  '@anthropic-ai/bedrock-sdk@0.30.2':
+    dependencies:
+      '@anthropic-ai/sdk': 0.104.2
+      '@aws-crypto/sha256-js': 4.0.0
+      '@aws-sdk/client-bedrock-runtime': 3.1071.0
+      '@aws-sdk/credential-providers': 3.1071.0
+      '@smithy/eventstream-serde-node': 2.2.0
+      '@smithy/fetch-http-handler': 5.5.1
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/signature-v4': 3.1.2
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/util-base64': 2.3.0
+    transitivePeerDependencies:
+      - zod
+
+  '@anthropic-ai/sdk@0.104.2':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+
+  '@aws-crypto/crc32@3.0.0':
+    dependencies:
+      '@aws-crypto/util': 3.0.0
+      '@aws-sdk/types': 3.973.13
+      tslib: 1.14.1
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/util-locate-window': 3.965.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@4.0.0':
+    dependencies:
+      '@aws-crypto/util': 4.0.0
+      '@aws-sdk/types': 3.973.13
+      tslib: 1.14.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@3.0.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/util-utf8-browser': 3.259.0
+      tslib: 1.14.1
+
+  '@aws-crypto/util@4.0.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/util-utf8-browser': 3.259.0
+      tslib: 1.14.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-bedrock-runtime@3.1071.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/credential-provider-node': 3.972.57
+      '@aws-sdk/eventstream-handler-node': 3.972.22
+      '@aws-sdk/middleware-eventstream': 3.972.18
+      '@aws-sdk/middleware-websocket': 3.972.30
+      '@aws-sdk/token-providers': 3.1071.0
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/fetch-http-handler': 5.5.1
+      '@smithy/node-http-handler': 4.8.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-cognito-identity@3.1071.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/credential-provider-node': 3.972.57
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/fetch-http-handler': 5.5.1
+      '@smithy/node-http-handler': 4.8.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.22':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/xml-builder': 3.972.30
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.25.1
+      '@smithy/signature-v4': 5.5.1
+      '@smithy/types': 4.15.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.47':
+    dependencies:
+      '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.48':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.50':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/fetch-http-handler': 5.5.1
+      '@smithy/node-http-handler': 4.8.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/credential-provider-env': 3.972.48
+      '@aws-sdk/credential-provider-http': 3.972.50
+      '@aws-sdk/credential-provider-login': 3.972.54
+      '@aws-sdk/credential-provider-process': 3.972.48
+      '@aws-sdk/credential-provider-sso': 3.972.54
+      '@aws-sdk/credential-provider-web-identity': 3.972.54
+      '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/credential-provider-imds': 4.4.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.57':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.48
+      '@aws-sdk/credential-provider-http': 3.972.50
+      '@aws-sdk/credential-provider-ini': 3.972.55
+      '@aws-sdk/credential-provider-process': 3.972.48
+      '@aws-sdk/credential-provider-sso': 3.972.54
+      '@aws-sdk/credential-provider-web-identity': 3.972.54
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/credential-provider-imds': 4.4.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.48':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/token-providers': 3.1071.0
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-providers@3.1071.0':
+    dependencies:
+      '@aws-sdk/client-cognito-identity': 3.1071.0
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/credential-provider-cognito-identity': 3.972.47
+      '@aws-sdk/credential-provider-env': 3.972.48
+      '@aws-sdk/credential-provider-http': 3.972.50
+      '@aws-sdk/credential-provider-ini': 3.972.55
+      '@aws-sdk/credential-provider-login': 3.972.54
+      '@aws-sdk/credential-provider-node': 3.972.57
+      '@aws-sdk/credential-provider-process': 3.972.48
+      '@aws-sdk/credential-provider-sso': 3.972.54
+      '@aws-sdk/credential-provider-web-identity': 3.972.54
+      '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/credential-provider-imds': 4.4.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/eventstream-handler-node@3.972.22':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.18':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.30':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/fetch-http-handler': 5.5.1
+      '@smithy/signature-v4': 5.5.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.22':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/fetch-http-handler': 5.5.1
+      '@smithy/node-http-handler': 4.8.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.35':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/signature-v4': 5.5.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1071.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.13':
+    dependencies:
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-utf8-browser@3.259.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.30':
+    dependencies:
+      '@smithy/types': 4.15.0
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
+
+  '@babel/runtime@7.29.7': {}
+
+  '@nodable/entities@2.2.0': {}
+
+  '@smithy/abort-controller@2.2.0':
+    dependencies:
+      '@smithy/types': 2.12.0
+      tslib: 2.8.1
+
+  '@smithy/core@3.25.1':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.1':
+    dependencies:
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-codec@2.2.0':
+    dependencies:
+      '@aws-crypto/crc32': 3.0.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-hex-encoding': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-node@2.2.0':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 2.2.0
+      '@smithy/types': 2.12.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-universal@2.2.0':
+    dependencies:
+      '@smithy/eventstream-codec': 2.2.0
+      '@smithy/types': 2.12.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@2.5.0':
+    dependencies:
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/querystring-builder': 2.2.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-base64': 2.3.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.5.1':
+    dependencies:
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@3.0.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@2.5.1':
+    dependencies:
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/shared-ini-file-loader': 2.4.0
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-middleware': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@2.3.0':
+    dependencies:
+      '@smithy/types': 2.12.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@2.2.0':
+    dependencies:
+      '@smithy/types': 2.12.0
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@2.3.0':
+    dependencies:
+      '@smithy/property-provider': 2.2.0
+      '@smithy/shared-ini-file-loader': 2.4.0
+      '@smithy/types': 2.12.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@2.5.0':
+    dependencies:
+      '@smithy/abort-controller': 2.2.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/querystring-builder': 2.2.0
+      '@smithy/types': 2.12.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.8.1':
+    dependencies:
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/property-provider@2.2.0':
+    dependencies:
+      '@smithy/types': 2.12.0
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@3.3.0':
+    dependencies:
+      '@smithy/types': 2.12.0
+      tslib: 2.8.1
+
+  '@smithy/querystring-builder@2.2.0':
+    dependencies:
+      '@smithy/types': 2.12.0
+      '@smithy/util-uri-escape': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@2.2.0':
+    dependencies:
+      '@smithy/types': 2.12.0
+      tslib: 2.8.1
+
+  '@smithy/shared-ini-file-loader@2.4.0':
+    dependencies:
+      '@smithy/types': 2.12.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@3.1.2':
+    dependencies:
+      '@smithy/is-array-buffer': 3.0.0
+      '@smithy/types': 3.7.2
+      '@smithy/util-hex-encoding': 3.0.0
+      '@smithy/util-middleware': 3.0.11
+      '@smithy/util-uri-escape': 3.0.0
+      '@smithy/util-utf8': 3.0.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.5.1':
+    dependencies:
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@2.5.1':
+    dependencies:
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-stream': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/types@2.12.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@3.7.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.15.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/url-parser@2.2.0':
+    dependencies:
+      '@smithy/querystring-parser': 2.2.0
+      '@smithy/types': 2.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-base64@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@3.0.0':
+    dependencies:
+      '@smithy/is-array-buffer': 3.0.0
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@3.0.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@2.2.0':
+    dependencies:
+      '@smithy/types': 2.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@3.0.11':
+    dependencies:
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+
+  '@smithy/util-stream@2.2.0':
+    dependencies:
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-buffer-from': 2.2.0
+      '@smithy/util-hex-encoding': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@3.0.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@3.0.0':
+    dependencies:
+      '@smithy/util-buffer-from': 3.0.0
+      tslib: 2.8.1
+
+  '@stablelib/base64@1.0.1': {}
+
+  anynum@1.0.1: {}
+
+  bowser@2.14.1: {}
+
+  fast-sha256@1.3.0: {}
+
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.2.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.4.1
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
+
+  path-expression-matcher@1.5.0: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
+  strnum@2.4.1:
+    dependencies:
+      anynum: 1.0.1
+
+  ts-algebra@2.0.0: {}
+
+  tslib@1.14.1: {}
+
+  tslib@2.8.1: {}
+
+  xml-naming@0.1.0: {}

--- a/e2e/scenarios/anthropic-bedrock-instrumentation/scenario.cjs
+++ b/e2e/scenarios/anthropic-bedrock-instrumentation/scenario.cjs
@@ -1,0 +1,17 @@
+const mod = require("@anthropic-ai/bedrock-sdk");
+const AnthropicBedrock = mod.default ?? mod.AnthropicBedrock ?? mod;
+
+void (async () => {
+  const { runMain } = await import("../../helpers/provider-runtime.mjs");
+  const { runAutoAnthropicBedrockInstrumentation } =
+    await import("./scenario.impl.mjs");
+
+  runMain(async () => {
+    await runAutoAnthropicBedrockInstrumentation({
+      AnthropicBedrock,
+    });
+  });
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/e2e/scenarios/anthropic-bedrock-instrumentation/scenario.impl.mjs
+++ b/e2e/scenarios/anthropic-bedrock-instrumentation/scenario.impl.mjs
@@ -1,0 +1,99 @@
+import { wrapAnthropic } from "braintrust";
+import {
+  collectAsync,
+  runOperation,
+  runTracedScenario,
+} from "../../helpers/provider-runtime.mjs";
+
+export const ROOT_NAME = "anthropic-bedrock-instrumentation-root";
+export const SCENARIO_NAME = "anthropic-bedrock-instrumentation";
+export const ANTHROPIC_BEDROCK_SCENARIO_TIMEOUT_MS = 180_000;
+
+const DEFAULT_MODEL = "us.anthropic.claude-sonnet-4-5-20250929-v1:0";
+const DEFAULT_REGION = "us-east-1";
+
+function getAwsRegion() {
+  return (
+    process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || DEFAULT_REGION
+  );
+}
+
+function getModel() {
+  const cassetteMode = process.env.BRAINTRUST_E2E_CASSETTE_MODE;
+  if (
+    (cassetteMode === "record" ||
+      cassetteMode === "record-missing" ||
+      cassetteMode === "passthrough") &&
+    process.env.BRAINTRUST_ANTHROPIC_BEDROCK_MODEL
+  ) {
+    return process.env.BRAINTRUST_ANTHROPIC_BEDROCK_MODEL;
+  }
+
+  return DEFAULT_MODEL;
+}
+
+async function runAnthropicBedrockInstrumentationScenario(options) {
+  const baseClient = new options.AnthropicBedrock({
+    apiKey: process.env.AWS_BEARER_TOKEN_BEDROCK,
+    awsRegion: getAwsRegion(),
+    baseURL: process.env.ANTHROPIC_BEDROCK_BASE_URL,
+  });
+  const client = options.decorateClient
+    ? options.decorateClient(baseClient)
+    : baseClient;
+  const model = getModel();
+
+  await runTracedScenario({
+    callback: async () => {
+      await runOperation(
+        "anthropic-bedrock-create-operation",
+        "create",
+        async () => {
+          await client.messages.create({
+            max_tokens: 24,
+            messages: [{ role: "user", content: "Reply with exactly OK." }],
+            model,
+            temperature: 0,
+          });
+        },
+      );
+
+      await runOperation(
+        "anthropic-bedrock-stream-operation",
+        "stream",
+        async () => {
+          const stream = await client.messages.create({
+            max_tokens: 32,
+            messages: [
+              {
+                role: "user",
+                content:
+                  "Count from 1 to 3 and include the words one two three.",
+              },
+            ],
+            model,
+            stream: true,
+            temperature: 0,
+          });
+          await collectAsync(stream);
+        },
+      );
+    },
+    metadata: {
+      scenario: SCENARIO_NAME,
+    },
+    projectNameBase: "e2e-anthropic-bedrock-instrumentation",
+    rootName: ROOT_NAME,
+  });
+}
+
+export async function runWrappedAnthropicBedrockInstrumentation(options) {
+  await runAnthropicBedrockInstrumentationScenario({
+    decorateClient: wrapAnthropic,
+    ...options,
+  });
+}
+
+export async function runAutoAnthropicBedrockInstrumentation(options) {
+  await runAnthropicBedrockInstrumentationScenario(options);
+}

--- a/e2e/scenarios/anthropic-bedrock-instrumentation/scenario.mjs
+++ b/e2e/scenarios/anthropic-bedrock-instrumentation/scenario.mjs
@@ -1,0 +1,9 @@
+import AnthropicBedrock from "@anthropic-ai/bedrock-sdk";
+import { runMain } from "../../helpers/provider-runtime.mjs";
+import { runAutoAnthropicBedrockInstrumentation } from "./scenario.impl.mjs";
+
+runMain(async () => {
+  await runAutoAnthropicBedrockInstrumentation({
+    AnthropicBedrock,
+  });
+});

--- a/e2e/scenarios/anthropic-bedrock-instrumentation/scenario.test.ts
+++ b/e2e/scenarios/anthropic-bedrock-instrumentation/scenario.test.ts
@@ -1,0 +1,75 @@
+import { describe } from "vitest";
+import {
+  prepareScenarioDir,
+  readInstalledPackageVersion,
+  resolveScenarioDir,
+} from "../../helpers/scenario-harness";
+import { defineAnthropicBedrockInstrumentationAssertions } from "./assertions";
+import { ANTHROPIC_BEDROCK_SCENARIO_TIMEOUT_MS } from "./scenario.impl.mjs";
+
+const originalScenarioDir = resolveScenarioDir(import.meta.url);
+const scenarioDir = await prepareScenarioDir({
+  scenarioDir: originalScenarioDir,
+});
+const bedrockSdkVersion = await readInstalledPackageVersion(
+  scenarioDir,
+  "@anthropic-ai/bedrock-sdk",
+);
+
+describe(`anthropic bedrock sdk ${bedrockSdkVersion}`, () => {
+  defineAnthropicBedrockInstrumentationAssertions({
+    name: "wrapped instrumentation",
+    runScenario: async ({ runScenarioDir }) => {
+      await runScenarioDir({
+        entry: "scenario.ts",
+        runContext: {
+          variantKey: "anthropic-bedrock-v0302-wrapped",
+          originalScenarioDir,
+        },
+        scenarioDir,
+        timeoutMs: ANTHROPIC_BEDROCK_SCENARIO_TIMEOUT_MS,
+      });
+    },
+    snapshotName: "anthropic-bedrock-v0302-wrapped",
+    testFileUrl: import.meta.url,
+    timeoutMs: ANTHROPIC_BEDROCK_SCENARIO_TIMEOUT_MS,
+  });
+
+  defineAnthropicBedrockInstrumentationAssertions({
+    name: "auto-hook instrumentation ESM",
+    runScenario: async ({ runNodeScenarioDir }) => {
+      await runNodeScenarioDir({
+        entry: "scenario.mjs",
+        nodeArgs: ["--import", "braintrust/hook.mjs"],
+        runContext: {
+          variantKey: "anthropic-bedrock-v0302-auto-esm",
+          originalScenarioDir,
+        },
+        scenarioDir,
+        timeoutMs: ANTHROPIC_BEDROCK_SCENARIO_TIMEOUT_MS,
+      });
+    },
+    snapshotName: "anthropic-bedrock-v0302-auto-esm",
+    testFileUrl: import.meta.url,
+    timeoutMs: ANTHROPIC_BEDROCK_SCENARIO_TIMEOUT_MS,
+  });
+
+  defineAnthropicBedrockInstrumentationAssertions({
+    name: "auto-hook instrumentation CJS",
+    runScenario: async ({ runNodeScenarioDir }) => {
+      await runNodeScenarioDir({
+        entry: "scenario.cjs",
+        nodeArgs: ["--import", "braintrust/hook.mjs"],
+        runContext: {
+          variantKey: "anthropic-bedrock-v0302-auto-cjs",
+          originalScenarioDir,
+        },
+        scenarioDir,
+        timeoutMs: ANTHROPIC_BEDROCK_SCENARIO_TIMEOUT_MS,
+      });
+    },
+    snapshotName: "anthropic-bedrock-v0302-auto-cjs",
+    testFileUrl: import.meta.url,
+    timeoutMs: ANTHROPIC_BEDROCK_SCENARIO_TIMEOUT_MS,
+  });
+});

--- a/e2e/scenarios/anthropic-bedrock-instrumentation/scenario.ts
+++ b/e2e/scenarios/anthropic-bedrock-instrumentation/scenario.ts
@@ -1,0 +1,9 @@
+import AnthropicBedrock from "@anthropic-ai/bedrock-sdk";
+import { runMain } from "../../helpers/provider-runtime.mjs";
+import { runWrappedAnthropicBedrockInstrumentation } from "./scenario.impl.mjs";
+
+runMain(async () => {
+  await runWrappedAnthropicBedrockInstrumentation({
+    AnthropicBedrock,
+  });
+});

--- a/js/src/auto-instrumentations/configs/anthropic.ts
+++ b/js/src/auto-instrumentations/configs/anthropic.ts
@@ -13,6 +13,11 @@ import { anthropicChannels } from "../../instrumentation/plugins/anthropic-chann
  * "orchestrion:@anthropic-ai/sdk:messages.create"
  */
 export const anthropicConfigs: InstrumentationConfig[] = [
+  // Each logical target is listed for both published module formats:
+  // `.mjs` covers ESM imports, while `.js` covers CJS requires. The Bedrock
+  // SDK delegates CJS `messages.create` calls through these Anthropic SDK
+  // `.js` resource files.
+
   // Messages API - create in older SDK layouts (supports streaming via stream=true parameter)
   {
     channelName: anthropicChannels.messagesCreate.channelName,
@@ -20,6 +25,19 @@ export const anthropicConfigs: InstrumentationConfig[] = [
       name: "@anthropic-ai/sdk",
       versionRange: ">=0.27.0 <0.39.0",
       filePath: "resources/messages.mjs",
+    },
+    functionQuery: {
+      className: "Messages",
+      methodName: "create",
+      kind: "Async",
+    },
+  },
+  {
+    channelName: anthropicChannels.messagesCreate.channelName,
+    module: {
+      name: "@anthropic-ai/sdk",
+      versionRange: ">=0.27.0 <0.39.0",
+      filePath: "resources/messages.js",
     },
     functionQuery: {
       className: "Messages",
@@ -42,6 +60,19 @@ export const anthropicConfigs: InstrumentationConfig[] = [
       kind: "Async",
     },
   },
+  {
+    channelName: anthropicChannels.messagesCreate.channelName,
+    module: {
+      name: "@anthropic-ai/sdk",
+      versionRange: ">=0.39.0",
+      filePath: "resources/messages/messages.js",
+    },
+    functionQuery: {
+      className: "Messages",
+      methodName: "create",
+      kind: "Async",
+    },
+  },
 
   // Beta Messages API - create (supports streaming via stream=true parameter)
   {
@@ -57,6 +88,19 @@ export const anthropicConfigs: InstrumentationConfig[] = [
       kind: "Async",
     },
   },
+  {
+    channelName: anthropicChannels.betaMessagesCreate.channelName,
+    module: {
+      name: "@anthropic-ai/sdk",
+      versionRange: ">=0.39.0",
+      filePath: "resources/beta/messages/messages.js",
+    },
+    functionQuery: {
+      className: "Messages",
+      methodName: "create",
+      kind: "Async",
+    },
+  },
 
   // Beta Messages API - toolRunner (sync helper returning async iterable/thenable)
   {
@@ -65,6 +109,19 @@ export const anthropicConfigs: InstrumentationConfig[] = [
       name: "@anthropic-ai/sdk",
       versionRange: ">=0.39.0",
       filePath: "resources/beta/messages/messages.mjs",
+    },
+    functionQuery: {
+      className: "Messages",
+      methodName: "toolRunner",
+      kind: "Sync",
+    },
+  },
+  {
+    channelName: anthropicChannels.betaMessagesToolRunner.channelName,
+    module: {
+      name: "@anthropic-ai/sdk",
+      versionRange: ">=0.39.0",
+      filePath: "resources/beta/messages/messages.js",
     },
     functionQuery: {
       className: "Messages",


### PR DESCRIPTION
Fixes https://github.com/braintrustdata/braintrust-sdk-javascript/issues/2047

Primarily adds e2e tests which uncovered a problem with patching since the bedrock package depends on the .js files in the normal anthropic package.