### PR TITLE
Fix AI SDK token total metrics

### DIFF
--- a/.changeset/ai-sdk-token-total-metrics.md
+++ b/.changeset/ai-sdk-token-total-metrics.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+fix: Synthesize AI SDK total token metrics from prompt and completion counts

--- a/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v3-auto-hook.span-tree.json
+++ b/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v3-auto-hook.span-tree.json
@@ -68,7 +68,8 @@
                   },
                   "metrics": {
                     "completion_tokens": 2,
-                    "prompt_tokens": 18
+                    "prompt_tokens": 18,
+                    "tokens": 20
                   }
                 }
               ],
@@ -229,7 +230,8 @@
                   "metrics": {
                     "completion_tokens": null,
                     "prompt_tokens": null,
-                    "time_to_first_token": 0
+                    "time_to_first_token": 0,
+                    "tokens": null
                   }
                 }
               ],
@@ -414,7 +416,8 @@
                   },
                   "metrics": {
                     "completion_tokens": 16,
-                    "prompt_tokens": 87
+                    "prompt_tokens": 87,
+                    "tokens": 103
                   }
                 },
                 {
@@ -737,7 +740,8 @@
                   },
                   "metrics": {
                     "completion_tokens": 5,
-                    "prompt_tokens": 59
+                    "prompt_tokens": 59,
+                    "tokens": 64
                   }
                 }
               ],
@@ -887,7 +891,8 @@
                   "metrics": {
                     "completion_tokens": null,
                     "prompt_tokens": null,
-                    "time_to_first_token": 0
+                    "time_to_first_token": 0,
+                    "tokens": null
                   }
                 }
               ],

--- a/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v3-auto-hook.span-tree.txt
+++ b/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v3-auto-hook.span-tree.txt
@@ -163,7 +163,8 @@ span_tree:
     │           }
     │           metrics: {
     │             "completion_tokens": 2,
-    │             "prompt_tokens": 18
+    │             "prompt_tokens": 18,
+    │             "tokens": 20
     │           }
     ├── ai-sdk-stream-operation
     │   metadata: {
@@ -246,7 +247,8 @@ span_tree:
     │           metrics: {
     │             "completion_tokens": null,
     │             "prompt_tokens": null,
-    │             "time_to_first_token": 0
+    │             "time_to_first_token": 0,
+    │             "tokens": null
     │           }
     ├── ai-sdk-embed-operation
     │   metadata: {
@@ -588,7 +590,8 @@ span_tree:
     │       │   }
     │       │   metrics: {
     │       │     "completion_tokens": 16,
-    │       │     "prompt_tokens": 87
+    │       │     "prompt_tokens": 87,
+    │       │     "tokens": 103
     │       │   }
     │       └── get_weather [tool]
     │           input: [
@@ -744,7 +747,8 @@ span_tree:
     │           }
     │           metrics: {
     │             "completion_tokens": 5,
-    │             "prompt_tokens": 59
+    │             "prompt_tokens": 59,
+    │             "tokens": 64
     │           }
     └── ai-sdk-stream-object-operation
         metadata: {
@@ -867,5 +871,6 @@ span_tree:
                 metrics: {
                   "completion_tokens": null,
                   "prompt_tokens": null,
-                  "time_to_first_token": 0
+                  "time_to_first_token": 0,
+                  "tokens": null
                 }

--- a/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v3-wrapped.span-tree.json
+++ b/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v3-wrapped.span-tree.json
@@ -68,7 +68,8 @@
                   },
                   "metrics": {
                     "completion_tokens": 2,
-                    "prompt_tokens": 18
+                    "prompt_tokens": 18,
+                    "tokens": 20
                   }
                 }
               ],
@@ -229,7 +230,8 @@
                   "metrics": {
                     "completion_tokens": null,
                     "prompt_tokens": null,
-                    "time_to_first_token": 0
+                    "time_to_first_token": 0,
+                    "tokens": null
                   }
                 }
               ],
@@ -414,7 +416,8 @@
                   },
                   "metrics": {
                     "completion_tokens": 16,
-                    "prompt_tokens": 87
+                    "prompt_tokens": 87,
+                    "tokens": 103
                   }
                 },
                 {
@@ -737,7 +740,8 @@
                   },
                   "metrics": {
                     "completion_tokens": 5,
-                    "prompt_tokens": 59
+                    "prompt_tokens": 59,
+                    "tokens": 64
                   }
                 }
               ],
@@ -887,7 +891,8 @@
                   "metrics": {
                     "completion_tokens": null,
                     "prompt_tokens": null,
-                    "time_to_first_token": 0
+                    "time_to_first_token": 0,
+                    "tokens": null
                   }
                 }
               ],

--- a/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v3-wrapped.span-tree.txt
+++ b/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v3-wrapped.span-tree.txt
@@ -163,7 +163,8 @@ span_tree:
     │           }
     │           metrics: {
     │             "completion_tokens": 2,
-    │             "prompt_tokens": 18
+    │             "prompt_tokens": 18,
+    │             "tokens": 20
     │           }
     ├── ai-sdk-stream-operation
     │   metadata: {
@@ -246,7 +247,8 @@ span_tree:
     │           metrics: {
     │             "completion_tokens": null,
     │             "prompt_tokens": null,
-    │             "time_to_first_token": 0
+    │             "time_to_first_token": 0,
+    │             "tokens": null
     │           }
     ├── ai-sdk-embed-operation
     │   metadata: {
@@ -588,7 +590,8 @@ span_tree:
     │       │   }
     │       │   metrics: {
     │       │     "completion_tokens": 16,
-    │       │     "prompt_tokens": 87
+    │       │     "prompt_tokens": 87,
+    │       │     "tokens": 103
     │       │   }
     │       └── get_weather [tool]
     │           input: [
@@ -744,7 +747,8 @@ span_tree:
     │           }
     │           metrics: {
     │             "completion_tokens": 5,
-    │             "prompt_tokens": 59
+    │             "prompt_tokens": 59,
+    │             "tokens": 64
     │           }
     └── ai-sdk-stream-object-operation
         metadata: {
@@ -867,5 +871,6 @@ span_tree:
                 metrics: {
                   "completion_tokens": null,
                   "prompt_tokens": null,
-                  "time_to_first_token": 0
+                  "time_to_first_token": 0,
+                  "tokens": null
                 }

--- a/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v4-auto-hook.span-tree.json
+++ b/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v4-auto-hook.span-tree.json
@@ -105,7 +105,8 @@
                   },
                   "metrics": {
                     "completion_tokens": 2,
-                    "prompt_tokens": 18
+                    "prompt_tokens": 18,
+                    "tokens": 20
                   }
                 }
               ],
@@ -343,7 +344,8 @@
                   },
                   "metrics": {
                     "completion_tokens": 5,
-                    "prompt_tokens": 83
+                    "prompt_tokens": 83,
+                    "tokens": 88
                   }
                 }
               ],
