### PR TITLE
feat: Add scorer that exposes helpers to evaluate agents

### DIFF
--- a/.changeset/sweet-pears-pay.md
+++ b/.changeset/sweet-pears-pay.md
@@ -1,0 +1,5 @@
+---
+"braintrust": minor
+---
+
+feat: Add scorer that exposes helpers to evaluate agents

--- a/js/src/agent-assertions.test.ts
+++ b/js/src/agent-assertions.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, expect, test, vi } from "vitest";
+import { beforeAll, expect, expectTypeOf, test, vi } from "vitest";
 import { z } from "zod";
 
 import { agentAssertionScorer, Eval } from "./exports";
@@ -11,6 +11,23 @@ beforeAll(() => {
   configureNode();
 });
 
+test("agentAssertionScorer callback receives default metadata", async () => {
+  let callbackMetadata: unknown;
+  const scorer = agentAssertionScorer(({ metadata, assert }) => {
+    expectTypeOf(metadata).toEqualTypeOf<Record<string, unknown>>();
+    callbackMetadata = metadata;
+    return [assert.equals(metadata, {}, "metadata defaults to empty object")];
+  });
+
+  const score = (await scorer({
+    input: "hello",
+    output: "done",
+  })) as Score;
+
+  expect(callbackMetadata).toEqual({});
+  expect(score.score).toBe(1);
+});
+
 test("agentAssertionScorer emits one score with assertion metadata", async () => {
   const scorer = agentAssertionScorer<
     string,
@@ -20,7 +37,8 @@ test("agentAssertionScorer emits one score with assertion metadata", async () =>
     ({ output, expected, assert }) => [
       assert.equals(output.answer, expected.answer, "answer matches"),
       assert.equals(output.count, 3, "count is three"),
-      assert.contains(output.answer, /hi/i, "answer contains greeting"),
+      assert.contains(output.answer, /^hi$/, "answer contains greeting"),
+      assert.contains(output, "hi", "output object contains greeting"),
       assert.matches(
         output,
         z.object({ answer: z.string(), count: z.number() }),
@@ -38,16 +56,53 @@ test("agentAssertionScorer emits one score with assertion metadata", async () =>
   })) as Score;
 
   expect(score.name).toBe("agent_contract");
-  expect(score.score).toBe(0.75);
+  expect(score.score).toBe(0.8);
   expect(score.metadata).toEqual({
     assertions: [
       { name: "answer matches", passed: true },
       { name: "count is three", passed: false },
       { name: "answer contains greeting", passed: true },
+      { name: "output object contains greeting", passed: true },
       { name: "output schema", passed: true },
     ],
     failed: ["count is three: expected 2 to equal 3"],
   } satisfies AgentAssertionScoreMetadata);
+});
+
+test("agentAssertionScorer compares object keys before undefined values", async () => {
+  const scorer = agentAssertionScorer(({ assert }) => [
+    assert.equals(
+      { a: undefined },
+      { b: undefined },
+      "different undefined keys are not equal",
+    ),
+    assert.notEquals(
+      { a: undefined },
+      { b: undefined },
+      "different undefined keys are not equal with notEquals",
+    ),
+  ]);
+
+  const score = (await scorer({
+    input: "hello",
+    output: "done",
+    metadata: {},
+  })) as Score;
+
+  expect(score.score).toBe(0.5);
+  expect(score.metadata).toMatchObject({
+    assertions: [
+      { name: "different undefined keys are not equal", passed: false },
+      {
+        name: "different undefined keys are not equal with notEquals",
+        passed: true,
+      },
+    ],
+  });
+  const metadata = score.metadata as AgentAssertionScoreMetadata;
+  expect(metadata.failed).toEqual([
+    'different undefined keys are not equal: expected {"a":undefined} to equal {"b":undefined}',
+  ]);
 });
 
 test("agentAssertionScorer evaluates trace-backed tool assertions after collection", async () => {
@@ -77,8 +132,8 @@ test("agentAssertionScorer evaluates trace-backed tool assertions after collecti
     callbackOrder.push("callback");
     return [
       assert.calledTool("get_weather", {
-        input: { city: /Brook/ },
-        output: { forecast: /sunny/ },
+        input: /Brooklyn/,
+        output: /sunny/,
         times: 1,
       }),
       assert.calledTool("charge_card"),
@@ -110,6 +165,300 @@ test("agentAssertionScorer evaluates trace-backed tool assertions after collecti
     failed: [
       'called tool charge_card: expected tool "charge_card" to be called; found 0 matching calls',
     ],
+  } satisfies AgentAssertionScoreMetadata);
+});
+
+test("agentAssertionScorer requires undefined matcher keys to exist", async () => {
+  const getSpans = vi.fn().mockResolvedValue([
+    {
+      input: {},
+      output: {},
+      span_attributes: { type: "tool", name: "lookup_cache" },
+    },
+    {
+      input: { foo: undefined },
+      output: { cached: undefined },
+      span_attributes: { type: "tool", name: "lookup_cache" },
+    },
+  ]);
+  const trace: Trace = {
+    getConfiguration: () => ({
+      object_type: "experiment",
+      object_id: "experiment-id",
+      root_span_id: "root-span-id",
+    }),
+    getSpans,
+    getThread: vi.fn(),
+  };
+  const scorer = agentAssertionScorer(({ assert }) => [
+    assert.calledTool(
+      "lookup_cache",
+      {
+        input: { foo: undefined },
+        output: { cached: undefined },
+        times: 1,
+      },
+      "matches present undefined fields once",
+    ),
+  ]);
+
+  const score = (await scorer({
+    input: "cache",
+    output: "done",
+    metadata: {},
+    trace,
+  })) as Score;
+
+  expect(score.score).toBe(1);
+  expect(score.metadata).toEqual({
+    assertions: [
+      { name: "matches present undefined fields once", passed: true },
+    ],
+    failed: [],
+  } satisfies AgentAssertionScoreMetadata);
+});
+
+test("agentAssertionScorer applies explicit undefined input and output matchers", async () => {
+  const getSpans = vi.fn().mockResolvedValue([
+    {
+      input: { foo: "present" },
+      output: { cached: false },
+      span_attributes: { type: "tool", name: "lookup_cache" },
+    },
+    {
+      input: undefined,
+      output: undefined,
+      span_attributes: { type: "tool", name: "lookup_cache" },
+    },
+  ]);
+  const trace: Trace = {
+    getConfiguration: () => ({
+      object_type: "experiment",
+      object_id: "experiment-id",
+      root_span_id: "root-span-id",
+    }),
+    getSpans,
+    getThread: vi.fn(),
+  };
+  const scorer = agentAssertionScorer(({ assert }) => [
+    assert.calledTool(
+      "lookup_cache",
+      {
+        input: undefined,
+        output: undefined,
+        times: 1,
+      },
+      "matches undefined input and output once",
+    ),
+  ]);
+
+  const score = (await scorer({
+    input: "cache",
+    output: "done",
+    metadata: {},
+    trace,
+  })) as Score;
+
+  expect(score.score).toBe(1);
+  expect(score.metadata).toEqual({
+    assertions: [
+      { name: "matches undefined input and output once", passed: true },
+    ],
+    failed: [],
+  } satisfies AgentAssertionScoreMetadata);
+});
+
+test("agentAssertionScorer matches object tool inputs and outputs with regexes", async () => {
+  const inputMatcher = /Brooklyn/g;
+  const outputMatcher = /sunny/g;
+  inputMatcher.lastIndex = 99;
+  outputMatcher.lastIndex = 99;
+  const getSpans = vi.fn().mockResolvedValue([
+    {
+      input: { city: "Brooklyn" },
+      output: { forecast: "sunny" },
+      span_attributes: { type: "tool", name: "get_weather" },
+    },
+    {
+      input: { city: "Brooklyn" },
+      output: { forecast: "sunny" },
+      span_attributes: { type: "tool", name: "get_weather" },
+    },
+  ]);
+  const trace: Trace = {
+    getConfiguration: () => ({
+      object_type: "experiment",
+      object_id: "experiment-id",
+      root_span_id: "root-span-id",
+    }),
+    getSpans,
+    getThread: vi.fn(),
+  };
+  const scorer = agentAssertionScorer(({ assert }) => [
+    assert.calledTool(
+      "get_weather",
+      {
+        input: inputMatcher,
+        output: outputMatcher,
+        times: 2,
+      },
+      "matches repeated object tool calls",
+    ),
+  ]);
+
+  const score = (await scorer({
+    input: "weather",
+    output: "done",
+    metadata: {},
+    trace,
+  })) as Score;
+
+  expect(score.score).toBe(1);
+  expect(score.metadata).toEqual({
+    assertions: [{ name: "matches repeated object tool calls", passed: true }],
+    failed: [],
+  } satisfies AgentAssertionScoreMetadata);
+});
+
+test("agentAssertionScorer matches raw string regexes and array matchers", async () => {
+  const getSpans = vi.fn().mockResolvedValue([
+    {
+      input: {
+        city: "Brooklyn",
+        messages: [{ content: "hi" }],
+        neighborhoods: ["Brooklyn"],
+      },
+      output: {
+        status: "sunny",
+        reports: [{ summary: "hi Brooklyn" }],
+      },
+      span_attributes: { type: "tool", name: "get_weather" },
+    },
+  ]);
+  const trace: Trace = {
+    getConfiguration: () => ({
+      object_type: "experiment",
+      object_id: "experiment-id",
+      root_span_id: "root-span-id",
+    }),
+    getSpans,
+    getThread: vi.fn(),
+  };
+  const scorer = agentAssertionScorer(({ assert }) => [
+    assert.contains("hi", /^hi$/, "contains raw string"),
+    assert.calledTool(
+      "get_weather",
+      {
+        input: {
+          city: /^Brooklyn$/,
+          messages: [{ content: /^hi$/ }],
+          neighborhoods: [/^Brooklyn$/],
+        },
+        output: {
+          status: /^sunny$/,
+          reports: [{ summary: /Brooklyn$/ }],
+        },
+      },
+      "matches nested tool values",
+    ),
+  ]);
+
+  const score = (await scorer({
+    input: "weather",
+    output: "done",
+    metadata: {},
+    trace,
+  })) as Score;
+
+  expect(score.score).toBe(1);
+  expect(score.metadata).toEqual({
+    assertions: [
+      { name: "contains raw string", passed: true },
+      { name: "matches nested tool values", passed: true },
+    ],
+    failed: [],
+  } satisfies AgentAssertionScoreMetadata);
+});
+
+test("agentAssertionScorer matches tool names from span metadata", async () => {
+  const getSpans = vi.fn().mockResolvedValue([
+    {
+      input: { city: "Vienna" },
+      output: { forecast: "Sunny in Vienna" },
+      metadata: {
+        provider: "openrouter",
+        tool_name: "lookup_weather",
+      },
+      span_attributes: { type: "tool", name: "openrouter.tool" },
+    },
+    {
+      input: { query: "Vienna weather" },
+      output: { result: "sunny" },
+      metadata: {
+        "gen_ai.tool.name": "web_search",
+      },
+      span_attributes: { type: "tool", name: "tool" },
+    },
+    {
+      input: { path: "README.md" },
+      output: { contents: "hello" },
+      metadata: {
+        "gen_ai.tool.name": "read_file",
+        "mcp.server": "filesystem",
+      },
+      span_attributes: { type: "tool", name: "tool: filesystem/read_file" },
+    },
+    {
+      input: { query: "docs" },
+      output: { result: "found" },
+      metadata: {
+        "gen_ai.tool.name": "search",
+        "mcp.server": "browser",
+      },
+      span_attributes: { type: "tool", name: "tool: search" },
+    },
+  ]);
+  const trace: Trace = {
+    getConfiguration: () => ({
+      object_type: "experiment",
+      object_id: "experiment-id",
+      root_span_id: "root-span-id",
+    }),
+    getSpans,
+    getThread: vi.fn(),
+  };
+  const scorer = agentAssertionScorer(({ assert }) => [
+    assert.calledTool("lookup_weather", {
+      input: { city: "Vienna" },
+      output: { forecast: /Vienna$/ },
+    }),
+    assert.calledTool("web_search"),
+    assert.notCalledTool("openrouter.tool"),
+    assert.calledTool("filesystem/read_file"),
+    assert.calledTool("browser/search"),
+    assert.notCalledTool("read_file"),
+    assert.notCalledTool("search"),
+  ]);
+
+  const score = (await scorer({
+    input: "weather",
+    output: "done",
+    metadata: {},
+    trace,
+  })) as Score;
+
+  expect(score.score).toBe(1);
+  expect(score.metadata).toEqual({
+    assertions: [
+      { name: "called tool lookup_weather", passed: true },
+      { name: "called tool web_search", passed: true },
+      { name: "did not call tool openrouter.tool", passed: true },
+      { name: "called tool filesystem/read_file", passed: true },
+      { name: "called tool browser/search", passed: true },
+      { name: "did not call tool read_file", passed: true },
+      { name: "did not call tool search", passed: true },
+    ],
+    failed: [],
   } satisfies AgentAssertionScoreMetadata);
 });
 

--- a/js/src/agent-assertions.test.ts
+++ b/js/src/agent-assertions.test.ts
@@ -1,0 +1,138 @@
+import { beforeAll, expect, test, vi } from "vitest";
+import { z } from "zod";
+
+import { agentAssertionScorer, Eval } from "./exports";
+import { configureNode } from "./node/config";
+import type { AgentAssertionScoreMetadata } from "./agent-assertions";
+import type { Trace } from "./trace";
+import type { Score } from "../util";
+
+beforeAll(() => {
+  configureNode();
+});
+
+test("agentAssertionScorer emits one score with assertion metadata", async () => {
+  const scorer = agentAssertionScorer<
+    string,
+    { answer: string; count: number },
+    { answer: string }
+  >(
+    ({ output, expected, assert }) => [
+      assert.equals(output.answer, expected.answer, "answer matches"),
+      assert.equals(output.count, 3, "count is three"),
+      assert.contains(output.answer, /hi/i, "answer contains greeting"),
+      assert.matches(
+        output,
+        z.object({ answer: z.string(), count: z.number() }),
+        "output schema",
+      ),
+    ],
+    { name: "agent_contract" },
+  );
+
+  const score = (await scorer({
+    input: "hello",
+    expected: { answer: "hi" },
+    output: { answer: "hi", count: 2 },
+    metadata: {},
+  })) as Score;
+
+  expect(score.name).toBe("agent_contract");
+  expect(score.score).toBe(0.75);
+  expect(score.metadata).toEqual({
+    assertions: [
+      { name: "answer matches", passed: true },
+      { name: "count is three", passed: false },
+      { name: "answer contains greeting", passed: true },
+      { name: "output schema", passed: true },
+    ],
+    failed: ["count is three: expected 2 to equal 3"],
+  } satisfies AgentAssertionScoreMetadata);
+});
+
+test("agentAssertionScorer evaluates trace-backed tool assertions after collection", async () => {
+  const getSpans = vi.fn().mockResolvedValue([
+    {
+      input: { city: "Brooklyn" },
+      output: { forecast: "72F and sunny" },
+      span_attributes: { type: "tool", name: "tool: get_weather" },
+    },
+    {
+      input: { city: "Brooklyn" },
+      output: { source: "cache" },
+      span_attributes: { type: "tool", name: "lookup_cache" },
+    },
+  ]);
+  const trace: Trace = {
+    getConfiguration: () => ({
+      object_type: "experiment",
+      object_id: "experiment-id",
+      root_span_id: "root-span-id",
+    }),
+    getSpans,
+    getThread: vi.fn(),
+  };
+  const callbackOrder: string[] = [];
+  const scorer = agentAssertionScorer(({ assert }) => {
+    callbackOrder.push("callback");
+    return [
+      assert.calledTool("get_weather", {
+        input: { city: /Brook/ },
+        output: { forecast: /sunny/ },
+        times: 1,
+      }),
+      assert.calledTool("charge_card"),
+      assert.notCalledTool("refund_customer"),
+      assert.toolOrder(["get_weather", "lookup_cache"]),
+      assert.maxToolCalls(2),
+    ];
+  });
+
+  const score = (await scorer({
+    input: "weather",
+    output: "done",
+    metadata: {},
+    trace,
+  })) as Score;
+
+  expect(callbackOrder).toEqual(["callback"]);
+  expect(getSpans).toHaveBeenCalledWith({ spanType: ["tool"] });
+  expect(score.name).toBe("assertions");
+  expect(score.score).toBe(0.8);
+  expect(score.metadata).toEqual({
+    assertions: [
+      { name: "called tool get_weather", passed: true },
+      { name: "called tool charge_card", passed: false },
+      { name: "did not call tool refund_customer", passed: true },
+      { name: "tool order", passed: true },
+      { name: "at most 2 tool calls", passed: true },
+    ],
+    failed: [
+      'called tool charge_card: expected tool "charge_card" to be called; found 0 matching calls',
+    ],
+  } satisfies AgentAssertionScoreMetadata);
+});
+
+test("agentAssertionScorer works as an Eval scorer", async () => {
+  const result = await Eval(
+    "agent assertions",
+    {
+      data: [
+        { input: "hello", expected: "hello world" },
+        { input: "bye", expected: "bye world" },
+      ] as const,
+      task: (input) => `${input} world` as const,
+      scores: [
+        agentAssertionScorer(({ output, expected, assert }) => [
+          assert.equals(output, expected, "output matches expected"),
+          assert.contains(output, "world", "output contains world"),
+        ]),
+      ],
+    },
+    { noSendLogs: true },
+  );
+
+  expect(result.results[0].scores.assertions).toBe(1);
+  expect(result.results[1].scores.assertions).toBe(1);
+  expect(result.summary.scores.assertions.score).toBe(1);
+});

--- a/js/src/agent-assertions.test.ts
+++ b/js/src/agent-assertions.test.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 
 import { agentAssertionScorer, Eval } from "./exports";
 import { configureNode } from "./node/config";
-import type { AgentAssertionScoreMetadata } from "./agent-assertions";
 import type { Trace } from "./trace";
 import type { Score } from "../util";
 
@@ -52,7 +51,6 @@ test("agentAssertionScorer emits one score with assertion metadata", async () =>
     input: "hello",
     expected: { answer: "hi" },
     output: { answer: "hi", count: 2 },
-    metadata: {},
   })) as Score;
 
   expect(score.name).toBe("agent_contract");
