### PR TITLE
feat(evals): Forward/pick up `bt eval <...> --sample N` flag

### DIFF
--- a/.changeset/tiny-sheep-send.md
+++ b/.changeset/tiny-sheep-send.md
@@ -1,0 +1,5 @@
+---
+"braintrust": minor
+---
+
+feat(evals): Forward/pick up `bt eval <...> --sample N` flag

--- a/js/src/logger.test.ts
+++ b/js/src/logger.test.ts
@@ -836,7 +836,10 @@ test("initDataset merges bt eval internal BTQL with existing _internal_btql", as
 test("initDataset preserves explicit _internal_btql sample", async () => {
   const state = await _exportsForTestingOnly.simulateLoginForTests();
   const previousInternalBtql = globalThis.__bt_eval_internal_btql;
-  globalThis.__bt_eval_internal_btql = { sample: 5 };
+  globalThis.__bt_eval_internal_btql = {
+    sample: 5,
+    limit: 7,
+  };
 
   try {
     vi.spyOn(state, "login").mockResolvedValue(state);
@@ -865,6 +868,7 @@ test("initDataset preserves explicit _internal_btql sample", async () => {
       dataset_id: "00000000-0000-0000-0000-000000000002",
       _internal_btql: {
         filter: "metadata.kind = 'synthetic'",
+        limit: 7,
         sample: 2,
       },
     });

--- a/js/src/logger.test.ts
+++ b/js/src/logger.test.ts
@@ -715,6 +715,251 @@ test("dataset fetch forwards _internal_btql filter arrays to btql", async () => 
   }
 });
 
+test("initDataset applies bt eval sample runtime value to eval data", async () => {
+  const state = await _exportsForTestingOnly.simulateLoginForTests();
+  const previousSampleRate = globalThis.__bt_eval_sample_rate;
+  globalThis.__bt_eval_sample_rate = 5;
+
+  try {
+    vi.spyOn(state, "login").mockResolvedValue(state);
+    vi.spyOn(state.appConn(), "post_json").mockResolvedValue({
+      project: {
+        id: "00000000-0000-0000-0000-000000000001",
+        name: "test-project",
+      },
+      dataset: {
+        id: "00000000-0000-0000-0000-000000000002",
+        name: "test-dataset",
+      },
+    });
+
+    const dataset = initDataset({
+      project: "test-project",
+      dataset: "test-dataset",
+      state,
+    });
+
+    await expect(dataset.toEvalData()).resolves.toEqual({
+      dataset_id: "00000000-0000-0000-0000-000000000002",
+      _internal_btql: {
+        sample: 5,
+      },
+    });
+  } finally {
+    globalThis.__bt_eval_sample_rate = previousSampleRate;
+    _exportsForTestingOnly.simulateLogoutForTests();
+    vi.restoreAllMocks();
+  }
+});
+
+test("legacy initDataset applies bt eval sample runtime value", async () => {
+  const state = await _exportsForTestingOnly.simulateLoginForTests();
+  const previousSampleRate = globalThis.__bt_eval_sample_rate;
+  globalThis.__bt_eval_sample_rate = 5;
+
+  try {
+    vi.spyOn(state, "login").mockResolvedValue(state);
+    vi.spyOn(state.appConn(), "post_json").mockResolvedValue({
+      project: {
+        id: "00000000-0000-0000-0000-000000000001",
+        name: "test-project",
+      },
+      dataset: {
+        id: "00000000-0000-0000-0000-000000000002",
+        name: "test-dataset",
+      },
+    });
+
+    const dataset = initDataset("test-project", {
+      dataset: "test-dataset",
+      state,
+    });
+
+    await expect(dataset.toEvalData()).resolves.toEqual({
+      dataset_id: "00000000-0000-0000-0000-000000000002",
+      _internal_btql: {
+        sample: 5,
+      },
+    });
+  } finally {
+    globalThis.__bt_eval_sample_rate = previousSampleRate;
+    _exportsForTestingOnly.simulateLogoutForTests();
+    vi.restoreAllMocks();
+  }
+});
+
+test("initDataset merges bt eval sample with existing _internal_btql", async () => {
+  const state = await _exportsForTestingOnly.simulateLoginForTests();
+  const previousSampleRate = globalThis.__bt_eval_sample_rate;
+  globalThis.__bt_eval_sample_rate = 5;
+
+  try {
+    vi.spyOn(state, "login").mockResolvedValue(state);
+    vi.spyOn(state.appConn(), "post_json").mockResolvedValue({
+      project: {
+        id: "00000000-0000-0000-0000-000000000001",
+        name: "test-project",
+      },
+      dataset: {
+        id: "00000000-0000-0000-0000-000000000002",
+        name: "test-dataset",
+      },
+    });
+
+    const dataset = initDataset({
+      project: "test-project",
+      dataset: "test-dataset",
+      _internal_btql: {
+        filter: "metadata.kind = 'synthetic'",
+      },
+      state,
+    });
+
+    await expect(dataset.toEvalData()).resolves.toEqual({
+      dataset_id: "00000000-0000-0000-0000-000000000002",
+      _internal_btql: {
+        filter: "metadata.kind = 'synthetic'",
+        sample: 5,
+      },
+    });
+  } finally {
+    globalThis.__bt_eval_sample_rate = previousSampleRate;
+    _exportsForTestingOnly.simulateLogoutForTests();
+    vi.restoreAllMocks();
+  }
+});
+
+test("initDataset preserves explicit _internal_btql sample", async () => {
+  const state = await _exportsForTestingOnly.simulateLoginForTests();
+  const previousSampleRate = globalThis.__bt_eval_sample_rate;
+  globalThis.__bt_eval_sample_rate = 5;
+
+  try {
+    vi.spyOn(state, "login").mockResolvedValue(state);
+    vi.spyOn(state.appConn(), "post_json").mockResolvedValue({
+      project: {
+        id: "00000000-0000-0000-0000-000000000001",
+        name: "test-project",
+      },
+      dataset: {
+        id: "00000000-0000-0000-0000-000000000002",
+        name: "test-dataset",
+      },
+    });
+
+    const dataset = initDataset({
+      project: "test-project",
+      dataset: "test-dataset",
+      _internal_btql: {
+        filter: "metadata.kind = 'synthetic'",
+        sample: 2,
+      },
+      state,
+    });
+
+    await expect(dataset.toEvalData()).resolves.toEqual({
+      dataset_id: "00000000-0000-0000-0000-000000000002",
+      _internal_btql: {
+        filter: "metadata.kind = 'synthetic'",
+        sample: 2,
+      },
+    });
+  } finally {
+    globalThis.__bt_eval_sample_rate = previousSampleRate;
+    _exportsForTestingOnly.simulateLogoutForTests();
+    vi.restoreAllMocks();
+  }
+});
+
+test("initDataset keeps eval data unchanged without bt eval sample runtime value", async () => {
+  const state = await _exportsForTestingOnly.simulateLoginForTests();
+  const previousSampleRate = globalThis.__bt_eval_sample_rate;
+  globalThis.__bt_eval_sample_rate = undefined;
+
+  try {
+    vi.spyOn(state, "login").mockResolvedValue(state);
+    vi.spyOn(state.appConn(), "post_json").mockResolvedValue({
+      project: {
+        id: "00000000-0000-0000-0000-000000000001",
+        name: "test-project",
+      },
+      dataset: {
+        id: "00000000-0000-0000-0000-000000000002",
+        name: "test-dataset",
+      },
+    });
+
+    const dataset = initDataset({
+      project: "test-project",
+      dataset: "test-dataset",
+      state,
+    });
+
+    await expect(dataset.toEvalData()).resolves.toEqual({
+      dataset_id: "00000000-0000-0000-0000-000000000002",
+    });
+  } finally {
+    globalThis.__bt_eval_sample_rate = previousSampleRate;
+    _exportsForTestingOnly.simulateLogoutForTests();
+    vi.restoreAllMocks();
+  }
+});
+
+test("dataset fetch forwards bt eval sample runtime value to btql", async () => {
+  const state = await _exportsForTestingOnly.simulateLoginForTests();
+  const previousSampleRate = globalThis.__bt_eval_sample_rate;
+  globalThis.__bt_eval_sample_rate = 5;
+
+  try {
+    vi.spyOn(state, "login").mockResolvedValue(state);
+    vi.spyOn(state.appConn(), "post_json").mockResolvedValue({
+      project: {
+        id: "00000000-0000-0000-0000-000000000001",
+        name: "test-project",
+      },
+      dataset: {
+        id: "00000000-0000-0000-0000-000000000002",
+        name: "test-dataset",
+      },
+    });
+
+    let btqlBody: unknown;
+    vi.spyOn(state.apiConn(), "post").mockImplementation(
+      async (_path, body) => {
+        btqlBody = body;
+        return new Response(JSON.stringify({ data: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    );
+
+    const dataset = initDataset({
+      project: "test-project",
+      dataset: "test-dataset",
+      state,
+    });
+
+    const rows: unknown[] = [];
+    for await (const row of dataset) {
+      rows.push(row);
+    }
+
+    expect(rows).toEqual([]);
+    expect(btqlBody).toEqual(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          sample: 5,
+        }),
+      }),
+    );
+  } finally {
+    globalThis.__bt_eval_sample_rate = previousSampleRate;
+    _exportsForTestingOnly.simulateLogoutForTests();
+    vi.restoreAllMocks();
+  }
+});
+
 test("initDataset prefers version over environment in eval data", async () => {
   const state = await _exportsForTestingOnly.simulateLoginForTests();
   vi.spyOn(state, "login").mockResolvedValue(state);

--- a/js/src/logger.test.ts
+++ b/js/src/logger.test.ts
@@ -715,10 +715,10 @@ test("dataset fetch forwards _internal_btql filter arrays to btql", async () => 
   }
 });
 
-test("initDataset applies bt eval sample runtime value to eval data", async () => {
+test("initDataset applies bt eval internal BTQL runtime value to eval data", async () => {
   const state = await _exportsForTestingOnly.simulateLoginForTests();
-  const previousSampleRate = globalThis.__bt_eval_sample_rate;
-  globalThis.__bt_eval_sample_rate = 5;
+  const previousInternalBtql = globalThis.__bt_eval_internal_btql;
+  globalThis.__bt_eval_internal_btql = { sample: 5 };
 
   try {
     vi.spyOn(state, "login").mockResolvedValue(state);
@@ -746,16 +746,16 @@ test("initDataset applies bt eval sample runtime value to eval data", async () =
       },
     });
   } finally {
-    globalThis.__bt_eval_sample_rate = previousSampleRate;
+    globalThis.__bt_eval_internal_btql = previousInternalBtql;
     _exportsForTestingOnly.simulateLogoutForTests();
     vi.restoreAllMocks();
   }
 });
 
-test("legacy initDataset applies bt eval sample runtime value", async () => {
+test("legacy initDataset applies bt eval internal BTQL runtime value", async () => {
   const state = await _exportsForTestingOnly.simulateLoginForTests();
-  const previousSampleRate = globalThis.__bt_eval_sample_rate;
-  globalThis.__bt_eval_sample_rate = 5;
+  const previousInternalBtql = globalThis.__bt_eval_internal_btql;
+  globalThis.__bt_eval_internal_btql = { sample: 5 };
 
   try {
     vi.spyOn(state, "login").mockResolvedValue(state);
@@ -782,16 +782,19 @@ test("legacy initDataset applies bt eval sample runtime value", async () => {
       },
     });
   } finally {
-    globalThis.__bt_eval_sample_rate = previousSampleRate;
+    globalThis.__bt_eval_internal_btql = previousInternalBtql;
     _exportsForTestingOnly.simulateLogoutForTests();
     vi.restoreAllMocks();
   }
 });
 
-test("initDataset merges bt eval sample with existing _internal_btql", async () => {
+test("initDataset merges bt eval internal BTQL with existing _internal_btql", async () => {
   const state = await _exportsForTestingOnly.simulateLoginForTests();
-  const previousSampleRate = globalThis.__bt_eval_sample_rate;
-  globalThis.__bt_eval_sample_rate = 5;
+  const previousInternalBtql = globalThis.__bt_eval_internal_btql;
+  globalThis.__bt_eval_internal_btql = {
+    sample: 5,
+    limit: 7,
+  };
 
   try {
     vi.spyOn(state, "login").mockResolvedValue(state);
@@ -819,11 +822,12 @@ test("initDataset merges bt eval sample with existing _internal_btql", async () 
       dataset_id: "00000000-0000-0000-0000-000000000002",
       _internal_btql: {
         filter: "metadata.kind = 'synthetic'",
+        limit: 7,
         sample: 5,
       },
     });
   } finally {
-    globalThis.__bt_eval_sample_rate = previousSampleRate;
+    globalThis.__bt_eval_internal_btql = previousInternalBtql;
     _exportsForTestingOnly.simulateLogoutForTests();
     vi.restoreAllMocks();
   }
@@ -831,8 +835,8 @@ test("initDataset merges bt eval sample with existing _internal_btql", async () 
 
 test("initDataset preserves explicit _internal_btql sample", async () => {
   const state = await _exportsForTestingOnly.simulateLoginForTests();
-  const previousSampleRate = globalThis.__bt_eval_sample_rate;
-  globalThis.__bt_eval_sample_rate = 5;
+  const previousInternalBtql = globalThis.__bt_eval_internal_btql;
+  globalThis.__bt_eval_internal_btql = { sample: 5 };
 
   try {
     vi.spyOn(state, "login").mockResolvedValue(state);
@@ -865,16 +869,16 @@ test("initDataset preserves explicit _internal_btql sample", async () => {
       },
     });
   } finally {
-    globalThis.__bt_eval_sample_rate = previousSampleRate;
+    globalThis.__bt_eval_internal_btql = previousInternalBtql;
     _exportsForTestingOnly.simulateLogoutForTests();
     vi.restoreAllMocks();
   }
 });
 
-test("initDataset keeps eval data unchanged without bt eval sample runtime value", async () => {
+test("initDataset keeps eval data unchanged without bt eval internal BTQL runtime value", async () => {
   const state = await _exportsForTestingOnly.simulateLoginForTests();
-  const previousSampleRate = globalThis.__bt_eval_sample_rate;
-  globalThis.__bt_eval_sample_rate = undefined;
+  const previousInternalBtql = globalThis.__bt_eval_internal_btql;
+  globalThis.__bt_eval_internal_btql = undefined;
 
   try {
     vi.spyOn(state, "login").mockResolvedValue(state);
@@ -899,16 +903,16 @@ test("initDataset keeps eval data unchanged without bt eval sample runtime value
       dataset_id: "00000000-0000-0000-0000-000000000002",
     });
   } finally {
-    globalThis.__bt_eval_sample_rate = previousSampleRate;
+    globalThis.__bt_eval_internal_btql = previousInternalBtql;
     _exportsForTestingOnly.simulateLogoutForTests();
     vi.restoreAllMocks();
   }
 });
 
-test("dataset fetch forwards bt eval sample runtime value to btql", async () => {
+test("dataset fetch forwards bt eval internal BTQL runtime value to btql", async () => {
   const state = await _exportsForTestingOnly.simulateLoginForTests();
-  const previousSampleRate = globalThis.__bt_eval_sample_rate;
-  globalThis.__bt_eval_sample_rate = 5;
+  const previousInternalBtql = globalThis.__bt_eval_internal_btql;
+  globalThis.__bt_eval_internal_btql = { sample: 5 };
 
   try {
     vi.spyOn(state, "login").mockResolvedValue(state);
@@ -954,7 +958,7 @@ test("dataset fetch forwards bt eval sample runtime value to btql", async () => 
       }),
     );
   } finally {
-    globalThis.__bt_eval_sample_rate = previousSampleRate;
+    globalThis.__bt_eval_internal_btql = previousInternalBtql;
     _exportsForTestingOnly.simulateLogoutForTests();
     vi.restoreAllMocks();
   }

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -4227,9 +4227,8 @@ export function initDataset<
       ? _internal_btql
       : _internal_btql === undefined
         ? cliInternalBtql
-        : isObject(_internal_btql) &&
-            !Object.prototype.hasOwnProperty.call(_internal_btql, "sample")
-          ? { ..._internal_btql, ...cliInternalBtql }
+        : isObject(_internal_btql)
+          ? { ...cliInternalBtql, ..._internal_btql }
           : _internal_btql;
 
   const state = stateArg ?? _globalState;

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -3904,10 +3904,10 @@ type UseOutputOption<IsLegacyDataset extends boolean> = {
 };
 
 declare global {
-  // Set by the bt eval runner when `bt eval --sample` should be pushed down
+  // Set by the bt eval runner when CLI-controlled BTQL should be pushed down
   // into dataset-backed evals.
   // eslint-disable-next-line no-var
-  var __bt_eval_sample_rate: number | undefined;
+  var __bt_eval_internal_btql: Record<string, unknown> | undefined;
 }
 
 export type InitDatasetOptions<IsLegacyDataset extends boolean> =
@@ -4221,15 +4221,15 @@ export function initDataset<
   const normalizedEnvironment = selection.environment;
   const normalizedSnapshotName = selection.snapshotName;
 
-  const sampleRate = globalThis.__bt_eval_sample_rate;
+  const cliInternalBtql = globalThis.__bt_eval_internal_btql;
   const internalBtql =
-    typeof sampleRate !== "number"
+    cliInternalBtql === undefined
       ? _internal_btql
       : _internal_btql === undefined
-        ? { sample: sampleRate }
+        ? cliInternalBtql
         : isObject(_internal_btql) &&
             !Object.prototype.hasOwnProperty.call(_internal_btql, "sample")
-          ? { ..._internal_btql, sample: sampleRate }
+          ? { ..._internal_btql, ...cliInternalBtql }
           : _internal_btql;
 
   const state = stateArg ?? _globalState;

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -3903,6 +3903,13 @@ type UseOutputOption<IsLegacyDataset extends boolean> = {
   useOutput?: IsLegacyDataset;
 };
 
+declare global {
+  // Set by the bt eval runner when `bt eval --sample` should be pushed down
+  // into dataset-backed evals.
+  // eslint-disable-next-line no-var
+  var __bt_eval_sample_rate: number | undefined;
+}
+
 export type InitDatasetOptions<IsLegacyDataset extends boolean> =
   FullLoginOptions & {
     dataset?: string;
@@ -4214,6 +4221,17 @@ export function initDataset<
   const normalizedEnvironment = selection.environment;
   const normalizedSnapshotName = selection.snapshotName;
 
+  const sampleRate = globalThis.__bt_eval_sample_rate;
+  const internalBtql =
+    typeof sampleRate !== "number"
+      ? _internal_btql
+      : _internal_btql === undefined
+        ? { sample: sampleRate }
+        : isObject(_internal_btql) &&
+            !Object.prototype.hasOwnProperty.call(_internal_btql, "sample")
+          ? { ..._internal_btql, sample: sampleRate }
+          : _internal_btql;
+
   const state = stateArg ?? _globalState;
 
   const lazyMetadata: LazyValue<ProjectDatasetMetadata> = new LazyValue(
@@ -4279,7 +4297,7 @@ export function initDataset<
     lazyMetadata,
     typeof resolvedVersion === "string" ? resolvedVersion : undefined,
     legacy,
-    _internal_btql,
+    internalBtql,
     resolvedVersion instanceof LazyValue ||
       normalizedEnvironment !== undefined ||
       normalizedSnapshotName !== undefined


### PR DESCRIPTION
Builds on https://github.com/braintrustdata/bt/pull/247

When doing `initDataset()` with the `--sample N` flag, it will sample the rows.