@@ -546,7 +548,8 @@
                   "metrics": {
                     "completion_tokens": null,
                     "prompt_tokens": null,
-                    "time_to_first_token": 0
+                    "time_to_first_token": 0,
+                    "tokens": null
                   }
                 }
               ],
@@ -774,7 +777,8 @@
                   },
                   "metrics": {
                     "completion_tokens": 16,
-                    "prompt_tokens": 87
+                    "prompt_tokens": 87,
+                    "tokens": 103
                   }
                 },
                 {
@@ -1169,7 +1173,8 @@
                   },
                   "metrics": {
                     "completion_tokens": 5,
-                    "prompt_tokens": 59
+                    "prompt_tokens": 59,
+                    "tokens": 64
                   }
                 }
               ],
@@ -1325,7 +1330,8 @@
                   "metrics": {
                     "completion_tokens": null,
                     "prompt_tokens": null,
-                    "time_to_first_token": 0
+                    "time_to_first_token": 0,
+                    "tokens": null
                   }
                 }
               ],

--- a/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v4-auto-hook.span-tree.txt
+++ b/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v4-auto-hook.span-tree.txt
@@ -221,7 +221,8 @@ span_tree:
     │           }
     │           metrics: {
     │             "completion_tokens": 2,
-    │             "prompt_tokens": 18
+    │             "prompt_tokens": 18,
+    │             "tokens": 20
     │           }
     ├── ai-sdk-output-object-operation
     │   metadata: {
@@ -468,7 +469,8 @@ span_tree:
     │           }
     │           metrics: {
     │             "completion_tokens": 5,
-    │             "prompt_tokens": 83
+    │             "prompt_tokens": 83,
+    │             "tokens": 88
     │           }
     ├── ai-sdk-stream-operation
     │   metadata: {
@@ -546,7 +548,8 @@ span_tree:
     │           metrics: {
     │             "completion_tokens": null,
     │             "prompt_tokens": null,
-    │             "time_to_first_token": 0
+    │             "time_to_first_token": 0,
+    │             "tokens": null
     │           }
     ├── ai-sdk-embed-operation
     │   metadata: {
@@ -952,7 +955,8 @@ span_tree:
     │       │   }
     │       │   metrics: {
     │       │     "completion_tokens": 16,
-    │       │     "prompt_tokens": 87
+    │       │     "prompt_tokens": 87,
+    │       │     "tokens": 103
     │       │   }
     │       └── get_weather [tool]
     │           input: [
@@ -1170,7 +1174,8 @@ span_tree:
     │           }
     │           metrics: {
     │             "completion_tokens": 5,
-    │             "prompt_tokens": 59
+    │             "prompt_tokens": 59,
+    │             "tokens": 64
     │           }
     └── ai-sdk-stream-object-operation
         metadata: {
@@ -1288,5 +1293,6 @@ span_tree:
                 metrics: {
                   "completion_tokens": null,
                   "prompt_tokens": null,
-                  "time_to_first_token": 0
+                  "time_to_first_token": 0,
+                  "tokens": null
                 }

--- a/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v4-wrapped.span-tree.json
+++ b/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v4-wrapped.span-tree.json
@@ -105,7 +105,8 @@
                   },
                   "metrics": {
                     "completion_tokens": 2,
-                    "prompt_tokens": 18
+                    "prompt_tokens": 18,
+                    "tokens": 20
                   }
                 }
               ],
@@ -343,7 +344,8 @@
                   },
                   "metrics": {
                     "completion_tokens": 5,
-                    "prompt_tokens": 83
+                    "prompt_tokens": 83,
+                    "tokens": 88
                   }
                 }
               ],
@@ -546,7 +548,8 @@
                   "metrics": {
                     "completion_tokens": null,
                     "prompt_tokens": null,
-                    "time_to_first_token": 0
+                    "time_to_first_token": 0,
+                    "tokens": null
                   }
                 }
               ],
@@ -774,7 +777,8 @@
                   },
                   "metrics": {
                     "completion_tokens": 16,
-                    "prompt_tokens": 87
+                    "prompt_tokens": 87,
+                    "tokens": 103
                   }
                 },
                 {
@@ -1169,7 +1173,8 @@
                   },
                   "metrics": {
                     "completion_tokens": 5,
-                    "prompt_tokens": 59
+                    "prompt_tokens": 59,
+                    "tokens": 64
                   }
                 }
               ],
@@ -1325,7 +1330,8 @@
                   "metrics": {
                     "completion_tokens": null,
                     "prompt_tokens": null,
-                    "time_to_first_token": 0
+                    "time_to_first_token": 0,
+                    "tokens": null
                   }
                 }
               ],

--- a/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v4-wrapped.span-tree.txt
+++ b/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v4-wrapped.span-tree.txt
@@ -221,7 +221,8 @@ span_tree:
     │           }
     │           metrics: {
     │             "completion_tokens": 2,
-    │             "prompt_tokens": 18
+    │             "prompt_tokens": 18,
+    │             "tokens": 20
     │           }
     ├── ai-sdk-output-object-operation
     │   metadata: {
@@ -468,7 +469,8 @@ span_tree:
     │           }
     │           metrics: {
     │             "completion_tokens": 5,
-    │             "prompt_tokens": 83
+    │             "prompt_tokens": 83,
+    │             "tokens": 88
     │           }
     ├── ai-sdk-stream-operation
     │   metadata: {
@@ -546,7 +548,8 @@ span_tree:
     │           metrics: {
     │             "completion_tokens": null,
     │             "prompt_tokens": null,
-    │             "time_to_first_token": 0
+    │             "time_to_first_token": 0,
+    │             "tokens": null
     │           }
     ├── ai-sdk-embed-operation
     │   metadata: {
@@ -952,7 +955,8 @@ span_tree:
     │       │   }
     │       │   metrics: {
     │       │     "completion_tokens": 16,
-    │       │     "prompt_tokens": 87
+    │       │     "prompt_tokens": 87,
+    │       │     "tokens": 103
     │       │   }
     │       └── get_weather [tool]
     │           input: [
@@ -1170,7 +1174,8 @@ span_tree:
     │           }
     │           metrics: {
     │             "completion_tokens": 5,
-    │             "prompt_tokens": 59
+    │             "prompt_tokens": 59,
+    │             "tokens": 64
     │           }
     └── ai-sdk-stream-object-operation
         metadata: {
@@ -1288,5 +1293,6 @@ span_tree:
                 metrics: {
                   "completion_tokens": null,
                   "prompt_tokens": null,
-                  "time_to_first_token": 0
+                  "time_to_first_token": 0,
+                  "tokens": null
                 }

--- a/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v6-auto-hook.span-tree.json
+++ b/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v6-auto-hook.span-tree.json
@@ -101,7 +101,8 @@
                     "completion_tokens": 3,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 18,
-                    "reasoning_tokens": 0
+                    "reasoning_tokens": 0,
+                    "tokens": 21
                   }
                 }
               ],
