### PR TITLE
fix: support AI SDK 7 telemetry end callbacks

### DIFF
--- a/.changeset/ai-sdk-v7-telemetry-end.md
+++ b/.changeset/ai-sdk-v7-telemetry-end.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+fix(ai-sdk): Close `braintrustAISDKTelemetry()` parent spans with AI SDK 7 `onEnd` callbacks

--- a/e2e/helpers/normalize.ts
+++ b/e2e/helpers/normalize.ts
@@ -17,9 +17,11 @@ type TokenMaps = {
 
 export type NormalizeOptions = {
   additionalProviderIdKeys?: Iterable<string>;
+  omittedKeys?: Iterable<string>;
 };
 
 type ResolvedNormalizeOptions = {
+  omittedKeys: Set<string>;
   providerIdKeys: Set<string>;
 };
 
@@ -231,16 +233,20 @@ function normalizeObject(
     shouldNormalizeNodeInternalStyleCaller(callerFilename);
 
   return Object.fromEntries(
-    Object.entries(value).map(([key, entry]) => {
+    Object.entries(value).flatMap(([key, entry]) => {
+      if (options.omittedKeys.has(key)) {
+        return [];
+      }
+
       if (isNodeInternalCaller) {
         if (key === "caller_filename") {
-          return [key, "<node-internal>"];
+          return [[key, "<node-internal>"]];
         }
         if (key === "caller_functionname") {
-          return [key, "<node-internal>"];
+          return [[key, "<node-internal>"]];
         }
         if (key === "caller_lineno") {
-          return [key, 0];
+          return [[key, 0]];
         }
       }
 
@@ -249,10 +255,10 @@ function normalizeObject(
         typeof entry === "string" &&
         (value.type === "thought" || value.type === "thought_signature")
       ) {
-        return [key, tokenFor(tokenMaps.ids, entry, "signature")];
+        return [[key, tokenFor(tokenMaps.ids, entry, "signature")]];
       }
 
-      return [key, normalizeValue(entry as Json, tokenMaps, options, key)];
+      return [[key, normalizeValue(entry as Json, tokenMaps, options, key)]];
     }),
   );
 }
@@ -430,6 +436,7 @@ function resolveNormalizeOptions(
   options: NormalizeOptions | undefined,
 ): ResolvedNormalizeOptions {
   return {
+    omittedKeys: new Set(options?.omittedKeys ?? []),
     providerIdKeys: new Set([
       ...PROVIDER_ID_KEYS,
       ...(options?.additionalProviderIdKeys ?? []),

--- a/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v7-auto-hook.span-tree.json
+++ b/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v7-auto-hook.span-tree.json
@@ -46,7 +46,6 @@
                       "id": "<span:1>"
                     },
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 18
@@ -67,7 +66,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 21
                     }
                   },
@@ -80,18 +78,16 @@
                     "provider": "openai.responses"
                   },
                   "metrics": {
-                    "completion_reasoning_tokens": 0,
                     "completion_tokens": 3,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 18,
-                    "reasoning_tokens": 0,
                     "tokens": 21
                   }
                 }
               ],
               "input": {
                 "headers": {
-                  "user-agent": "ai/7.0.0-beta.116"
+                  "user-agent": "ai/7.0.0"
                 },
                 "maxOutputTokens": 24,
                 "maxRetries": 2,
@@ -127,7 +123,6 @@
                   }
                 },
                 "response": {
-                  "body": "<omitted>",
                   "headers": "<omitted>",
                   "id": "<span:3>",
                   "messages": [
@@ -149,6 +144,7 @@
                   "modelId": "gpt-4o-mini-2024-07-18",
                   "timestamp": "<timestamp>"
                 },
+                "responseMessages": "<omitted>",
                 "steps": [
                   {
                     "callId": "<callId:1>",
@@ -175,7 +171,6 @@
                       }
                     },
                     "response": {
-                      "body": "<omitted>",
                       "headers": "<omitted>",
                       "id": "<span:3>",
                       "messages": [
@@ -201,7 +196,6 @@
                     "stepNumber": 0,
                     "toolsContext": {},
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 18
@@ -222,7 +216,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 21
                     },
                     "warnings": []
@@ -232,7 +225,6 @@
                 "toolCalls": [],
                 "toolResults": [],
                 "totalUsage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "noCacheTokens": 18
@@ -243,11 +235,9 @@
                     "textTokens": 3
                   },
                   "outputTokens": 3,
-                  "reasoningTokens": 0,
                   "totalTokens": 21
                 },
                 "usage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "noCacheTokens": 18
@@ -258,17 +248,6 @@
                     "textTokens": 3
                   },
                   "outputTokens": 3,
-                  "raw": {
-                    "input_tokens": 18,
-                    "input_tokens_details": {
-                      "cached_tokens": 0
-                    },
-                    "output_tokens": 3,
-                    "output_tokens_details": {
-                      "reasoning_tokens": 0
-                    }
-                  },
-                  "reasoningTokens": 0,
                   "totalTokens": 21
                 },
                 "warnings": []
@@ -338,7 +317,6 @@
                       "id": "<span:1>"
                     },
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 45
@@ -359,7 +337,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 51
                     }
                   },
@@ -372,18 +349,16 @@
                     "provider": "openai.responses"
                   },
                   "metrics": {
-                    "completion_reasoning_tokens": 0,
                     "completion_tokens": 6,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 45,
-                    "reasoning_tokens": 0,
                     "tokens": 51
                   }
                 }
               ],
               "input": {
                 "headers": {
-                  "user-agent": "ai/7.0.0-beta.116"
+                  "user-agent": "ai/7.0.0"
                 },
                 "maxOutputTokens": 32,
                 "maxRetries": 2,
@@ -437,7 +412,6 @@
                   }
                 },
                 "response": {
-                  "body": "<omitted>",
                   "headers": "<omitted>",
                   "id": "<span:3>",
                   "messages": [
@@ -459,6 +433,7 @@
                   "modelId": "gpt-4o-mini-2024-07-18",
                   "timestamp": "<timestamp>"
                 },
+                "responseMessages": "<omitted>",
                 "steps": [
                   {
                     "callId": "<callId:1>",
@@ -485,7 +460,6 @@
                       }
                     },
                     "response": {
-                      "body": "<omitted>",
                       "headers": "<omitted>",
                       "id": "<span:3>",
                       "messages": [
@@ -511,7 +485,6 @@
                     "stepNumber": 0,
                     "toolsContext": {},
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 45
@@ -532,7 +505,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 51
                     },
                     "warnings": []
@@ -542,7 +514,6 @@
                 "toolCalls": [],
                 "toolResults": [],
                 "totalUsage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "noCacheTokens": 45
@@ -553,11 +524,9 @@
                     "textTokens": 6
                   },
                   "outputTokens": 6,
-                  "reasoningTokens": 0,
                   "totalTokens": 51
                 },
                 "usage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "noCacheTokens": 45
@@ -568,17 +537,6 @@
                     "textTokens": 6
                   },
                   "outputTokens": 6,
-                  "raw": {
-                    "input_tokens": 45,
-                    "input_tokens_details": {
-                      "cached_tokens": 0
-                    },
-                    "output_tokens": 6,
-                    "output_tokens_details": {
-                      "reasoning_tokens": 0
-                    }
-                  },
-                  "reasoningTokens": 0,
                   "totalTokens": 51
                 },
                 "warnings": []
@@ -640,7 +598,6 @@
                       "id": "<span:1>"
                     },
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 22
@@ -661,7 +618,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 29
                     }
                   },
@@ -674,11 +630,9 @@
                     "provider": "openai.responses"
                   },
                   "metrics": {
-                    "completion_reasoning_tokens": 0,
                     "completion_tokens": 7,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 22,
-                    "reasoning_tokens": 0,
                     "tokens": 29
                   }
                 }
@@ -739,6 +693,7 @@
                   "modelId": "gpt-4o-mini-2024-07-18",
                   "timestamp": "<timestamp>"
                 },
+                "responseMessages": "<omitted>",
                 "steps": [
                   {
                     "callId": "<callId:1>",
@@ -790,7 +745,6 @@
                     "stepNumber": 0,
                     "toolsContext": {},
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 22
@@ -811,7 +765,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 29
                     },
                     "warnings": []
@@ -821,7 +774,6 @@
                 "toolCalls": [],
                 "toolResults": [],
                 "totalUsage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "noCacheTokens": 22
@@ -832,11 +784,9 @@
                     "textTokens": 7
                   },
                   "outputTokens": 7,
-                  "reasoningTokens": 0,
                   "totalTokens": 29
                 },
                 "usage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "noCacheTokens": 22
@@ -847,17 +797,6 @@
                     "textTokens": 7
                   },
                   "outputTokens": 7,
-                  "raw": {
-                    "input_tokens": 22,
-                    "input_tokens_details": {
-                      "cached_tokens": 0
-                    },
-                    "output_tokens": 7,
-                    "output_tokens_details": {
-                      "reasoning_tokens": 0
-                    }
-                  },
-                  "reasoningTokens": 0,
                   "totalTokens": 29
                 },
                 "warnings": []
@@ -1040,7 +979,6 @@
                       "modelId": "gpt-4o-mini-2024-07-18",
                       "provider": "openai.responses"
                     },
-                    "system": "You must inspect live weather via the provided get_weather tool before responding.",
                     "temperature": 0,
                     "tools": [
                       {
@@ -1085,7 +1023,6 @@
                       "id": "<span:1>"
                     },
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 94
@@ -1106,7 +1043,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 102
                     }
                   },
@@ -1119,11 +1055,9 @@
                     "provider": "openai.responses"
                   },
                   "metrics": {
-                    "completion_reasoning_tokens": 0,
                     "completion_tokens": 8,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 94,
-                    "reasoning_tokens": 0,
                     "tokens": 102
                   }
                 },
@@ -1142,9 +1076,6 @@
                     },
                     "toolCallId": "<toolCallId:1>",
                     "toolName": "get_weather"
-                  },
-                  "metrics": {
-                    "duration_ms": 0
                   }
                 },
                 {
@@ -1200,7 +1131,6 @@
                       "modelId": "gpt-4o-mini-2024-07-18",
                       "provider": "openai.responses"
                     },
-                    "system": "You must inspect live weather via the provided get_weather tool before responding.",
                     "temperature": 0,
                     "tools": [
                       {
@@ -1245,7 +1175,6 @@
                       "id": "<span:1>"
                     },
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 133
@@ -1266,7 +1195,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 141
                     }
                   },
@@ -1279,11 +1207,9 @@
                     "provider": "openai.responses"
                   },
                   "metrics": {
-                    "completion_reasoning_tokens": 0,
                     "completion_tokens": 8,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 133,
-                    "reasoning_tokens": 0,
                     "tokens": 141
                   }
                 },
@@ -1302,9 +1228,6 @@
                     },
                     "toolCallId": "<toolCallId:1>",
                     "toolName": "get_weather"
-                  },
-                  "metrics": {
-                    "duration_ms": 0
                   }
                 },
                 {
@@ -1397,7 +1320,6 @@
                       "modelId": "gpt-4o-mini-2024-07-18",
                       "provider": "openai.responses"
                     },
-                    "system": "You must inspect live weather via the provided get_weather tool before responding.",
                     "temperature": 0,
                     "tools": [
                       {
@@ -1442,7 +1364,6 @@
                       "id": "<span:1>"
                     },
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 172
@@ -1463,7 +1384,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 180
                     }
                   },
@@ -1476,11 +1396,9 @@
                     "provider": "openai.responses"
                   },
                   "metrics": {
-                    "completion_reasoning_tokens": 0,
                     "completion_tokens": 8,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 172,
-                    "reasoning_tokens": 0,
                     "tokens": 180
                   }
                 },
@@ -1499,9 +1417,6 @@
                     },
                     "toolCallId": "<toolCallId:1>",
                     "toolName": "get_weather"
-                  },
-                  "metrics": {
-                    "duration_ms": 0
                   }
                 },
                 {
@@ -1631,7 +1546,6 @@
                       "modelId": "gpt-4o-mini-2024-07-18",
                       "provider": "openai.responses"
                     },
-                    "system": "You must inspect live weather via the provided get_weather tool before responding.",
                     "temperature": 0,
                     "tools": [
                       {
@@ -1676,7 +1590,6 @@
                       "id": "<span:1>"
                     },
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 211
@@ -1697,7 +1610,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 219
                     }
                   },
@@ -1710,11 +1622,9 @@
                     "provider": "openai.responses"
                   },
                   "metrics": {
-                    "completion_reasoning_tokens": 0,
                     "completion_tokens": 8,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 211,
-                    "reasoning_tokens": 0,
                     "tokens": 219
                   }
                 },
@@ -1733,15 +1643,12 @@
                     },
                     "toolCallId": "<toolCallId:1>",
                     "toolName": "get_weather"
-                  },
-                  "metrics": {
-                    "duration_ms": 0
                   }
                 }
               ],
               "input": {
                 "headers": {
-                  "user-agent": "ai/7.0.0-beta.116"
+                  "user-agent": "ai/7.0.0"
                 },
                 "maxOutputTokens": 128,
                 "maxRetries": 2,
@@ -1755,7 +1662,6 @@
                   "modelId": "gpt-4o-mini-2024-07-18",
                   "provider": "openai.responses"
                 },