@@ -66,7 +64,7 @@ test("agentAssertionScorer emits one score with assertion metadata", async () =>
       { name: "output schema", passed: true },
     ],
     failed: ["count is three: expected 2 to equal 3"],
-  } satisfies AgentAssertionScoreMetadata);
+  });
 });
 
 test("agentAssertionScorer compares object keys before undefined values", async () => {
@@ -86,7 +84,6 @@ test("agentAssertionScorer compares object keys before undefined values", async 
   const score = (await scorer({
     input: "hello",
     output: "done",
-    metadata: {},
   })) as Score;
 
   expect(score.score).toBe(0.5);
@@ -99,7 +96,7 @@ test("agentAssertionScorer compares object keys before undefined values", async 
       },
     ],
   });
-  const metadata = score.metadata as AgentAssertionScoreMetadata;
+  const metadata = score.metadata as any;
   expect(metadata.failed).toEqual([
     'different undefined keys are not equal: expected {"a":undefined} to equal {"b":undefined}',
   ]);
@@ -146,7 +143,6 @@ test("agentAssertionScorer evaluates trace-backed tool assertions after collecti
   const score = (await scorer({
     input: "weather",
     output: "done",
-    metadata: {},
     trace,
   })) as Score;
 
@@ -165,7 +161,7 @@ test("agentAssertionScorer evaluates trace-backed tool assertions after collecti
     failed: [
       'called tool charge_card: expected tool "charge_card" to be called; found 0 matching calls',
     ],
-  } satisfies AgentAssertionScoreMetadata);
+  });
 });
 
 test("agentAssertionScorer requires undefined matcher keys to exist", async () => {
@@ -205,7 +201,6 @@ test("agentAssertionScorer requires undefined matcher keys to exist", async () =
   const score = (await scorer({
     input: "cache",
     output: "done",
-    metadata: {},
     trace,
   })) as Score;
 
@@ -215,7 +210,7 @@ test("agentAssertionScorer requires undefined matcher keys to exist", async () =
       { name: "matches present undefined fields once", passed: true },
     ],
     failed: [],
-  } satisfies AgentAssertionScoreMetadata);
+  });
 });
 
 test("agentAssertionScorer applies explicit undefined input and output matchers", async () => {
@@ -255,7 +250,6 @@ test("agentAssertionScorer applies explicit undefined input and output matchers"
   const score = (await scorer({
     input: "cache",
     output: "done",
-    metadata: {},
     trace,
   })) as Score;
 
@@ -265,7 +259,7 @@ test("agentAssertionScorer applies explicit undefined input and output matchers"
       { name: "matches undefined input and output once", passed: true },
     ],
     failed: [],
-  } satisfies AgentAssertionScoreMetadata);
+  });
 });
 
 test("agentAssertionScorer matches object tool inputs and outputs with regexes", async () => {
@@ -309,7 +303,6 @@ test("agentAssertionScorer matches object tool inputs and outputs with regexes",
   const score = (await scorer({
     input: "weather",
     output: "done",
-    metadata: {},
     trace,
   })) as Score;
 
@@ -317,7 +310,7 @@ test("agentAssertionScorer matches object tool inputs and outputs with regexes",
   expect(score.metadata).toEqual({
     assertions: [{ name: "matches repeated object tool calls", passed: true }],
     failed: [],
-  } satisfies AgentAssertionScoreMetadata);
+  });
 });
 
 test("agentAssertionScorer matches raw string regexes and array matchers", async () => {
@@ -366,7 +359,6 @@ test("agentAssertionScorer matches raw string regexes and array matchers", async
   const score = (await scorer({
     input: "weather",
     output: "done",
-    metadata: {},
     trace,
   })) as Score;
 
@@ -377,7 +369,7 @@ test("agentAssertionScorer matches raw string regexes and array matchers", async
       { name: "matches nested tool values", passed: true },
     ],
     failed: [],
-  } satisfies AgentAssertionScoreMetadata);
+  });
 });
 
 test("agentAssertionScorer matches tool names from span metadata", async () => {
@@ -443,7 +435,6 @@ test("agentAssertionScorer matches tool names from span metadata", async () => {
   const score = (await scorer({
     input: "weather",
     output: "done",
-    metadata: {},
     trace,
   })) as Score;
 
@@ -459,7 +450,7 @@ test("agentAssertionScorer matches tool names from span metadata", async () => {
       { name: "did not call tool search", passed: true },
     ],
     failed: [],
-  } satisfies AgentAssertionScoreMetadata);
+  });
 });
 
 test("agentAssertionScorer works as an Eval scorer", async () => {

--- a/js/src/agent-assertions.ts
+++ b/js/src/agent-assertions.ts
@@ -230,10 +230,11 @@ export function agentAssertionScorer<
 ): EvalScorer<Input, Output, Expected, Metadata> {
   return async (args) => {
     const { trace: _trace, ...callbackArgs } = args;
-    const metadata = (callbackArgs as { metadata?: unknown }).metadata ?? {};
+    const callbackMetadata =
+      (callbackArgs as { metadata?: unknown }).metadata ?? {};
     const assertions = await callback({
       ...callbackArgs,
-      metadata,
+      metadata: callbackMetadata,
       assert: agentAssertionHelpers,
     } as AgentAssertionScorerCallbackArgs<Input, Output, Expected, Metadata>);
     const resources: AgentAssertionResources = {};

--- a/js/src/agent-assertions.ts
+++ b/js/src/agent-assertions.ts
@@ -1,0 +1,553 @@
+import type { EvalScorer, EvalScorerArgs } from "./framework";
+import type { SpanData } from "./trace";
+import type { BaseMetadata, DefaultMetadataType } from "./logger";
+import type { Score } from "../util";
+
+type MaybePromise<T> = T | Promise<T>;
+
+type AssertionMatcher =
+  | RegExp
+  | ((value: unknown) => boolean)
+  | readonly AssertionMatcher[]
+  | { [key: string]: AssertionMatcher }
+  | string
+  | number
+  | boolean
+  | null
+  | undefined;
+
+interface ToolCallAssertionOptions {
+  /**
+   * Match against the tool call input. Objects are matched partially, regular
+   * expressions are matched against stringified values, and functions are
+   * treated as predicates.
+   */
+  input?: AssertionMatcher;
+  /**
+   * Match against the tool call output. Objects are matched partially, regular
+   * expressions are matched against stringified values, and functions are
+   * treated as predicates.
+   */
+  output?: AssertionMatcher;
+  /** If set, require the matching tool call to have, or not have, an error. */
+  isError?: boolean;
+  /** If set, require exactly this many matching calls. */
+  times?: number;
+}
+
+interface AgentAssertion {
+  name: string;
+  evaluate: (resources: AgentAssertionResources) => MaybePromise<{
+    passed: boolean;
+    failure?: string;
+  }>;
+  requiresTrace?: boolean;
+}
+
+interface AgentAssertionHelpers {
+  /**
+   * Assert that two values are deeply equal.
+   *
+   * @param actual - The value produced by the task or derived by the scorer.
+   * @param expected - The value to compare against.
+   * @param name - Optional assertion name. Defaults to `"equals"`.
+   */
+  equals: (actual: unknown, expected: unknown, name?: string) => AgentAssertion;
+  /**
+   * Assert that two values are not deeply equal.
+   *
+   * @param actual - The value produced by the task or derived by the scorer.
+   * @param expected - The value that should not be returned.
+   * @param name - Optional assertion name. Defaults to `"not equals"`.
+   */
+  notEquals: (
+    actual: unknown,
+    expected: unknown,
+    name?: string,
+  ) => AgentAssertion;
+  /**
+   * Assert that a stringified value contains a substring or matches a regular
+   * expression.
+   *
+   * @param value - The value to inspect.
+   * @param expected - The substring or regular expression to find.
+   * @param name - Optional assertion name. Defaults to `"contains"`.
+   */
+  contains: (
+    value: unknown,
+    expected: string | RegExp,
+    name?: string,
+  ) => AgentAssertion;
+  /**
+   * Assert that a value matches a schema.
+   *
+   * Supports schemas with `safeParse` or `parse`, such as Zod, and Standard
+   * Schema `~standard.validate`, used by libraries such as Valibot and ArkType.
+   *
+   * @param value - The value to validate.
+   * @param schema - The schema to validate against.
+   * @param name - Optional assertion name. Defaults to `"matches schema"`.
+   */
+  matches: (
+    value: unknown,
+    schema: SchemaLike,
+    name?: string,
+  ) => AgentAssertion;
+  /**
+   * Assert that a tool was called, optionally constrained by input, output,
+   * error state, or exact call count.
+   *
+   * @param toolName - The tool name to find in trace spans.
+   * @param options - Optional constraints for matching calls.
+   * @param name - Optional assertion name. Defaults to `"called tool ${toolName}"`.
+   */
+  calledTool: (
+    toolName: string,
+    options?: ToolCallAssertionOptions,
+    name?: string,
+  ) => AgentAssertion;
+  /**
+   * Assert that a tool was not called.
+   *
+   * @param toolName - The tool name to reject in trace spans.
+   * @param name - Optional assertion name. Defaults to `"did not call tool ${toolName}"`.
+   */
+  notCalledTool: (toolName: string, name?: string) => AgentAssertion;
+  /**
+   * Assert that tools were called in the given relative order.
+   *
+   * The tools do not need to be adjacent. Extra tool calls between them are
+   * allowed.
+   *
+   * @param toolNames - The ordered list of tool names to find.
+   * @param name - Optional assertion name. Defaults to `"tool order"`.
+   */
+  toolOrder: (toolNames: string[], name?: string) => AgentAssertion;
+  /**
+   * Assert that the task made no tool calls.
+   *
+   * @param name - Optional assertion name. Defaults to `"used no tools"`.
+   */
+  usedNoTools: (name?: string) => AgentAssertion;
+  /**
+   * Assert that the task made no more than `max` tool calls.
+   *
+   * @param max - The maximum number of allowed tool calls.
+   * @param name - Optional assertion name. Defaults to `"at most ${max} tool calls"`.
+   */
+  maxToolCalls: (max: number, name?: string) => AgentAssertion;
+}
+
+type AgentAssertionScorerCallback<
+  Input,
+  Output,
+  Expected,
+  Metadata extends BaseMetadata = DefaultMetadataType,
+> = (
+  args: AgentAssertionScorerCallbackArgs<Input, Output, Expected, Metadata>,
+) => MaybePromise<AgentAssertion[]>;
+
+type AgentAssertionScorerCallbackArgs<
+  Input,
+  Output,
+  Expected,
+  Metadata extends BaseMetadata = DefaultMetadataType,
+> = {
+  input: Input;
+  output: Output;
+  /** Helpers for building assertions from Eval inputs, outputs, and traces. */
+  assert: AgentAssertionHelpers;
+} & (Expected extends void
+  ? { expected?: undefined }
+  : { expected: Expected }) &
+  (Metadata extends void ? { metadata?: undefined } : { metadata: Metadata });
+
+interface AgentAssertionResources {
+  spans?: SpanData[];
+}
+
+type SchemaLike =
+  | {
+      safeParse: (value: unknown) => {
+        success: boolean;
+        error?: unknown;
+      };
+    }
+  | {
+      parse: (value: unknown) => unknown;
+    }
+  | {
+      "~standard": {
+        validate: (value: unknown) => MaybePromise<unknown>;
+      };
+    };
+
+/**
+ * Create an Eval scorer that will evaluate an agent based on assertions on the
+ * generated trace.
+ *
+ * The callback receives `input`, `output`, `expected`, `metadata` plus an `assert`
+ * helper object. It should return the assertions to evaluate the agent against.
+ *
+ * **Important**: Tool-call assertions require Braintrust tracing to be set up
+ * during the Eval so the scorer can read tool spans from the trace.
+ *
+ * The score emitted by this scorer is the fraction of assertions that passed. If there are no
+ * assertions, the score is `1`. The score metadata includes every assertion's name and
+ * pass/fail state, plus human-readable failure messages.
+ *
+ * @example
+ * ```ts
+ * import { Eval, agentAssertionScorer } from "braintrust";
+ *
+ * await Eval("agent-eval", {
+ *   data: () => [{ input: "What is the capital of Estonia?" }],
+ *   task: () => ({ answer: `Tallinn is the capital of Estonia. ${input}` }),
+ *   scores: [
+ *     agentAssertionScorer(({ output, assert }) => [
+ *       assert.contains(output.answer, /Tallinn/i, "mentions Tallinn"),
+ *       assert.calledTool("web_search", { times: 1 }, "searched once"),
+ *       assert.maxToolCalls(3, "bounded tool use"),
+ *     ]),
+ *   ],
+ * });
+ * ```
+ */
+export function agentAssertionScorer<
+  Input,
+  Output,
+  Expected = void,
+  Metadata extends BaseMetadata = DefaultMetadataType,
+>(
+  callback: AgentAssertionScorerCallback<Input, Output, Expected, Metadata>,
+  options: {
+    /** The score name to emit. Defaults to `"assertions"`. */
+    name?: string;
+  } = {},
+): EvalScorer<Input, Output, Expected, Metadata> {
+  return async (args) => {
+    const callbackArgs = {
+      input: args.input,
+      output: args.output,
+      ...("expected" in args ? { expected: args.expected } : {}),
+      ...("metadata" in args ? { metadata: args.metadata } : {}),
+      assert: agentAssertionHelpers,
+    } as AgentAssertionScorerCallbackArgs<Input, Output, Expected, Metadata>;
+    const assertions = await callback(callbackArgs);
+    const resources: AgentAssertionResources = {};
+    if (assertions.some((assertion) => assertion.requiresTrace)) {
+      resources.spans = await args.trace?.getSpans({ spanType: ["tool"] });
+    }
+
+    const results = await Promise.all(
+      assertions.map(async (assertion) => {
+        const result = await assertion.evaluate(resources);
+        return {
+          name: assertion.name,
+          passed: result.passed,
+          failure: result.failure,
+        };
+      }),
+    );
+
+    const passed = results.filter((result) => result.passed).length;
+    const total = results.length;
+    const failed = results
+      .filter((result) => !result.passed)
+      .map(
+        (result) =>
+          `${result.name}: ${result.failure ?? "assertion did not pass"}`,
+      );
+
+    return {
+      name: options.name ?? "assertions",
+      score: total === 0 ? 1 : passed / total,
+      metadata: {
+        assertions: results.map(({ name, passed }) => ({ name, passed })),
+        failed,
+      },
+    } satisfies Score;
+  };
+}
+
+const agentAssertionHelpers: AgentAssertionHelpers = {
+  equals: (actual, expected, name = "equals") => ({
+    name,
+    evaluate: () => {
+      const passed = deepEqual(actual, expected);
+      return {
+        passed,
+        failure: passed
+          ? undefined
+          : `expected ${formatValue(actual)} to equal ${formatValue(expected)}`,
+      };
+    },
+  }),
+  notEquals: (actual, expected, name = "not equals") => ({
+    name,
+    evaluate: () => {
+      const passed = !deepEqual(actual, expected);
+      return {
+        passed,
+        failure: passed
+          ? undefined
+          : `expected ${formatValue(actual)} not to equal ${formatValue(expected)}`,
+      };
+    },
+  }),
+  contains: (value, expected, name = "contains") => ({
+    name,
+    evaluate: () => {
+      const stringValue = String(value);
+      const passed =
+        expected instanceof RegExp
+          ? expected.test(stringValue)
+          : stringValue.includes(expected);
+      return {
+        passed,
+        failure: passed
+          ? undefined
+          : `expected ${formatValue(value)} to contain ${formatValue(expected)}`,
+      };
+    },
+  }),
+  matches: (value, schema, name = "matches schema") => ({
+    name,
+    evaluate: async () => {
+      const result = await validateSchema(schema, value);
+      return {
+        passed: result.passed,
+        failure: result.passed
+          ? undefined
+          : `expected value to match schema: ${result.message}`,
+      };
+    },
+  }),
+  calledTool: (toolName, options = {}, name = `called tool ${toolName}`) => ({
+    name,
+    requiresTrace: true,
+    evaluate: ({ spans }) => {
+      const calls = matchingToolCalls(spans ?? [], toolName, options);
+      const passed =
+        options.times === undefined
+          ? calls.length > 0
+          : calls.length === options.times;
+      return {
+        passed,
+        failure: passed
+          ? undefined
+          : options.times === undefined
+            ? `expected tool "${toolName}" to be called; found ${calls.length} matching call${calls.length === 1 ? "" : "s"}`
+            : `expected tool "${toolName}" to be called ${options.times} time${options.times === 1 ? "" : "s"}; found ${calls.length} matching call${calls.length === 1 ? "" : "s"}`,
+      };
+    },
+  }),
+  notCalledTool: (toolName, name = `did not call tool ${toolName}`) => ({
+    name,
+    requiresTrace: true,
+    evaluate: ({ spans }) => {
+      const calls = toolCalls(spans ?? []).filter(
+        (span) => getToolName(span) === toolName,
+      );
+      const passed = calls.length === 0;
+      return {
+        passed,
+        failure: passed
+          ? undefined
+          : `expected tool "${toolName}" not to be called; found ${calls.length} call${calls.length === 1 ? "" : "s"}`,
+      };
+    },
+  }),
+  toolOrder: (toolNames, name = "tool order") => ({
+    name,
+    requiresTrace: true,
+    evaluate: ({ spans }) => {
+      const observed = toolCalls(spans ?? [])
+        .map(getToolName)
+        .filter((toolName) => toolName !== undefined);
+      let fromIndex = 0;
+      const passed = toolNames.every((toolName) => {
+        const index = observed.indexOf(toolName, fromIndex);
+        if (index === -1) return false;
+        fromIndex = index + 1;
+        return true;
+      });
+      return {
+        passed,
+        failure: passed
+          ? undefined
+          : `expected tool order ${toolNames.join(" -> ")}; observed ${observed.join(" -> ") || "no tools"}`,
+      };
+    },
+  }),
+  usedNoTools: (name = "used no tools") => ({
+    name,
+    requiresTrace: true,
+    evaluate: ({ spans }) => {
+      const calls = toolCalls(spans ?? []);
+      const passed = calls.length === 0;
+      return {
+        passed,
+        failure: passed
+          ? undefined
+          : `expected no tool calls; found ${calls.length}`,
+      };
+    },
+  }),
+  maxToolCalls: (max, name = `at most ${max} tool calls`) => ({
+    name,
+    requiresTrace: true,
+    evaluate: ({ spans }) => {
+      const calls = toolCalls(spans ?? []);
+      const passed = calls.length <= max;
+      return {
+        passed,
+        failure: passed
+          ? undefined
+          : `expected at most ${max} tool call${max === 1 ? "" : "s"}; found ${calls.length}`,
+      };
+    },
+  }),
+};
+
+async function validateSchema(
+  schema: SchemaLike,
+  value: unknown,
+): Promise<{ passed: boolean; message: string }> {
+  try {
+    if ("safeParse" in schema) {
+      const result = schema.safeParse(value);
+      return result.success
+        ? { passed: true, message: "" }
+        : { passed: false, message: formatSchemaError(result.error) };
+    }
+    if ("parse" in schema) {
+      schema.parse(value);
+      return { passed: true, message: "" };
+    }
+    const result = await schema["~standard"].validate(value);
+    if (
+      typeof result === "object" &&
+      result !== null &&
+      "issues" in result &&
+      Array.isArray(result.issues) &&
+      result.issues.length > 0
+    ) {
+      return { passed: false, message: formatValue(result.issues) };
+    }
+    return { passed: true, message: "" };
+  } catch (e) {
+    return { passed: false, message: formatSchemaError(e) };
+  }
+}
+
+function toolCalls(spans: SpanData[]) {
+  return spans.filter((span) => span.span_attributes?.type === "tool");
+}
+
+function matchingToolCalls(
+  spans: SpanData[],
+  toolName: string,
+  options: ToolCallAssertionOptions,
+) {
+  return toolCalls(spans).filter((span) => {
+    if (getToolName(span) !== toolName) return false;
+    if (
+      options.input !== undefined &&
+      !matchesValue(span.input, options.input)
+    ) {
+      return false;
+    }
+    if (
+      options.output !== undefined &&
+      !matchesValue(span.output, options.output)
+    ) {
+      return false;
+    }
+    if (
+      options.isError !== undefined &&
+      Boolean(span.error) !== options.isError
+    ) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function getToolName(span: SpanData) {
+  const rawName =
+    typeof span.span_attributes?.name === "string"
+      ? span.span_attributes.name
+      : typeof span.name === "string"
+        ? span.name
+        : undefined;
+  if (!rawName) return undefined;
+  return rawName.startsWith("tool:")
+    ? rawName.slice("tool:".length).trim()
+    : rawName;
+}
+
+function matchesValue(actual: unknown, matcher: AssertionMatcher): boolean {
+  if (matcher instanceof RegExp) {
+    return matcher.test(String(actual));
+  }
+  if (typeof matcher === "function") {
+    return matcher(actual);
+  }
+  if (isPlainObject(matcher) && isPlainObject(actual)) {
+    return Object.entries(matcher).every(([key, value]) =>
+      matchesValue(actual[key], value),
+    );
+  }
+  return deepEqual(actual, matcher);
+}
+
+function deepEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return (
+      left.length === right.length &&
+      left.every((item, index) => deepEqual(item, right[index]))
+    );
+  }
+  if (isPlainObject(left) && isPlainObject(right)) {
+    const leftKeys = Object.keys(left);
+    const rightKeys = Object.keys(right);
+    return (
+      leftKeys.length === rightKeys.length &&
+      leftKeys.every((key) => deepEqual(left[key], right[key]))
+    );
+  }
+  return false;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
+function formatSchemaError(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return formatValue(error);
+}
+
+function formatValue(value: unknown) {
+  if (value instanceof RegExp) {
+    return value.toString();
+  }
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? String(value) : serialized;
+  } catch {
+    return String(value);
+  }
+}

--- a/js/src/agent-assertions.ts
+++ b/js/src/agent-assertions.ts
@@ -144,23 +144,11 @@ type AgentAssertionScorerCallback<
   Expected,
   Metadata extends BaseMetadata = DefaultMetadataType,
 > = (
-  args: AgentAssertionScorerCallbackArgs<Input, Output, Expected, Metadata>,
+  args: Omit<EvalScorerArgs<Input, Output, Expected, Metadata>, "trace"> & {
+    /** Helpers for building assertions from Eval inputs, outputs, and traces. */
+    assert: AgentAssertionHelpers;
+  },
 ) => MaybePromise<AgentAssertion[]>;
-
-type AgentAssertionScorerCallbackArgs<
-  Input,
-  Output,
-  Expected,
-  Metadata extends BaseMetadata = DefaultMetadataType,
-> = {
-  input: Input;
-  output: Output;
-  /** Helpers for building assertions from Eval inputs, outputs, and traces. */
-  assert: AgentAssertionHelpers;
-} & (Expected extends void
-  ? { expected?: undefined }
-  : { expected: Expected }) &
-  (Metadata extends void ? { metadata?: undefined } : { metadata: Metadata });
 
 interface AgentAssertionResources {
   spans?: SpanData[];
@@ -202,7 +190,7 @@ type SchemaLike =
  *
  * await Eval("agent-eval", {
  *   data: () => [{ input: "What is the capital of Estonia?" }],
- *   task: () => ({ answer: `Tallinn is the capital of Estonia. ${input}` }),
+ *   task: async () => ({ answer: "Tallinn is the capital of Estonia." }),
  *   scores: [
  *     agentAssertionScorer(({ output, assert }) => [
  *       assert.contains(output.answer, /Tallinn/i, "mentions Tallinn"),
@@ -226,14 +214,11 @@ export function agentAssertionScorer<
   } = {},
 ): EvalScorer<Input, Output, Expected, Metadata> {
   return async (args) => {
-    const callbackArgs = {
-      input: args.input,
-      output: args.output,
-      ...("expected" in args ? { expected: args.expected } : {}),
-      ...("metadata" in args ? { metadata: args.metadata } : {}),
+    const { trace: _trace, ...callbackArgs } = args;
+    const assertions = await callback({
+      ...callbackArgs,
       assert: agentAssertionHelpers,
-    } as AgentAssertionScorerCallbackArgs<Input, Output, Expected, Metadata>;
-    const assertions = await callback(callbackArgs);
+    });
     const resources: AgentAssertionResources = {};
     if (assertions.some((assertion) => assertion.requiresTrace)) {
       resources.spans = await args.trace?.getSpans({ spanType: ["tool"] });

--- a/js/src/agent-assertions.ts
+++ b/js/src/agent-assertions.ts
@@ -18,15 +18,15 @@ type AssertionMatcher =
 
 interface ToolCallAssertionOptions {
   /**
-   * Match against the tool call input. Objects are matched partially, regular
-   * expressions are matched against stringified values, and functions are
-   * treated as predicates.
+   * Match against the tool call input. Objects are matched partially, arrays
+   * are matched recursively, regular expressions match raw strings as-is and
+   * formatted non-string values, and functions are treated as predicates.
    */
   input?: AssertionMatcher;
   /**
-   * Match against the tool call output. Objects are matched partially, regular
-   * expressions are matched against stringified values, and functions are
-   * treated as predicates.
+   * Match against the tool call output. Objects are matched partially, arrays
+   * are matched recursively, regular expressions match raw strings as-is and
+   * formatted non-string values, and functions are treated as predicates.
    */
   output?: AssertionMatcher;
   /** If set, require the matching tool call to have, or not have, an error. */
@@ -66,8 +66,8 @@ interface AgentAssertionHelpers {
     name?: string,
   ) => AgentAssertion;
   /**
-   * Assert that a stringified value contains a substring or matches a regular
-   * expression.
+   * Assert that a value contains a substring or matches a regular expression.
+   * Regular expressions test raw strings as-is and formatted non-string values.
    *
    * @param value - The value to inspect.
    * @param expected - The substring or regular expression to find.
@@ -144,11 +144,26 @@ type AgentAssertionScorerCallback<
   Expected,
   Metadata extends BaseMetadata = DefaultMetadataType,
 > = (
-  args: Omit<EvalScorerArgs<Input, Output, Expected, Metadata>, "trace"> & {
-    /** Helpers for building assertions from Eval inputs, outputs, and traces. */
-    assert: AgentAssertionHelpers;
-  },
+  args: AgentAssertionScorerCallbackArgs<Input, Output, Expected, Metadata>,
 ) => MaybePromise<AgentAssertion[]>;
+
+type AgentAssertionScorerCallbackArgs<
+  Input,
+  Output,
+  Expected,
+  Metadata extends BaseMetadata,
+> = Omit<
+  EvalScorerArgs<Input, Output, Expected, Metadata>,
+  "metadata" | "trace"
+> & {
+  /**
+   * Row metadata passed to the Eval scorer. Defaults to an empty object when
+   * the Eval row does not have typed metadata.
+   */
+  metadata: Metadata extends void ? Record<string, unknown> : Metadata;
+  /** Helpers for building assertions from Eval inputs, outputs, and traces. */
+  assert: AgentAssertionHelpers;
+};
 
 interface AgentAssertionResources {
   spans?: SpanData[];
@@ -215,10 +230,12 @@ export function agentAssertionScorer<
 ): EvalScorer<Input, Output, Expected, Metadata> {
   return async (args) => {
     const { trace: _trace, ...callbackArgs } = args;
+    const metadata = (callbackArgs as { metadata?: unknown }).metadata ?? {};
     const assertions = await callback({
       ...callbackArgs,
+      metadata,
       assert: agentAssertionHelpers,
-    });
+    } as AgentAssertionScorerCallbackArgs<Input, Output, Expected, Metadata>);
     const resources: AgentAssertionResources = {};
     if (assertions.some((assertion) => assertion.requiresTrace)) {
       resources.spans = await args.trace?.getSpans({ spanType: ["tool"] });
@@ -283,11 +300,12 @@ const agentAssertionHelpers: AgentAssertionHelpers = {
   contains: (value, expected, name = "contains") => ({
     name,
     evaluate: () => {
-      const stringValue = String(value);
+      const searchedValue =
+        typeof value === "string" ? value : formatValue(value);
       const passed =
         expected instanceof RegExp
-          ? expected.test(stringValue)
-          : stringValue.includes(expected);
+          ? testRegex(expected, value)
+          : searchedValue.includes(expected);
       return {
         passed,
         failure: passed
@@ -331,6 +349,11 @@ const agentAssertionHelpers: AgentAssertionHelpers = {
     name,
     requiresTrace: true,
     evaluate: ({ spans }) => {
+      // This negative assertion treats an unavailable trace as "no observed
+      // tool calls" on purpose. It lets users run the scorer for tasks that do
+      // not collect traces without turning the absence of tracing itself into a
+      // failure. Positive tool assertions still fail because they cannot find
+      // the required call.
       const calls = toolCalls(spans ?? []).filter(
         (span) => getToolName(span) === toolName,
       );
@@ -369,6 +392,9 @@ const agentAssertionHelpers: AgentAssertionHelpers = {
     name,
     requiresTrace: true,
     evaluate: ({ spans }) => {
+      // This is intentionally based on observed tool calls: if no trace is
+      // available, there are no observed calls, so this negative assertion
+      // passes instead of treating missing tracing as a scorer failure.
       const calls = toolCalls(spans ?? []);
       const passed = calls.length === 0;
       return {
@@ -383,6 +409,9 @@ const agentAssertionHelpers: AgentAssertionHelpers = {
     name,
     requiresTrace: true,
     evaluate: ({ spans }) => {
+      // Limit checks intentionally use the same "observed tool calls" model as
+      // usedNoTools: without trace data, the observed count is zero. This keeps
+      // missing tracing distinct from a task that actually exceeded the limit.
       const calls = toolCalls(spans ?? []);
       const passed = calls.length <= max;
       return {
@@ -438,13 +467,13 @@ function matchingToolCalls(
   return toolCalls(spans).filter((span) => {
     if (getToolName(span) !== toolName) return false;
     if (
-      options.input !== undefined &&
+      Object.prototype.hasOwnProperty.call(options, "input") &&
       !matchesValue(span.input, options.input)
     ) {
       return false;
     }
     if (
-      options.output !== undefined &&
+      Object.prototype.hasOwnProperty.call(options, "output") &&
       !matchesValue(span.output, options.output)
     ) {
       return false;
@@ -460,31 +489,65 @@ function matchingToolCalls(
 }
 
 function getToolName(span: SpanData) {
-  const rawName =
-    typeof span.span_attributes?.name === "string"
-      ? span.span_attributes.name
-      : typeof span.name === "string"
-        ? span.name
-        : undefined;
-  if (!rawName) return undefined;
-  return rawName.startsWith("tool:")
-    ? rawName.slice("tool:".length).trim()
-    : rawName;
+  const spanName = [span.span_attributes?.name, span.name]
+    .map(normalizeToolName)
+    .find((value): value is string => value !== undefined);
+  if (spanName?.includes("/")) {
+    return spanName;
+  }
+
+  const metadataName = [
+    span.metadata?.tool_name,
+    span.metadata?.["gen_ai.tool.name"],
+  ]
+    .map(normalizeToolName)
+    .find((value): value is string => value !== undefined);
+  const mcpServer = [
+    span.metadata?.["mcp.server"],
+    span.metadata?.["openai_codex.mcp.server"],
+  ].find((value): value is string => typeof value === "string" && value !== "");
+
+  if (metadataName && mcpServer) {
+    return `${mcpServer}/${metadataName}`;
+  }
+
+  return metadataName ?? spanName;
+}
+
+function normalizeToolName(value: unknown) {
+  if (typeof value !== "string" || value === "") {
+    return undefined;
+  }
+  return value.startsWith("tool:") ? value.slice("tool:".length).trim() : value;
 }
 
 function matchesValue(actual: unknown, matcher: AssertionMatcher): boolean {
   if (matcher instanceof RegExp) {
-    return matcher.test(String(actual));
+    return testRegex(matcher, actual);
   }
   if (typeof matcher === "function") {
     return matcher(actual);
   }
+  if (Array.isArray(matcher)) {
+    return (
+      Array.isArray(actual) &&
+      actual.length === matcher.length &&
+      matcher.every((value, index) => matchesValue(actual[index], value))
+    );
+  }
   if (isPlainObject(matcher) && isPlainObject(actual)) {
-    return Object.entries(matcher).every(([key, value]) =>
-      matchesValue(actual[key], value),
+    return Object.entries(matcher).every(
+      ([key, value]) =>
+        Object.prototype.hasOwnProperty.call(actual, key) &&
+        matchesValue(actual[key], value),
     );
   }
   return deepEqual(actual, matcher);
+}
+
+function testRegex(matcher: RegExp, value: unknown) {
+  matcher.lastIndex = 0;
+  return matcher.test(typeof value === "string" ? value : formatValue(value));
 }
 
 function deepEqual(left: unknown, right: unknown): boolean {
@@ -500,7 +563,11 @@ function deepEqual(left: unknown, right: unknown): boolean {
     const rightKeys = Object.keys(right);
     return (
       leftKeys.length === rightKeys.length &&
-      leftKeys.every((key) => deepEqual(left[key], right[key]))
+      leftKeys.every(
+        (key) =>
+          Object.prototype.hasOwnProperty.call(right, key) &&
+          deepEqual(left[key], right[key]),
+      )
     );
   }
   return false;
@@ -531,8 +598,91 @@ function formatValue(value: unknown) {
   }
   try {
     const serialized = JSON.stringify(value);
-    return serialized === undefined ? String(value) : serialized;
+    if (serialized !== undefined && !hasUndefinedJsonValue(value)) {
+      return serialized;
+    }
+    return formatValueWithUndefined(value, new Set());
   } catch {
     return String(value);
   }
+}
+
+function hasUndefinedJsonValue(
+  value: unknown,
+  seen = new Set<object>(),
+): boolean {
+  if (value === undefined) {
+    return true;
+  }
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  if (seen.has(value)) {
+    return false;
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return Array.from({ length: value.length }).some((_, index) =>
+      hasUndefinedJsonValue(value[index], seen),
+    );
+  }
+
+  return Object.keys(value).some((key) =>
+    hasUndefinedJsonValue((value as Record<string, unknown>)[key], seen),
+  );
+}
+
+function formatValueWithUndefined(value: unknown, seen: Set<object>): string {
+  if (value === undefined) {
+    return "undefined";
+  }
+  if (value === null) {
+    return "null";
+  }
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "bigint" || typeof value === "function") {
+    return String(value);
+  }
+  if (typeof value === "symbol") {
+    return String(value);
+  }
+  if (value instanceof RegExp) {
+    return value.toString();
+  }
+  if (typeof value !== "object") {
+    return String(value);
+  }
+  if (seen.has(value)) {
+    return '"[Circular]"';
+  }
+
+  seen.add(value);
+  if (typeof (value as { toJSON?: unknown }).toJSON === "function") {
+    const jsonValue = (value as { toJSON: () => unknown }).toJSON();
+    seen.delete(value);
+    return formatValueWithUndefined(jsonValue, seen);
+  }
+  if (Array.isArray(value)) {
+    const formatted = Array.from({ length: value.length }, (_, index) =>
+      formatValueWithUndefined(value[index], seen),
+    );
+    seen.delete(value);
+    return `[${formatted.join(",")}]`;
+  }
+
+  const formatted = Object.keys(value).map(
+    (key) =>
+      `${JSON.stringify(key)}:${formatValueWithUndefined(
+        (value as Record<string, unknown>)[key],
+        seen,
+      )}`,
+  );
+  seen.delete(value);
+  return `{${formatted.join(",")}}`;
 }

--- a/js/src/exports.ts
+++ b/js/src/exports.ts
@@ -230,6 +230,8 @@ export {
   defaultErrorScoreHandler,
 } from "./framework";
 
+export { agentAssertionScorer } from "./agent-assertions";
+
 export { DatasetPipeline } from "./dataset-pipeline";
 
 export type {


### PR DESCRIPTION
```ts
import { Eval, agentAssertionScorer } from "braintrust";
import { z } from "zod";

await Eval("agent-behavior", {
  data: () => [],
  task: async (input) => {},
  scores: [
    agentAssertionScorer(({ output, expected, assert }) => [
      // Tool helpers
      assert.calledTool(
        "web_search",
        {
          input: { query: /capital of Estonia/i },
          times: 1,
        },
        "searches for the answer once",
      ),
      assert.calledTool(
        "summarize_source",
        {
          output: { citations: (value) => Array.isArray(value) },
          isError: false,
        },
        "summarizes sources successfully",
      ),
      assert.notCalledTool("send_email", "does not send email"),
      assert.toolOrder(
        ["web_search", "summarize_source"],
        "searches before summarizing",
      ),
      assert.maxToolCalls(3, "keeps tool use bounded"),
      assert.usedNoTools("does not need tools for memorized fact"),

      // Generic assertion helpers
      assert.contains(output, "Tallinn", "answers directly"),
      assert.equals(output.answer, expected.answer, "exact expected answer"),
      assert.notEquals(output.answer, "I don't know", "does not punt"),
      assert.contains(output.answer, /Tallinn/i, "mentions Tallinn"),
      assert.matches(
        output,
        z.object({
          answer: z.string(),
          citations: z.array(z.string()).min(1),
          confidence: z.number().min(0).max(1),
        }),
        "returns the expected shape",
      ),
    ]),
  ],
});
```

scorer output

```

{
  name: "assertions",
  score: passedAssertions / totalAssertions,
  metadata: {
    assertions: [
      { name: "routes to expected department", passed: true },
      { name: "returns valid route shape", passed: false },
      { name: "called tool classify_ticket", passed: true },
    ],
    failed: [
      "returns valid route shape: expected output to match RouteSchema",
    ],
  },
}
```