@@ -422,7 +423,8 @@
                     "completion_tokens": 6,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 45,
-                    "reasoning_tokens": 0
+                    "reasoning_tokens": 0,
+                    "tokens": 51
                   }
                 }
               ],
@@ -716,7 +718,8 @@
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 22,
                     "reasoning_tokens": 0,
-                    "time_to_first_token": 0
+                    "time_to_first_token": 0,
+                    "tokens": 29
                   }
                 }
               ],
@@ -978,7 +981,8 @@
                     "completion_tokens": 8,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 94,
-                    "reasoning_tokens": 0
+                    "reasoning_tokens": 0,
+                    "tokens": 102
                   }
                 },
                 {
@@ -1158,7 +1162,8 @@
                     "completion_tokens": 8,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 133,
-                    "reasoning_tokens": 0
+                    "reasoning_tokens": 0,
+                    "tokens": 141
                   }
                 },
                 {
@@ -1412,7 +1417,8 @@
                     "completion_tokens": 8,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 172,
-                    "reasoning_tokens": 0
+                    "reasoning_tokens": 0,
+                    "tokens": 180
                   }
                 },
                 {
@@ -1740,7 +1746,8 @@
                     "completion_tokens": 8,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 211,
-                    "reasoning_tokens": 0
+                    "reasoning_tokens": 0,
+                    "tokens": 219
                   }
                 },
                 {
@@ -2990,7 +2997,8 @@
                 "completion_tokens": 3,
                 "prompt_cached_tokens": 3456,
                 "prompt_tokens": 3617,
-                "reasoning_tokens": 0
+                "reasoning_tokens": 0,
+                "tokens": 3620
               }
             }
           ],
@@ -3291,7 +3299,8 @@
                     "completion_tokens": 3,
                     "prompt_cached_tokens": 3456,
                     "prompt_tokens": 3617,
-                    "reasoning_tokens": 0
+                    "reasoning_tokens": 0,
+                    "tokens": 3620
                   }
                 }
               ],
@@ -3589,7 +3598,8 @@
                     "completion_tokens": 3,
                     "prompt_cached_tokens": 3456,
                     "prompt_tokens": 3617,
-                    "reasoning_tokens": 0
+                    "reasoning_tokens": 0,
+                    "tokens": 3620
                   }
                 }
               ],
@@ -3906,7 +3916,8 @@
                 "completion_tokens": 7,
                 "prompt_cache_creation_tokens": 0,
                 "prompt_cached_tokens": 4516,
-                "prompt_tokens": 4519
+                "prompt_tokens": 4519,
+                "tokens": 4526
               }
             }
           ],
@@ -4228,7 +4239,8 @@
                     "completion_tokens": 7,
                     "prompt_cache_creation_tokens": 0,
                     "prompt_cached_tokens": 4516,
-                    "prompt_tokens": 4519
+                    "prompt_tokens": 4519,
+                    "tokens": 4526
                   }
                 }
               ],
@@ -4547,7 +4559,8 @@
                     "completion_tokens": 7,
                     "prompt_cache_creation_tokens": 0,
                     "prompt_cached_tokens": 4516,
-                    "prompt_tokens": 4519
+                    "prompt_tokens": 4519,
+                    "tokens": 4526
                   }
                 }
               ],
@@ -4857,7 +4870,8 @@
                     "completion_tokens": 3,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 17,
-                    "reasoning_tokens": 0
+                    "reasoning_tokens": 0,
+                    "tokens": 20
                   }
                 }
               ],
@@ -5398,7 +5412,8 @@
                     "completion_tokens": 6,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 38,
-                    "reasoning_tokens": 0
+                    "reasoning_tokens": 0,
+                    "tokens": 44
                   }
                 }
               ],
@@ -5587,7 +5602,8 @@
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 38,
                     "reasoning_tokens": 0,
-                    "time_to_first_token": 0
+                    "time_to_first_token": 0,
+                    "tokens": 44
                   }
                 }
               ],
@@ -5953,7 +5969,8 @@
                     "completion_tokens": 3,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 16,
-                    "reasoning_tokens": 0
+                    "reasoning_tokens": 0,
+                    "tokens": 19
                   }
                 }
               ],
@@ -6258,7 +6275,8 @@
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 17,
                     "reasoning_tokens": 0,
-                    "time_to_first_token": 0
+                    "time_to_first_token": 0,
+                    "tokens": 21
                   }
                 }
               ],