-                "system": "You must inspect live weather via the provided get_weather tool before responding.",
                 "temperature": 0,
                 "toolChoice": "required",
                 "tools": {
@@ -1780,6 +1686,90 @@
               },
               "output": {
                 "content": [
+                  {
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "providerMetadata": {
+                      "openai": {
+                        "itemId": "<itemId:3>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:2>",
+                    "toolName": "get_weather",
+                    "type": "tool-call"
+                  },
+                  {
+                    "dynamic": false,
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+                    "providerMetadata": {
+                      "openai": {
+                        "itemId": "<itemId:3>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:2>",
+                    "toolName": "get_weather",
+                    "type": "tool-result"
+                  },
+                  {
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "providerMetadata": {
+                      "openai": {
+                        "itemId": "<itemId:6>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:5>",
+                    "toolName": "get_weather",
+                    "type": "tool-call"
+                  },
+                  {
+                    "dynamic": false,
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+                    "providerMetadata": {
+                      "openai": {
+                        "itemId": "<itemId:6>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:5>",
+                    "toolName": "get_weather",
+                    "type": "tool-result"
+                  },
+                  {
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "providerMetadata": {
+                      "openai": {
+                        "itemId": "<itemId:9>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:8>",
+                    "toolName": "get_weather",
+                    "type": "tool-call"
+                  },
+                  {
+                    "dynamic": false,
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+                    "providerMetadata": {
+                      "openai": {
+                        "itemId": "<itemId:9>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:8>",
+                    "toolName": "get_weather",
+                    "type": "tool-result"
+                  },
                   {
                     "input": {
                       "location": "Paris, France"
@@ -1817,121 +1807,9 @@
                   }
                 },
                 "response": {
-                  "body": "<omitted>",
                   "headers": "<omitted>",
                   "id": "<span:13>",
                   "messages": [
-                    {
-                      "content": [
-                        {
-                          "input": {
-                            "location": "Paris, France"
-                          },
-                          "providerOptions": {
-                            "openai": {
-                              "itemId": "<itemId:3>"
-                            }
-                          },
-                          "toolCallId": "<toolCallId:2>",
-                          "toolName": "get_weather",
-                          "type": "tool-call"
-                        }
-                      ],
-                      "role": "assistant"
-                    },
-                    {
-                      "content": [
-                        {
-                          "output": {
-                            "type": "text",
-                            "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-                          },
-                          "providerOptions": {
-                            "openai": {
-                              "itemId": "<itemId:3>"
-                            }
-                          },
-                          "toolCallId": "<toolCallId:2>",
-                          "toolName": "get_weather",
-                          "type": "tool-result"
-                        }
-                      ],
-                      "role": "tool"
-                    },
-                    {
-                      "content": [
-                        {
-                          "input": {
-                            "location": "Paris, France"
-                          },
-                          "providerOptions": {
-                            "openai": {
-                              "itemId": "<itemId:6>"
-                            }
-                          },
-                          "toolCallId": "<toolCallId:5>",
-                          "toolName": "get_weather",
-                          "type": "tool-call"
-                        }
-                      ],
-                      "role": "assistant"
-                    },
-                    {
-                      "content": [
-                        {
-                          "output": {
-                            "type": "text",
-                            "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-                          },
-                          "providerOptions": {
-                            "openai": {
-                              "itemId": "<itemId:6>"
-                            }
-                          },
-                          "toolCallId": "<toolCallId:5>",
-                          "toolName": "get_weather",
-                          "type": "tool-result"
-                        }
-                      ],
-                      "role": "tool"
-                    },
-                    {
-                      "content": [
-                        {
-                          "input": {
-                            "location": "Paris, France"
-                          },
-                          "providerOptions": {
-                            "openai": {
-                              "itemId": "<itemId:9>"
-                            }
-                          },
-                          "toolCallId": "<toolCallId:8>",
-                          "toolName": "get_weather",
-                          "type": "tool-call"
-                        }
-                      ],
-                      "role": "assistant"
-                    },
-                    {
-                      "content": [
-                        {
-                          "output": {
-                            "type": "text",
-                            "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-                          },
-                          "providerOptions": {
-                            "openai": {
-                              "itemId": "<itemId:9>"
-                            }
-                          },
-                          "toolCallId": "<toolCallId:8>",
-                          "toolName": "get_weather",
-                          "type": "tool-result"
-                        }
-                      ],
-                      "role": "tool"
-                    },
                     {
                       "content": [
                         {
@@ -1973,6 +1851,7 @@
                   "modelId": "gpt-4o-mini-2024-07-18",
                   "timestamp": "<timestamp>"
                 },
+                "responseMessages": "<omitted>",
                 "steps": [
                   {
                     "callId": "<callId:1>",
@@ -2018,7 +1897,6 @@
                       }
                     },
                     "response": {
-                      "body": "<omitted>",
                       "headers": "<omitted>",
                       "id": "<span:4>",
                       "messages": [
@@ -2067,7 +1945,6 @@
                     "stepNumber": 0,
                     "toolsContext": {},
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 94
@@ -2088,7 +1965,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 102
                     },
                     "warnings": []
@@ -2137,47 +2013,9 @@
                       }
                     },
                     "response": {
-                      "body": "<omitted>",
                       "headers": "<omitted>",
                       "id": "<span:7>",
                       "messages": [
-                        {
-                          "content": [
-                            {
-                              "input": {
-                                "location": "Paris, France"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:3>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:2>",
-                              "toolName": "get_weather",
-                              "type": "tool-call"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "output": {
-                                "type": "text",
-                                "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:3>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:2>",
-                              "toolName": "get_weather",
-                              "type": "tool-result"
-                            }
-                          ],
-                          "role": "tool"
-                        },
                         {
                           "content": [
                             {
@@ -2223,7 +2061,6 @@
                     "stepNumber": 1,
                     "toolsContext": {},
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 133
@@ -2244,7 +2081,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 141
                     },
                     "warnings": []
@@ -2293,84 +2129,9 @@
                       }
                     },
                     "response": {
-                      "body": "<omitted>",
                       "headers": "<omitted>",
                       "id": "<span:10>",
                       "messages": [
-                        {
-                          "content": [
-                            {
-                              "input": {
-                                "location": "Paris, France"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:3>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:2>",
-                              "toolName": "get_weather",
-                              "type": "tool-call"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "output": {
-                                "type": "text",
-                                "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:3>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:2>",
-                              "toolName": "get_weather",
-                              "type": "tool-result"
-                            }
-                          ],
-                          "role": "tool"
-                        },
-                        {
-                          "content": [
-                            {
-                              "input": {
-                                "location": "Paris, France"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:6>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:5>",
-                              "toolName": "get_weather",
-                              "type": "tool-call"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "output": {
-                                "type": "text",
-                                "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:6>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:5>",
-                              "toolName": "get_weather",
-                              "type": "tool-result"
-                            }
-                          ],
-                          "role": "tool"
-                        },
                         {
                           "content": [
                             {
@@ -2416,7 +2177,6 @@
                     "stepNumber": 2,
                     "toolsContext": {},
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 172
@@ -2437,7 +2197,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 180
                     },
                     "warnings": []
@@ -2486,121 +2245,9 @@
                       }
                     },
                     "response": {
-                      "body": "<omitted>",
                       "headers": "<omitted>",
                       "id": "<span:13>",
                       "messages": [
-                        {
-                          "content": [
-                            {
-                              "input": {
-                                "location": "Paris, France"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:3>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:2>",
-                              "toolName": "get_weather",
-                              "type": "tool-call"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "output": {
-                                "type": "text",
-                                "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:3>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:2>",
-                              "toolName": "get_weather",
-                              "type": "tool-result"
-                            }
-                          ],
-                          "role": "tool"
-                        },
-                        {
-                          "content": [
-                            {
-                              "input": {
-                                "location": "Paris, France"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:6>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:5>",
-                              "toolName": "get_weather",
-                              "type": "tool-call"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "output": {
-                                "type": "text",
-                                "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:6>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:5>",
-                              "toolName": "get_weather",
-                              "type": "tool-result"
-                            }
-                          ],
-                          "role": "tool"
-                        },
-                        {
-                          "content": [
-                            {
-                              "input": {
-                                "location": "Paris, France"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:9>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:8>",
-                              "toolName": "get_weather",
-                              "type": "tool-call"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "output": {
-                                "type": "text",
-                                "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:9>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:8>",
-                              "toolName": "get_weather",
-                              "type": "tool-result"
-                            }
-                          ],
-                          "role": "tool"
-                        },
                         {
                           "content": [
                             {
@@ -2646,7 +2293,6 @@
                     "stepNumber": 3,
                     "toolsContext": {},
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 211
@@ -2667,7 +2313,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 219
                     },
                     "warnings": []
@@ -2675,6 +2320,45 @@
                 ],
                 "text": "",
                 "toolCalls": [
+                  {
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "providerMetadata": {
+                      "openai": {
+                        "itemId": "<itemId:3>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:2>",
+                    "toolName": "get_weather",
+                    "type": "tool-call"
+                  },
+                  {
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "providerMetadata": {
+                      "openai": {
+                        "itemId": "<itemId:6>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:5>",
+                    "toolName": "get_weather",
+                    "type": "tool-call"
+                  },
+                  {
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "providerMetadata": {
+                      "openai": {
+                        "itemId": "<itemId:9>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:8>",
+                    "toolName": "get_weather",
+                    "type": "tool-call"
+                  },
                   {
                     "input": {
                       "location": "Paris, France"
@@ -2698,6 +2382,51 @@
                     "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
                     "providerMetadata": {
                       "openai": {
+                        "itemId": "<itemId:3>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:2>",
+                    "toolName": "get_weather",
+                    "type": "tool-result"
+                  },
+                  {
+                    "dynamic": false,
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+                    "providerMetadata": {
+                      "openai": {
+                        "itemId": "<itemId:6>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:5>",
+                    "toolName": "get_weather",
+                    "type": "tool-result"
+                  },
+                  {
+                    "dynamic": false,
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+                    "providerMetadata": {
+                      "openai": {
+                        "itemId": "<itemId:9>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:8>",
+                    "toolName": "get_weather",
+                    "type": "tool-result"
+                  },
+                  {
+                    "dynamic": false,
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+                    "providerMetadata": {
+                      "openai": {
                         "itemId": "<itemId:12>"
                       }
                     },
@@ -2707,7 +2436,6 @@
                   }
                 ],
                 "totalUsage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "noCacheTokens": 610
@@ -2718,33 +2446,20 @@
                     "textTokens": 32
                   },
                   "outputTokens": 32,
-                  "reasoningTokens": 0,
                   "totalTokens": 642
                 },
                 "usage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
-                    "noCacheTokens": 211
+                    "noCacheTokens": 610
                   },
-                  "inputTokens": 211,
+                  "inputTokens": 610,
                   "outputTokenDetails": {
                     "reasoningTokens": 0,
-                    "textTokens": 8
+                    "textTokens": 32
                   },
-                  "outputTokens": 8,
-                  "raw": {
-                    "input_tokens": 211,
-                    "input_tokens_details": {
-                      "cached_tokens": 0
-                    },
-                    "output_tokens": 8,
-                    "output_tokens_details": {
-                      "reasoning_tokens": 0
-                    }
-                  },
-                  "reasoningTokens": 0,
-                  "totalTokens": 219
+                  "outputTokens": 32,
+                  "totalTokens": 642
                 },
                 "warnings": []
               },
@@ -2804,7 +2519,6 @@
                     },
                     "text": "{\"city\":\"Paris\"}",
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 38
@@ -2825,7 +2539,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 44
                     },
                     "warnings": []
@@ -2839,18 +2552,16 @@
                     "provider": "openai.responses"
                   },
                   "metrics": {
-                    "completion_reasoning_tokens": 0,
                     "completion_tokens": 6,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 38,
-                    "reasoning_tokens": 0,
                     "tokens": 44
                   }
                 }
               ],
               "input": {
                 "headers": {
-                  "user-agent": "ai/7.0.0-beta.116"
+                  "user-agent": "ai/7.0.0"
                 },
                 "maxOutputTokens": 32,
                 "maxRetries": 2,
@@ -2894,7 +2605,6 @@
                   "timestamp": "<timestamp>"
                 },
                 "usage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "noCacheTokens": 38
@@ -2915,7 +2625,6 @@
                       "reasoning_tokens": 0
                     }
                   },
-                  "reasoningTokens": 0,
                   "totalTokens": 44
                 },
                 "warnings": []
@@ -2975,7 +2684,6 @@
                     },
                     "text": "{\"city\":\"Paris\"}",
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 38
@@ -2996,7 +2704,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 44
                     },
                     "warnings": []
@@ -3010,11 +2717,9 @@
                     "provider": "openai.responses"
                   },
                   "metrics": {
-                    "completion_reasoning_tokens": 0,
                     "completion_tokens": 6,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 38,
-                    "reasoning_tokens": 0,
                     "tokens": 44
                   }
                 }
@@ -3061,7 +2766,6 @@
                   "timestamp": "<timestamp>"
                 },
                 "usage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "noCacheTokens": 38
@@ -3082,7 +2786,6 @@
                       "reasoning_tokens": 0
                     }
                   },
-                  "reasoningTokens": 0,
                   "totalTokens": 44
                 },
                 "warnings": []
@@ -3104,7 +2807,7 @@
         }
       ],
       "metadata": {
-        "aiSdkVersion": "7.0.0-beta.116",
+        "aiSdkVersion": "7.0.0",
         "scenario": "ai-sdk-instrumentation",
         "testRunId": "<run:1>"
       }

--- a/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v7-auto-hook.span-tree.txt
+++ b/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v7-auto-hook.span-tree.txt
@@ -1,7 +1,7 @@
 span_tree:
 └── ai-sdk-instrumentation-root [task]
     metadata: {
-      "aiSdkVersion": "7.0.0-beta.116",
+      "aiSdkVersion": "7.0.0",
       "scenario": "ai-sdk-instrumentation",
       "testRunId": "<run:1>"
     }
@@ -13,7 +13,7 @@ span_tree:
     │   └── generateText [function]
     │       input: {
     │         "headers": {
-    │           "user-agent": "ai/7.0.0-beta.116"
+    │           "user-agent": "ai/7.0.0"
     │         },
     │         "maxOutputTokens": 24,
     │         "maxRetries": 2,
@@ -49,7 +49,6 @@ span_tree:
     │           }
     │         },
     │         "response": {
-    │           "body": "<omitted>",
     │           "headers": "<omitted>",
     │           "id": "<span:3>",
     │           "messages": [
@@ -71,6 +70,7 @@ span_tree:
     │           "modelId": "gpt-4o-mini-2024-07-18",
     │           "timestamp": "<timestamp>"
     │         },
+    │         "responseMessages": "<omitted>",
     │         "steps": [
     │           {
     │             "callId": "<callId:1>",
@@ -97,7 +97,6 @@ span_tree:
     │               }
     │             },
     │             "response": {
-    │               "body": "<omitted>",
     │               "headers": "<omitted>",
     │               "id": "<span:3>",
     │               "messages": [
@@ -123,7 +122,6 @@ span_tree:
     │             "stepNumber": 0,
     │             "toolsContext": {},
     │             "usage": {
-    │               "cachedInputTokens": 0,
     │               "inputTokenDetails": {
     │                 "cacheReadTokens": 0,
     │                 "noCacheTokens": 18
@@ -144,7 +142,6 @@ span_tree:
     │                   "reasoning_tokens": 0
     │                 }
     │               },
-    │               "reasoningTokens": 0,
     │               "totalTokens": 21
     │             },
     │             "warnings": []
@@ -154,7 +151,6 @@ span_tree:
     │         "toolCalls": [],
     │         "toolResults": [],
     │         "totalUsage": {
-    │           "cachedInputTokens": 0,
     │           "inputTokenDetails": {
     │             "cacheReadTokens": 0,
     │             "noCacheTokens": 18
@@ -165,11 +161,9 @@ span_tree:
     │             "textTokens": 3
     │           },
     │           "outputTokens": 3,
-    │           "reasoningTokens": 0,
     │           "totalTokens": 21
     │         },
     │         "usage": {
-    │           "cachedInputTokens": 0,
     │           "inputTokenDetails": {
     │             "cacheReadTokens": 0,
     │             "noCacheTokens": 18
@@ -180,17 +174,6 @@ span_tree:
     │             "textTokens": 3
     │           },
     │           "outputTokens": 3,
-    │           "raw": {
-    │             "input_tokens": 18,
-    │             "input_tokens_details": {
-    │               "cached_tokens": 0
-    │             },
-    │             "output_tokens": 3,
-    │             "output_tokens_details": {
-    │               "reasoning_tokens": 0
-    │             }
-    │           },
-    │           "reasoningTokens": 0,
     │           "totalTokens": 21
     │         },
     │         "warnings": []
@@ -235,7 +218,6 @@ span_tree:
     │               "id": "<span:1>"
     │             },
     │             "usage": {
-    │               "cachedInputTokens": 0,
     │               "inputTokenDetails": {
     │                 "cacheReadTokens": 0,
     │                 "noCacheTokens": 18
@@ -256,7 +238,6 @@ span_tree:
     │                   "reasoning_tokens": 0
     │                 }
     │               },
-    │               "reasoningTokens": 0,
     │               "totalTokens": 21
     │             }
     │           }
@@ -269,11 +250,9 @@ span_tree:
     │             "provider": "openai.responses"
     │           }
     │           metrics: {
-    │             "completion_reasoning_tokens": 0,
     │             "completion_tokens": 3,
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 18,
-    │             "reasoning_tokens": 0,
     │             "tokens": 21
     │           }
     ├── ai-sdk-output-object-response-format-operation
@@ -289,7 +268,7 @@ span_tree:
     │   └── generateText [function]
     │       input: {
     │         "headers": {
-    │           "user-agent": "ai/7.0.0-beta.116"
+    │           "user-agent": "ai/7.0.0"
     │         },
     │         "maxOutputTokens": 32,
     │         "maxRetries": 2,
@@ -343,7 +322,6 @@ span_tree:
     │           }
     │         },
     │         "response": {
-    │           "body": "<omitted>",
     │           "headers": "<omitted>",
     │           "id": "<span:3>",
     │           "messages": [
@@ -365,6 +343,7 @@ span_tree:
     │           "modelId": "gpt-4o-mini-2024-07-18",
     │           "timestamp": "<timestamp>"
     │         },
+    │         "responseMessages": "<omitted>",
     │         "steps": [
     │           {
     │             "callId": "<callId:1>",
@@ -391,7 +370,6 @@ span_tree:
     │               }
     │             },
     │             "response": {
-    │               "body": "<omitted>",
     │               "headers": "<omitted>",
     │               "id": "<span:3>",
     │               "messages": [
@@ -417,7 +395,6 @@ span_tree:
     │             "stepNumber": 0,
     │             "toolsContext": {},
     │             "usage": {
-    │               "cachedInputTokens": 0,
     │               "inputTokenDetails": {
     │                 "cacheReadTokens": 0,
     │                 "noCacheTokens": 45
@@ -438,7 +415,6 @@ span_tree:
     │                   "reasoning_tokens": 0
     │                 }
     │               },
-    │               "reasoningTokens": 0,
     │               "totalTokens": 51
     │             },
     │             "warnings": []
@@ -448,7 +424,6 @@ span_tree:
     │         "toolCalls": [],
     │         "toolResults": [],
     │         "totalUsage": {
-    │           "cachedInputTokens": 0,
     │           "inputTokenDetails": {
     │             "cacheReadTokens": 0,
     │             "noCacheTokens": 45
@@ -459,11 +434,9 @@ span_tree:
     │             "textTokens": 6
     │           },
     │           "outputTokens": 6,
-    │           "reasoningTokens": 0,
     │           "totalTokens": 51
     │         },
     │         "usage": {
-    │           "cachedInputTokens": 0,
     │           "inputTokenDetails": {
     │             "cacheReadTokens": 0,
     │             "noCacheTokens": 45
@@ -474,17 +447,6 @@ span_tree:
     │             "textTokens": 6
     │           },
     │           "outputTokens": 6,
-    │           "raw": {
-    │             "input_tokens": 45,
-    │             "input_tokens_details": {
-    │               "cached_tokens": 0
-    │             },
-    │             "output_tokens": 6,
-    │             "output_tokens_details": {
-    │               "reasoning_tokens": 0
-    │             }
-    │           },
-    │           "reasoningTokens": 0,
     │           "totalTokens": 51
     │         },
     │         "warnings": []
@@ -529,7 +491,6 @@ span_tree:
     │               "id": "<span:1>"
     │             },
     │             "usage": {
-    │               "cachedInputTokens": 0,
     │               "inputTokenDetails": {
     │                 "cacheReadTokens": 0,
     │                 "noCacheTokens": 45
@@ -550,7 +511,6 @@ span_tree:
     │                   "reasoning_tokens": 0
     │                 }
     │               },
-    │               "reasoningTokens": 0,
     │               "totalTokens": 51
     │             }
     │           }
@@ -563,11 +523,9 @@ span_tree:
     │             "provider": "openai.responses"
     │           }
     │           metrics: {
-    │             "completion_reasoning_tokens": 0,
     │             "completion_tokens": 6,
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 45,
-    │             "reasoning_tokens": 0,
     │             "tokens": 51
     │           }
     ├── ai-sdk-stream-operation
@@ -632,6 +590,7 @@ span_tree:
     │           "modelId": "gpt-4o-mini-2024-07-18",
     │           "timestamp": "<timestamp>"
     │         },
+    │         "responseMessages": "<omitted>",
     │         "steps": [
     │           {
     │             "callId": "<callId:1>",
@@ -683,7 +642,6 @@ span_tree:
     │             "stepNumber": 0,
     │             "toolsContext": {},
     │             "usage": {
-    │               "cachedInputTokens": 0,
     │               "inputTokenDetails": {
     │                 "cacheReadTokens": 0,
     │                 "noCacheTokens": 22
@@ -704,7 +662,6 @@ span_tree:
     │                   "reasoning_tokens": 0
     │                 }
     │               },
-    │               "reasoningTokens": 0,
     │               "totalTokens": 29
     │             },
     │             "warnings": []
@@ -714,7 +671,6 @@ span_tree:
     │         "toolCalls": [],
     │         "toolResults": [],
     │         "totalUsage": {
-    │           "cachedInputTokens": 0,
     │           "inputTokenDetails": {
     │             "cacheReadTokens": 0,
     │             "noCacheTokens": 22
@@ -725,11 +681,9 @@ span_tree:
     │             "textTokens": 7
     │           },
     │           "outputTokens": 7,
-    │           "reasoningTokens": 0,
     │           "totalTokens": 29
     │         },
     │         "usage": {
-    │           "cachedInputTokens": 0,
     │           "inputTokenDetails": {
     │             "cacheReadTokens": 0,
     │             "noCacheTokens": 22
@@ -740,17 +694,6 @@ span_tree:
     │             "textTokens": 7
     │           },
     │           "outputTokens": 7,
-    │           "raw": {
-    │             "input_tokens": 22,
-    │             "input_tokens_details": {
-    │               "cached_tokens": 0
-    │             },
-    │             "output_tokens": 7,
-    │             "output_tokens_details": {
-    │               "reasoning_tokens": 0
-    │             }
-    │           },
-    │           "reasoningTokens": 0,
     │           "totalTokens": 29
     │         },
     │         "warnings": []
@@ -798,7 +741,6 @@ span_tree:
     │               "id": "<span:1>"
     │             },
     │             "usage": {
-    │               "cachedInputTokens": 0,
     │               "inputTokenDetails": {
     │                 "cacheReadTokens": 0,
     │                 "noCacheTokens": 22
@@ -819,7 +761,6 @@ span_tree:
     │                   "reasoning_tokens": 0
     │                 }
     │               },
-    │               "reasoningTokens": 0,
     │               "totalTokens": 29
     │             }
     │           }
@@ -832,11 +773,9 @@ span_tree:
     │             "provider": "openai.responses"
     │           }
     │           metrics: {
-    │             "completion_reasoning_tokens": 0,
     │             "completion_tokens": 7,
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 22,
-    │             "reasoning_tokens": 0,
     │             "tokens": 29
     │           }
     ├── ai-sdk-embed-operation
@@ -958,7 +897,7 @@ span_tree:
     │   └── generateText [function]
     │       input: {
     │         "headers": {
-    │           "user-agent": "ai/7.0.0-beta.116"
+    │           "user-agent": "ai/7.0.0"
     │         },
     │         "maxOutputTokens": 128,
     │         "maxRetries": 2,
@@ -972,7 +911,6 @@ span_tree:
     │           "modelId": "gpt-4o-mini-2024-07-18",
     │           "provider": "openai.responses"
     │         },
-    │         "system": "You must inspect live weather via the provided get_weather tool before responding.",
     │         "temperature": 0,
     │         "toolChoice": "required",
     │         "tools": {
@@ -997,6 +935,90 @@ span_tree:
     │       }
     │       output: {
     │         "content": [
+    │           {
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "providerMetadata": {
+    │               "openai": {
+    │                 "itemId": "<itemId:3>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:2>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-call"
+    │           },
+    │           {
+    │             "dynamic": false,
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+    │             "providerMetadata": {
+    │               "openai": {
+    │                 "itemId": "<itemId:3>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:2>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-result"
+    │           },
+    │           {
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "providerMetadata": {
+    │               "openai": {
+    │                 "itemId": "<itemId:6>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:5>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-call"
+    │           },
+    │           {
+    │             "dynamic": false,
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+    │             "providerMetadata": {
+    │               "openai": {
+    │                 "itemId": "<itemId:6>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:5>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-result"
+    │           },
+    │           {
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "providerMetadata": {
+    │               "openai": {
+    │                 "itemId": "<itemId:9>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:8>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-call"
+    │           },
+    │           {
+    │             "dynamic": false,
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+    │             "providerMetadata": {
+    │               "openai": {
+    │                 "itemId": "<itemId:9>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:8>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-result"
+    │           },
     │           {
     │             "input": {
     │               "location": "Paris, France"
@@ -1034,121 +1056,9 @@ span_tree:
     │           }
     │         },
     │         "response": {
-    │           "body": "<omitted>",
     │           "headers": "<omitted>",
     │           "id": "<span:13>",
     │           "messages": [
-    │             {
-    │               "content": [
-    │                 {
-    │                   "input": {
-    │                     "location": "Paris, France"
-    │                   },
-    │                   "providerOptions": {
-    │                     "openai": {
-    │                       "itemId": "<itemId:3>"
-    │                     }
-    │                   },
-    │                   "toolCallId": "<toolCallId:2>",
-    │                   "toolName": "get_weather",
-    │                   "type": "tool-call"
-    │                 }
-    │               ],
-    │               "role": "assistant"
-    │             },
-    │             {
-    │               "content": [
-    │                 {
-    │                   "output": {
-    │                     "type": "text",
-    │                     "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-    │                   },
-    │                   "providerOptions": {
-    │                     "openai": {
-    │                       "itemId": "<itemId:3>"
-    │                     }
-    │                   },
-    │                   "toolCallId": "<toolCallId:2>",
-    │                   "toolName": "get_weather",
-    │                   "type": "tool-result"
-    │                 }
-    │               ],
-    │               "role": "tool"
-    │             },
-    │             {
-    │               "content": [
-    │                 {
-    │                   "input": {
-    │                     "location": "Paris, France"
-    │                   },
-    │                   "providerOptions": {
-    │                     "openai": {
-    │                       "itemId": "<itemId:6>"
-    │                     }
-    │                   },
-    │                   "toolCallId": "<toolCallId:5>",
-    │                   "toolName": "get_weather",
-    │                   "type": "tool-call"
-    │                 }
-    │               ],
-    │               "role": "assistant"
-    │             },
-    │             {
-    │               "content": [
-    │                 {
-    │                   "output": {
-    │                     "type": "text",
-    │                     "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-    │                   },
-    │                   "providerOptions": {
-    │                     "openai": {
-    │                       "itemId": "<itemId:6>"
-    │                     }
-    │                   },
-    │                   "toolCallId": "<toolCallId:5>",
-    │                   "toolName": "get_weather",
-    │                   "type": "tool-result"
-    │                 }
-    │               ],
-    │               "role": "tool"
-    │             },
-    │             {
-    │               "content": [
-    │                 {
-    │                   "input": {
-    │                     "location": "Paris, France"
-    │                   },
-    │                   "providerOptions": {
-    │                     "openai": {
-    │                       "itemId": "<itemId:9>"
-    │                     }
-    │                   },
-    │                   "toolCallId": "<toolCallId:8>",
-    │                   "toolName": "get_weather",
-    │                   "type": "tool-call"
-    │                 }
-    │               ],
-    │               "role": "assistant"
-    │             },
-    │             {
-    │               "content": [
-    │                 {
-    │                   "output": {
-    │                     "type": "text",
-    │                     "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-    │                   },
-    │                   "providerOptions": {
-    │                     "openai": {
-    │                       "itemId": "<itemId:9>"
-    │                     }
-    │                   },
-    │                   "toolCallId": "<toolCallId:8>",
-    │                   "toolName": "get_weather",
-    │                   "type": "tool-result"
-    │                 }
-    │               ],
-    │               "role": "tool"
-    │             },
     │             {
     │               "content": [
     │                 {
@@ -1190,6 +1100,7 @@ span_tree:
     │           "modelId": "gpt-4o-mini-2024-07-18",
     │           "timestamp": "<timestamp>"
     │         },
+    │         "responseMessages": "<omitted>",
     │         "steps": [
     │           {
     │             "callId": "<callId:1>",
@@ -1235,7 +1146,6 @@ span_tree:
     │               }
     │             },
     │             "response": {
-    │               "body": "<omitted>",
     │               "headers": "<omitted>",
     │               "id": "<span:4>",
     │               "messages": [
@@ -1284,7 +1194,6 @@ span_tree:
     │             "stepNumber": 0,
     │             "toolsContext": {},
     │             "usage": {
-    │               "cachedInputTokens": 0,
     │               "inputTokenDetails": {
     │                 "cacheReadTokens": 0,
     │                 "noCacheTokens": 94
@@ -1305,7 +1214,6 @@ span_tree:
     │                   "reasoning_tokens": 0
     │                 }
     │               },
-    │               "reasoningTokens": 0,
     │               "totalTokens": 102
     │             },
     │             "warnings": []
@@ -1354,47 +1262,9 @@ span_tree:
     │               }
     │             },
     │             "response": {
-    │               "body": "<omitted>",
     │               "headers": "<omitted>",
     │               "id": "<span:7>",
     │               "messages": [
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "input": {
-    │                         "location": "Paris, France"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:3>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:2>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-call"
-    │                     }
-    │                   ],
-    │                   "role": "assistant"
-    │                 },
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "output": {
-    │                         "type": "text",
-    │                         "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:3>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:2>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-result"
-    │                     }
-    │                   ],
-    │                   "role": "tool"
-    │                 },
     │                 {
     │                   "content": [
     │                     {
@@ -1440,7 +1310,6 @@ span_tree:
     │             "stepNumber": 1,
     │             "toolsContext": {},
     │             "usage": {
-    │               "cachedInputTokens": 0,
     │               "inputTokenDetails": {
     │                 "cacheReadTokens": 0,
     │                 "noCacheTokens": 133
@@ -1461,7 +1330,6 @@ span_tree:
     │                   "reasoning_tokens": 0
     │                 }
     │               },
-    │               "reasoningTokens": 0,
     │               "totalTokens": 141
     │             },
     │             "warnings": []
@@ -1510,84 +1378,9 @@ span_tree:
     │               }
     │             },
     │             "response": {
-    │               "body": "<omitted>",
     │               "headers": "<omitted>",
     │               "id": "<span:10>",
     │               "messages": [
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "input": {
-    │                         "location": "Paris, France"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:3>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:2>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-call"
-    │                     }
-    │                   ],
-    │                   "role": "assistant"
-    │                 },
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "output": {
-    │                         "type": "text",
-    │                         "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:3>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:2>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-result"
-    │                     }
-    │                   ],
-    │                   "role": "tool"
-    │                 },
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "input": {
-    │                         "location": "Paris, France"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:6>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:5>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-call"
-    │                     }
-    │                   ],
-    │                   "role": "assistant"
-    │                 },
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "output": {
-    │                         "type": "text",
-    │                         "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:6>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:5>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-result"
-    │                     }
-    │                   ],
-    │                   "role": "tool"
-    │                 },
     │                 {
     │                   "content": [
     │                     {
@@ -1633,7 +1426,6 @@ span_tree:
     │             "stepNumber": 2,
     │             "toolsContext": {},
     │             "usage": {
-    │               "cachedInputTokens": 0,
     │               "inputTokenDetails": {
     │                 "cacheReadTokens": 0,
     │                 "noCacheTokens": 172
@@ -1654,7 +1446,6 @@ span_tree:
     │                   "reasoning_tokens": 0
     │                 }
     │               },
-    │               "reasoningTokens": 0,
     │               "totalTokens": 180
     │             },
     │             "warnings": []
@@ -1703,121 +1494,9 @@ span_tree:
     │               }
     │             },
     │             "response": {
-    │               "body": "<omitted>",
     │               "headers": "<omitted>",
     │               "id": "<span:13>",
     │               "messages": [
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "input": {
-    │                         "location": "Paris, France"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:3>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:2>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-call"
-    │                     }
-    │                   ],
-    │                   "role": "assistant"
-    │                 },
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "output": {
-    │                         "type": "text",
-    │                         "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:3>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:2>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-result"
-    │                     }
-    │                   ],
-    │                   "role": "tool"
-    │                 },
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "input": {
-    │                         "location": "Paris, France"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:6>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:5>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-call"
-    │                     }
-    │                   ],
-    │                   "role": "assistant"
-    │                 },
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "output": {
-    │                         "type": "text",
-    │                         "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:6>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:5>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-result"
-    │                     }
-    │                   ],
-    │                   "role": "tool"
-    │                 },
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "input": {
-    │                         "location": "Paris, France"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:9>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:8>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-call"
-    │                     }
-    │                   ],
-    │                   "role": "assistant"
-    │                 },
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "output": {
-    │                         "type": "text",
-    │                         "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:9>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:8>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-result"
-    │                     }
-    │                   ],
-    │                   "role": "tool"
-    │                 },
     │                 {
     │                   "content": [
     │                     {
@@ -1863,7 +1542,6 @@ span_tree:
     │             "stepNumber": 3,
     │             "toolsContext": {},
     │             "usage": {
-    │               "cachedInputTokens": 0,
     │               "inputTokenDetails": {
     │                 "cacheReadTokens": 0,
     │                 "noCacheTokens": 211
@@ -1884,7 +1562,6 @@ span_tree:
     │                   "reasoning_tokens": 0
     │                 }
     │               },
-    │               "reasoningTokens": 0,
     │               "totalTokens": 219
     │             },
     │             "warnings": []
@@ -1892,6 +1569,45 @@ span_tree:
     │         ],
     │         "text": "",
     │         "toolCalls": [
+    │           {
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "providerMetadata": {
+    │               "openai": {
+    │                 "itemId": "<itemId:3>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:2>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-call"
+    │           },
+    │           {
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "providerMetadata": {
+    │               "openai": {
+    │                 "itemId": "<itemId:6>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:5>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-call"
+    │           },
+    │           {
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "providerMetadata": {
+    │               "openai": {
+    │                 "itemId": "<itemId:9>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:8>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-call"
+    │           },
     │           {
     │             "input": {
     │               "location": "Paris, France"
@@ -1915,6 +1631,51 @@ span_tree:
     │             "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
     │             "providerMetadata": {
     │               "openai": {
+    │                 "itemId": "<itemId:3>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:2>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-result"
+    │           },
+    │           {
+    │             "dynamic": false,
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+    │             "providerMetadata": {
+    │               "openai": {
+    │                 "itemId": "<itemId:6>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:5>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-result"
+    │           },
+    │           {
+    │             "dynamic": false,
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+    │             "providerMetadata": {
+    │               "openai": {
+    │                 "itemId": "<itemId:9>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:8>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-result"
+    │           },
+    │           {
+    │             "dynamic": false,
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+    │             "providerMetadata": {
+    │               "openai": {
     │                 "itemId": "<itemId:12>"
     │               }
     │             },
@@ -1924,7 +1685,6 @@ span_tree:
     │           }
     │         ],
     │         "totalUsage": {
-    │           "cachedInputTokens": 0,
     │           "inputTokenDetails": {
     │             "cacheReadTokens": 0,
     │             "noCacheTokens": 610
@@ -1935,33 +1695,20 @@ span_tree:
     │             "textTokens": 32
     │           },
     │           "outputTokens": 32,
-    │           "reasoningTokens": 0,
     │           "totalTokens": 642
     │         },
     │         "usage": {
-    │           "cachedInputTokens": 0,
     │           "inputTokenDetails": {
     │             "cacheReadTokens": 0,
-    │             "noCacheTokens": 211
+    │             "noCacheTokens": 610
     │           },
-    │           "inputTokens": 211,
+    │           "inputTokens": 610,
     │           "outputTokenDetails": {
     │             "reasoningTokens": 0,
-    │             "textTokens": 8
+    │             "textTokens": 32
     │           },
-    │           "outputTokens": 8,
-    │           "raw": {
-    │             "input_tokens": 211,
-    │             "input_tokens_details": {
-    │               "cached_tokens": 0
-    │             },
-    │             "output_tokens": 8,
-    │             "output_tokens_details": {
-    │               "reasoning_tokens": 0
-    │             }
-    │           },
-    │           "reasoningTokens": 0,
-    │           "totalTokens": 219
+    │           "outputTokens": 32,
+    │           "totalTokens": 642
     │         },
     │         "warnings": []
     │       }
@@ -1986,7 +1733,6 @@ span_tree:
     │       │       "modelId": "gpt-4o-mini-2024-07-18",
     │       │       "provider": "openai.responses"
     │       │     },
-    │       │     "system": "You must inspect live weather via the provided get_weather tool before responding.",
     │       │     "temperature": 0,
     │       │     "tools": [
     │       │       {
@@ -2031,7 +1777,6 @@ span_tree:
     │       │       "id": "<span:1>"
     │       │     },
     │       │     "usage": {
-    │       │       "cachedInputTokens": 0,
     │       │       "inputTokenDetails": {
     │       │         "cacheReadTokens": 0,
     │       │         "noCacheTokens": 94
@@ -2052,7 +1797,6 @@ span_tree:
     │       │           "reasoning_tokens": 0
     │       │         }
     │       │       },
-    │       │       "reasoningTokens": 0,
     │       │       "totalTokens": 102
     │       │     }
     │       │   }
@@ -2065,11 +1809,9 @@ span_tree:
     │       │     "provider": "openai.responses"
     │       │   }
     │       │   metrics: {
-    │       │     "completion_reasoning_tokens": 0,
     │       │     "completion_tokens": 8,
     │       │     "prompt_cached_tokens": 0,
     │       │     "prompt_tokens": 94,
-    │       │     "reasoning_tokens": 0,
     │       │     "tokens": 102
     │       │   }
     │       ├── get_weather [tool]
@@ -2084,9 +1826,6 @@ span_tree:
     │       │     },
     │       │     "toolCallId": "<toolCallId:1>",
     │       │     "toolName": "get_weather"
-    │       │   }
-    │       │   metrics: {
-    │       │     "duration_ms": 0
     │       │   }
     │       ├── doGenerate [llm]
     │       │   input: {
@@ -2138,7 +1877,6 @@ span_tree:
     │       │       "modelId": "gpt-4o-mini-2024-07-18",
     │       │       "provider": "openai.responses"
     │       │     },
-    │       │     "system": "You must inspect live weather via the provided get_weather tool before responding.",
     │       │     "temperature": 0,
     │       │     "tools": [
     │       │       {
@@ -2183,7 +1921,6 @@ span_tree:
     │       │       "id": "<span:1>"
     │       │     },
     │       │     "usage": {
-    │       │       "cachedInputTokens": 0,
     │       │       "inputTokenDetails": {
     │       │         "cacheReadTokens": 0,
     │       │         "noCacheTokens": 133
@@ -2204,7 +1941,6 @@ span_tree:
     │       │           "reasoning_tokens": 0
     │       │         }
     │       │       },
-    │       │       "reasoningTokens": 0,
     │       │       "totalTokens": 141
     │       │     }
     │       │   }
@@ -2217,11 +1953,9 @@ span_tree:
     │       │     "provider": "openai.responses"
     │       │   }
     │       │   metrics: {
-    │       │     "completion_reasoning_tokens": 0,
     │       │     "completion_tokens": 8,
     │       │     "prompt_cached_tokens": 0,
     │       │     "prompt_tokens": 133,
-    │       │     "reasoning_tokens": 0,
     │       │     "tokens": 141
     │       │   }
     │       ├── get_weather [tool]
@@ -2236,9 +1970,6 @@ span_tree:
     │       │     },
     │       │     "toolCallId": "<toolCallId:1>",
     │       │     "toolName": "get_weather"
-    │       │   }
-    │       │   metrics: {
-    │       │     "duration_ms": 0
     │       │   }
     │       ├── doGenerate [llm]
     │       │   input: {
@@ -2327,7 +2058,6 @@ span_tree:
     │       │       "modelId": "gpt-4o-mini-2024-07-18",
     │       │       "provider": "openai.responses"
     │       │     },
-    │       │     "system": "You must inspect live weather via the provided get_weather tool before responding.",
     │       │     "temperature": 0,
     │       │     "tools": [
     │       │       {
@@ -2372,7 +2102,6 @@ span_tree:
     │       │       "id": "<span:1>"
     │       │     },
     │       │     "usage": {
-    │       │       "cachedInputTokens": 0,
     │       │       "inputTokenDetails": {
     │       │         "cacheReadTokens": 0,
     │       │         "noCacheTokens": 172
@@ -2393,7 +2122,6 @@ span_tree:
     │       │           "reasoning_tokens": 0
     │       │         }
     │       │       },
-    │       │       "reasoningTokens": 0,
     │       │       "totalTokens": 180
     │       │     }
     │       │   }
@@ -2406,11 +2134,9 @@ span_tree:
     │       │     "provider": "openai.responses"
     │       │   }
     │       │   metrics: {
-    │       │     "completion_reasoning_tokens": 0,
     │       │     "completion_tokens": 8,
     │       │     "prompt_cached_tokens": 0,
     │       │     "prompt_tokens": 172,
-    │       │     "reasoning_tokens": 0,
     │       │     "tokens": 180
     │       │   }
     │       ├── get_weather [tool]
@@ -2425,9 +2151,6 @@ span_tree:
     │       │     },
     │       │     "toolCallId": "<toolCallId:1>",
     │       │     "toolName": "get_weather"
-    │       │   }
-    │       │   metrics: {
-    │       │     "duration_ms": 0
     │       │   }
     │       ├── doGenerate [llm]
     │       │   input: {
@@ -2553,7 +2276,6 @@ span_tree:
     │       │       "modelId": "gpt-4o-mini-2024-07-18",
     │       │       "provider": "openai.responses"
     │       │     },
-    │       │     "system": "You must inspect live weather via the provided get_weather tool before responding.",
     │       │     "temperature": 0,
     │       │     "tools": [
     │       │       {
@@ -2598,7 +2320,6 @@ span_tree:
     │       │       "id": "<span:1>"
     │       │     },
     │       │     "usage": {
-    │       │       "cachedInputTokens": 0,
     │       │       "inputTokenDetails": {
     │       │         "cacheReadTokens": 0,
     │       │         "noCacheTokens": 211
@@ -2619,7 +2340,6 @@ span_tree:
     │       │           "reasoning_tokens": 0
     │       │         }
     │       │       },
-    │       │       "reasoningTokens": 0,
     │       │       "totalTokens": 219
     │       │     }
     │       │   }
@@ -2632,11 +2352,9 @@ span_tree:
     │       │     "provider": "openai.responses"
     │       │   }
     │       │   metrics: {
-    │       │     "completion_reasoning_tokens": 0,
     │       │     "completion_tokens": 8,
     │       │     "prompt_cached_tokens": 0,
     │       │     "prompt_tokens": 211,
-    │       │     "reasoning_tokens": 0,
     │       │     "tokens": 219
     │       │   }
     │       └── get_weather [tool]
@@ -2652,9 +2370,6 @@ span_tree:
     │             "toolCallId": "<toolCallId:1>",
     │             "toolName": "get_weather"
     │           }
-    │           metrics: {
-    │             "duration_ms": 0
-    │           }
     ├── ai-sdk-generate-object-operation
     │   metadata: {
     │     "operation": "generate-object",
@@ -2663,7 +2378,7 @@ span_tree:
     │   └── generateObject [function]
     │       input: {
     │         "headers": {
-    │           "user-agent": "ai/7.0.0-beta.116"
+    │           "user-agent": "ai/7.0.0"
     │         },
     │         "maxOutputTokens": 32,
     │         "maxRetries": 2,
@@ -2707,7 +2422,6 @@ span_tree:
     │           "timestamp": "<timestamp>"
     │         },
     │         "usage": {
-    │           "cachedInputTokens": 0,
     │           "inputTokenDetails": {
     │             "cacheReadTokens": 0,
     │             "noCacheTokens": 38
@@ -2728,7 +2442,6 @@ span_tree:
     │               "reasoning_tokens": 0
     │             }
     │           },
-    │           "reasoningTokens": 0,
     │           "totalTokens": 44
     │         },
     │         "warnings": []
@@ -2772,7 +2485,6 @@ span_tree:
     │             },
     │             "text": "{\"city\":\"Paris\"}",
     │             "usage": {
-    │               "cachedInputTokens": 0,
     │               "inputTokenDetails": {
     │                 "cacheReadTokens": 0,
     │                 "noCacheTokens": 38
@@ -2793,7 +2505,6 @@ span_tree:
     │                   "reasoning_tokens": 0
     │                 }
     │               },
-    │               "reasoningTokens": 0,
     │               "totalTokens": 44
     │             },
     │             "warnings": []
@@ -2807,11 +2518,9 @@ span_tree:
     │             "provider": "openai.responses"
     │           }
     │           metrics: {
-    │             "completion_reasoning_tokens": 0,
     │             "completion_tokens": 6,
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 38,
-    │             "reasoning_tokens": 0,
     │             "tokens": 44
     │           }
     └── ai-sdk-stream-object-operation
@@ -2862,7 +2571,6 @@ span_tree:
                 "timestamp": "<timestamp>"
               },
               "usage": {
-                "cachedInputTokens": 0,
                 "inputTokenDetails": {
                   "cacheReadTokens": 0,
                   "noCacheTokens": 38
@@ -2883,7 +2591,6 @@ span_tree:
                     "reasoning_tokens": 0
                   }
                 },
-                "reasoningTokens": 0,
                 "totalTokens": 44
               },
               "warnings": []
@@ -2926,7 +2633,6 @@ span_tree:
                   },
                   "text": "{\"city\":\"Paris\"}",
                   "usage": {
-                    "cachedInputTokens": 0,
                     "inputTokenDetails": {
                       "cacheReadTokens": 0,
                       "noCacheTokens": 38
@@ -2947,7 +2653,6 @@ span_tree:
                         "reasoning_tokens": 0
                       }
                     },
-                    "reasoningTokens": 0,
                     "totalTokens": 44
                   },
                   "warnings": []
@@ -2961,10 +2666,8 @@ span_tree:
                   "provider": "openai.responses"
                 }
                 metrics: {
-                  "completion_reasoning_tokens": 0,
                   "completion_tokens": 6,
                   "prompt_cached_tokens": 0,
                   "prompt_tokens": 38,
-                  "reasoning_tokens": 0,
                   "tokens": 44
                 }

--- a/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v7-explicit.span-tree.json
+++ b/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v7-explicit.span-tree.json
@@ -46,7 +46,6 @@
                       "id": "<span:1>"
                     },
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 18
@@ -67,7 +66,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 21
                     }
                   },
@@ -80,18 +78,16 @@
                     "provider": "openai.responses"
                   },
                   "metrics": {
-                    "completion_reasoning_tokens": 0,
                     "completion_tokens": 3,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 18,
-                    "reasoning_tokens": 0,
                     "tokens": 21
                   }
                 }
               ],
               "input": {
                 "headers": {
-                  "user-agent": "ai/7.0.0-beta.116"
+                  "user-agent": "ai/7.0.0"
                 },
                 "maxOutputTokens": 24,
                 "maxRetries": 2,
@@ -127,7 +123,6 @@
                   }
                 },
                 "response": {
-                  "body": "<omitted>",
                   "headers": "<omitted>",
                   "id": "<span:3>",
                   "messages": [
@@ -149,6 +144,7 @@
                   "modelId": "gpt-4o-mini-2024-07-18",
                   "timestamp": "<timestamp>"
                 },
+                "responseMessages": "<omitted>",
                 "steps": [
                   {
                     "callId": "<callId:1>",
@@ -175,7 +171,6 @@
                       }
                     },
                     "response": {
-                      "body": "<omitted>",
                       "headers": "<omitted>",
                       "id": "<span:3>",
                       "messages": [
@@ -201,7 +196,6 @@
                     "stepNumber": 0,
                     "toolsContext": {},
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 18
@@ -222,7 +216,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 21
                     },
                     "warnings": []
@@ -232,7 +225,6 @@
                 "toolCalls": [],
                 "toolResults": [],
                 "totalUsage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "noCacheTokens": 18
@@ -243,11 +235,9 @@
                     "textTokens": 3
                   },
                   "outputTokens": 3,
-                  "reasoningTokens": 0,
                   "totalTokens": 21
                 },
                 "usage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "noCacheTokens": 18
@@ -258,17 +248,6 @@
                     "textTokens": 3
                   },
                   "outputTokens": 3,
-                  "raw": {
-                    "input_tokens": 18,
-                    "input_tokens_details": {
-                      "cached_tokens": 0
-                    },
-                    "output_tokens": 3,
-                    "output_tokens_details": {
-                      "reasoning_tokens": 0
-                    }
-                  },
-                  "reasoningTokens": 0,
                   "totalTokens": 21
                 },
                 "warnings": []
@@ -338,7 +317,6 @@
                       "id": "<span:1>"
                     },
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 45
@@ -359,7 +337,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 51
                     }
                   },
