### PR TITLE
fix: Fix function invocations by stripping `/v1/proxy` from functions endpoint

### DIFF
--- a/.changeset/eu-proxy-url-function-invoke.md
+++ b/.changeset/eu-proxy-url-function-invoke.md
@@ -2,4 +2,4 @@
 "braintrust": patch
 ---
 
-Fix `405 Method POST not supported` when invoking functions (e.g. `initFunction`/`Eval` scorers) on EU and self-hosted data planes. These orgs' login response sets `proxy_url` to `{apiUrl}/v1/proxy`, but the `function/*` endpoints reached via `proxyConn` are served at the API host root; the proxy connection now strips a trailing `/v1/proxy` so requests resolve correctly on all data planes.
+fix: Fix function invocations by stripping `/v1/proxy` from functions endpoint

--- a/.changeset/eu-proxy-url-function-invoke.md
+++ b/.changeset/eu-proxy-url-function-invoke.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+Fix `405 Method POST not supported` when invoking functions (e.g. `initFunction`/`Eval` scorers) on EU and self-hosted data planes. These orgs' login response sets `proxy_url` to `{apiUrl}/v1/proxy`, but the `function/*` endpoints reached via `proxyConn` are served at the API host root; the proxy connection now strips a trailing `/v1/proxy` so requests resolve correctly on all data planes.

--- a/js/src/logger.test.ts
+++ b/js/src/logger.test.ts
@@ -2814,6 +2814,18 @@ describe("sensitive data redaction", () => {
     expect(str.length).toBeLessThan(150);
   });
 
+  test("proxyConn strips the /v1/proxy suffix for EU/self-hosted proxy URLs", () => {
+    const euState = new BraintrustState({});
+    euState.proxyUrl = "https://api-eu.braintrust.dev/v1/proxy";
+    expect(euState.proxyConn().base_url).toBe("https://api-eu.braintrust.dev");
+  });
+
+  test("proxyConn leaves a bare proxy host unchanged", () => {
+    const usState = new BraintrustState({});
+    usState.proxyUrl = "https://api.braintrust.dev";
+    expect(usState.proxyConn().base_url).toBe("https://api.braintrust.dev");
+  });
+
   test("redaction works in nested objects and JSON.stringify", () => {
     const span = logger.startSpan({ name: "test-span" });
 

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -639,6 +639,18 @@ export type SerializedBraintrustState = z.infer<typeof loginSchema>;
 
 let stateNonce = 0;
 
+const V1_PROXY_SUFFIX = "/v1/proxy";
+
+// proxyUrl may point at the universal proxy (`{apiUrl}/v1/proxy`) for
+// EU/self-hosted orgs, but proxyConn only targets Braintrust API endpoints
+// (e.g. function/invoke, function/sandbox-list) served at the API host root.
+// Drop the suffix so these requests resolve on all data planes.
+function normalizeProxyConnUrl(proxyUrl: string): string {
+  return proxyUrl.endsWith(V1_PROXY_SUFFIX)
+    ? proxyUrl.slice(0, proxyUrl.length - V1_PROXY_SUFFIX.length)
+    : proxyUrl;
+}
+
 export class BraintrustState {
   public id: string;
   public currentExperiment: Experiment | undefined;
@@ -969,7 +981,10 @@ export class BraintrustState {
       if (!this.proxyUrl) {
         throw new Error("Must initialize proxyUrl before requesting proxyConn");
       }
-      this._proxyConn = new HTTPConnection(this.proxyUrl, this.fetch);
+      this._proxyConn = new HTTPConnection(
+        normalizeProxyConnUrl(this.proxyUrl),
+        this.fetch,
+      );
     }
     return this._proxyConn!;
   }


### PR DESCRIPTION
## Issue

Function invocation on EU (and self-hosted) data planes fails with **`405 Method POST not supported`**. Reported by a customer using `initFunction()` scorers inside `Eval()` on `https://api-eu.braintrust.dev` (Pylon #18531).

`function/invoke`, `function/sandbox-list`, and `function/code` are all POSTed through `proxyConn`. For EU/self-hosted orgs the login response sets `proxy_url = {apiUrl}/v1/proxy`, but these `function/*` endpoints are served at the **API host root**, not under `/v1/proxy`. So the SDK posts to `.../v1/proxy/function/invoke` → 405.

US multi-tenant orgs avoid this by accident: their stored `proxy_url` is null, so login falls back to the bare `api_url` (no `/v1/proxy`), which routes correctly. That's why this went unnoticed.

## Repro on current version

Login on an EU org returns:
```
proxy_url = https://api-eu.braintrust.dev/v1/proxy
```
The SDK then POSTs `function/invoke` under it. Probing the endpoints directly with a real EU key:

| POST target | Result |
|---|---|
| `api-eu.braintrust.dev/v1/proxy/function/invoke` (current SDK) | **405 Method POST not supported** |
| `api-eu.braintrust.dev/function/invoke` (API host root) | 400 — routed, POST accepted |

Customer workaround was `BRAINTRUST_PROXY_URL=https://api-eu.braintrust.dev` (bare host).

## Fix

Normalize the `proxyConn` base URL by stripping a trailing `/v1/proxy`, so `function/*` requests resolve at the API host root on every data plane. `state.proxyUrl` is left untouched (nothing else reads it as an LLM base URL).

## No endpoint-level regression

Every endpoint that flows through `proxyConn` was probed against both bases — all three route at the bare host and all three 405 under `/v1/proxy` today:

| Endpoint | bare host | `/v1/proxy` |
|---|---|---|
| `function/invoke` | 400 ✓ routed | 405 ✗ |
| `function/sandbox-list` | 500 ✓ routed | 405 ✗ |
| `function/code` | 400 ✓ routed | 405 ✗ |

The OpenAI-compatible proxy path (chat/completions) does **not** go through `proxyConn`, so the `/v1/proxy` suffix it relies on is unaffected.

## Tests

Added `proxyConn` normalization tests in `logger.test.ts`. Verified end-to-end against a live EU org: login returns `.../v1/proxy`, `proxyConn().base_url` now resolves to the bare host.

## Note

A server-side fix (not stamping `/v1/proxy` into `org.proxy_url` for EU/self-hosted, matching US) would also fix already-released SDK versions; this SDK change helps users who upgrade.