--- a/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v6-auto-hook.span-tree.txt
+++ b/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v6-auto-hook.span-tree.txt
@@ -287,7 +287,8 @@ span_tree:
     │             "completion_tokens": 3,
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 18,
-    │             "reasoning_tokens": 0
+    │             "reasoning_tokens": 0,
+    │             "tokens": 21
     │           }
     ├── ai-sdk-output-object-response-format-operation
     │   metadata: {
@@ -613,7 +614,8 @@ span_tree:
     │             "completion_tokens": 6,
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 45,
-    │             "reasoning_tokens": 0
+    │             "reasoning_tokens": 0,
+    │             "tokens": 51
     │           }
     ├── ai-sdk-stream-operation
     │   metadata: {
@@ -722,7 +724,8 @@ span_tree:
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 22,
     │             "reasoning_tokens": 0,
-    │             "time_to_first_token": 0
+    │             "time_to_first_token": 0,
+    │             "tokens": 29
     │           }
     ├── ai-sdk-embed-operation
     │   metadata: {
@@ -1926,7 +1929,8 @@ span_tree:
     │       │     "completion_tokens": 8,
     │       │     "prompt_cached_tokens": 0,
     │       │     "prompt_tokens": 94,
-    │       │     "reasoning_tokens": 0
+    │       │     "reasoning_tokens": 0,
+    │       │     "tokens": 102
     │       │   }
     │       ├── get_weather [tool]
     │       │   input: [
@@ -2098,7 +2102,8 @@ span_tree:
     │       │     "completion_tokens": 8,
     │       │     "prompt_cached_tokens": 0,
     │       │     "prompt_tokens": 133,
-    │       │     "reasoning_tokens": 0
+    │       │     "reasoning_tokens": 0,
+    │       │     "tokens": 141
     │       │   }
     │       ├── get_weather [tool]
     │       │   input: [
@@ -2344,7 +2349,8 @@ span_tree:
     │       │     "completion_tokens": 8,
     │       │     "prompt_cached_tokens": 0,
     │       │     "prompt_tokens": 172,
-    │       │     "reasoning_tokens": 0
+    │       │     "reasoning_tokens": 0,
+    │       │     "tokens": 180
     │       │   }
     │       ├── get_weather [tool]
     │       │   input: [
@@ -2664,7 +2670,8 @@ span_tree:
     │       │     "completion_tokens": 8,
     │       │     "prompt_cached_tokens": 0,
     │       │     "prompt_tokens": 211,
-    │       │     "reasoning_tokens": 0
+    │       │     "reasoning_tokens": 0,
+    │       │     "tokens": 219
     │       │   }
     │       └── get_weather [tool]
     │           input: [
@@ -3080,7 +3087,8 @@ span_tree:
     │         "completion_tokens": 3,
     │         "prompt_cached_tokens": 3456,
     │         "prompt_tokens": 3617,
-    │         "reasoning_tokens": 0
+    │         "reasoning_tokens": 0,
+    │         "tokens": 3620
     │       }
     ├── ai-sdk-openai-cache-operation
     │   metadata: {
@@ -3374,7 +3382,8 @@ span_tree:
     │   │         "completion_tokens": 3,
     │   │         "prompt_cached_tokens": 3456,
     │   │         "prompt_tokens": 3617,
-    │   │         "reasoning_tokens": 0
+    │   │         "reasoning_tokens": 0,
+    │   │         "tokens": 3620
     │   │       }
     │   └── generateText [function]
     │       input: {
@@ -3663,7 +3672,8 @@ span_tree:
     │             "completion_tokens": 3,
     │             "prompt_cached_tokens": 3456,
     │             "prompt_tokens": 3617,
-    │             "reasoning_tokens": 0
+    │             "reasoning_tokens": 0,
+    │             "tokens": 3620
     │           }
     ├── generateText [function]
     │   input: {
@@ -3973,7 +3983,8 @@ span_tree:
     │         "completion_tokens": 7,
     │         "prompt_cache_creation_tokens": 0,
     │         "prompt_cached_tokens": 4516,
-    │         "prompt_tokens": 4519
+    │         "prompt_tokens": 4519,
+    │         "tokens": 4526
     │       }
     ├── ai-sdk-anthropic-cache-operation
     │   metadata: {
@@ -4288,7 +4299,8 @@ span_tree:
     │   │         "completion_tokens": 7,
     │   │         "prompt_cache_creation_tokens": 0,
     │   │         "prompt_cached_tokens": 4516,
-    │   │         "prompt_tokens": 4519
+    │   │         "prompt_tokens": 4519,
+    │   │         "tokens": 4526
     │   │       }
     │   └── generateText [function]
     │       input: {
@@ -4598,7 +4610,8 @@ span_tree:
     │             "completion_tokens": 7,
     │             "prompt_cache_creation_tokens": 0,
     │             "prompt_cached_tokens": 4516,
-    │             "prompt_tokens": 4519
+    │             "prompt_tokens": 4519,
+    │             "tokens": 4526
     │           }
     ├── ai-sdk-deny-output-override-operation
     │   metadata: {
@@ -5110,7 +5123,8 @@ span_tree:
     │             "completion_tokens": 3,
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 17,
-    │             "reasoning_tokens": 0
+    │             "reasoning_tokens": 0,
+    │             "tokens": 20
     │           }
     ├── ai-sdk-generate-object-operation
     │   metadata: {
@@ -5310,7 +5324,8 @@ span_tree:
     │             "completion_tokens": 6,
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 38,
-    │             "reasoning_tokens": 0
+    │             "reasoning_tokens": 0,
+    │             "tokens": 44
     │           }
     ├── ai-sdk-stream-object-operation
     │   metadata: {
@@ -5450,7 +5465,8 @@ span_tree:
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 38,
     │             "reasoning_tokens": 0,
-    │             "time_to_first_token": 0
+    │             "time_to_first_token": 0,
+    │             "tokens": 44
     │           }
     ├── ai-sdk-agent-generate-operation
     │   metadata: {
@@ -5921,7 +5937,8 @@ span_tree:
     │             "completion_tokens": 3,
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 16,
-    │             "reasoning_tokens": 0
+    │             "reasoning_tokens": 0,
+    │             "tokens": 19
     │           }
     └── ai-sdk-agent-stream-operation
         metadata: {
@@ -6058,5 +6075,6 @@ span_tree:
                   "prompt_cached_tokens": 0,
                   "prompt_tokens": 17,
                   "reasoning_tokens": 0,
-                  "time_to_first_token": 0
+                  "time_to_first_token": 0,
+                  "tokens": 21
                 }

--- a/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v6-wrapped.span-tree.json
+++ b/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v6-wrapped.span-tree.json
@@ -101,7 +101,8 @@
                     "completion_tokens": 3,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 18,
-                    "reasoning_tokens": 0
+                    "reasoning_tokens": 0,
+                    "tokens": 21
                   }
                 }
               ],
@@ -422,7 +423,8 @@
                     "completion_tokens": 6,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 45,
-                    "reasoning_tokens": 0
+                    "reasoning_tokens": 0,
+                    "tokens": 51
                   }
                 }
               ],
@@ -716,7 +718,8 @@
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 22,
                     "reasoning_tokens": 0,
-                    "time_to_first_token": 0
+                    "time_to_first_token": 0,
+                    "tokens": 29
                   }
                 }
               ],
@@ -978,7 +981,8 @@
                     "completion_tokens": 8,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 94,
-                    "reasoning_tokens": 0
+                    "reasoning_tokens": 0,
+                    "tokens": 102
                   }
                 },
                 {
@@ -1158,7 +1162,8 @@
                     "completion_tokens": 8,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 133,
-                    "reasoning_tokens": 0
+                    "reasoning_tokens": 0,
+                    "tokens": 141
                   }
                 },
                 {
@@ -1412,7 +1417,8 @@
                     "completion_tokens": 8,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 172,
-                    "reasoning_tokens": 0
+                    "reasoning_tokens": 0,
+                    "tokens": 180
                   }
                 },
                 {
@@ -1740,7 +1746,8 @@
                     "completion_tokens": 8,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 211,
-                    "reasoning_tokens": 0
+                    "reasoning_tokens": 0,
+                    "tokens": 219
                   }
                 },
                 {
@@ -2993,7 +3000,8 @@
                     "completion_tokens": 3,
                     "prompt_cached_tokens": 3456,
                     "prompt_tokens": 3617,
-                    "reasoning_tokens": 0
+                    "reasoning_tokens": 0,
+                    "tokens": 3620
                   }
                 }
               ],
@@ -3291,7 +3299,8 @@
                     "completion_tokens": 3,
                     "prompt_cached_tokens": 3456,
                     "prompt_tokens": 3617,
-                    "reasoning_tokens": 0
+                    "reasoning_tokens": 0,
+                    "tokens": 3620
                   }
                 }
               ],
@@ -3611,7 +3620,8 @@
                     "completion_tokens": 7,
                     "prompt_cache_creation_tokens": 0,
                     "prompt_cached_tokens": 4516,