@@ -372,18 +349,16 @@
                     "provider": "openai.responses"
                   },
                   "metrics": {
-                    "completion_reasoning_tokens": 0,
                     "completion_tokens": 6,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 45,
-                    "reasoning_tokens": 0,
                     "tokens": 51
                   }
                 }
               ],
               "input": {
                 "headers": {
-                  "user-agent": "ai/7.0.0-beta.116"
+                  "user-agent": "ai/7.0.0"
                 },
                 "maxOutputTokens": 32,
                 "maxRetries": 2,
@@ -437,7 +412,6 @@
                   }
                 },
                 "response": {
-                  "body": "<omitted>",
                   "headers": "<omitted>",
                   "id": "<span:3>",
                   "messages": [
@@ -459,6 +433,7 @@
                   "modelId": "gpt-4o-mini-2024-07-18",
                   "timestamp": "<timestamp>"
                 },
+                "responseMessages": "<omitted>",
                 "steps": [
                   {
                     "callId": "<callId:1>",
@@ -485,7 +460,6 @@
                       }
                     },
                     "response": {
-                      "body": "<omitted>",
                       "headers": "<omitted>",
                       "id": "<span:3>",
                       "messages": [
@@ -511,7 +485,6 @@
                     "stepNumber": 0,
                     "toolsContext": {},
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 45
@@ -532,7 +505,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 51
                     },
                     "warnings": []
@@ -542,7 +514,6 @@
                 "toolCalls": [],
                 "toolResults": [],
                 "totalUsage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "noCacheTokens": 45
@@ -553,11 +524,9 @@
                     "textTokens": 6
                   },
                   "outputTokens": 6,
-                  "reasoningTokens": 0,
                   "totalTokens": 51
                 },
                 "usage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "noCacheTokens": 45
@@ -568,17 +537,6 @@
                     "textTokens": 6
                   },
                   "outputTokens": 6,
-                  "raw": {
-                    "input_tokens": 45,
-                    "input_tokens_details": {
-                      "cached_tokens": 0
-                    },
-                    "output_tokens": 6,
-                    "output_tokens_details": {
-                      "reasoning_tokens": 0
-                    }
-                  },
-                  "reasoningTokens": 0,
                   "totalTokens": 51
                 },
                 "warnings": []
@@ -640,7 +598,6 @@
                       "id": "<span:1>"
                     },
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 22
@@ -661,7 +618,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 29
                     }
                   },
@@ -674,11 +630,9 @@
                     "provider": "openai.responses"
                   },
                   "metrics": {
-                    "completion_reasoning_tokens": 0,
                     "completion_tokens": 7,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 22,
-                    "reasoning_tokens": 0,
                     "tokens": 29
                   }
                 }
@@ -739,6 +693,7 @@
                   "modelId": "gpt-4o-mini-2024-07-18",
                   "timestamp": "<timestamp>"
                 },
+                "responseMessages": "<omitted>",
                 "steps": [
                   {
                     "callId": "<callId:1>",
@@ -790,7 +745,6 @@
                     "stepNumber": 0,
                     "toolsContext": {},
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 22
@@ -811,7 +765,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 29
                     },
                     "warnings": []
@@ -821,7 +774,6 @@
                 "toolCalls": [],
                 "toolResults": [],
                 "totalUsage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "noCacheTokens": 22
@@ -832,11 +784,9 @@
                     "textTokens": 7
                   },
                   "outputTokens": 7,
-                  "reasoningTokens": 0,
                   "totalTokens": 29
                 },
                 "usage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "noCacheTokens": 22
@@ -847,17 +797,6 @@
                     "textTokens": 7
                   },
                   "outputTokens": 7,
-                  "raw": {
-                    "input_tokens": 22,
-                    "input_tokens_details": {
-                      "cached_tokens": 0
-                    },
-                    "output_tokens": 7,
-                    "output_tokens_details": {
-                      "reasoning_tokens": 0
-                    }
-                  },
-                  "reasoningTokens": 0,
                   "totalTokens": 29
                 },
                 "warnings": []
@@ -1040,7 +979,6 @@
                       "modelId": "gpt-4o-mini-2024-07-18",
                       "provider": "openai.responses"
                     },
-                    "system": "You must inspect live weather via the provided get_weather tool before responding.",
                     "temperature": 0,
                     "tools": [
                       {
@@ -1085,7 +1023,6 @@
                       "id": "<span:1>"
                     },
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 94
@@ -1106,7 +1043,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 102
                     }
                   },
@@ -1119,11 +1055,9 @@
                     "provider": "openai.responses"
                   },
                   "metrics": {
-                    "completion_reasoning_tokens": 0,
                     "completion_tokens": 8,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 94,
-                    "reasoning_tokens": 0,
                     "tokens": 102
                   }
                 },
@@ -1142,9 +1076,6 @@
                     },
                     "toolCallId": "<toolCallId:1>",
                     "toolName": "get_weather"
-                  },
-                  "metrics": {
-                    "duration_ms": 0
                   }
                 },
                 {
@@ -1200,7 +1131,6 @@
                       "modelId": "gpt-4o-mini-2024-07-18",
                       "provider": "openai.responses"
                     },
-                    "system": "You must inspect live weather via the provided get_weather tool before responding.",
                     "temperature": 0,
                     "tools": [
                       {
@@ -1245,7 +1175,6 @@
                       "id": "<span:1>"
                     },
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 133
@@ -1266,7 +1195,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 141
                     }
                   },
@@ -1279,11 +1207,9 @@
                     "provider": "openai.responses"
                   },
                   "metrics": {
-                    "completion_reasoning_tokens": 0,
                     "completion_tokens": 8,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 133,
-                    "reasoning_tokens": 0,
                     "tokens": 141
                   }
                 },
@@ -1302,9 +1228,6 @@
                     },
                     "toolCallId": "<toolCallId:1>",
                     "toolName": "get_weather"
-                  },
-                  "metrics": {
-                    "duration_ms": 0
                   }
                 },
                 {
@@ -1397,7 +1320,6 @@
                       "modelId": "gpt-4o-mini-2024-07-18",
                       "provider": "openai.responses"
                     },
-                    "system": "You must inspect live weather via the provided get_weather tool before responding.",
                     "temperature": 0,
                     "tools": [
                       {
@@ -1442,7 +1364,6 @@
                       "id": "<span:1>"
                     },
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 172
@@ -1463,7 +1384,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 180
                     }
                   },
@@ -1476,11 +1396,9 @@
                     "provider": "openai.responses"
                   },
                   "metrics": {
-                    "completion_reasoning_tokens": 0,
                     "completion_tokens": 8,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 172,
-                    "reasoning_tokens": 0,
                     "tokens": 180
                   }
                 },
@@ -1499,9 +1417,6 @@
                     },
                     "toolCallId": "<toolCallId:1>",
                     "toolName": "get_weather"
-                  },
-                  "metrics": {
-                    "duration_ms": 0
                   }
                 },
                 {
@@ -1631,7 +1546,6 @@
                       "modelId": "gpt-4o-mini-2024-07-18",
                       "provider": "openai.responses"
                     },
-                    "system": "You must inspect live weather via the provided get_weather tool before responding.",
                     "temperature": 0,
                     "tools": [
                       {
@@ -1676,7 +1590,6 @@
                       "id": "<span:1>"
                     },
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 211
@@ -1697,7 +1610,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 219
                     }
                   },
@@ -1710,11 +1622,9 @@
                     "provider": "openai.responses"
                   },
                   "metrics": {
-                    "completion_reasoning_tokens": 0,
                     "completion_tokens": 8,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 211,
-                    "reasoning_tokens": 0,
                     "tokens": 219
                   }
                 },
@@ -1733,15 +1643,12 @@
                     },
                     "toolCallId": "<toolCallId:1>",
                     "toolName": "get_weather"
-                  },
-                  "metrics": {
-                    "duration_ms": 0
                   }
                 }
               ],
               "input": {
                 "headers": {
-                  "user-agent": "ai/7.0.0-beta.116"
+                  "user-agent": "ai/7.0.0"
                 },
                 "maxOutputTokens": 128,
                 "maxRetries": 2,
@@ -1755,7 +1662,6 @@
                   "modelId": "gpt-4o-mini-2024-07-18",
                   "provider": "openai.responses"
                 },