-                    "prompt_tokens": 4519
+                    "prompt_tokens": 4519,
+                    "tokens": 4526
                   }
                 }
               ],
@@ -3930,7 +3940,8 @@
                     "completion_tokens": 7,
                     "prompt_cache_creation_tokens": 0,
                     "prompt_cached_tokens": 4516,
-                    "prompt_tokens": 4519
+                    "prompt_tokens": 4519,
+                    "tokens": 4526
                   }
                 }
               ],
@@ -4240,7 +4251,8 @@
                     "completion_tokens": 3,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 17,
-                    "reasoning_tokens": 0
+                    "reasoning_tokens": 0,
+                    "tokens": 20
                   }
                 }
               ],
@@ -4781,7 +4793,8 @@
                     "completion_tokens": 6,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 38,
-                    "reasoning_tokens": 0
+                    "reasoning_tokens": 0,
+                    "tokens": 44
                   }
                 }
               ],
@@ -4970,7 +4983,8 @@
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 38,
                     "reasoning_tokens": 0,
-                    "time_to_first_token": 0
+                    "time_to_first_token": 0,
+                    "tokens": 44
                   }
                 }
               ],
@@ -5130,7 +5144,8 @@
                     "completion_tokens": 3,
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 16,
-                    "reasoning_tokens": 0
+                    "reasoning_tokens": 0,
+                    "tokens": 19
                   }
                 }
               ],
@@ -5407,7 +5422,8 @@
                     "prompt_cached_tokens": 0,
                     "prompt_tokens": 17,
                     "reasoning_tokens": 0,
-                    "time_to_first_token": 0
+                    "time_to_first_token": 0,
+                    "tokens": 21
                   }
                 }
               ],

--- a/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v6-wrapped.span-tree.txt
+++ b/e2e/scenarios/ai-sdk-instrumentation/__snapshots__/ai-sdk-v6-wrapped.span-tree.txt
@@ -287,7 +287,8 @@ span_tree:
     │             "completion_tokens": 3,
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 18,
-    │             "reasoning_tokens": 0
+    │             "reasoning_tokens": 0,
+    │             "tokens": 21
     │           }
     ├── ai-sdk-output-object-response-format-operation
     │   metadata: {
@@ -613,7 +614,8 @@ span_tree:
     │             "completion_tokens": 6,
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 45,
-    │             "reasoning_tokens": 0
+    │             "reasoning_tokens": 0,
+    │             "tokens": 51
     │           }
     ├── ai-sdk-stream-operation
     │   metadata: {
@@ -722,7 +724,8 @@ span_tree:
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 22,
     │             "reasoning_tokens": 0,
-    │             "time_to_first_token": 0
+    │             "time_to_first_token": 0,
+    │             "tokens": 29
     │           }
     ├── ai-sdk-embed-operation
     │   metadata: {
@@ -1926,7 +1929,8 @@ span_tree:
     │       │     "completion_tokens": 8,
     │       │     "prompt_cached_tokens": 0,
     │       │     "prompt_tokens": 94,
-    │       │     "reasoning_tokens": 0
+    │       │     "reasoning_tokens": 0,
+    │       │     "tokens": 102
     │       │   }
     │       ├── get_weather [tool]
     │       │   input: [
@@ -2098,7 +2102,8 @@ span_tree:
     │       │     "completion_tokens": 8,
     │       │     "prompt_cached_tokens": 0,
     │       │     "prompt_tokens": 133,
-    │       │     "reasoning_tokens": 0
+    │       │     "reasoning_tokens": 0,
+    │       │     "tokens": 141
     │       │   }
     │       ├── get_weather [tool]
     │       │   input: [
@@ -2344,7 +2349,8 @@ span_tree:
     │       │     "completion_tokens": 8,
     │       │     "prompt_cached_tokens": 0,
     │       │     "prompt_tokens": 172,
-    │       │     "reasoning_tokens": 0
+    │       │     "reasoning_tokens": 0,
+    │       │     "tokens": 180
     │       │   }
     │       ├── get_weather [tool]
     │       │   input: [
@@ -2664,7 +2670,8 @@ span_tree:
     │       │     "completion_tokens": 8,
     │       │     "prompt_cached_tokens": 0,
     │       │     "prompt_tokens": 211,
-    │       │     "reasoning_tokens": 0
+    │       │     "reasoning_tokens": 0,
+    │       │     "tokens": 219
     │       │   }
     │       └── get_weather [tool]
     │           input: [
@@ -3085,7 +3092,8 @@ span_tree:
     │   │         "completion_tokens": 3,
     │   │         "prompt_cached_tokens": 3456,
     │   │         "prompt_tokens": 3617,
-    │   │         "reasoning_tokens": 0
+    │   │         "reasoning_tokens": 0,
+    │   │         "tokens": 3620
     │   │       }
     │   └── generateText [function]
     │       input: {
@@ -3374,7 +3382,8 @@ span_tree:
     │             "completion_tokens": 3,
     │             "prompt_cached_tokens": 3456,
     │             "prompt_tokens": 3617,
-    │             "reasoning_tokens": 0
+    │             "reasoning_tokens": 0,
+    │             "tokens": 3620
     │           }
     ├── ai-sdk-anthropic-cache-operation
     │   metadata: {
@@ -3689,7 +3698,8 @@ span_tree:
     │   │         "completion_tokens": 7,
     │   │         "prompt_cache_creation_tokens": 0,
     │   │         "prompt_cached_tokens": 4516,
-    │   │         "prompt_tokens": 4519
+    │   │         "prompt_tokens": 4519,
+    │   │         "tokens": 4526
     │   │       }
     │   └── generateText [function]
     │       input: {
@@ -3999,7 +4009,8 @@ span_tree:
     │             "completion_tokens": 7,
     │             "prompt_cache_creation_tokens": 0,
     │             "prompt_cached_tokens": 4516,
-    │             "prompt_tokens": 4519
+    │             "prompt_tokens": 4519,
+    │             "tokens": 4526
     │           }
     ├── ai-sdk-deny-output-override-operation
     │   metadata: {
@@ -4511,7 +4522,8 @@ span_tree:
     │             "completion_tokens": 3,
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 17,
-    │             "reasoning_tokens": 0
+    │             "reasoning_tokens": 0,
+    │             "tokens": 20
     │           }
     ├── ai-sdk-generate-object-operation
     │   metadata: {
@@ -4711,7 +4723,8 @@ span_tree:
     │             "completion_tokens": 6,
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 38,
-    │             "reasoning_tokens": 0
+    │             "reasoning_tokens": 0,
+    │             "tokens": 44
     │           }
     ├── ai-sdk-stream-object-operation
     │   metadata: {
@@ -4851,7 +4864,8 @@ span_tree:
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 38,
     │             "reasoning_tokens": 0,
-    │             "time_to_first_token": 0
+    │             "time_to_first_token": 0,
+    │             "tokens": 44
     │           }
     ├── ai-sdk-agent-generate-operation
     │   metadata: {
@@ -5139,7 +5153,8 @@ span_tree:
     │             "completion_tokens": 3,
     │             "prompt_cached_tokens": 0,
     │             "prompt_tokens": 16,
-    │             "reasoning_tokens": 0
+    │             "reasoning_tokens": 0,
+    │             "tokens": 19
     │           }
     └── ai-sdk-agent-stream-operation
         metadata: {
@@ -5252,5 +5267,6 @@ span_tree:
                   "prompt_cached_tokens": 0,
                   "prompt_tokens": 17,
                   "reasoning_tokens": 0,
-                  "time_to_first_token": 0
+                  "time_to_first_token": 0,
+                  "tokens": 21
                 }

--- a/js/src/instrumentation/plugins/ai-sdk-plugin.streaming.test.ts
+++ b/js/src/instrumentation/plugins/ai-sdk-plugin.streaming.test.ts
@@ -46,6 +46,178 @@ describe("AI SDK streaming instrumentation", () => {
     _exportsForTestingOnly.clearTestBackgroundLogger();
   });
 
+  test("generateText child span logs missing usage diagnostic when output has no usage", async () => {
+    expect(await backgroundLogger.drain()).toHaveLength(0);
+
+    const model = {
+      specificationVersion: "v3",
+      provider: "mock-provider",
+      modelId: "mock-model",
+      supportedUrls: {},
+      doGenerate: async () => ({
+        text: "hello",
+        finishReason: "stop",
+        usage: null,
+      }),
+      doStream: async () => {
+        throw new Error("doStream should not be called");
+      },
+    } as any;
+
+    const params = {
+      model,
+      prompt: "Say hello.",
+      maxOutputTokens: 16,
+    };
+    const result = (await aiSDKChannels.generateText.tracePromise(
+      async () => params.model.doGenerate(params),
+      {
+        arguments: [params],
+      } as any,
+    )) as any;
+
+    expect(result.text).toBe("hello");
+
+    const spans = (await backgroundLogger.drain()) as any[];
+    const doGenerateSpan = spans.find(
+      (s) => s?.span_attributes?.name === "doGenerate",
+    );
+
+    expect(doGenerateSpan?.output?.text).toBe("hello");
+    expect(doGenerateSpan?.metrics?.prompt_tokens).toBeUndefined();
+    expect(doGenerateSpan?.metrics?.completion_tokens).toBeUndefined();
+    expect(doGenerateSpan?.metrics?.tokens).toBeUndefined();
+    expect(doGenerateSpan?.metadata?.usage_unavailable_reason).toBe(
+      "ai_sdk_result_missing_usage",
+    );
+  });
+
+  test("streamText child span logs missing usage diagnostic when finish usage is empty", async () => {
+    expect(await backgroundLogger.drain()).toHaveLength(0);
+
+    const model = {
+      specificationVersion: "v3",
+      provider: "mock-provider",
+      modelId: "mock-model",
+      supportedUrls: {},
+      doGenerate: async () => {
+        throw new Error("doGenerate should not be called");
+      },
+      doStream: async () => ({
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({
+              type: "text-delta",
+              textDelta: "hello",
+            });
+            controller.enqueue({
+              type: "finish",
+              finishReason: "stop",
+              usage: {},
+            });
+            controller.close();
+          },
+        }),
+        warnings: [],
+      }),
+    } as any;
+
+    const params = {
+      model,
+      prompt: "Say hello.",
+      maxOutputTokens: 16,
+    };
+    const result = (await aiSDKChannels.streamText.tracePromise(
+      async () => params.model.doStream(params),
+      {
+        arguments: [params],
+      } as any,
+    )) as any;
+
+    for await (const _chunk of result.stream) {
+      // Drain stream so the TransformStream flush and finish handlers run.
+    }
+
+    const spans = (await backgroundLogger.drain()) as any[];
+    const doStreamSpan = spans.find(
+      (s) => s?.span_attributes?.name === "doStream",
+    );
+
+    expect(doStreamSpan?.output?.text).toBe("hello");
+    expect(doStreamSpan?.output?.finishReason).toBe("stop");
+    expect(doStreamSpan?.metrics?.prompt_tokens).toBeUndefined();
+    expect(doStreamSpan?.metrics?.completion_tokens).toBeUndefined();
+    expect(doStreamSpan?.metrics?.tokens).toBeUndefined();
+    expect(doStreamSpan?.metadata?.usage_unavailable_reason).toBe(
+      "ai_sdk_result_missing_usage",
+    );
+  });
+
+  test("streamText child span logs accumulated output when stream ends without finish chunk", async () => {
+    expect(await backgroundLogger.drain()).toHaveLength(0);
+
+    const model = {
+      specificationVersion: "v3",
+      provider: "mock-provider",
+      modelId: "mock-model",
+      supportedUrls: {},
+      doGenerate: async () => {
+        throw new Error("doGenerate should not be called");
+      },
+      doStream: async () => ({
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({
+              type: "text-delta",
+              textDelta: "hel",
+            });
+            controller.enqueue({
+              type: "text-delta",
+              textDelta: "lo",
+            });
+            controller.close();
+          },
+        }),
+        warnings: [],
+      }),
+    } as any;
+
+    const params = {
+      model,
+      prompt: "Say hello.",
+      maxOutputTokens: 16,
+    };
+    const result = (await aiSDKChannels.streamText.tracePromise(
+      async () => params.model.doStream(params),
+      {
+        arguments: [params],
+      } as any,
+    )) as any;
+
+    const chunks: any[] = [];
+    for await (const chunk of result.stream) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toHaveLength(2);
+
+    const spans = (await backgroundLogger.drain()) as any[];
+    const doStreamSpan = spans.find(
+      (s) => s?.span_attributes?.name === "doStream",
+    );
+
+    expect(doStreamSpan?.output?.text).toBe("hello");
+    expect(doStreamSpan?.output?.finishReason).toBeUndefined();
+    expect(doStreamSpan?.output?.usage).toBeUndefined();
+    expect(doStreamSpan?.metrics?.prompt_tokens).toBeUndefined();
+    expect(doStreamSpan?.metrics?.completion_tokens).toBeUndefined();
+    expect(doStreamSpan?.metrics?.tokens).toBeUndefined();
+    expect(doStreamSpan?.metrics?.time_to_first_token).toBeGreaterThan(0);
+    expect(doStreamSpan?.metadata?.usage_unavailable_reason).toBe(
+      "ai_sdk_stream_finished_without_usage",
+    );
+  });
+
   test("streamText time_to_first_token ignores AI SDK v6 framing chunks", async () => {
     expect(await backgroundLogger.drain()).toHaveLength(0);
 

--- a/js/src/instrumentation/plugins/ai-sdk-plugin.test.ts
+++ b/js/src/instrumentation/plugins/ai-sdk-plugin.test.ts
@@ -659,6 +659,94 @@ describe("AI SDK utility functions", () => {
       expect(metrics).toEqual({
         prompt_tokens: 100,
         completion_tokens: 50,
+        tokens: 150,
+      });
+    });
+
+    it("should synthesize total tokens from input and output tokens", () => {
+      const result = {
+        usage: {
+          inputTokens: 10,
+          outputTokens: 2,
+        },
+      };
+      const metrics = extractTokenMetrics(result);
+      expect(metrics).toEqual({
+        prompt_tokens: 10,
+        completion_tokens: 2,
+        tokens: 12,
+      });
+    });
+
+    it("should synthesize total tokens from prompt and completion tokens", () => {
+      const result = {
+        usage: {
+          promptTokens: 10,
+          completionTokens: 2,
+        },
+      };
+      const metrics = extractTokenMetrics(result);
+      expect(metrics).toEqual({
+        prompt_tokens: 10,
+        completion_tokens: 2,
+        tokens: 12,
+      });
+    });
+
+    it("should prefer explicit total tokens over synthesized total", () => {
+      const result = {
+        usage: {
+          promptTokens: 10,
+          completionTokens: 2,
+          totalTokens: 99,
+        },
+      };
+      const metrics = extractTokenMetrics(result);
+      expect(metrics).toEqual({
+        prompt_tokens: 10,
+        completion_tokens: 2,
+        tokens: 99,
+      });
+    });
+
+    it("should synthesize total tokens for OpenAI-style usage", () => {
+      const result = {
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 2,
+        },
+      };
+      const metrics = extractTokenMetrics(result);
+      expect(metrics).toEqual({
+        prompt_tokens: 10,
+        completion_tokens: 2,
+        tokens: 12,
+      });
+    });
+
+    it("should synthesize total tokens for Anthropic-style usage", () => {
+      const result = {
+        usage: {
+          inputTokens: 10,
+          inputTokenDetails: {
+            cacheWriteTokens: 3,
+          },
+          outputTokens: 2,
+        },
+        providerMetadata: {
+          anthropic: {
+            usage: {
+              cache_creation_input_tokens: 3,
+            },
+          },
+        },
+      };
+      const metrics = extractTokenMetrics(result);
+      expect(metrics).toEqual({
+        prompt_tokens: 10,
+        completion_tokens: 2,
+        tokens: 12,
+        prompt_cache_creation_tokens: 3,
       });
     });
 
@@ -678,6 +766,7 @@ describe("AI SDK utility functions", () => {
       expect(metrics).toEqual({
         prompt_tokens: 10,
         completion_tokens: 20,
+        tokens: 30,
         estimated_cost: 0.05,
       });
     });
@@ -709,6 +798,7 @@ describe("AI SDK utility functions", () => {
       expect(metrics).toEqual({
         prompt_tokens: 10,
         completion_tokens: 20,
+        tokens: 30,
         estimated_cost: 0.05,
       });
     });
@@ -737,6 +827,7 @@ describe("AI SDK utility functions", () => {
       expect(metrics).toEqual({
         prompt_tokens: 100,
         completion_tokens: 20,
+        tokens: 120,
         prompt_cached_tokens: 0,
         prompt_cache_creation_tokens: 80,
       });
@@ -1351,6 +1442,8 @@ function extractTokenMetrics(result: any): Record<string, number> {
   );
   if (totalTokens !== undefined) {
     metrics.tokens = totalTokens;
+  } else if (promptTokens !== undefined && completionTokens !== undefined) {
+    metrics.tokens = promptTokens + completionTokens;
   }
 
   const promptCachedTokens = firstNumber(

--- a/js/src/instrumentation/plugins/ai-sdk-plugin.ts
+++ b/js/src/instrumentation/plugins/ai-sdk-plugin.ts
@@ -1177,10 +1177,19 @@ function prepareAISDKChildTracing(
             [options],
           );
 
+          const output = processAISDKOutput(result, denyOutputPaths);
+          const metrics = extractTokenMetrics(result);
+          const metadataPayload = buildResolvedMetadataPayload(result);
+          const missingUsageMetadata = buildMissingUsageMetadata(
+            output,
+            metrics,
+            "ai_sdk_result_missing_usage",
+          );
+
           span.log({
-            output: processAISDKOutput(result, denyOutputPaths),
-            metrics: extractTokenMetrics(result),
-            ...buildResolvedMetadataPayload(result),
+            output,
+            metrics,
+            ...mergeMetadataPayload(metadataPayload, missingUsageMetadata),
           });
 
           return result;
@@ -1225,6 +1234,48 @@ function prepareAISDKChildTracing(
         let reasoning = "";
         const toolCalls: unknown[] = [];
         let object: unknown = undefined;
+        let streamSpanEnded = false;
+
+        const logAndEndStreamSpan = (usageUnavailableReason?: string): void => {
+          if (streamSpanEnded) {
+            return;
+          }
+
+          output.text = text;
+          output.reasoning = reasoning;
+          output.toolCalls = toolCalls;
+
+          if (object !== undefined) {
+            output.object = object;
+          }
+
+          const metrics = extractTokenMetrics(output as AISDKResult);
+          if (firstChunkTime !== undefined) {
+            metrics.time_to_first_token = Math.max(
+              firstChunkTime - streamStartTime,
+              1e-6,
+            );
+          }
+
+          const metadataPayload = buildResolvedMetadataPayload(
+            output as AISDKResult,
+          );
+          const missingUsageMetadata = usageUnavailableReason
+            ? { usage_unavailable_reason: usageUnavailableReason }
+            : buildMissingUsageMetadata(
+                output,
+                metrics,
+                "ai_sdk_result_missing_usage",
+              );
+
+          span.log({
+            output: processAISDKOutput(output as AISDKResult, denyOutputPaths),
+            metrics,
+            ...mergeMetadataPayload(metadataPayload, missingUsageMetadata),
+          });
+          span.end();
+          streamSpanEnded = true;
+        };
 
         const transformStream = new TransformStream({
           transform(chunk: AISDKModelStreamChunk, controller) {
@@ -1272,36 +1323,16 @@ function prepareAISDKChildTracing(
                 }
                 break;
               case "finish":
-                output.text = text;
-                output.reasoning = reasoning;
-                output.toolCalls = toolCalls;
                 output.finishReason = chunk.finishReason;
                 output.usage = chunk.usage;
 
-                if (object !== undefined) {
-                  output.object = object;
-                }
-
-                const metrics = extractTokenMetrics(output as AISDKResult);
-                if (firstChunkTime !== undefined) {
-                  metrics.time_to_first_token = Math.max(
-                    firstChunkTime - streamStartTime,
-                    1e-6,
-                  );
-                }
-
-                span.log({
-                  output: processAISDKOutput(
-                    output as AISDKResult,
-                    denyOutputPaths,
-                  ),
-                  metrics,
-                  ...buildResolvedMetadataPayload(output as AISDKResult),
-                });
-                span.end();
+                logAndEndStreamSpan();
                 break;
             }
             controller.enqueue(chunk);
+          },
+          flush() {
+            logAndEndStreamSpan("ai_sdk_stream_finished_without_usage");
           },
         });
 
@@ -1923,6 +1954,56 @@ function buildResolvedMetadataPayload(result: AISDKResult): {
   return Object.keys(metadata).length > 0 ? { metadata } : {};
 }
 
+function mergeMetadataPayload(
+  metadataPayload: { metadata?: Record<string, unknown> },
+  extraMetadata?: Record<string, unknown>,
+): { metadata?: Record<string, unknown> } {
+  if (!extraMetadata || Object.keys(extraMetadata).length === 0) {
+    return metadataPayload;
+  }
+
+  return {
+    metadata: {
+      ...(metadataPayload.metadata ?? {}),
+      ...extraMetadata,
+    },
+  };
+}
+
+function buildMissingUsageMetadata(
+  output: unknown,
+  metrics: Record<string, number>,
+  reason: string,
+): Record<string, unknown> | undefined {
+  if (!hasLoggedOutput(output) || hasTokenUsageMetrics(metrics)) {
+    return undefined;
+  }
+
+  return { usage_unavailable_reason: reason };
+}
+
+function hasLoggedOutput(output: unknown): boolean {
+  if (output === null || output === undefined) {
+    return false;
+  }
+
+  if (Array.isArray(output)) {
+    return output.length > 0;
+  }
+
+  if (typeof output === "object") {
+    return Object.keys(output as Record<string, unknown>).length > 0;
+  }
+
+  return true;
+}
+
+function hasTokenUsageMetrics(metrics: Record<string, number>): boolean {
+  return Object.keys(metrics).some(
+    (key) => key !== "estimated_cost" && key !== "time_to_first_token",
+  );
+}
+
 function resolveAISDKModel(
   model: AISDKModel | undefined,
   aiSDK?: AISDK,
@@ -2107,6 +2188,8 @@ export function extractTokenMetrics(
   );
   if (totalTokens !== undefined) {
     metrics.tokens = totalTokens;
+  } else if (promptTokens !== undefined && completionTokens !== undefined) {
+    metrics.tokens = promptTokens + completionTokens;
   }
 
   const promptCachedTokens = firstNumber(

--- a/js/src/wrappers/ai-sdk/ai-sdk.test.ts
+++ b/js/src/wrappers/ai-sdk/ai-sdk.test.ts
@@ -2676,6 +2676,8 @@ function extractTokenMetrics(result: any): Record<string, number> {
   );
   if (totalTokens !== undefined) {
     metrics.tokens = totalTokens;
+  } else if (promptTokens !== undefined && completionTokens !== undefined) {
+    metrics.tokens = promptTokens + completionTokens;
   }
 
   const promptCachedTokens = firstNumber(
@@ -2878,6 +2880,7 @@ describe("extractTokenMetrics", () => {
 
     expect(result.prompt_tokens).toBe(100);
     expect(result.completion_tokens).toBe(50);
+    expect(result.tokens).toBe(150);
     // null should not be included - it should be undefined or not present
     expect(result.prompt_cached_tokens).toBeUndefined();
   });
@@ -2893,6 +2896,7 @@ describe("extractTokenMetrics", () => {
 
     expect(result.prompt_tokens).toBe(100);
     expect(result.completion_tokens).toBe(50);
+    expect(result.tokens).toBe(150);
     // Zero should be preserved, not treated as falsy
     expect(result.prompt_cached_tokens).toBe(0);
   });
@@ -2932,6 +2936,7 @@ describe("extractTokenMetrics", () => {
 
     expect(result.prompt_tokens).toBe(25);
     expect(result.completion_tokens).toBe(790);
+    expect(result.tokens).toBe(815);
     expect(result.reasoning_tokens).toBe(768);
     expect(result.completion_reasoning_tokens).toBe(768);
     expect(result.prompt_cached_tokens).toBe(0);
@@ -2970,6 +2975,33 @@ describe("extractTokenMetrics", () => {
     expect(result.tokens).toBe(75);
     expect(result.reasoning_tokens).toBe(20);
     expect(result.completion_reasoning_tokens).toBe(20);
+  });
+
+  test("synthesizes total tokens when usage has no explicit total", () => {
+    const result = extractTokenMetrics({
+      usage: {
+        inputTokens: 10,
+        outputTokens: 2,
+      },
+    });
+
+    expect(result.prompt_tokens).toBe(10);
+    expect(result.completion_tokens).toBe(2);
+    expect(result.tokens).toBe(12);
+  });
+
+  test("prefers explicit total tokens over synthesized total", () => {
+    const result = extractTokenMetrics({
+      usage: {
+        promptTokens: 10,
+        completionTokens: 2,
+        totalTokens: 99,
+      },
+    });
+
+    expect(result.prompt_tokens).toBe(10);
+    expect(result.completion_tokens).toBe(2);
+    expect(result.tokens).toBe(99);
   });
 });
 


### PR DESCRIPTION
## Summary

- Synthesize `metrics.tokens` from prompt and completion token counts when AI SDK usage omits an explicit total.
- Keep explicit totals (`totalTokens`, `tokens`, `total_tokens`) preferred over synthesized totals.
- Add missing-usage diagnostics for AI SDK child LLM spans when output exists but usable token usage is absent.
- Ensure `doStream` child spans flush accumulated output and end even when a stream closes without a `finish` chunk.

## Root Cause

AI SDK provider results often expose prompt/input and completion/output token counts without an explicit total. The AI SDK plugin only emitted `metrics.tokens` when an explicit total was present, so backend cost and token insights could miss totals even when both sides were available.

## Validation

- `mise exec -- pnpm --dir js exec vitest run --config /private/tmp/vitest-ai-sdk-wrapper.config.mjs src/instrumentation/plugins/ai-sdk-plugin.test.ts`
- `mise exec -- pnpm --dir js exec vitest run --config /private/tmp/vitest-ai-sdk-wrapper.config.mjs src/instrumentation/plugins/ai-sdk-plugin.streaming.test.ts`
- `mise exec -- pnpm exec prettier --check js/src/instrumentation/plugins/ai-sdk-plugin.ts js/src/instrumentation/plugins/ai-sdk-plugin.test.ts js/src/instrumentation/plugins/ai-sdk-plugin.streaming.test.ts js/src/wrappers/ai-sdk/ai-sdk.test.ts`
- `git diff --check`

Note: repo-wide `pnpm run formatting` is currently blocked by the pre-existing untracked `.claude/worktrees/` directory and existing fixture formatting warnings; the changed files pass Prettier.