-                "system": "You must inspect live weather via the provided get_weather tool before responding.",
                 "temperature": 0,
                 "toolChoice": "required",
                 "tools": {
@@ -1780,6 +1686,90 @@
               },
               "output": {
                 "content": [
+                  {
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "providerMetadata": {
+                      "openai": {
+                        "itemId": "<itemId:3>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:2>",
+                    "toolName": "get_weather",
+                    "type": "tool-call"
+                  },
+                  {
+                    "dynamic": false,
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+                    "providerMetadata": {
+                      "openai": {
+                        "itemId": "<itemId:3>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:2>",
+                    "toolName": "get_weather",
+                    "type": "tool-result"
+                  },
+                  {
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "providerMetadata": {
+                      "openai": {
+                        "itemId": "<itemId:6>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:5>",
+                    "toolName": "get_weather",
+                    "type": "tool-call"
+                  },
+                  {
+                    "dynamic": false,
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+                    "providerMetadata": {
+                      "openai": {
+                        "itemId": "<itemId:6>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:5>",
+                    "toolName": "get_weather",
+                    "type": "tool-result"
+                  },
+                  {
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "providerMetadata": {
+                      "openai": {
+                        "itemId": "<itemId:9>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:8>",
+                    "toolName": "get_weather",
+                    "type": "tool-call"
+                  },
+                  {
+                    "dynamic": false,
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+                    "providerMetadata": {
+                      "openai": {
+                        "itemId": "<itemId:9>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:8>",
+                    "toolName": "get_weather",
+                    "type": "tool-result"
+                  },
                   {
                     "input": {
                       "location": "Paris, France"
@@ -1817,121 +1807,9 @@
                   }
                 },
                 "response": {
-                  "body": "<omitted>",
                   "headers": "<omitted>",
                   "id": "<span:13>",
                   "messages": [
-                    {
-                      "content": [
-                        {
-                          "input": {
-                            "location": "Paris, France"
-                          },
-                          "providerOptions": {
-                            "openai": {
-                              "itemId": "<itemId:3>"
-                            }
-                          },
-                          "toolCallId": "<toolCallId:2>",
-                          "toolName": "get_weather",
-                          "type": "tool-call"
-                        }
-                      ],
-                      "role": "assistant"
-                    },
-                    {
-                      "content": [
-                        {
-                          "output": {
-                            "type": "text",
-                            "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-                          },
-                          "providerOptions": {
-                            "openai": {
-                              "itemId": "<itemId:3>"
-                            }
-                          },
-                          "toolCallId": "<toolCallId:2>",
-                          "toolName": "get_weather",
-                          "type": "tool-result"
-                        }
-                      ],
-                      "role": "tool"
-                    },
-                    {
-                      "content": [
-                        {
-                          "input": {
-                            "location": "Paris, France"
-                          },
-                          "providerOptions": {
-                            "openai": {
-                              "itemId": "<itemId:6>"
-                            }
-                          },
-                          "toolCallId": "<toolCallId:5>",
-                          "toolName": "get_weather",
-                          "type": "tool-call"
-                        }
-                      ],
-                      "role": "assistant"
-                    },
-                    {
-                      "content": [
-                        {
-                          "output": {
-                            "type": "text",
-                            "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-                          },
-                          "providerOptions": {
-                            "openai": {
-                              "itemId": "<itemId:6>"
-                            }
-                          },
-                          "toolCallId": "<toolCallId:5>",
-                          "toolName": "get_weather",
-                          "type": "tool-result"
-                        }
-                      ],
-                      "role": "tool"
-                    },
-                    {
-                      "content": [
-                        {
-                          "input": {
-                            "location": "Paris, France"
-                          },
-                          "providerOptions": {
-                            "openai": {
-                              "itemId": "<itemId:9>"
-                            }
-                          },
-                          "toolCallId": "<toolCallId:8>",
-                          "toolName": "get_weather",
-                          "type": "tool-call"
-                        }
-                      ],
-                      "role": "assistant"
-                    },
-                    {
-                      "content": [
-                        {
-                          "output": {
-                            "type": "text",
-                            "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-                          },
-                          "providerOptions": {
-                            "openai": {
-                              "itemId": "<itemId:9>"
-                            }
-                          },
-                          "toolCallId": "<toolCallId:8>",
-                          "toolName": "get_weather",
-                          "type": "tool-result"
-                        }
-                      ],
-                      "role": "tool"
-                    },
                     {
                       "content": [
                         {
@@ -1973,6 +1851,7 @@
                   "modelId": "gpt-4o-mini-2024-07-18",
                   "timestamp": "<timestamp>"
                 },
+                "responseMessages": "<omitted>",
                 "steps": [
                   {
                     "callId": "<callId:1>",
@@ -2018,7 +1897,6 @@
                       }
                     },
                     "response": {
-                      "body": "<omitted>",
                       "headers": "<omitted>",
                       "id": "<span:4>",
                       "messages": [
@@ -2067,7 +1945,6 @@
                     "stepNumber": 0,
                     "toolsContext": {},
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 94
@@ -2088,7 +1965,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 102
                     },
                     "warnings": []
@@ -2137,47 +2013,9 @@
                       }
                     },
                     "response": {
-                      "body": "<omitted>",
                       "headers": "<omitted>",
                       "id": "<span:7>",
                       "messages": [
-                        {
-                          "content": [
-                            {
-                              "input": {
-                                "location": "Paris, France"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:3>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:2>",
-                              "toolName": "get_weather",
-                              "type": "tool-call"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "output": {
-                                "type": "text",
-                                "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:3>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:2>",
-                              "toolName": "get_weather",
-                              "type": "tool-result"
-                            }
-                          ],
-                          "role": "tool"
-                        },
                         {
                           "content": [
                             {
@@ -2223,7 +2061,6 @@
                     "stepNumber": 1,
                     "toolsContext": {},
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 133
@@ -2244,7 +2081,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 141
                     },
                     "warnings": []
@@ -2293,84 +2129,9 @@
                       }
                     },
                     "response": {
-                      "body": "<omitted>",
                       "headers": "<omitted>",
                       "id": "<span:10>",
                       "messages": [
-                        {
-                          "content": [
-                            {
-                              "input": {
-                                "location": "Paris, France"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:3>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:2>",
-                              "toolName": "get_weather",
-                              "type": "tool-call"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "output": {
-                                "type": "text",
-                                "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:3>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:2>",
-                              "toolName": "get_weather",
-                              "type": "tool-result"
-                            }
-                          ],
-                          "role": "tool"
-                        },
-                        {
-                          "content": [
-                            {
-                              "input": {
-                                "location": "Paris, France"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:6>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:5>",
-                              "toolName": "get_weather",
-                              "type": "tool-call"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "output": {
-                                "type": "text",
-                                "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:6>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:5>",
-                              "toolName": "get_weather",
-                              "type": "tool-result"
-                            }
-                          ],
-                          "role": "tool"
-                        },
                         {
                           "content": [
                             {
@@ -2416,7 +2177,6 @@
                     "stepNumber": 2,
                     "toolsContext": {},
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 172
@@ -2437,7 +2197,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 180
                     },
                     "warnings": []
@@ -2486,121 +2245,9 @@
                       }
                     },
                     "response": {
-                      "body": "<omitted>",
                       "headers": "<omitted>",
                       "id": "<span:13>",
                       "messages": [
-                        {
-                          "content": [
-                            {
-                              "input": {
-                                "location": "Paris, France"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:3>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:2>",
-                              "toolName": "get_weather",
-                              "type": "tool-call"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "output": {
-                                "type": "text",
-                                "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:3>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:2>",
-                              "toolName": "get_weather",
-                              "type": "tool-result"
-                            }
-                          ],
-                          "role": "tool"
-                        },
-                        {
-                          "content": [
-                            {
-                              "input": {
-                                "location": "Paris, France"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:6>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:5>",
-                              "toolName": "get_weather",
-                              "type": "tool-call"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "output": {
-                                "type": "text",
-                                "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:6>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:5>",
-                              "toolName": "get_weather",
-                              "type": "tool-result"
-                            }
-                          ],
-                          "role": "tool"
-                        },
-                        {
-                          "content": [
-                            {
-                              "input": {
-                                "location": "Paris, France"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:9>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:8>",
-                              "toolName": "get_weather",
-                              "type": "tool-call"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "output": {
-                                "type": "text",
-                                "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-                              },
-                              "providerOptions": {
-                                "openai": {
-                                  "itemId": "<itemId:9>"
-                                }
-                              },
-                              "toolCallId": "<toolCallId:8>",
-                              "toolName": "get_weather",
-                              "type": "tool-result"
-                            }
-                          ],
-                          "role": "tool"
-                        },
                         {
                           "content": [
                             {
@@ -2646,7 +2293,6 @@
                     "stepNumber": 3,
                     "toolsContext": {},
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 211
@@ -2667,7 +2313,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 219
                     },
                     "warnings": []
@@ -2675,6 +2320,45 @@
                 ],
                 "text": "",
                 "toolCalls": [
+                  {
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "providerMetadata": {
+                      "openai": {
+                        "itemId": "<itemId:3>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:2>",
+                    "toolName": "get_weather",
+                    "type": "tool-call"
+                  },
+                  {
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "providerMetadata": {
+                      "openai": {
+                        "itemId": "<itemId:6>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:5>",
+                    "toolName": "get_weather",
+                    "type": "tool-call"
+                  },
+                  {
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "providerMetadata": {
+                      "openai": {
+                        "itemId": "<itemId:9>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:8>",
+                    "toolName": "get_weather",
+                    "type": "tool-call"
+                  },
                   {
                     "input": {
                       "location": "Paris, France"
@@ -2698,6 +2382,51 @@
                     "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
                     "providerMetadata": {
                       "openai": {
+                        "itemId": "<itemId:3>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:2>",
+                    "toolName": "get_weather",
+                    "type": "tool-result"
+                  },
+                  {
+                    "dynamic": false,
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+                    "providerMetadata": {
+                      "openai": {
+                        "itemId": "<itemId:6>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:5>",
+                    "toolName": "get_weather",
+                    "type": "tool-result"
+                  },
+                  {
+                    "dynamic": false,
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+                    "providerMetadata": {
+                      "openai": {
+                        "itemId": "<itemId:9>"
+                      }
+                    },
+                    "toolCallId": "<toolCallId:8>",
+                    "toolName": "get_weather",
+                    "type": "tool-result"
+                  },
+                  {
+                    "dynamic": false,
+                    "input": {
+                      "location": "Paris, France"
+                    },
+                    "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+                    "providerMetadata": {
+                      "openai": {
                         "itemId": "<itemId:12>"
                       }
                     },
@@ -2707,7 +2436,6 @@
                   }
                 ],
                 "totalUsage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "noCacheTokens": 610
@@ -2718,33 +2446,20 @@
                     "textTokens": 32
                   },
                   "outputTokens": 32,
-                  "reasoningTokens": 0,
                   "totalTokens": 642
                 },
                 "usage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
-                    "noCacheTokens": 211
+                    "noCacheTokens": 610
                   },
-                  "inputTokens": 211,
+                  "inputTokens": 610,
                   "outputTokenDetails": {
                     "reasoningTokens": 0,
-                    "textTokens": 8
+                    "textTokens": 32
                   },
-                  "outputTokens": 8,
-                  "raw": {
-                    "input_tokens": 211,
-                    "input_tokens_details": {
-                      "cached_tokens": 0
-                    },
-                    "output_tokens": 8,
-                    "output_tokens_details": {
-                      "reasoning_tokens": 0
-                    }
-                  },
-                  "reasoningTokens": 0,
-                  "totalTokens": 219
+                  "outputTokens": 32,
+                  "totalTokens": 642
                 },
                 "warnings": []
               },
@@ -2804,7 +2519,6 @@
                     },
                     "text": "{\"city\":\"Paris\"}",
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 38
@@ -2825,7 +2539,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 44
                     },
                     "warnings": []
@@ -2839,18 +2552,16 @@
                     "provider": "openai.responses"
                   },
                   "metrics": {
-                    "completion_reasoning_tokens": 0,
                     "completion_tokens": 6,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 38,
-                    "reasoning_tokens": 0,
                     "tokens": 44
                   }
                 }
               ],
               "input": {
                 "headers": {
-                  "user-agent": "ai/7.0.0-beta.116"
+                  "user-agent": "ai/7.0.0"
                 },
                 "maxOutputTokens": 32,
                 "maxRetries": 2,
@@ -2894,7 +2605,6 @@
                   "timestamp": "<timestamp>"
                 },
                 "usage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "noCacheTokens": 38
@@ -2915,7 +2625,6 @@
                       "reasoning_tokens": 0
                     }
                   },
-                  "reasoningTokens": 0,
                   "totalTokens": 44
                 },
                 "warnings": []
@@ -2975,7 +2684,6 @@
                     },
                     "text": "{\"city\":\"Paris\"}",
                     "usage": {
-                      "cachedInputTokens": 0,
                       "inputTokenDetails": {
                         "cacheReadTokens": 0,
                         "noCacheTokens": 38
@@ -2996,7 +2704,6 @@
                           "reasoning_tokens": 0
                         }
                       },
-                      "reasoningTokens": 0,
                       "totalTokens": 44
                     },
                     "warnings": []
@@ -3010,11 +2717,9 @@
                     "provider": "openai.responses"
                   },
                   "metrics": {
-                    "completion_reasoning_tokens": 0,
                     "completion_tokens": 6,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 38,
-                    "reasoning_tokens": 0,
                     "tokens": 44
                   }
                 }
@@ -3061,7 +2766,6 @@
                   "timestamp": "<timestamp>"
                 },
                 "usage": {
-                  "cachedInputTokens": 0,
                   "inputTokenDetails": {
                     "cacheReadTokens": 0,
                     "noCacheTokens": 38
@@ -3082,7 +2786,6 @@
                       "reasoning_tokens": 0
                     }
                   },
-                  "reasoningTokens": 0,
                   "totalTokens": 44
                 },
                 "warnings": []
@@ -3104,7 +2807,7 @@
         }
       ],
       "metadata": {
-        "aiSdkVersion": "7.0.0-beta.116",
+        "aiSdkVersion": "7.0.0",
         "scenario": "ai-sdk-instrumentation",
         "testRunId": "<run:1>"
       }

--- a/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v7-explicit.span-tree.txt
+++ b/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v7-explicit.span-tree.txt
@@ -1,7 +1,7 @@
 span_tree:
 └── ai-sdk-instrumentation-root [task]
     metadata: {
-      "aiSdkVersion": "7.0.0-beta.116",
+      "aiSdkVersion": "7.0.0",
       "scenario": "ai-sdk-instrumentation",
       "testRunId": "<run:1>"
     }
@@ -13,7 +13,7 @@ span_tree:
     │   └── generateText [function]
     │       input: {
     │         "headers": {
-    │           "user-agent": "ai/7.0.0-beta.116"
+    │           "user-agent": "ai/7.0.0"
     │         },
     │         "maxOutputTokens": 24,
     │         "maxRetries": 2,
@@ -49,7 +49,6 @@ span_tree:
     │           }
     │         },
     │         "response": {
-    │           "body": "<omitted>",
     │           "headers": "<omitted>",
     │           "id": "<span:3>",
     │           "messages": [
@@ -71,6 +70,7 @@ span_tree:
     │           "modelId": "gpt-4o-mini-2024-07-18",
     │           "timestamp": "<timestamp>"
     │         },
+    │         "responseMessages": "<omitted>",
     │         "steps": [
     │           {
     │             "callId": "<callId:1>",
@@ -97,7 +97,6 @@ span_tree:
     │               }
     │             },
     │             "response": {
-    │               "body": "<omitted>",
     │               "headers": "<omitted>",
     │               "id": "<span:3>",
     │               "messages": [
@@ -123,7 +122,6 @@ span_tree:
     │             "stepNumber": 0,
     │             "toolsContext": {},
     │             "usage": {
-    │               "cachedInputTokens": 0,
     │               "inputTokenDetails": {
     │                 "cacheReadTokens": 0,
     │                 "noCacheTokens": 18
@@ -144,7 +142,6 @@ span_tree:
     │                   "reasoning_tokens": 0
     │                 }
     │               },
-    │               "reasoningTokens": 0,
     │               "totalTokens": 21
     │             },
     │             "warnings": []
@@ -154,7 +151,6 @@ span_tree:
     │         "toolCalls": [],
     │         "toolResults": [],
     │         "totalUsage": {
-    │           "cachedInputTokens": 0,
     │           "inputTokenDetails": {
     │             "cacheReadTokens": 0,
     │             "noCacheTokens": 18
@@ -165,11 +161,9 @@ span_tree:
     │             "textTokens": 3
     │           },
     │           "outputTokens": 3,
-    │           "reasoningTokens": 0,
     │           "totalTokens": 21
     │         },
     │         "usage": {
-    │           "cachedInputTokens": 0,
     │           "inputTokenDetails": {
     │             "cacheReadTokens": 0,
     │             "noCacheTokens": 18
@@ -180,17 +174,6 @@ span_tree:
     │             "textTokens": 3
     │           },
     │           "outputTokens": 3,
-    │           "raw": {
-    │             "input_tokens": 18,
-    │             "input_tokens_details": {
-    │               "cached_tokens": 0
-    │             },
-    │             "output_tokens": 3,
-    │             "output_tokens_details": {
-    │               "reasoning_tokens": 0
-    │             }
-    │           },
-    │           "reasoningTokens": 0,
     │           "totalTokens": 21
     │         },
     │         "warnings": []
@@ -235,7 +218,6 @@ span_tree:
     │               "id": "<span:1>"
     │             },
     │             "usage": {
-    │               "cachedInputTokens": 0,
     │               "inputTokenDetails": {
     │                 "cacheReadTokens": 0,
     │                 "noCacheTokens": 18
@@ -256,7 +238,6 @@ span_tree:
     │                   "reasoning_tokens": 0
     │                 }
     │               },
-    │               "reasoningTokens": 0,
     │               "totalTokens": 21
     │             }
     │           }
@@ -269,11 +250,9 @@ span_tree:
     │             "provider": "openai.responses"
     │           }
     │           metrics: {
-    │             "completion_reasoning_tokens": 0,
     │             "completion_tokens": 3,
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 18,
-    │             "reasoning_tokens": 0,
     │             "tokens": 21
     │           }
     ├── ai-sdk-output-object-response-format-operation
@@ -289,7 +268,7 @@ span_tree:
     │   └── generateText [function]
     │       input: {
     │         "headers": {
-    │           "user-agent": "ai/7.0.0-beta.116"
+    │           "user-agent": "ai/7.0.0"
     │         },
     │         "maxOutputTokens": 32,
     │         "maxRetries": 2,
@@ -343,7 +322,6 @@ span_tree:
     │           }
     │         },
     │         "response": {
-    │           "body": "<omitted>",
     │           "headers": "<omitted>",
     │           "id": "<span:3>",
     │           "messages": [
@@ -365,6 +343,7 @@ span_tree:
     │           "modelId": "gpt-4o-mini-2024-07-18",
     │           "timestamp": "<timestamp>"
     │         },
+    │         "responseMessages": "<omitted>",
     │         "steps": [
     │           {
     │             "callId": "<callId:1>",
@@ -391,7 +370,6 @@ span_tree:
     │               }
     │             },
     │             "response": {
-    │               "body": "<omitted>",
     │               "headers": "<omitted>",
     │               "id": "<span:3>",
     │               "messages": [
@@ -417,7 +395,6 @@ span_tree:
     │             "stepNumber": 0,
     │             "toolsContext": {},
     │             "usage": {
-    │               "cachedInputTokens": 0,
     │               "inputTokenDetails": {
     │                 "cacheReadTokens": 0,
     │                 "noCacheTokens": 45
@@ -438,7 +415,6 @@ span_tree:
     │                   "reasoning_tokens": 0
     │                 }
     │               },
-    │               "reasoningTokens": 0,
     │               "totalTokens": 51
     │             },
     │             "warnings": []
@@ -448,7 +424,6 @@ span_tree:
     │         "toolCalls": [],
     │         "toolResults": [],
     │         "totalUsage": {
-    │           "cachedInputTokens": 0,
     │           "inputTokenDetails": {
     │             "cacheReadTokens": 0,
     │             "noCacheTokens": 45
@@ -459,11 +434,9 @@ span_tree:
     │             "textTokens": 6
     │           },
     │           "outputTokens": 6,
-    │           "reasoningTokens": 0,
     │           "totalTokens": 51
     │         },
     │         "usage": {
-    │           "cachedInputTokens": 0,
     │           "inputTokenDetails": {
     │             "cacheReadTokens": 0,
     │             "noCacheTokens": 45
@@ -474,17 +447,6 @@ span_tree:
     │             "textTokens": 6
     │           },
     │           "outputTokens": 6,
-    │           "raw": {
-    │             "input_tokens": 45,
-    │             "input_tokens_details": {
-    │               "cached_tokens": 0
-    │             },
-    │             "output_tokens": 6,
-    │             "output_tokens_details": {
-    │               "reasoning_tokens": 0
-    │             }
-    │           },
-    │           "reasoningTokens": 0,
     │           "totalTokens": 51
     │         },
     │         "warnings": []
@@ -529,7 +491,6 @@ span_tree:
     │               "id": "<span:1>"
     │             },
     │             "usage": {
-    │               "cachedInputTokens": 0,
     │               "inputTokenDetails": {
     │                 "cacheReadTokens": 0,
     │                 "noCacheTokens": 45
@@ -550,7 +511,6 @@ span_tree:
     │                   "reasoning_tokens": 0
     │                 }
     │               },
-    │               "reasoningTokens": 0,
     │               "totalTokens": 51
     │             }
     │           }
@@ -563,11 +523,9 @@ span_tree:
     │             "provider": "openai.responses"
     │           }
     │           metrics: {
-    │             "completion_reasoning_tokens": 0,
     │             "completion_tokens": 6,
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 45,
-    │             "reasoning_tokens": 0,
     │             "tokens": 51
     │           }
     ├── ai-sdk-stream-operation
@@ -632,6 +590,7 @@ span_tree:
     │           "modelId": "gpt-4o-mini-2024-07-18",
     │           "timestamp": "<timestamp>"
     │         },
+    │         "responseMessages": "<omitted>",
     │         "steps": [
     │           {
     │             "callId": "<callId:1>",
@@ -683,7 +642,6 @@ span_tree:
     │             "stepNumber": 0,
     │             "toolsContext": {},
     │             "usage": {
-    │               "cachedInputTokens": 0,
     │               "inputTokenDetails": {
     │                 "cacheReadTokens": 0,
     │                 "noCacheTokens": 22
@@ -704,7 +662,6 @@ span_tree:
     │                   "reasoning_tokens": 0
     │                 }
     │               },
-    │               "reasoningTokens": 0,
     │               "totalTokens": 29
     │             },
     │             "warnings": []
@@ -714,7 +671,6 @@ span_tree:
     │         "toolCalls": [],
     │         "toolResults": [],
     │         "totalUsage": {
-    │           "cachedInputTokens": 0,
     │           "inputTokenDetails": {
     │             "cacheReadTokens": 0,
     │             "noCacheTokens": 22
@@ -725,11 +681,9 @@ span_tree:
     │             "textTokens": 7
     │           },
     │           "outputTokens": 7,
-    │           "reasoningTokens": 0,
     │           "totalTokens": 29
     │         },
     │         "usage": {
-    │           "cachedInputTokens": 0,
     │           "inputTokenDetails": {
     │             "cacheReadTokens": 0,
     │             "noCacheTokens": 22
@@ -740,17 +694,6 @@ span_tree:
     │             "textTokens": 7
     │           },
     │           "outputTokens": 7,
-    │           "raw": {
-    │             "input_tokens": 22,
-    │             "input_tokens_details": {
-    │               "cached_tokens": 0
-    │             },
-    │             "output_tokens": 7,
-    │             "output_tokens_details": {
-    │               "reasoning_tokens": 0
-    │             }
-    │           },
-    │           "reasoningTokens": 0,
     │           "totalTokens": 29
     │         },
     │         "warnings": []
@@ -798,7 +741,6 @@ span_tree:
     │               "id": "<span:1>"
     │             },
     │             "usage": {
-    │               "cachedInputTokens": 0,
     │               "inputTokenDetails": {
     │                 "cacheReadTokens": 0,
     │                 "noCacheTokens": 22
@@ -819,7 +761,6 @@ span_tree:
     │                   "reasoning_tokens": 0
     │                 }
     │               },
-    │               "reasoningTokens": 0,
     │               "totalTokens": 29
     │             }
     │           }
@@ -832,11 +773,9 @@ span_tree:
     │             "provider": "openai.responses"
     │           }
     │           metrics: {
-    │             "completion_reasoning_tokens": 0,
     │             "completion_tokens": 7,
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 22,
-    │             "reasoning_tokens": 0,
     │             "tokens": 29
     │           }
     ├── ai-sdk-embed-operation
@@ -958,7 +897,7 @@ span_tree:
     │   └── generateText [function]
     │       input: {
     │         "headers": {
-    │           "user-agent": "ai/7.0.0-beta.116"
+    │           "user-agent": "ai/7.0.0"
     │         },
     │         "maxOutputTokens": 128,
     │         "maxRetries": 2,
@@ -972,7 +911,6 @@ span_tree:
     │           "modelId": "gpt-4o-mini-2024-07-18",
     │           "provider": "openai.responses"
     │         },
-    │         "system": "You must inspect live weather via the provided get_weather tool before responding.",
     │         "temperature": 0,
     │         "toolChoice": "required",
     │         "tools": {
@@ -997,6 +935,90 @@ span_tree:
     │       }
     │       output: {
     │         "content": [
+    │           {
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "providerMetadata": {
+    │               "openai": {
+    │                 "itemId": "<itemId:3>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:2>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-call"
+    │           },
+    │           {
+    │             "dynamic": false,
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+    │             "providerMetadata": {
+    │               "openai": {
+    │                 "itemId": "<itemId:3>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:2>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-result"
+    │           },
+    │           {
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "providerMetadata": {
+    │               "openai": {
+    │                 "itemId": "<itemId:6>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:5>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-call"
+    │           },
+    │           {
+    │             "dynamic": false,
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+    │             "providerMetadata": {
+    │               "openai": {
+    │                 "itemId": "<itemId:6>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:5>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-result"
+    │           },
+    │           {
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "providerMetadata": {
+    │               "openai": {
+    │                 "itemId": "<itemId:9>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:8>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-call"
+    │           },
+    │           {
+    │             "dynamic": false,
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+    │             "providerMetadata": {
+    │               "openai": {
+    │                 "itemId": "<itemId:9>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:8>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-result"
+    │           },
     │           {
     │             "input": {
     │               "location": "Paris, France"
@@ -1034,121 +1056,9 @@ span_tree:
     │           }
     │         },
     │         "response": {
-    │           "body": "<omitted>",
     │           "headers": "<omitted>",
     │           "id": "<span:13>",
     │           "messages": [
-    │             {
-    │               "content": [
-    │                 {
-    │                   "input": {
-    │                     "location": "Paris, France"
-    │                   },
-    │                   "providerOptions": {
-    │                     "openai": {
-    │                       "itemId": "<itemId:3>"
-    │                     }
-    │                   },
-    │                   "toolCallId": "<toolCallId:2>",
-    │                   "toolName": "get_weather",
-    │                   "type": "tool-call"
-    │                 }
-    │               ],
-    │               "role": "assistant"
-    │             },
-    │             {
-    │               "content": [
-    │                 {
-    │                   "output": {
-    │                     "type": "text",
-    │                     "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-    │                   },
-    │                   "providerOptions": {
-    │                     "openai": {
-    │                       "itemId": "<itemId:3>"
-    │                     }
-    │                   },
-    │                   "toolCallId": "<toolCallId:2>",
-    │                   "toolName": "get_weather",
-    │                   "type": "tool-result"
-    │                 }
-    │               ],
-    │               "role": "tool"
-    │             },
-    │             {
-    │               "content": [
-    │                 {
-    │                   "input": {
-    │                     "location": "Paris, France"
-    │                   },
-    │                   "providerOptions": {
-    │                     "openai": {
-    │                       "itemId": "<itemId:6>"
-    │                     }
-    │                   },
-    │                   "toolCallId": "<toolCallId:5>",
-    │                   "toolName": "get_weather",
-    │                   "type": "tool-call"
-    │                 }
-    │               ],
-    │               "role": "assistant"
-    │             },
-    │             {
-    │               "content": [
-    │                 {
-    │                   "output": {
-    │                     "type": "text",
-    │                     "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-    │                   },
-    │                   "providerOptions": {
-    │                     "openai": {
-    │                       "itemId": "<itemId:6>"
-    │                     }
-    │                   },
-    │                   "toolCallId": "<toolCallId:5>",
-    │                   "toolName": "get_weather",
-    │                   "type": "tool-result"
-    │                 }
-    │               ],
-    │               "role": "tool"
-    │             },
-    │             {
-    │               "content": [
-    │                 {
-    │                   "input": {
-    │                     "location": "Paris, France"
-    │                   },
-    │                   "providerOptions": {
-    │                     "openai": {
-    │                       "itemId": "<itemId:9>"
-    │                     }
-    │                   },
-    │                   "toolCallId": "<toolCallId:8>",
-    │                   "toolName": "get_weather",
-    │                   "type": "tool-call"
-    │                 }
-    │               ],
-    │               "role": "assistant"
-    │             },
-    │             {
-    │               "content": [
-    │                 {
-    │                   "output": {
-    │                     "type": "text",
-    │                     "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-    │                   },
-    │                   "providerOptions": {
-    │                     "openai": {
-    │                       "itemId": "<itemId:9>"
-    │                     }
-    │                   },
-    │                   "toolCallId": "<toolCallId:8>",
-    │                   "toolName": "get_weather",
-    │                   "type": "tool-result"
-    │                 }
-    │               ],
-    │               "role": "tool"
-    │             },
     │             {
     │               "content": [
     │                 {
@@ -1190,6 +1100,7 @@ span_tree:
     │           "modelId": "gpt-4o-mini-2024-07-18",
     │           "timestamp": "<timestamp>"
     │         },
+    │         "responseMessages": "<omitted>",
     │         "steps": [
     │           {
     │             "callId": "<callId:1>",
@@ -1235,7 +1146,6 @@ span_tree:
     │               }
     │             },
     │             "response": {
-    │               "body": "<omitted>",
     │               "headers": "<omitted>",
     │               "id": "<span:4>",
     │               "messages": [
@@ -1284,7 +1194,6 @@ span_tree:
     │             "stepNumber": 0,
     │             "toolsContext": {},
     │             "usage": {
-    │               "cachedInputTokens": 0,
     │               "inputTokenDetails": {
     │                 "cacheReadTokens": 0,
     │                 "noCacheTokens": 94
@@ -1305,7 +1214,6 @@ span_tree:
     │                   "reasoning_tokens": 0
     │                 }
     │               },
-    │               "reasoningTokens": 0,
     │               "totalTokens": 102
     │             },
     │             "warnings": []
@@ -1354,47 +1262,9 @@ span_tree:
     │               }
     │             },
     │             "response": {
-    │               "body": "<omitted>",
     │               "headers": "<omitted>",
     │               "id": "<span:7>",
     │               "messages": [
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "input": {
-    │                         "location": "Paris, France"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:3>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:2>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-call"
-    │                     }
-    │                   ],
-    │                   "role": "assistant"
-    │                 },
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "output": {
-    │                         "type": "text",
-    │                         "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:3>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:2>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-result"
-    │                     }
-    │                   ],
-    │                   "role": "tool"
-    │                 },
     │                 {
     │                   "content": [
     │                     {
@@ -1440,7 +1310,6 @@ span_tree:
     │             "stepNumber": 1,
     │             "toolsContext": {},
     │             "usage": {
-    │               "cachedInputTokens": 0,
     │               "inputTokenDetails": {
     │                 "cacheReadTokens": 0,
     │                 "noCacheTokens": 133
@@ -1461,7 +1330,6 @@ span_tree:
     │                   "reasoning_tokens": 0
     │                 }
     │               },
-    │               "reasoningTokens": 0,
     │               "totalTokens": 141
     │             },
     │             "warnings": []
@@ -1510,84 +1378,9 @@ span_tree:
     │               }
     │             },
     │             "response": {
-    │               "body": "<omitted>",
     │               "headers": "<omitted>",
     │               "id": "<span:10>",
     │               "messages": [
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "input": {
-    │                         "location": "Paris, France"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:3>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:2>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-call"
-    │                     }
-    │                   ],
-    │                   "role": "assistant"
-    │                 },
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "output": {
-    │                         "type": "text",
-    │                         "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:3>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:2>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-result"
-    │                     }
-    │                   ],
-    │                   "role": "tool"
-    │                 },
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "input": {
-    │                         "location": "Paris, France"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:6>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:5>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-call"
-    │                     }
-    │                   ],
-    │                   "role": "assistant"
-    │                 },
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "output": {
-    │                         "type": "text",
-    │                         "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:6>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:5>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-result"
-    │                     }
-    │                   ],
-    │                   "role": "tool"
-    │                 },
     │                 {
     │                   "content": [
     │                     {
@@ -1633,7 +1426,6 @@ span_tree:
     │             "stepNumber": 2,
     │             "toolsContext": {},
     │             "usage": {
-    │               "cachedInputTokens": 0,
     │               "inputTokenDetails": {
     │                 "cacheReadTokens": 0,
     │                 "noCacheTokens": 172
@@ -1654,7 +1446,6 @@ span_tree:
     │                   "reasoning_tokens": 0
     │                 }
     │               },
-    │               "reasoningTokens": 0,
     │               "totalTokens": 180
     │             },
     │             "warnings": []
@@ -1703,121 +1494,9 @@ span_tree:
     │               }
     │             },
     │             "response": {
-    │               "body": "<omitted>",
     │               "headers": "<omitted>",
     │               "id": "<span:13>",
     │               "messages": [
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "input": {
-    │                         "location": "Paris, France"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:3>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:2>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-call"
-    │                     }
-    │                   ],
-    │                   "role": "assistant"
-    │                 },
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "output": {
-    │                         "type": "text",
-    │                         "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:3>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:2>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-result"
-    │                     }
-    │                   ],
-    │                   "role": "tool"
-    │                 },
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "input": {
-    │                         "location": "Paris, France"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:6>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:5>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-call"
-    │                     }
-    │                   ],
-    │                   "role": "assistant"
-    │                 },
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "output": {
-    │                         "type": "text",
-    │                         "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:6>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:5>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-result"
-    │                     }
-    │                   ],
-    │                   "role": "tool"
-    │                 },
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "input": {
-    │                         "location": "Paris, France"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:9>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:8>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-call"
-    │                     }
-    │                   ],
-    │                   "role": "assistant"
-    │                 },
-    │                 {
-    │                   "content": [
-    │                     {
-    │                       "output": {
-    │                         "type": "text",
-    │                         "value": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}"
-    │                       },
-    │                       "providerOptions": {
-    │                         "openai": {
-    │                           "itemId": "<itemId:9>"
-    │                         }
-    │                       },
-    │                       "toolCallId": "<toolCallId:8>",
-    │                       "toolName": "get_weather",
-    │                       "type": "tool-result"
-    │                     }
-    │                   ],
-    │                   "role": "tool"
-    │                 },
     │                 {
     │                   "content": [
     │                     {
@@ -1863,7 +1542,6 @@ span_tree:
     │             "stepNumber": 3,
     │             "toolsContext": {},
     │             "usage": {
-    │               "cachedInputTokens": 0,
     │               "inputTokenDetails": {
     │                 "cacheReadTokens": 0,
     │                 "noCacheTokens": 211
@@ -1884,7 +1562,6 @@ span_tree:
     │                   "reasoning_tokens": 0
     │                 }
     │               },
-    │               "reasoningTokens": 0,
     │               "totalTokens": 219
     │             },
     │             "warnings": []
@@ -1892,6 +1569,45 @@ span_tree:
     │         ],
     │         "text": "",
     │         "toolCalls": [
+    │           {
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "providerMetadata": {
+    │               "openai": {
+    │                 "itemId": "<itemId:3>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:2>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-call"
+    │           },
+    │           {
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "providerMetadata": {
+    │               "openai": {
+    │                 "itemId": "<itemId:6>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:5>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-call"
+    │           },
+    │           {
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "providerMetadata": {
+    │               "openai": {
+    │                 "itemId": "<itemId:9>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:8>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-call"
+    │           },
     │           {
     │             "input": {
     │               "location": "Paris, France"
@@ -1915,6 +1631,51 @@ span_tree:
     │             "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
     │             "providerMetadata": {
     │               "openai": {
+    │                 "itemId": "<itemId:3>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:2>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-result"
+    │           },
+    │           {
+    │             "dynamic": false,
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+    │             "providerMetadata": {
+    │               "openai": {
+    │                 "itemId": "<itemId:6>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:5>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-result"
+    │           },
+    │           {
+    │             "dynamic": false,
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+    │             "providerMetadata": {
+    │               "openai": {
+    │                 "itemId": "<itemId:9>"
+    │               }
+    │             },
+    │             "toolCallId": "<toolCallId:8>",
+    │             "toolName": "get_weather",
+    │             "type": "tool-result"
+    │           },
+    │           {
+    │             "dynamic": false,
+    │             "input": {
+    │               "location": "Paris, France"
+    │             },
+    │             "output": "{\"condition\":\"sunny\",\"location\":\"Paris, France\",\"temperatureC\":22}",
+    │             "providerMetadata": {
+    │               "openai": {
     │                 "itemId": "<itemId:12>"
     │               }
     │             },
@@ -1924,7 +1685,6 @@ span_tree:
     │           }
     │         ],
     │         "totalUsage": {
-    │           "cachedInputTokens": 0,
     │           "inputTokenDetails": {
     │             "cacheReadTokens": 0,
     │             "noCacheTokens": 610
@@ -1935,33 +1695,20 @@ span_tree:
     │             "textTokens": 32
     │           },
     │           "outputTokens": 32,
-    │           "reasoningTokens": 0,
     │           "totalTokens": 642
     │         },
     │         "usage": {
-    │           "cachedInputTokens": 0,
     │           "inputTokenDetails": {
     │             "cacheReadTokens": 0,
-    │             "noCacheTokens": 211
+    │             "noCacheTokens": 610
     │           },
-    │           "inputTokens": 211,
+    │           "inputTokens": 610,
     │           "outputTokenDetails": {
     │             "reasoningTokens": 0,
-    │             "textTokens": 8
+    │             "textTokens": 32
     │           },
-    │           "outputTokens": 8,
-    │           "raw": {
-    │             "input_tokens": 211,
-    │             "input_tokens_details": {
-    │               "cached_tokens": 0
-    │             },
-    │             "output_tokens": 8,
-    │             "output_tokens_details": {
-    │               "reasoning_tokens": 0
-    │             }
-    │           },
-    │           "reasoningTokens": 0,
-    │           "totalTokens": 219
+    │           "outputTokens": 32,
+    │           "totalTokens": 642
     │         },
     │         "warnings": []
     │       }
@@ -1986,7 +1733,6 @@ span_tree:
     │       │       "modelId": "gpt-4o-mini-2024-07-18",
     │       │       "provider": "openai.responses"
     │       │     },
-    │       │     "system": "You must inspect live weather via the provided get_weather tool before responding.",
     │       │     "temperature": 0,
     │       │     "tools": [
     │       │       {
@@ -2031,7 +1777,6 @@ span_tree:
     │       │       "id": "<span:1>"
     │       │     },
     │       │     "usage": {
-    │       │       "cachedInputTokens": 0,
     │       │       "inputTokenDetails": {
     │       │         "cacheReadTokens": 0,
     │       │         "noCacheTokens": 94
@@ -2052,7 +1797,6 @@ span_tree:
     │       │           "reasoning_tokens": 0
     │       │         }
     │       │       },
-    │       │       "reasoningTokens": 0,
     │       │       "totalTokens": 102
     │       │     }
     │       │   }
@@ -2065,11 +1809,9 @@ span_tree:
     │       │     "provider": "openai.responses"
     │       │   }
     │       │   metrics: {
-    │       │     "completion_reasoning_tokens": 0,
     │       │     "completion_tokens": 8,
     │       │     "prompt_cached_tokens": 0,
     │       │     "prompt_tokens": 94,
-    │       │     "reasoning_tokens": 0,
     │       │     "tokens": 102
     │       │   }
     │       ├── get_weather [tool]
@@ -2084,9 +1826,6 @@ span_tree:
     │       │     },
     │       │     "toolCallId": "<toolCallId:1>",
     │       │     "toolName": "get_weather"
-    │       │   }
-    │       │   metrics: {
-    │       │     "duration_ms": 0
     │       │   }
     │       ├── doGenerate [llm]
     │       │   input: {
@@ -2138,7 +1877,6 @@ span_tree:
     │       │       "modelId": "gpt-4o-mini-2024-07-18",
     │       │       "provider": "openai.responses"
     │       │     },
-    │       │     "system": "You must inspect live weather via the provided get_weather tool before responding.",
     │       │     "temperature": 0,
     │       │     "tools": [
     │       │       {
@@ -2183,7 +1921,6 @@ span_tree:
     │       │       "id": "<span:1>"
     │       │     },
     │       │     "usage": {
-    │       │       "cachedInputTokens": 0,
     │       │       "inputTokenDetails": {
     │       │         "cacheReadTokens": 0,
     │       │         "noCacheTokens": 133
@@ -2204,7 +1941,6 @@ span_tree:
     │       │           "reasoning_tokens": 0
     │       │         }
     │       │       },
-    │       │       "reasoningTokens": 0,
     │       │       "totalTokens": 141
     │       │     }
     │       │   }
@@ -2217,11 +1953,9 @@ span_tree:
     │       │     "provider": "openai.responses"
     │       │   }
     │       │   metrics: {
-    │       │     "completion_reasoning_tokens": 0,
     │       │     "completion_tokens": 8,
     │       │     "prompt_cached_tokens": 0,
     │       │     "prompt_tokens": 133,
-    │       │     "reasoning_tokens": 0,
     │       │     "tokens": 141
     │       │   }
     │       ├── get_weather [tool]
@@ -2236,9 +1970,6 @@ span_tree:
     │       │     },
     │       │     "toolCallId": "<toolCallId:1>",
     │       │     "toolName": "get_weather"
-    │       │   }
-    │       │   metrics: {
-    │       │     "duration_ms": 0
     │       │   }
     │       ├── doGenerate [llm]
     │       │   input: {
@@ -2327,7 +2058,6 @@ span_tree:
     │       │       "modelId": "gpt-4o-mini-2024-07-18",
     │       │       "provider": "openai.responses"
     │       │     },
-    │       │     "system": "You must inspect live weather via the provided get_weather tool before responding.",
     │       │     "temperature": 0,
     │       │     "tools": [
     │       │       {
@@ -2372,7 +2102,6 @@ span_tree:
     │       │       "id": "<span:1>"
     │       │     },
     │       │     "usage": {
-    │       │       "cachedInputTokens": 0,
     │       │       "inputTokenDetails": {
     │       │         "cacheReadTokens": 0,
     │       │         "noCacheTokens": 172
@@ -2393,7 +2122,6 @@ span_tree:
     │       │           "reasoning_tokens": 0
     │       │         }
     │       │       },
-    │       │       "reasoningTokens": 0,
     │       │       "totalTokens": 180
     │       │     }
     │       │   }
@@ -2406,11 +2134,9 @@ span_tree:
     │       │     "provider": "openai.responses"
     │       │   }
     │       │   metrics: {
-    │       │     "completion_reasoning_tokens": 0,
     │       │     "completion_tokens": 8,
     │       │     "prompt_cached_tokens": 0,
     │       │     "prompt_tokens": 172,
-    │       │     "reasoning_tokens": 0,
     │       │     "tokens": 180
     │       │   }
     │       ├── get_weather [tool]
@@ -2425,9 +2151,6 @@ span_tree:
     │       │     },
     │       │     "toolCallId": "<toolCallId:1>",
     │       │     "toolName": "get_weather"
-    │       │   }
-    │       │   metrics: {
-    │       │     "duration_ms": 0
     │       │   }
     │       ├── doGenerate [llm]
     │       │   input: {
@@ -2553,7 +2276,6 @@ span_tree:
     │       │       "modelId": "gpt-4o-mini-2024-07-18",
     │       │       "provider": "openai.responses"
     │       │     },
-    │       │     "system": "You must inspect live weather via the provided get_weather tool before responding.",
     │       │     "temperature": 0,
     │       │     "tools": [
     │       │       {
@@ -2598,7 +2320,6 @@ span_tree:
     │       │       "id": "<span:1>"
     │       │     },
     │       │     "usage": {
-    │       │       "cachedInputTokens": 0,
     │       │       "inputTokenDetails": {
     │       │         "cacheReadTokens": 0,
     │       │         "noCacheTokens": 211
@@ -2619,7 +2340,6 @@ span_tree:
     │       │           "reasoning_tokens": 0
     │       │         }
     │       │       },
-    │       │       "reasoningTokens": 0,
     │       │       "totalTokens": 219
     │       │     }
     │       │   }
@@ -2632,11 +2352,9 @@ span_tree:
     │       │     "provider": "openai.responses"
     │       │   }
     │       │   metrics: {
-    │       │     "completion_reasoning_tokens": 0,
     │       │     "completion_tokens": 8,
     │       │     "prompt_cached_tokens": 0,
     │       │     "prompt_tokens": 211,
-    │       │     "reasoning_tokens": 0,
     │       │     "tokens": 219
     │       │   }
     │       └── get_weather [tool]
@@ -2652,9 +2370,6 @@ span_tree:
     │             "toolCallId": "<toolCallId:1>",
     │             "toolName": "get_weather"
     │           }
-    │           metrics: {
-    │             "duration_ms": 0
-    │           }
     ├── ai-sdk-generate-object-operation
     │   metadata: {
     │     "operation": "generate-object",
@@ -2663,7 +2378,7 @@ span_tree:
     │   └── generateObject [function]
     │       input: {
     │         "headers": {
-    │           "user-agent": "ai/7.0.0-beta.116"
+    │           "user-agent": "ai/7.0.0"
     │         },
     │         "maxOutputTokens": 32,
     │         "maxRetries": 2,
@@ -2707,7 +2422,6 @@ span_tree:
     │           "timestamp": "<timestamp>"
     │         },
     │         "usage": {
-    │           "cachedInputTokens": 0,
     │           "inputTokenDetails": {
     │             "cacheReadTokens": 0,
     │             "noCacheTokens": 38
@@ -2728,7 +2442,6 @@ span_tree:
     │               "reasoning_tokens": 0
     │             }
     │           },
-    │           "reasoningTokens": 0,
     │           "totalTokens": 44
     │         },
     │         "warnings": []
@@ -2772,7 +2485,6 @@ span_tree:
     │             },
     │             "text": "{\"city\":\"Paris\"}",
     │             "usage": {
-    │               "cachedInputTokens": 0,
     │               "inputTokenDetails": {
     │                 "cacheReadTokens": 0,
     │                 "noCacheTokens": 38
@@ -2793,7 +2505,6 @@ span_tree:
     │                   "reasoning_tokens": 0
     │                 }
     │               },
-    │               "reasoningTokens": 0,
     │               "totalTokens": 44
     │             },
     │             "warnings": []
@@ -2807,11 +2518,9 @@ span_tree:
     │             "provider": "openai.responses"
     │           }
     │           metrics: {
-    │             "completion_reasoning_tokens": 0,
     │             "completion_tokens": 6,
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 38,
-    │             "reasoning_tokens": 0,
     │             "tokens": 44
     │           }
     └── ai-sdk-stream-object-operation
@@ -2862,7 +2571,6 @@ span_tree:
                 "timestamp": "<timestamp>"
               },
               "usage": {
-                "cachedInputTokens": 0,
                 "inputTokenDetails": {
                   "cacheReadTokens": 0,
                   "noCacheTokens": 38
@@ -2883,7 +2591,6 @@ span_tree:
                     "reasoning_tokens": 0
                   }
                 },
-                "reasoningTokens": 0,
                 "totalTokens": 44
               },
               "warnings": []
@@ -2926,7 +2633,6 @@ span_tree:
                   },
                   "text": "{\"city\":\"Paris\"}",
                   "usage": {
-                    "cachedInputTokens": 0,
                     "inputTokenDetails": {
                       "cacheReadTokens": 0,
                       "noCacheTokens": 38
@@ -2947,7 +2653,6 @@ span_tree:
                         "reasoning_tokens": 0
                       }
                     },
-                    "reasoningTokens": 0,
                     "totalTokens": 44
                   },
                   "warnings": []
@@ -2961,10 +2666,8 @@ span_tree:
                   "provider": "openai.responses"
                 }
                 metrics: {
-                  "completion_reasoning_tokens": 0,
                   "completion_tokens": 6,
                   "prompt_cached_tokens": 0,
                   "prompt_tokens": 38,
-                  "reasoning_tokens": 0,
                   "tokens": 44
                 }

--- a/e2e/scenarios/ai-sdk-instrumentation/assertions.ts
+++ b/e2e/scenarios/ai-sdk-instrumentation/assertions.ts
@@ -535,7 +535,7 @@ function normalizeAISDKSnapshotValue(value: unknown): unknown {
       continue;
     }
 
-    if (key === "stepNumber") {
+    if (key === "performance" || key === "stepNumber") {
       continue;
     }
 
@@ -1251,7 +1251,10 @@ export function defineAISDKInstrumentationAssertions(options: {
 
     test("matches the shared span tree snapshot", testConfig, async () => {
       await matchSpanTreeSnapshot(events, spanSnapshotPath, {
-        normalize: { additionalProviderIdKeys: ["callId"] },
+        normalize: {
+          additionalProviderIdKeys: ["callId"],
+          omittedKeys: ["performance"],
+        },
       });
     });
   });

--- a/e2e/scenarios/ai-sdk-instrumentation/package.json
+++ b/e2e/scenarios/ai-sdk-instrumentation/package.json
@@ -17,7 +17,7 @@
         "ai-sdk-v4": "ai@4",
         "ai-sdk-v5": "ai@5",
         "ai-sdk-v6": "ai@6",
-        "ai-sdk-v7": "ai@7.0.0-beta.116"
+        "ai-sdk-v7": "ai@7.0.0"
       }
     }
   },
@@ -35,7 +35,7 @@
     "ai-sdk-v4": "npm:ai@4.3.19",
     "ai-sdk-v5": "npm:ai@5.0.82",
     "ai-sdk-v6": "npm:ai@6.0.1",
-    "ai-sdk-v7": "npm:ai@7.0.0-beta.116",
+    "ai-sdk-v7": "npm:ai@7.0.0",
     "zod": "3.25.76"
   },
   "pnpm": {

--- a/e2e/scenarios/ai-sdk-instrumentation/pnpm-lock.yaml
+++ b/e2e/scenarios/ai-sdk-instrumentation/pnpm-lock.yaml
@@ -53,8 +53,8 @@ importers:
         specifier: npm:ai@6.0.1
         version: ai@6.0.1(zod@3.25.76)
       ai-sdk-v7:
-        specifier: npm:ai@7.0.0-beta.116
-        version: ai@7.0.0-beta.116(zod@3.25.76)
+        specifier: npm:ai@7.0.0
+        version: ai@7.0.0(zod@3.25.76)
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -97,9 +97,9 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@4.0.0-beta.67':
-    resolution: {integrity: sha512-qG1a0wwjLL+oVI1LOdpEs74PRl3yNPF5i0CgiuXTbU0Bb+JyUFuSwCJiQvlsIylu/mNpav3Mb+ODj15EF6/NZA==}
-    engines: {node: '>=18'}
+  '@ai-sdk/gateway@4.0.0':
+    resolution: {integrity: sha512-rcKukspbM4h511ot2E8TsPl7rXjRK1zHKrMCP7w4+XF55UKqQHaDzo2kKbGv5rp8Bjb1yQatIHJZE1E2yrOOMw==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -199,6 +199,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@5.0.0':
+    resolution: {integrity: sha512-zj66M02jc6ASYwIgWZowsooDUwaVngeNZQ3H10GwcPMZ+KR6gHMhcUuKl6tkai+JPXTKDyHY1pnszuxRtw2D4A==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@5.0.0-beta.30':
     resolution: {integrity: sha512-X3AxTsFJZr9Mw32SncWJA4/ShU8NA/XjhoallCYdcdQZ2gZZ/cIDyJJ6pNh1aBhicRNHv2ndgI6w/H2NGNIjOA==}
     engines: {node: '>=18'}
@@ -240,6 +246,10 @@ packages:
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
+
+  '@ai-sdk/provider@4.0.0':
+    resolution: {integrity: sha512-fr9Gs89prDWiuox/T+kCA+i2cJkHpxU5S+tr4megjTzRC27ZsvFhwjU/+XrqqMbvBUlfmXxTOYWy8ng45dsjIg==}
+    engines: {node: '>=22'}
 
   '@ai-sdk/provider@4.0.0-beta.14':
     resolution: {integrity: sha512-SMijtjVHs38n0dMkTcNuGrnStiF76OhAqS0R+ZX4iXUnuPPyTxQoVcF8Xuf2AoBB5rqndTId5FVT05bgqD5KsA==}
@@ -455,9 +465,9 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  ai@7.0.0-beta.116:
-    resolution: {integrity: sha512-xLVY+YU0sKmQ7zVU6y/6vCFn7o8HHNNgGTK789rqxxmcwSIau/RsmoCzXp/1c6sppA+PU6i4Uh5aCwFAQmjwEA==}
-    engines: {node: '>=18'}
+  ai@7.0.0:
+    resolution: {integrity: sha512-hncs+jamJh8r36K6G8xky7oF4Ai/RLU5TF85FMzI2vElyMJGGnLoHihpdmuDiuY2BsktDWHevKaJM1l0VcRLGw==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -651,10 +661,10 @@ snapshots:
       '@vercel/oidc': 3.0.5
       zod: 3.25.76
 
-  '@ai-sdk/gateway@4.0.0-beta.67(zod@3.25.76)':
+  '@ai-sdk/gateway@4.0.0(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0-beta.14
-      '@ai-sdk/provider-utils': 5.0.0-beta.30(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@3.25.76)
       '@vercel/oidc': 3.2.0
       zod: 3.25.76
 
@@ -762,6 +772,14 @@ snapshots:
       eventsource-parser: 3.0.8
       zod: 3.25.76
 
+  '@ai-sdk/provider-utils@5.0.0(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.0
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.0.8
+      zod: 3.25.76
+
   '@ai-sdk/provider-utils@5.0.0-beta.30(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 4.0.0-beta.14
@@ -803,6 +821,10 @@ snapshots:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.8':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@4.0.0':
     dependencies:
       json-schema: 0.4.0
 
@@ -1036,11 +1058,11 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 
-  ai@7.0.0-beta.116(zod@3.25.76):
+  ai@7.0.0(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 4.0.0-beta.67(zod@3.25.76)
-      '@ai-sdk/provider': 4.0.0-beta.14
-      '@ai-sdk/provider-utils': 5.0.0-beta.30(zod@3.25.76)
+      '@ai-sdk/gateway': 4.0.0(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@3.25.76)
       zod: 3.25.76
 
   aria-query@5.3.1: {}

--- a/js/src/instrumentation/plugins/ai-sdk-plugin.test.ts
+++ b/js/src/instrumentation/plugins/ai-sdk-plugin.test.ts
@@ -4,6 +4,7 @@ const telemetryMocks = vi.hoisted(() => ({
   braintrustAISDKTelemetry: vi.fn(),
   telemetry: {} as {
     executeTool?: ReturnType<typeof vi.fn>;
+    onEnd?: ReturnType<typeof vi.fn>;
     onStart?: ReturnType<typeof vi.fn>;
   },
 }));
@@ -44,6 +45,7 @@ describe("AISDKPlugin", () => {
     mockChannels.clear();
     telemetryMocks.telemetry = {
       executeTool: vi.fn(({ execute }) => execute()),
+      onEnd: vi.fn(),
       onStart: vi.fn(),
     };
     telemetryMocks.braintrustAISDKTelemetry.mockReturnValue(
@@ -124,11 +126,13 @@ describe("AISDKPlugin", () => {
 
   describe("AI SDK v7 telemetry dispatcher", () => {
     it("patches dispatcher callbacks through the standard channel", async () => {
+      const existingOnEnd = vi.fn();
       const existingOnStart = vi.fn();
       const originalExecute = vi.fn(async () => "done");
       const existingExecuteTool = vi.fn(({ execute }) => execute());
       const dispatcher = {
         executeTool: existingExecuteTool,
+        onEnd: existingOnEnd,
         onStart: existingOnStart,
       };
 
@@ -150,6 +154,16 @@ describe("AISDKPlugin", () => {
       });
       expect(existingOnStart).toHaveBeenCalledTimes(1);
       expect(telemetryMocks.telemetry.onStart).toHaveBeenCalledWith({
+        callId: "call-1",
+        operationId: "ai.generateText",
+      });
+
+      await dispatcher.onEnd({
+        callId: "call-1",
+        operationId: "ai.generateText",
+      });
+      expect(existingOnEnd).toHaveBeenCalledTimes(1);
+      expect(telemetryMocks.telemetry.onEnd).toHaveBeenCalledWith({
         callId: "call-1",
         operationId: "ai.generateText",
       });

--- a/js/src/instrumentation/plugins/ai-sdk-plugin.ts
+++ b/js/src/instrumentation/plugins/ai-sdk-plugin.ts
@@ -89,12 +89,12 @@ const AI_SDK_V7_TELEMETRY_CALLBACKS = [
   "onChunk",
   "onStepFinish",
   "onObjectStepStart",
-  "onObjectStepFinish",
+  "onObjectStepEnd",
   "onEmbedStart",
-  "onEmbedFinish",
+  "onEmbedEnd",
   "onRerankStart",
-  "onRerankFinish",
-  "onFinish",
+  "onRerankEnd",
+  "onEnd",
   "onError",
 ] as const;
 

--- a/js/src/instrumentation/plugins/ai-sdk-v7-telemetry.test.ts
+++ b/js/src/instrumentation/plugins/ai-sdk-v7-telemetry.test.ts
@@ -30,6 +30,160 @@ describe("braintrustAISDKTelemetry", () => {
     _exportsForTestingOnly.clearTestBackgroundLogger();
   });
 
+  it("logs operations from AI SDK v7 end-family callbacks", async () => {
+    const telemetry = braintrustAISDKTelemetry();
+
+    expect(telemetry.onEnd).toEqual(expect.any(Function));
+    expect(telemetry.onEmbedEnd).toEqual(expect.any(Function));
+    expect(telemetry.onObjectStepEnd).toEqual(expect.any(Function));
+    expect(telemetry.onRerankEnd).toEqual(expect.any(Function));
+
+    telemetry.onStart?.({
+      callId: "call-v7-end",
+      operationId: "ai.streamText",
+      provider: "openai",
+      modelId: "gpt-4.1-mini",
+      messages: [{ role: "user", content: "Reply with OK." }],
+    });
+    telemetry.onLanguageModelCallStart?.({
+      callId: "call-v7-end",
+      provider: "openai",
+      modelId: "gpt-4.1-mini",
+      prompt: [{ role: "user", content: "Reply with OK." }],
+    });
+    telemetry.onLanguageModelCallEnd?.({
+      callId: "call-v7-end",
+      performance: {
+        timeToFirstOutputMs: 250,
+      },
+      provider: "openai",
+      modelId: "gpt-4.1-mini",
+      text: "OK",
+      usage: {
+        inputTokens: 6,
+        outputTokens: 1,
+        totalTokens: 7,
+      },
+    });
+    telemetry.onEnd?.({
+      callId: "call-v7-end",
+      operationId: "ai.streamText",
+      text: "OK",
+    });
+
+    telemetry.onStart?.({
+      callId: "object-v7-end",
+      operationId: "ai.generateObject",
+      provider: "openai",
+      modelId: "gpt-4.1-mini",
+    });
+    telemetry.onObjectStepStart?.({
+      callId: "object-v7-end",
+      provider: "openai",
+      modelId: "gpt-4.1-mini",
+      promptMessages: [{ role: "user", content: "Return JSON." }],
+    });
+    telemetry.onObjectStepEnd?.({
+      callId: "object-v7-end",
+      objectText: '{"answer":"OK"}',
+      usage: {
+        inputTokens: 6,
+        outputTokens: 4,
+        totalTokens: 10,
+      },
+    });
+    telemetry.onEnd?.({
+      callId: "object-v7-end",
+      operationId: "ai.generateObject",
+      object: { answer: "OK" },
+    });
+
+    telemetry.onStart?.({
+      callId: "embed-v7-end",
+      operationId: "ai.embed",
+      provider: "openai",
+      modelId: "text-embedding-3-small",
+      value: "hello",
+    });
+    telemetry.onEmbedStart?.({
+      callId: "embed-v7-end",
+      embedCallId: "embed-child-v7-end",
+      operationId: "ai.embed.doEmbed",
+      provider: "openai",
+      modelId: "text-embedding-3-small",
+      values: ["hello"],
+    });
+    telemetry.onEmbedEnd?.({
+      callId: "embed-v7-end",
+      embedCallId: "embed-child-v7-end",
+      operationId: "ai.embed.doEmbed",
+      embeddings: [[0.1, 0.2]],
+      usage: { tokens: 3 },
+    });
+    telemetry.onEnd?.({
+      callId: "embed-v7-end",
+      operationId: "ai.embed",
+      embedding: [0.1, 0.2],
+    });
+
+    telemetry.onStart?.({
+      callId: "rerank-v7-end",
+      operationId: "ai.rerank",
+      provider: "cohere",
+      modelId: "rerank-v3.5",
+      documents: ["alpha", "beta"],
+      query: "alpha",
+    });
+    telemetry.onRerankStart?.({
+      callId: "rerank-v7-end",
+      provider: "cohere",
+      modelId: "rerank-v3.5",
+      documents: ["alpha", "beta"],
+      query: "alpha",
+    });
+    telemetry.onRerankEnd?.({
+      callId: "rerank-v7-end",
+      ranking: [{ index: 0, relevanceScore: 0.9 }],
+    });
+    telemetry.onEnd?.({
+      callId: "rerank-v7-end",
+      operationId: "ai.rerank",
+      ranking: [{ originalIndex: 0, score: 0.9 }],
+    });
+
+    const spans = (await backgroundLogger.drain()) as Array<
+      Record<string, any>
+    >;
+
+    expect(
+      spans.find((span) => span.span_attributes?.name === "streamText"),
+    ).toMatchObject({
+      metrics: { time_to_first_token: 0.25 },
+      output: { text: "OK" },
+    });
+    expect(
+      spans.find((span) => span.span_attributes?.name === "generateObject"),
+    ).toMatchObject({ output: { object: { answer: "OK" } } });
+    expect(
+      spans.find((span) => span.span_attributes?.name === "embed"),
+    ).toMatchObject({ output: { embedding_length: 2 } });
+    expect(
+      spans.find((span) => span.span_attributes?.name === "rerank"),
+    ).toMatchObject({ output: [{ index: 0, relevance_score: 0.9 }] });
+    expect(
+      spans.find((span) => span.span_attributes?.name === "doStream"),
+    ).toMatchObject({ output: { text: "OK" } });
+    expect(
+      spans.find((span) => span.span_attributes?.name === "doGenerate"),
+    ).toMatchObject({ output: { text: '{"answer":"OK"}' } });
+    expect(
+      spans.find((span) => span.span_attributes?.name === "doEmbed"),
+    ).toMatchObject({ output: { embedding_count: 1, embedding_length: 2 } });
+    expect(
+      spans.find((span) => span.span_attributes?.name === "doRerank"),
+    ).toMatchObject({ output: [{ index: 0, relevance_score: 0.9 }] });
+  });
+
   it("logs a generateText operation and model call", async () => {
     const telemetry = braintrustAISDKTelemetry();
 
@@ -58,7 +212,7 @@ describe("braintrustAISDKTelemetry", () => {
         totalTokens: 7,
       },
     });
-    telemetry.onFinish?.({
+    telemetry.onEnd?.({
       callId: "call-1",
       operationId: "ai.generateText",
       text: "OK",
@@ -121,7 +275,7 @@ describe("braintrustAISDKTelemetry", () => {
       recordInputs: false,
       messages: [{ role: "user", content: "hidden" }],
     });
-    telemetry.onFinish?.({
+    telemetry.onEnd?.({
       callId: "call-2",
       operationId: "ai.generateText",
       recordOutputs: false,
@@ -208,14 +362,14 @@ describe("braintrustAISDKTelemetry", () => {
     );
 
     telemetry.onLanguageModelCallEnd?.({ callId, text: "late" });
-    telemetry.onObjectStepFinish?.({ callId, objectText: "{}" });
-    telemetry.onEmbedFinish?.({
+    telemetry.onObjectStepEnd?.({ callId, objectText: "{}" });
+    telemetry.onEmbedEnd?.({
       callId,
       embedCallId: "embed-error",
       operationId: "ai.embed",
       embeddings: [[0.1]],
     });
-    telemetry.onRerankFinish?.({
+    telemetry.onRerankEnd?.({
       callId,
       ranking: [{ index: 0, relevanceScore: 1 }],
     });
@@ -224,7 +378,7 @@ describe("braintrustAISDKTelemetry", () => {
       toolCall: { toolCallId: "tool-error", toolName: "lookupWeather" },
       toolOutput: { type: "tool-result", output: "late" },
     });
-    telemetry.onFinish?.({
+    telemetry.onEnd?.({
       callId,
       operationId: "ai.streamText",
       text: "late",
@@ -252,7 +406,7 @@ describe("braintrustAISDKTelemetry", () => {
       callId: "stream-retry",
       text: "OK",
     });
-    telemetry.onFinish?.({
+    telemetry.onEnd?.({
       callId: "stream-retry",
       operationId: "ai.streamText",
       text: "OK",
@@ -274,13 +428,13 @@ describe("braintrustAISDKTelemetry", () => {
       operationId: "ai.embed.doEmbed",
       values: ["retry embed attempt"],
     });
-    telemetry.onEmbedFinish?.({
+    telemetry.onEmbedEnd?.({
       callId: "embed-retry",
       embedCallId: "embed-attempt-2",
       operationId: "ai.embed.doEmbed",
       embeddings: [[0.1]],
     });
-    telemetry.onFinish?.({
+    telemetry.onEnd?.({
       callId: "embed-retry",
       operationId: "ai.embed",
       embedding: [0.1],
@@ -300,11 +454,11 @@ describe("braintrustAISDKTelemetry", () => {
       documents: ["retry rerank attempt"],
       query: "retry",
     });
-    telemetry.onRerankFinish?.({
+    telemetry.onRerankEnd?.({
       callId: "rerank-retry",
       ranking: [{ index: 0, relevanceScore: 1 }],
     });
-    telemetry.onFinish?.({
+    telemetry.onEnd?.({
       callId: "rerank-retry",
       operationId: "ai.rerank",
       ranking: [{ originalIndex: 0, score: 1 }],
@@ -398,7 +552,7 @@ describe("braintrustAISDKTelemetry", () => {
         output: { temperature: 21 },
       },
     });
-    telemetry.onFinish?.({
+    telemetry.onEnd?.({
       callId: "call-3",
       operationId: "ai.generateText",
       text: "It is 21 C.",

--- a/js/src/vendor-sdk-types/ai-sdk-v7-telemetry.ts
+++ b/js/src/vendor-sdk-types/ai-sdk-v7-telemetry.ts
@@ -147,13 +147,13 @@ export interface AISDKV7Telemetry {
   onObjectStepStart?: (
     event: AISDKV7ObjectStepStartEvent,
   ) => void | PromiseLike<void>;
-  onObjectStepFinish?: (
+  onObjectStepEnd?: (
     event: AISDKV7ObjectStepEndEvent,
   ) => void | PromiseLike<void>;
   onEmbedStart?: (event: AISDKV7EmbedStartEvent) => void | PromiseLike<void>;
-  onEmbedFinish?: (event: AISDKV7EmbedEndEvent) => void | PromiseLike<void>;
+  onEmbedEnd?: (event: AISDKV7EmbedEndEvent) => void | PromiseLike<void>;
   onRerankStart?: (event: AISDKV7RerankStartEvent) => void | PromiseLike<void>;
-  onRerankFinish?: (event: AISDKV7RerankEndEvent) => void | PromiseLike<void>;
+  onRerankEnd?: (event: AISDKV7RerankEndEvent) => void | PromiseLike<void>;
   onToolExecutionStart?: (
     event: AISDKV7ToolExecutionStartEvent,
   ) => void | PromiseLike<void>;
@@ -162,7 +162,7 @@ export interface AISDKV7Telemetry {
   ) => void | PromiseLike<void>;
   onChunk?: (event: AISDKV7ChunkEvent) => void | PromiseLike<void>;
   onStepFinish?: (event: unknown) => void | PromiseLike<void>;
-  onFinish?: (event: AISDKV7OperationEvent) => void | PromiseLike<void>;
+  onEnd?: (event: AISDKV7OperationEvent) => void | PromiseLike<void>;
   onError?: (event: unknown) => void | PromiseLike<void>;
   executeTool?: <T>(options: {
     callId: string;

--- a/js/src/wrappers/ai-sdk/telemetry.ts
+++ b/js/src/wrappers/ai-sdk/telemetry.ts
@@ -86,6 +86,122 @@ export function braintrustAISDKTelemetry(): AISDKV7Telemetry {
     return span;
   };
 
+  const onObjectStepEnd = (
+    event: Parameters<NonNullable<AISDKV7Telemetry["onObjectStepEnd"]>>[0],
+  ) => {
+    runSafely("onObjectStepEnd", () => {
+      const span = objectSpans.get(event.callId);
+      if (!span) {
+        return;
+      }
+
+      const result = {
+        ...event,
+        text: event.objectText,
+      } as AISDKResult;
+      span.log({
+        ...(shouldRecordOutputs(event)
+          ? {
+              output: processAISDKOutput(result, DEFAULT_DENY_OUTPUT_PATHS),
+            }
+          : {}),
+        metrics: extractTokenMetrics(result),
+      });
+      span.end();
+      objectSpans.delete(event.callId);
+    });
+  };
+
+  const onEmbedEnd = (
+    event: Parameters<NonNullable<AISDKV7Telemetry["onEmbedEnd"]>>[0],
+  ) => {
+    runSafely("onEmbedEnd", () => {
+      const state = embedSpans.get(event.embedCallId);
+      if (!state) {
+        return;
+      }
+
+      const result = {
+        ...event,
+        embeddings: event.embeddings,
+      } as AISDKEmbeddingResult;
+      state.span.log({
+        ...(shouldRecordOutputs(event)
+          ? {
+              output: processAISDKEmbeddingOutput(
+                result,
+                DEFAULT_DENY_OUTPUT_PATHS,
+              ),
+            }
+          : {}),
+        metrics: extractTokenMetrics(result),
+      });
+      state.span.end();
+      embedSpans.delete(event.embedCallId);
+    });
+  };
+
+  const onRerankEnd = (
+    event: Parameters<NonNullable<AISDKV7Telemetry["onRerankEnd"]>>[0],
+  ) => {
+    runSafely("onRerankEnd", () => {
+      const span = rerankSpans.get(event.callId);
+      if (!span) {
+        return;
+      }
+
+      const result = {
+        ranking: event.ranking?.map((entry) => ({
+          originalIndex: entry.index,
+          score: entry.relevanceScore,
+        })),
+      } as AISDKRerankResult;
+      span.log({
+        ...(shouldRecordOutputs(event)
+          ? {
+              output: processAISDKRerankOutput(
+                result,
+                DEFAULT_DENY_OUTPUT_PATHS,
+              ),
+            }
+          : {}),
+      });
+      span.end();
+      rerankSpans.delete(event.callId);
+    });
+  };
+
+  const onEnd = (
+    event: Parameters<NonNullable<AISDKV7Telemetry["onEnd"]>>[0],
+  ) => {
+    runSafely("onEnd", () => {
+      const state = operations.get(event.callId);
+      if (!state) {
+        return;
+      }
+
+      const result = finishResult(event, state.operationName);
+      const metrics: Record<string, number> = state.hadModelChild
+        ? {}
+        : extractTokenMetrics(result);
+      const timeToFirstToken = extractTimeToFirstToken(result, state);
+      if (timeToFirstToken !== undefined) {
+        metrics.time_to_first_token = timeToFirstToken;
+      }
+
+      state.span.log({
+        ...(shouldRecordOutputs(event)
+          ? {
+              output: finishOutput(result, state.operationName),
+            }
+          : {}),
+        metrics,
+      });
+      state.span.end();
+      operations.delete(event.callId);
+    });
+  };
+
   return {
     onStart(event) {
       runSafely("onStart", () => {
@@ -175,6 +291,16 @@ export function braintrustAISDKTelemetry(): AISDKV7Telemetry {
           return;
         }
 
+        const state = operations.get(event.callId);
+        const timeToFirstOutputMs = safePerformance(event)?.timeToFirstOutputMs;
+        if (
+          state?.operationName === "streamText" &&
+          state.firstChunkTime === undefined &&
+          typeof timeToFirstOutputMs === "number"
+        ) {
+          state.firstChunkTime = state.startTime + timeToFirstOutputMs / 1000;
+        }
+
         const result = {
           ...event,
           response: event.responseId ? { id: event.responseId } : undefined,
@@ -219,29 +345,7 @@ export function braintrustAISDKTelemetry(): AISDKV7Telemetry {
       });
     },
 
-    onObjectStepFinish(event) {
-      runSafely("onObjectStepFinish", () => {
-        const span = objectSpans.get(event.callId);
-        if (!span) {
-          return;
-        }
-
-        const result = {
-          ...event,
-          text: event.objectText,
-        } as AISDKResult;
-        span.log({
-          ...(shouldRecordOutputs(event)
-            ? {
-                output: processAISDKOutput(result, DEFAULT_DENY_OUTPUT_PATHS),
-              }
-            : {}),
-          metrics: extractTokenMetrics(result),
-        });
-        span.end();
-        objectSpans.delete(event.callId);
-      });
-    },
+    onObjectStepEnd,
 
     onEmbedStart(event) {
       runSafely("onEmbedStart", () => {
@@ -280,32 +384,7 @@ export function braintrustAISDKTelemetry(): AISDKV7Telemetry {
       });
     },
 
-    onEmbedFinish(event) {
-      runSafely("onEmbedFinish", () => {
-        const state = embedSpans.get(event.embedCallId);
-        if (!state) {
-          return;
-        }
-
-        const result = {
-          ...event,
-          embeddings: event.embeddings,
-        } as AISDKEmbeddingResult;
-        state.span.log({
-          ...(shouldRecordOutputs(event)
-            ? {
-                output: processAISDKEmbeddingOutput(
-                  result,
-                  DEFAULT_DENY_OUTPUT_PATHS,
-                ),
-              }
-            : {}),
-          metrics: extractTokenMetrics(result),
-        });
-        state.span.end();
-        embedSpans.delete(event.embedCallId);
-      });
-    },
+    onEmbedEnd,
 
     onRerankStart(event) {
       runSafely("onRerankStart", () => {
@@ -336,33 +415,7 @@ export function braintrustAISDKTelemetry(): AISDKV7Telemetry {
       });
     },
 
-    onRerankFinish(event) {
-      runSafely("onRerankFinish", () => {
-        const span = rerankSpans.get(event.callId);
-        if (!span) {
-          return;
-        }
-
-        const result = {
-          ranking: event.ranking?.map((entry) => ({
-            originalIndex: entry.index,
-            score: entry.relevanceScore,
-          })),
-        } as AISDKRerankResult;
-        span.log({
-          ...(shouldRecordOutputs(event)
-            ? {
-                output: processAISDKRerankOutput(
-                  result,
-                  DEFAULT_DENY_OUTPUT_PATHS,
-                ),
-              }
-            : {}),
-        });
-        span.end();
-        rerankSpans.delete(event.callId);
-      });
-    },
+    onRerankEnd,
 
     onToolExecutionStart(event) {
       runSafely("onToolExecutionStart", () => {
@@ -444,33 +497,7 @@ export function braintrustAISDKTelemetry(): AISDKV7Telemetry {
       });
     },
 
-    onFinish(event) {
-      runSafely("onFinish", () => {
-        const state = operations.get(event.callId);
-        if (!state) {
-          return;
-        }
-
-        const result = finishResult(event, state.operationName);
-        const metrics: Record<string, number> = state.hadModelChild
-          ? {}
-          : extractTokenMetrics(result);
-        if (state.firstChunkTime !== undefined) {
-          metrics.time_to_first_token = state.firstChunkTime - state.startTime;
-        }
-
-        state.span.log({
-          ...(shouldRecordOutputs(event)
-            ? {
-                output: finishOutput(result, state.operationName),
-              }
-            : {}),
-          metrics,
-        });
-        state.span.end();
-        operations.delete(event.callId);
-      });
-    },
+    onEnd,
 
     onError(event) {
       runSafely("onError", () => {
@@ -673,6 +700,45 @@ function finishResult(
   }
 
   return event as AISDKResult;
+}
+
+function extractTimeToFirstToken(
+  result: AISDKResult | AISDKEmbeddingResult | AISDKRerankResult,
+  state: OperationState,
+): number | undefined {
+  if (state.firstChunkTime !== undefined) {
+    return state.firstChunkTime - state.startTime;
+  }
+
+  const performanceCandidates = [
+    safePerformance(result),
+    safePerformance((result as { finalStep?: unknown }).finalStep),
+    ...(Array.isArray((result as { steps?: unknown }).steps)
+      ? ((result as { steps: unknown[] }).steps ?? []).map(safePerformance)
+      : []),
+  ];
+
+  for (const performance of performanceCandidates) {
+    const timeToFirstOutputMs = performance?.timeToFirstOutputMs;
+    if (typeof timeToFirstOutputMs === "number") {
+      return timeToFirstOutputMs / 1000;
+    }
+  }
+
+  return undefined;
+}
+
+function safePerformance(
+  value: unknown,
+): { timeToFirstOutputMs?: unknown } | undefined {
+  if (!isObject(value)) {
+    return undefined;
+  }
+
+  const performance = (value as { performance?: unknown }).performance;
+  return isObject(performance)
+    ? (performance as { timeToFirstOutputMs?: unknown })
+    : undefined;
 }
 
 function finishOutput(


### PR DESCRIPTION
AI SDK 7 registerTelemetry dispatches completion events through onEnd, onEmbedEnd, onRerankEnd, and onObjectStepEnd. braintrustAISDKTelemetry was still exposing the older *Finish callback names, so those completion handlers were never invoked and successful generate/stream/embed/rerank parent spans could remain open indefinitely.

Switch the telemetry integration and auto-patched dispatcher to the stable AI SDK 7 callback names, derive stream TTFT from v7 model-call performance data, and run the AI SDK v7 e2e matrix against ai@7.0.0