### PR TITLE
feat: Track eve turns as individual traces

### DIFF
--- a/.changeset/heavy-horses-tickle.md
+++ b/.changeset/heavy-horses-tickle.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+feat: Track eve turns as individual traces

--- a/.changeset/heavy-horses-tickle.md
+++ b/.changeset/heavy-horses-tickle.md
@@ -1,5 +1,5 @@
 ---
-"braintrust": patch
+"braintrust": minor
 ---
 
-feat: Track eve turns as individual traces
+feat: Track Eve turns as individual traces and record Eve session IDs on all spans

--- a/e2e/scenarios/eve-instrumentation/__snapshots__/eve-instrumentation.span-tree.json
+++ b/e2e/scenarios/eve-instrumentation/__snapshots__/eve-instrumentation.span-tree.json
@@ -39,6 +39,7 @@
             }
           ],
           "metadata": {
+            "eve.session_id": "<eve.session_id:1>",
             "model": "gpt-5.4-mini",
             "provider": "openai",
             "scenario": "eve-instrumentation",
@@ -94,6 +95,7 @@
                     }
                   ],
                   "metadata": {
+                    "eve.session_id": "<eve.session_id:1>",
                     "model": "gpt-5.4-mini",
                     "provider": "openai",
                     "scenario": "eve-instrumentation",
@@ -119,6 +121,7 @@
                     "url": "https://eve.dev/docs/guides/instrumentation"
                   },
                   "metadata": {
+                    "eve.session_id": "<eve.session_id:1>",
                     "scenario": "eve-instrumentation",
                     "testRunId": "<run:1>"
                   }
@@ -189,6 +192,7 @@
                     }
                   ],
                   "metadata": {
+                    "eve.session_id": "<eve.session_id:1>",
                     "model": "gpt-5.4-mini",
                     "provider": "openai",
                     "scenario": "eve-instrumentation",
@@ -210,6 +214,7 @@
               ],
               "output": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
               "metadata": {
+                "eve.session_id": "<eve.session_id:1>",
                 "model": "gpt-5.4-mini",
                 "provider": "openai",
                 "scenario": "eve-instrumentation",
@@ -228,6 +233,7 @@
           },
           "output": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
           "metadata": {
+            "eve.session_id": "<eve.session_id:1>",
             "scenario": "eve-instrumentation",
             "testRunId": "<run:1>"
           }
@@ -299,6 +305,7 @@
             }
           ],
           "metadata": {
+            "eve.session_id": "<eve.session_id:1>",
             "model": "gpt-5.4-mini",
             "provider": "openai",
             "scenario": "eve-instrumentation",
@@ -325,6 +332,7 @@
             "url": "https://eve.dev/docs/guides/instrumentation"
           },
           "metadata": {
+            "eve.session_id": "<eve.session_id:1>",
             "scenario": "eve-instrumentation",
             "testRunId": "<run:1>"
           }
@@ -428,6 +436,7 @@
             }
           ],
           "metadata": {
+            "eve.session_id": "<eve.session_id:1>",
             "model": "gpt-5.4-mini",
             "provider": "openai",
             "scenario": "eve-instrumentation",
@@ -449,6 +458,7 @@
       ],
       "output": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
       "metadata": {
+        "eve.session_id": "<eve.session_id:1>",
         "model": "gpt-5.4-mini",
         "provider": "openai",
         "scenario": "eve-instrumentation",
@@ -593,6 +603,7 @@
             }
           ],
           "metadata": {
+            "eve.session_id": "<eve.session_id:1>",
             "model": "gpt-5.4-mini",
             "provider": "openai",
             "scenario": "eve-instrumentation",
@@ -648,6 +659,7 @@
                     }
                   ],
                   "metadata": {
+                    "eve.session_id": "<eve.session_id:1>",
                     "model": "gpt-5.4-mini",
                     "provider": "openai",
                     "scenario": "eve-instrumentation",
@@ -673,6 +685,7 @@
                     "url": "https://eve.dev/docs/guides/instrumentation"
                   },
                   "metadata": {
+                    "eve.session_id": "<eve.session_id:1>",
                     "scenario": "eve-instrumentation",
                     "testRunId": "<run:1>"
                   }
@@ -743,6 +756,7 @@
                     }
                   ],
                   "metadata": {
+                    "eve.session_id": "<eve.session_id:1>",
                     "model": "gpt-5.4-mini",
                     "provider": "openai",
                     "scenario": "eve-instrumentation",
@@ -764,6 +778,7 @@
               ],
               "output": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
               "metadata": {
+                "eve.session_id": "<eve.session_id:1>",
                 "model": "gpt-5.4-mini",
                 "provider": "openai",
                 "scenario": "eve-instrumentation",
@@ -782,6 +797,7 @@
           },
           "output": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
           "metadata": {
+            "eve.session_id": "<eve.session_id:1>",
             "scenario": "eve-instrumentation",
             "testRunId": "<run:1>"
           }
@@ -946,6 +962,7 @@
             }
           ],
           "metadata": {
+            "eve.session_id": "<eve.session_id:1>",
             "model": "gpt-5.4-mini",
             "provider": "openai",
             "scenario": "eve-instrumentation",
@@ -972,6 +989,7 @@
             "url": "https://eve.dev/docs/guides/instrumentation"
           },
           "metadata": {
+            "eve.session_id": "<eve.session_id:1>",
             "scenario": "eve-instrumentation",
             "testRunId": "<run:1>"
           }
@@ -1168,6 +1186,7 @@
             }
           ],
           "metadata": {
+            "eve.session_id": "<eve.session_id:1>",
             "model": "gpt-5.4-mini",
             "provider": "openai",
             "scenario": "eve-instrumentation",
@@ -1189,6 +1208,7 @@
       ],
       "output": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
       "metadata": {
+        "eve.session_id": "<eve.session_id:1>",
         "model": "gpt-5.4-mini",
         "provider": "openai",
         "scenario": "eve-instrumentation",

--- a/e2e/scenarios/eve-instrumentation/__snapshots__/eve-instrumentation.span-tree.json
+++ b/e2e/scenarios/eve-instrumentation/__snapshots__/eve-instrumentation.span-tree.json
@@ -54,7 +54,175 @@
         {
           "name": "researcher",
           "type": "tool",
-          "children": [],
+          "children": [
+            {
+              "name": "eve.turn",
+              "type": "task",
+              "children": [
+                {
+                  "name": "eve.step",
+                  "type": "llm",
+                  "children": [],
+                  "input": [
+                    {
+                      "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+                      "role": "system"
+                    },
+                    {
+                      "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
+                      "role": "user"
+                    }
+                  ],
+                  "output": [
+                    {
+                      "finish_reason": "tool_calls",
+                      "index": 0,
+                      "message": {
+                        "content": null,
+                        "role": "assistant",
+                        "tool_calls": [
+                          {
+                            "function": {
+                              "arguments": "{\"query\":\"Run the Braintrust Eve instrumentation e2e scenario\"}",
+                              "name": "search"
+                            },
+                            "id": "<span:1>",
+                            "type": "function"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "model": "gpt-5.4-mini",
+                    "provider": "openai",
+                    "scenario": "eve-instrumentation",
+                    "testRunId": "<run:1>"
+                  },
+                  "metrics": {
+                    "completion_tokens": 26,
+                    "prompt_cached_tokens": 0,
+                    "prompt_tokens": 6554,
+                    "tokens": 6580
+                  }
+                },
+                {
+                  "name": "search",
+                  "type": "tool",
+                  "children": [],
+                  "input": {
+                    "query": "Run the Braintrust Eve instrumentation e2e scenario"
+                  },
+                  "output": {
+                    "query": "Run the Braintrust Eve instrumentation e2e scenario",
+                    "title": "Eve instrumentation",
+                    "url": "https://eve.dev/docs/guides/instrumentation"
+                  },
+                  "metadata": {
+                    "scenario": "eve-instrumentation",
+                    "testRunId": "<run:1>"
+                  }
+                },
+                {
+                  "name": "eve.step",
+                  "type": "llm",
+                  "children": [],
+                  "input": [
+                    {
+                      "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+                      "role": "system"
+                    },
+                    {
+                      "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
+                      "role": "user"
+                    },
+                    {
+                      "content": [
+                        {
+                          "input": {
+                            "query": "Run the Braintrust Eve instrumentation e2e scenario"
+                          },
+                          "providerOptions": {
+                            "openai": {
+                              "itemId": "<itemId:2>"
+                            }
+                          },
+                          "toolCallId": "<toolCallId:1>",
+                          "toolName": "search",
+                          "type": "tool-call"
+                        }
+                      ],
+                      "role": "assistant"
+                    },
+                    {
+                      "content": [
+                        {
+                          "output": {
+                            "type": "json",
+                            "value": {
+                              "query": "Run the Braintrust Eve instrumentation e2e scenario",
+                              "title": "Eve instrumentation",
+                              "url": "https://eve.dev/docs/guides/instrumentation"
+                            }
+                          },
+                          "providerOptions": {
+                            "openai": {
+                              "itemId": "<itemId:2>"
+                            }
+                          },
+                          "toolCallId": "<toolCallId:1>",
+                          "toolName": "search",
+                          "type": "tool-result"
+                        }
+                      ],
+                      "role": "tool"
+                    }
+                  ],
+                  "output": [
+                    {
+                      "finish_reason": "stop",
+                      "index": 0,
+                      "message": {
+                        "content": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
+                        "role": "assistant"
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "model": "gpt-5.4-mini",
+                    "provider": "openai",
+                    "scenario": "eve-instrumentation",
+                    "testRunId": "<run:1>"
+                  },
+                  "metrics": {
+                    "completion_tokens": 22,
+                    "prompt_cached_tokens": 5504,
+                    "prompt_tokens": 6624,
+                    "tokens": 6646
+                  }
+                }
+              ],
+              "input": [
+                {
+                  "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
+                  "role": "user"
+                }
+              ],
+              "output": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
+              "metadata": {
+                "model": "gpt-5.4-mini",
+                "provider": "openai",
+                "scenario": "eve-instrumentation",
+                "testRunId": "<run:1>"
+              },
+              "metrics": {
+                "completion_tokens": 48,
+                "prompt_cached_tokens": 5504,
+                "prompt_tokens": 13178,
+                "tokens": 13226
+              }
+            }
+          ],
           "input": {
             "message": "Run the Braintrust Eve instrumentation e2e scenario"
           },
@@ -303,173 +471,6 @@
           "children": [],
           "input": [
             {
-              "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-              "role": "system"
-            },
-            {
-              "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
-              "role": "user"
-            }
-          ],
-          "output": [
-            {
-              "finish_reason": "tool_calls",
-              "index": 0,
-              "message": {
-                "content": null,
-                "role": "assistant",
-                "tool_calls": [
-                  {
-                    "function": {
-                      "arguments": "{\"query\":\"Run the Braintrust Eve instrumentation e2e scenario\"}",
-                      "name": "search"
-                    },
-                    "id": "<span:1>",
-                    "type": "function"
-                  }
-                ]
-              }
-            }
-          ],
-          "metadata": {
-            "model": "gpt-5.4-mini",
-            "provider": "openai",
-            "scenario": "eve-instrumentation",
-            "testRunId": "<run:1>"
-          },
-          "metrics": {
-            "completion_tokens": 26,
-            "prompt_cached_tokens": 0,
-            "prompt_tokens": 6554,
-            "tokens": 6580
-          }
-        },
-        {
-          "name": "search",
-          "type": "tool",
-          "children": [],
-          "input": {
-            "query": "Run the Braintrust Eve instrumentation e2e scenario"
-          },
-          "output": {
-            "query": "Run the Braintrust Eve instrumentation e2e scenario",
-            "title": "Eve instrumentation",
-            "url": "https://eve.dev/docs/guides/instrumentation"
-          },
-          "metadata": {
-            "scenario": "eve-instrumentation",
-            "testRunId": "<run:1>"
-          }
-        },
-        {
-          "name": "eve.step",
-          "type": "llm",
-          "children": [],
-          "input": [
-            {
-              "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-              "role": "system"
-            },
-            {
-              "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
-              "role": "user"
-            },
-            {
-              "content": [
-                {
-                  "input": {
-                    "query": "Run the Braintrust Eve instrumentation e2e scenario"
-                  },
-                  "providerOptions": {
-                    "openai": {
-                      "itemId": "<itemId:2>"
-                    }
-                  },
-                  "toolCallId": "<toolCallId:1>",
-                  "toolName": "search",
-                  "type": "tool-call"
-                }
-              ],
-              "role": "assistant"
-            },
-            {
-              "content": [
-                {
-                  "output": {
-                    "type": "json",
-                    "value": {
-                      "query": "Run the Braintrust Eve instrumentation e2e scenario",
-                      "title": "Eve instrumentation",
-                      "url": "https://eve.dev/docs/guides/instrumentation"
-                    }
-                  },
-                  "providerOptions": {
-                    "openai": {
-                      "itemId": "<itemId:2>"
-                    }
-                  },
-                  "toolCallId": "<toolCallId:1>",
-                  "toolName": "search",
-                  "type": "tool-result"
-                }
-              ],
-              "role": "tool"
-            }
-          ],
-          "output": [
-            {
-              "finish_reason": "stop",
-              "index": 0,
-              "message": {
-                "content": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
-                "role": "assistant"
-              }
-            }
-          ],
-          "metadata": {
-            "model": "gpt-5.4-mini",
-            "provider": "openai",
-            "scenario": "eve-instrumentation",
-            "testRunId": "<run:1>"
-          },
-          "metrics": {
-            "completion_tokens": 22,
-            "prompt_cached_tokens": 5504,
-            "prompt_tokens": 6624,
-            "tokens": 6646
-          }
-        }
-      ],
-      "input": [
-        {
-          "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
-          "role": "user"
-        }
-      ],
-      "output": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
-      "metadata": {
-        "model": "gpt-5.4-mini",
-        "provider": "openai",
-        "scenario": "eve-instrumentation",
-        "testRunId": "<run:1>"
-      },
-      "metrics": {
-        "completion_tokens": 48,
-        "prompt_cached_tokens": 5504,
-        "prompt_tokens": 13178,
-        "tokens": 13226
-      }
-    },
-    {
-      "name": "eve.turn",
-      "type": "task",
-      "children": [
-        {
-          "name": "eve.step",
-          "type": "llm",
-          "children": [],
-          "input": [
-            {
               "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
               "role": "system"
             },
@@ -607,7 +608,175 @@
         {
           "name": "researcher",
           "type": "tool",
-          "children": [],
+          "children": [
+            {
+              "name": "eve.turn",
+              "type": "task",
+              "children": [
+                {
+                  "name": "eve.step",
+                  "type": "llm",
+                  "children": [],
+                  "input": [
+                    {
+                      "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+                      "role": "system"
+                    },
+                    {
+                      "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
+                      "role": "user"
+                    }
+                  ],
+                  "output": [
+                    {
+                      "finish_reason": "tool_calls",
+                      "index": 0,
+                      "message": {
+                        "content": null,
+                        "role": "assistant",
+                        "tool_calls": [
+                          {
+                            "function": {
+                              "arguments": "{\"query\":\"Run the Braintrust Eve instrumentation e2e scenario again\"}",
+                              "name": "search"
+                            },
+                            "id": "<span:1>",
+                            "type": "function"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "model": "gpt-5.4-mini",
+                    "provider": "openai",
+                    "scenario": "eve-instrumentation",
+                    "testRunId": "<run:1>"
+                  },
+                  "metrics": {
+                    "completion_tokens": 27,
+                    "prompt_cached_tokens": 6528,
+                    "prompt_tokens": 6555,
+                    "tokens": 6582
+                  }
+                },
+                {
+                  "name": "search",
+                  "type": "tool",
+                  "children": [],
+                  "input": {
+                    "query": "Run the Braintrust Eve instrumentation e2e scenario again"
+                  },
+                  "output": {
+                    "query": "Run the Braintrust Eve instrumentation e2e scenario again",
+                    "title": "Eve instrumentation",
+                    "url": "https://eve.dev/docs/guides/instrumentation"
+                  },
+                  "metadata": {
+                    "scenario": "eve-instrumentation",
+                    "testRunId": "<run:1>"
+                  }
+                },
+                {
+                  "name": "eve.step",
+                  "type": "llm",
+                  "children": [],
+                  "input": [
+                    {
+                      "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+                      "role": "system"
+                    },
+                    {
+                      "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
+                      "role": "user"
+                    },
+                    {
+                      "content": [
+                        {
+                          "input": {
+                            "query": "Run the Braintrust Eve instrumentation e2e scenario again"
+                          },
+                          "providerOptions": {
+                            "openai": {
+                              "itemId": "<itemId:2>"
+                            }
+                          },
+                          "toolCallId": "<toolCallId:1>",
+                          "toolName": "search",
+                          "type": "tool-call"
+                        }
+                      ],
+                      "role": "assistant"
+                    },
+                    {
+                      "content": [
+                        {
+                          "output": {
+                            "type": "json",
+                            "value": {
+                              "query": "Run the Braintrust Eve instrumentation e2e scenario again",
+                              "title": "Eve instrumentation",
+                              "url": "https://eve.dev/docs/guides/instrumentation"
+                            }
+                          },
+                          "providerOptions": {
+                            "openai": {
+                              "itemId": "<itemId:2>"
+                            }
+                          },
+                          "toolCallId": "<toolCallId:1>",
+                          "toolName": "search",
+                          "type": "tool-result"
+                        }
+                      ],
+                      "role": "tool"
+                    }
+                  ],
+                  "output": [
+                    {
+                      "finish_reason": "stop",
+                      "index": 0,
+                      "message": {
+                        "content": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
+                        "role": "assistant"
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "model": "gpt-5.4-mini",
+                    "provider": "openai",
+                    "scenario": "eve-instrumentation",
+                    "testRunId": "<run:1>"
+                  },
+                  "metrics": {
+                    "completion_tokens": 22,
+                    "prompt_cached_tokens": 6528,
+                    "prompt_tokens": 6627,
+                    "tokens": 6649
+                  }
+                }
+              ],
+              "input": [
+                {
+                  "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
+                  "role": "user"
+                }
+              ],
+              "output": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
+              "metadata": {
+                "model": "gpt-5.4-mini",
+                "provider": "openai",
+                "scenario": "eve-instrumentation",
+                "testRunId": "<run:1>"
+              },
+              "metrics": {
+                "completion_tokens": 49,
+                "prompt_cached_tokens": 13056,
+                "prompt_tokens": 13182,
+                "tokens": 13231
+              }
+            }
+          ],
           "input": {
             "message": "Run the Braintrust Eve instrumentation e2e scenario again"
           },
@@ -1030,173 +1199,6 @@
         "prompt_cached_tokens": 19584,
         "prompt_tokens": 20864,
         "tokens": 20985
-      }
-    },
-    {
-      "name": "eve.turn",
-      "type": "task",
-      "children": [
-        {
-          "name": "eve.step",
-          "type": "llm",
-          "children": [],
-          "input": [
-            {
-              "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-              "role": "system"
-            },
-            {
-              "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
-              "role": "user"
-            }
-          ],
-          "output": [
-            {
-              "finish_reason": "tool_calls",
-              "index": 0,
-              "message": {
-                "content": null,
-                "role": "assistant",
-                "tool_calls": [
-                  {
-                    "function": {
-                      "arguments": "{\"query\":\"Run the Braintrust Eve instrumentation e2e scenario again\"}",
-                      "name": "search"
-                    },
-                    "id": "<span:1>",
-                    "type": "function"
-                  }
-                ]
-              }
-            }
-          ],
-          "metadata": {
-            "model": "gpt-5.4-mini",
-            "provider": "openai",
-            "scenario": "eve-instrumentation",
-            "testRunId": "<run:1>"
-          },
-          "metrics": {
-            "completion_tokens": 27,
-            "prompt_cached_tokens": 6528,
-            "prompt_tokens": 6555,
-            "tokens": 6582
-          }
-        },
-        {
-          "name": "search",
-          "type": "tool",
-          "children": [],
-          "input": {
-            "query": "Run the Braintrust Eve instrumentation e2e scenario again"
-          },
-          "output": {
-            "query": "Run the Braintrust Eve instrumentation e2e scenario again",
-            "title": "Eve instrumentation",
-            "url": "https://eve.dev/docs/guides/instrumentation"
-          },
-          "metadata": {
-            "scenario": "eve-instrumentation",
-            "testRunId": "<run:1>"
-          }
-        },
-        {
-          "name": "eve.step",
-          "type": "llm",
-          "children": [],
-          "input": [
-            {
-              "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-              "role": "system"
-            },
-            {
-              "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
-              "role": "user"
-            },
-            {
-              "content": [
-                {
-                  "input": {
-                    "query": "Run the Braintrust Eve instrumentation e2e scenario again"
-                  },
-                  "providerOptions": {
-                    "openai": {
-                      "itemId": "<itemId:2>"
-                    }
-                  },
-                  "toolCallId": "<toolCallId:1>",
-                  "toolName": "search",
-                  "type": "tool-call"
-                }
-              ],
-              "role": "assistant"
-            },
-            {
-              "content": [
-                {
-                  "output": {
-                    "type": "json",
-                    "value": {
-                      "query": "Run the Braintrust Eve instrumentation e2e scenario again",
-                      "title": "Eve instrumentation",
-                      "url": "https://eve.dev/docs/guides/instrumentation"
-                    }
-                  },
-                  "providerOptions": {
-                    "openai": {
-                      "itemId": "<itemId:2>"
-                    }
-                  },
-                  "toolCallId": "<toolCallId:1>",
-                  "toolName": "search",
-                  "type": "tool-result"
-                }
-              ],
-              "role": "tool"
-            }
-          ],
-          "output": [
-            {
-              "finish_reason": "stop",
-              "index": 0,
-              "message": {
-                "content": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
-                "role": "assistant"
-              }
-            }
-          ],
-          "metadata": {
-            "model": "gpt-5.4-mini",
-            "provider": "openai",
-            "scenario": "eve-instrumentation",
-            "testRunId": "<run:1>"
-          },
-          "metrics": {
-            "completion_tokens": 22,
-            "prompt_cached_tokens": 6528,
-            "prompt_tokens": 6627,
-            "tokens": 6649
-          }
-        }
-      ],
-      "input": [
-        {
-          "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
-          "role": "user"
-        }
-      ],
-      "output": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
-      "metadata": {
-        "model": "gpt-5.4-mini",
-        "provider": "openai",
-        "scenario": "eve-instrumentation",
-        "testRunId": "<run:1>"
-      },
-      "metrics": {
-        "completion_tokens": 49,
-        "prompt_cached_tokens": 13056,
-        "prompt_tokens": 13182,
-        "tokens": 13231
       }
     }
   ]

--- a/e2e/scenarios/eve-instrumentation/__snapshots__/eve-instrumentation.span-tree.json
+++ b/e2e/scenarios/eve-instrumentation/__snapshots__/eve-instrumentation.span-tree.json
@@ -1,469 +1,43 @@
 {
   "span_tree": [
     {
-      "name": "eve.session",
+      "name": "eve.turn",
       "type": "task",
       "children": [
         {
-          "name": "eve.turn",
-          "type": "task",
-          "children": [
-            {
-              "name": "eve.step",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-                  "role": "system"
-                },
-                {
-                  "content": "Run the Braintrust Eve instrumentation e2e scenario",
-                  "role": "user"
-                }
-              ],
-              "output": [
-                {
-                  "finish_reason": "tool_calls",
-                  "index": 0,
-                  "message": {
-                    "content": null,
-                    "role": "assistant",
-                    "tool_calls": [
-                      {
-                        "function": {
-                          "arguments": "{\"message\":\"Run the Braintrust Eve instrumentation e2e scenario\"}",
-                          "name": "researcher"
-                        },
-                        "id": "<span:1>",
-                        "type": "function"
-                      }
-                    ]
-                  }
-                }
-              ],
-              "metadata": {
-                "model": "gpt-5.4-mini",
-                "provider": "openai",
-                "scenario": "eve-instrumentation",
-                "testRunId": "<run:1>"
-              },
-              "metrics": {
-                "completion_tokens": 28,
-                "prompt_cached_tokens": 0,
-                "prompt_tokens": 6666,
-                "tokens": 6694
-              }
-            },
-            {
-              "name": "researcher",
-              "type": "tool",
-              "children": [
-                {
-                  "name": "eve.session",
-                  "type": "task",
-                  "children": [
-                    {
-                      "name": "eve.turn",
-                      "type": "task",
-                      "children": [
-                        {
-                          "name": "eve.step",
-                          "type": "llm",
-                          "children": [],
-                          "input": [
-                            {
-                              "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-                              "role": "system"
-                            },
-                            {
-                              "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
-                              "role": "user"
-                            }
-                          ],
-                          "output": [
-                            {
-                              "finish_reason": "tool_calls",
-                              "index": 0,
-                              "message": {
-                                "content": null,
-                                "role": "assistant",
-                                "tool_calls": [
-                                  {
-                                    "function": {
-                                      "arguments": "{\"query\":\"Run the Braintrust Eve instrumentation e2e scenario\"}",
-                                      "name": "search"
-                                    },
-                                    "id": "<span:1>",
-                                    "type": "function"
-                                  }
-                                ]
-                              }
-                            }
-                          ],
-                          "metadata": {
-                            "model": "gpt-5.4-mini",
-                            "provider": "openai",
-                            "scenario": "eve-instrumentation",
-                            "testRunId": "<run:1>"
-                          },
-                          "metrics": {
-                            "completion_tokens": 26,
-                            "prompt_cached_tokens": 0,
-                            "prompt_tokens": 6554,
-                            "tokens": 6580
-                          }
-                        },
-                        {
-                          "name": "search",
-                          "type": "tool",
-                          "children": [],
-                          "input": {
-                            "query": "Run the Braintrust Eve instrumentation e2e scenario"
-                          },
-                          "output": {
-                            "query": "Run the Braintrust Eve instrumentation e2e scenario",
-                            "title": "Eve instrumentation",
-                            "url": "https://eve.dev/docs/guides/instrumentation"
-                          },
-                          "metadata": {
-                            "scenario": "eve-instrumentation",
-                            "testRunId": "<run:1>"
-                          }
-                        },
-                        {
-                          "name": "eve.step",
-                          "type": "llm",
-                          "children": [],
-                          "input": [
-                            {
-                              "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-                              "role": "system"
-                            },
-                            {
-                              "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
-                              "role": "user"
-                            },
-                            {
-                              "content": [
-                                {
-                                  "input": {
-                                    "query": "Run the Braintrust Eve instrumentation e2e scenario"
-                                  },
-                                  "providerOptions": {
-                                    "openai": {
-                                      "itemId": "<itemId:2>"
-                                    }
-                                  },
-                                  "toolCallId": "<toolCallId:1>",
-                                  "toolName": "search",
-                                  "type": "tool-call"
-                                }
-                              ],
-                              "role": "assistant"
-                            },
-                            {
-                              "content": [
-                                {
-                                  "output": {
-                                    "type": "json",
-                                    "value": {
-                                      "query": "Run the Braintrust Eve instrumentation e2e scenario",
-                                      "title": "Eve instrumentation",
-                                      "url": "https://eve.dev/docs/guides/instrumentation"
-                                    }
-                                  },
-                                  "providerOptions": {
-                                    "openai": {
-                                      "itemId": "<itemId:2>"
-                                    }
-                                  },
-                                  "toolCallId": "<toolCallId:1>",
-                                  "toolName": "search",
-                                  "type": "tool-result"
-                                }
-                              ],
-                              "role": "tool"
-                            }
-                          ],
-                          "output": [
-                            {
-                              "finish_reason": "stop",
-                              "index": 0,
-                              "message": {
-                                "content": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
-                                "role": "assistant"
-                              }
-                            }
-                          ],
-                          "metadata": {
-                            "model": "gpt-5.4-mini",
-                            "provider": "openai",
-                            "scenario": "eve-instrumentation",
-                            "testRunId": "<run:1>"
-                          },
-                          "metrics": {
-                            "completion_tokens": 22,
-                            "prompt_cached_tokens": 5504,
-                            "prompt_tokens": 6624,
-                            "tokens": 6646
-                          }
-                        }
-                      ],
-                      "input": [
-                        {
-                          "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
-                          "role": "user"
-                        }
-                      ],
-                      "output": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
-                      "metadata": {
-                        "model": "gpt-5.4-mini",
-                        "provider": "openai",
-                        "scenario": "eve-instrumentation",
-                        "testRunId": "<run:1>"
-                      },
-                      "metrics": {
-                        "completion_tokens": 48,
-                        "prompt_cached_tokens": 5504,
-                        "prompt_tokens": 13178,
-                        "tokens": 13226
-                      }
-                    }
-                  ],
-                  "metadata": {
-                    "model": "gpt-5.4-mini",
-                    "provider": "openai",
-                    "scenario": "eve-instrumentation",
-                    "testRunId": "<run:1>"
-                  }
-                }
-              ],
-              "input": {
-                "message": "Run the Braintrust Eve instrumentation e2e scenario"
-              },
-              "output": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
-              "metadata": {
-                "scenario": "eve-instrumentation",
-                "testRunId": "<run:1>"
-              }
-            },
-            {
-              "name": "eve.step",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-                  "role": "system"
-                },
-                {
-                  "content": "Run the Braintrust Eve instrumentation e2e scenario",
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "input": {
-                        "message": "Run the Braintrust Eve instrumentation e2e scenario"
-                      },
-                      "providerOptions": {
-                        "openai": {
-                          "itemId": "<itemId:2>"
-                        }
-                      },
-                      "toolCallId": "<toolCallId:1>",
-                      "toolName": "researcher",
-                      "type": "tool-call"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "output": {
-                        "type": "text",
-                        "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-                      },
-                      "toolCallId": "<toolCallId:1>",
-                      "toolName": "researcher",
-                      "type": "tool-result"
-                    }
-                  ],
-                  "role": "tool"
-                }
-              ],
-              "output": [
-                {
-                  "finish_reason": "tool_calls",
-                  "index": 0,
-                  "message": {
-                    "content": null,
-                    "role": "assistant",
-                    "tool_calls": [
-                      {
-                        "function": {
-                          "arguments": "{\"url\":\"https://eve.dev/docs/guides/instrumentation\"}",
-                          "name": "read"
-                        },
-                        "id": "<span:1>",
-                        "type": "function"
-                      }
-                    ]
-                  }
-                }
-              ],
-              "metadata": {
-                "model": "gpt-5.4-mini",
-                "provider": "openai",
-                "scenario": "eve-instrumentation",
-                "testRunId": "<run:1>"
-              },
-              "metrics": {
-                "completion_tokens": 27,
-                "prompt_cached_tokens": 6528,
-                "prompt_tokens": 6724,
-                "tokens": 6751
-              }
-            },
-            {
-              "name": "read",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "url": "https://eve.dev/docs/guides/instrumentation"
-              },
-              "output": {
-                "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-                "section": "Runtime context",
-                "title": "Eve instrumentation",
-                "url": "https://eve.dev/docs/guides/instrumentation"
-              },
-              "metadata": {
-                "scenario": "eve-instrumentation",
-                "testRunId": "<run:1>"
-              }
-            },
-            {
-              "name": "eve.step",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-                  "role": "system"
-                },
-                {
-                  "content": "Run the Braintrust Eve instrumentation e2e scenario",
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "input": {
-                        "message": "Run the Braintrust Eve instrumentation e2e scenario"
-                      },
-                      "providerOptions": {
-                        "openai": {
-                          "itemId": "<itemId:2>"
-                        }
-                      },
-                      "toolCallId": "<toolCallId:1>",
-                      "toolName": "researcher",
-                      "type": "tool-call"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "output": {
-                        "type": "text",
-                        "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-                      },
-                      "toolCallId": "<toolCallId:1>",
-                      "toolName": "researcher",
-                      "type": "tool-result"
-                    }
-                  ],
-                  "role": "tool"
-                },
-                {
-                  "content": [
-                    {
-                      "input": {
-                        "url": "https://eve.dev/docs/guides/instrumentation"
-                      },
-                      "providerOptions": {
-                        "openai": {
-                          "itemId": "<itemId:4>"
-                        }
-                      },
-                      "toolCallId": "<toolCallId:3>",
-                      "toolName": "read",
-                      "type": "tool-call"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "output": {
-                        "type": "json",
-                        "value": {
-                          "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-                          "section": "Runtime context",
-                          "title": "Eve instrumentation",
-                          "url": "https://eve.dev/docs/guides/instrumentation"
-                        }
-                      },
-                      "providerOptions": {
-                        "openai": {
-                          "itemId": "<itemId:4>"
-                        }
-                      },
-                      "toolCallId": "<toolCallId:3>",
-                      "toolName": "read",
-                      "type": "tool-result"
-                    }
-                  ],
-                  "role": "tool"
-                }
-              ],
-              "output": [
-                {
-                  "finish_reason": "stop",
-                  "index": 0,
-                  "message": {
-                    "content": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-                    "role": "assistant"
-                  }
-                }
-              ],
-              "metadata": {
-                "model": "gpt-5.4-mini",
-                "provider": "openai",
-                "scenario": "eve-instrumentation",
-                "testRunId": "<run:1>"
-              },
-              "metrics": {
-                "completion_tokens": 65,
-                "prompt_cached_tokens": 6528,
-                "prompt_tokens": 6806,
-                "tokens": 6871
-              }
-            }
-          ],
+          "name": "eve.step",
+          "type": "llm",
+          "children": [],
           "input": [
+            {
+              "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+              "role": "system"
+            },
             {
               "content": "Run the Braintrust Eve instrumentation e2e scenario",
               "role": "user"
             }
           ],
-          "output": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+          "output": [
+            {
+              "finish_reason": "tool_calls",
+              "index": 0,
+              "message": {
+                "content": null,
+                "role": "assistant",
+                "tool_calls": [
+                  {
+                    "function": {
+                      "arguments": "{\"message\":\"Run the Braintrust Eve instrumentation e2e scenario\"}",
+                      "name": "researcher"
+                    },
+                    "id": "<span:1>",
+                    "type": "function"
+                  }
+                ]
+              }
+            }
+          ],
           "metadata": {
             "model": "gpt-5.4-mini",
             "provider": "openai",
@@ -471,751 +45,91 @@
             "testRunId": "<run:1>"
           },
           "metrics": {
-            "completion_tokens": 120,
-            "prompt_cached_tokens": 13056,
-            "prompt_tokens": 20196,
-            "tokens": 20316
+            "completion_tokens": 28,
+            "prompt_cached_tokens": 0,
+            "prompt_tokens": 6666,
+            "tokens": 6694
           }
         },
         {
-          "name": "eve.turn",
-          "type": "task",
-          "children": [
-            {
-              "name": "eve.step",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-                  "role": "system"
-                },
-                {
-                  "content": "Run the Braintrust Eve instrumentation e2e scenario",
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "input": {
-                        "message": "Run the Braintrust Eve instrumentation e2e scenario"
-                      },
-                      "providerOptions": {
-                        "openai": {
-                          "itemId": "<itemId:2>"
-                        }
-                      },
-                      "toolCallId": "<toolCallId:1>",
-                      "toolName": "researcher",
-                      "type": "tool-call"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "output": {
-                        "type": "text",
-                        "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-                      },
-                      "toolCallId": "<toolCallId:1>",
-                      "toolName": "researcher",
-                      "type": "tool-result"
-                    }
-                  ],
-                  "role": "tool"
-                },
-                {
-                  "content": [
-                    {
-                      "input": {
-                        "url": "https://eve.dev/docs/guides/instrumentation"
-                      },
-                      "providerOptions": {
-                        "openai": {
-                          "itemId": "<itemId:4>"
-                        }
-                      },
-                      "toolCallId": "<toolCallId:3>",
-                      "toolName": "read",
-                      "type": "tool-call"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "output": {
-                        "type": "json",
-                        "value": {
-                          "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-                          "section": "Runtime context",
-                          "title": "Eve instrumentation",
-                          "url": "https://eve.dev/docs/guides/instrumentation"
-                        }
-                      },
-                      "providerOptions": {
-                        "openai": {
-                          "itemId": "<itemId:4>"
-                        }
-                      },
-                      "toolCallId": "<toolCallId:3>",
-                      "toolName": "read",
-                      "type": "tool-result"
-                    }
-                  ],
-                  "role": "tool"
-                },
-                {
-                  "content": [
-                    {
-                      "providerOptions": {
-                        "openai": {
-                          "itemId": "<itemId:5>",
-                          "phase": "final_answer"
-                        }
-                      },
-                      "text": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": "Run the Braintrust Eve instrumentation e2e scenario again",
-                  "role": "user"
-                }
-              ],
-              "output": [
-                {
-                  "finish_reason": "tool_calls",
-                  "index": 0,
-                  "message": {
-                    "content": null,
-                    "role": "assistant",
-                    "tool_calls": [
-                      {
-                        "function": {
-                          "arguments": "{\"message\":\"Run the Braintrust Eve instrumentation e2e scenario again\"}",
-                          "name": "researcher"
-                        },
-                        "id": "<span:1>",
-                        "type": "function"
-                      }
-                    ]
-                  }
-                }
-              ],
-              "metadata": {
-                "model": "gpt-5.4-mini",
-                "provider": "openai",
-                "scenario": "eve-instrumentation",
-                "testRunId": "<run:1>"
-              },
-              "metrics": {
-                "completion_tokens": 29,
-                "prompt_cached_tokens": 6528,
-                "prompt_tokens": 6888,
-                "tokens": 6917
-              }
-            },
-            {
-              "name": "researcher",
-              "type": "tool",
-              "children": [
-                {
-                  "name": "eve.session",
-                  "type": "task",
-                  "children": [
-                    {
-                      "name": "eve.turn",
-                      "type": "task",
-                      "children": [
-                        {
-                          "name": "eve.step",
-                          "type": "llm",
-                          "children": [],
-                          "input": [
-                            {
-                              "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-                              "role": "system"
-                            },
-                            {
-                              "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
-                              "role": "user"
-                            }
-                          ],
-                          "output": [
-                            {
-                              "finish_reason": "tool_calls",
-                              "index": 0,
-                              "message": {
-                                "content": null,
-                                "role": "assistant",
-                                "tool_calls": [
-                                  {
-                                    "function": {
-                                      "arguments": "{\"query\":\"Run the Braintrust Eve instrumentation e2e scenario again\"}",
-                                      "name": "search"
-                                    },
-                                    "id": "<span:1>",
-                                    "type": "function"
-                                  }
-                                ]
-                              }
-                            }
-                          ],
-                          "metadata": {
-                            "model": "gpt-5.4-mini",
-                            "provider": "openai",
-                            "scenario": "eve-instrumentation",
-                            "testRunId": "<run:1>"
-                          },
-                          "metrics": {
-                            "completion_tokens": 27,
-                            "prompt_cached_tokens": 6528,
-                            "prompt_tokens": 6555,
-                            "tokens": 6582
-                          }
-                        },
-                        {
-                          "name": "search",
-                          "type": "tool",
-                          "children": [],
-                          "input": {
-                            "query": "Run the Braintrust Eve instrumentation e2e scenario again"
-                          },
-                          "output": {
-                            "query": "Run the Braintrust Eve instrumentation e2e scenario again",
-                            "title": "Eve instrumentation",
-                            "url": "https://eve.dev/docs/guides/instrumentation"
-                          },
-                          "metadata": {
-                            "scenario": "eve-instrumentation",
-                            "testRunId": "<run:1>"
-                          }
-                        },
-                        {
-                          "name": "eve.step",
-                          "type": "llm",
-                          "children": [],
-                          "input": [
-                            {
-                              "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-                              "role": "system"
-                            },
-                            {
-                              "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
-                              "role": "user"
-                            },
-                            {
-                              "content": [
-                                {
-                                  "input": {
-                                    "query": "Run the Braintrust Eve instrumentation e2e scenario again"
-                                  },
-                                  "providerOptions": {
-                                    "openai": {
-                                      "itemId": "<itemId:2>"
-                                    }
-                                  },
-                                  "toolCallId": "<toolCallId:1>",
-                                  "toolName": "search",
-                                  "type": "tool-call"
-                                }
-                              ],
-                              "role": "assistant"
-                            },
-                            {
-                              "content": [
-                                {
-                                  "output": {
-                                    "type": "json",
-                                    "value": {
-                                      "query": "Run the Braintrust Eve instrumentation e2e scenario again",
-                                      "title": "Eve instrumentation",
-                                      "url": "https://eve.dev/docs/guides/instrumentation"
-                                    }
-                                  },
-                                  "providerOptions": {
-                                    "openai": {
-                                      "itemId": "<itemId:2>"
-                                    }
-                                  },
-                                  "toolCallId": "<toolCallId:1>",
-                                  "toolName": "search",
-                                  "type": "tool-result"
-                                }
-                              ],
-                              "role": "tool"
-                            }
-                          ],
-                          "output": [
-                            {
-                              "finish_reason": "stop",
-                              "index": 0,
-                              "message": {
-                                "content": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
-                                "role": "assistant"
-                              }
-                            }
-                          ],
-                          "metadata": {
-                            "model": "gpt-5.4-mini",
-                            "provider": "openai",
-                            "scenario": "eve-instrumentation",
-                            "testRunId": "<run:1>"
-                          },
-                          "metrics": {
-                            "completion_tokens": 22,
-                            "prompt_cached_tokens": 6528,
-                            "prompt_tokens": 6627,
-                            "tokens": 6649
-                          }
-                        }
-                      ],
-                      "input": [
-                        {
-                          "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
-                          "role": "user"
-                        }
-                      ],
-                      "output": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
-                      "metadata": {
-                        "model": "gpt-5.4-mini",
-                        "provider": "openai",
-                        "scenario": "eve-instrumentation",
-                        "testRunId": "<run:1>"
-                      },
-                      "metrics": {
-                        "completion_tokens": 49,
-                        "prompt_cached_tokens": 13056,
-                        "prompt_tokens": 13182,
-                        "tokens": 13231
-                      }
-                    }
-                  ],
-                  "metadata": {
-                    "model": "gpt-5.4-mini",
-                    "provider": "openai",
-                    "scenario": "eve-instrumentation",
-                    "testRunId": "<run:1>"
-                  }
-                }
-              ],
-              "input": {
-                "message": "Run the Braintrust Eve instrumentation e2e scenario again"
-              },
-              "output": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
-              "metadata": {
-                "scenario": "eve-instrumentation",
-                "testRunId": "<run:1>"
-              }
-            },
-            {
-              "name": "eve.step",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-                  "role": "system"
-                },
-                {
-                  "content": "Run the Braintrust Eve instrumentation e2e scenario",
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "input": {
-                        "message": "Run the Braintrust Eve instrumentation e2e scenario"
-                      },
-                      "providerOptions": {
-                        "openai": {
-                          "itemId": "<itemId:2>"
-                        }
-                      },
-                      "toolCallId": "<toolCallId:1>",
-                      "toolName": "researcher",
-                      "type": "tool-call"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "output": {
-                        "type": "text",
-                        "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-                      },
-                      "toolCallId": "<toolCallId:1>",
-                      "toolName": "researcher",
-                      "type": "tool-result"
-                    }
-                  ],
-                  "role": "tool"
-                },
-                {
-                  "content": [
-                    {
-                      "input": {
-                        "url": "https://eve.dev/docs/guides/instrumentation"
-                      },
-                      "providerOptions": {
-                        "openai": {
-                          "itemId": "<itemId:4>"
-                        }
-                      },
-                      "toolCallId": "<toolCallId:3>",
-                      "toolName": "read",
-                      "type": "tool-call"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "output": {
-                        "type": "json",
-                        "value": {
-                          "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-                          "section": "Runtime context",
-                          "title": "Eve instrumentation",
-                          "url": "https://eve.dev/docs/guides/instrumentation"
-                        }
-                      },
-                      "providerOptions": {
-                        "openai": {
-                          "itemId": "<itemId:4>"
-                        }
-                      },
-                      "toolCallId": "<toolCallId:3>",
-                      "toolName": "read",
-                      "type": "tool-result"
-                    }
-                  ],
-                  "role": "tool"
-                },
-                {
-                  "content": [
-                    {
-                      "providerOptions": {
-                        "openai": {
-                          "itemId": "<itemId:5>",
-                          "phase": "final_answer"
-                        }
-                      },
-                      "text": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": "Run the Braintrust Eve instrumentation e2e scenario again",
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "input": {
-                        "message": "Run the Braintrust Eve instrumentation e2e scenario again"
-                      },
-                      "providerOptions": {
-                        "openai": {
-                          "itemId": "<itemId:7>"
-                        }
-                      },
-                      "toolCallId": "<toolCallId:6>",
-                      "toolName": "researcher",
-                      "type": "tool-call"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "output": {
-                        "type": "text",
-                        "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-                      },
-                      "toolCallId": "<toolCallId:6>",
-                      "toolName": "researcher",
-                      "type": "tool-result"
-                    }
-                  ],
-                  "role": "tool"
-                }
-              ],
-              "output": [
-                {
-                  "finish_reason": "tool_calls",
-                  "index": 0,
-                  "message": {
-                    "content": null,
-                    "role": "assistant",
-                    "tool_calls": [
-                      {
-                        "function": {
-                          "arguments": "{\"url\":\"https://eve.dev/docs/guides/instrumentation\"}",
-                          "name": "read"
-                        },
-                        "id": "<span:1>",
-                        "type": "function"
-                      }
-                    ]
-                  }
-                }
-              ],
-              "metadata": {
-                "model": "gpt-5.4-mini",
-                "provider": "openai",
-                "scenario": "eve-instrumentation",
-                "testRunId": "<run:1>"
-              },
-              "metrics": {
-                "completion_tokens": 27,
-                "prompt_cached_tokens": 6528,
-                "prompt_tokens": 6947,
-                "tokens": 6974
-              }
-            },
-            {
-              "name": "read",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "url": "https://eve.dev/docs/guides/instrumentation"
-              },
-              "output": {
-                "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-                "section": "Runtime context",
-                "title": "Eve instrumentation",
-                "url": "https://eve.dev/docs/guides/instrumentation"
-              },
-              "metadata": {
-                "scenario": "eve-instrumentation",
-                "testRunId": "<run:1>"
-              }
-            },
-            {
-              "name": "eve.step",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-                  "role": "system"
-                },
-                {
-                  "content": "Run the Braintrust Eve instrumentation e2e scenario",
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "input": {
-                        "message": "Run the Braintrust Eve instrumentation e2e scenario"
-                      },
-                      "providerOptions": {
-                        "openai": {
-                          "itemId": "<itemId:2>"
-                        }
-                      },
-                      "toolCallId": "<toolCallId:1>",
-                      "toolName": "researcher",
-                      "type": "tool-call"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "output": {
-                        "type": "text",
-                        "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-                      },
-                      "toolCallId": "<toolCallId:1>",
-                      "toolName": "researcher",
-                      "type": "tool-result"
-                    }
-                  ],
-                  "role": "tool"
-                },
-                {
-                  "content": [
-                    {
-                      "input": {
-                        "url": "https://eve.dev/docs/guides/instrumentation"
-                      },
-                      "providerOptions": {
-                        "openai": {
-                          "itemId": "<itemId:4>"
-                        }
-                      },
-                      "toolCallId": "<toolCallId:3>",
-                      "toolName": "read",
-                      "type": "tool-call"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "output": {
-                        "type": "json",
-                        "value": {
-                          "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-                          "section": "Runtime context",
-                          "title": "Eve instrumentation",
-                          "url": "https://eve.dev/docs/guides/instrumentation"
-                        }
-                      },
-                      "providerOptions": {
-                        "openai": {
-                          "itemId": "<itemId:4>"
-                        }
-                      },
-                      "toolCallId": "<toolCallId:3>",
-                      "toolName": "read",
-                      "type": "tool-result"
-                    }
-                  ],
-                  "role": "tool"
-                },
-                {
-                  "content": [
-                    {
-                      "providerOptions": {
-                        "openai": {
-                          "itemId": "<itemId:5>",
-                          "phase": "final_answer"
-                        }
-                      },
-                      "text": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": "Run the Braintrust Eve instrumentation e2e scenario again",
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "input": {
-                        "message": "Run the Braintrust Eve instrumentation e2e scenario again"
-                      },
-                      "providerOptions": {
-                        "openai": {
-                          "itemId": "<itemId:7>"
-                        }
-                      },
-                      "toolCallId": "<toolCallId:6>",
-                      "toolName": "researcher",
-                      "type": "tool-call"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "output": {
-                        "type": "text",
-                        "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-                      },
-                      "toolCallId": "<toolCallId:6>",
-                      "toolName": "researcher",
-                      "type": "tool-result"
-                    }
-                  ],
-                  "role": "tool"
-                },
-                {
-                  "content": [
-                    {
-                      "input": {
-                        "url": "https://eve.dev/docs/guides/instrumentation"
-                      },
-                      "providerOptions": {
-                        "openai": {
-                          "itemId": "<itemId:9>"
-                        }
-                      },
-                      "toolCallId": "<toolCallId:8>",
-                      "toolName": "read",
-                      "type": "tool-call"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "output": {
-                        "type": "json",
-                        "value": {
-                          "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-                          "section": "Runtime context",
-                          "title": "Eve instrumentation",
-                          "url": "https://eve.dev/docs/guides/instrumentation"
-                        }
-                      },
-                      "providerOptions": {
-                        "openai": {
-                          "itemId": "<itemId:9>"
-                        }
-                      },
-                      "toolCallId": "<toolCallId:8>",
-                      "toolName": "read",
-                      "type": "tool-result"
-                    }
-                  ],
-                  "role": "tool"
-                }
-              ],
-              "output": [
-                {
-                  "finish_reason": "stop",
-                  "index": 0,
-                  "message": {
-                    "content": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-                    "role": "assistant"
-                  }
-                }
-              ],
-              "metadata": {
-                "model": "gpt-5.4-mini",
-                "provider": "openai",
-                "scenario": "eve-instrumentation",
-                "testRunId": "<run:1>"
-              },
-              "metrics": {
-                "completion_tokens": 65,
-                "prompt_cached_tokens": 6528,
-                "prompt_tokens": 7029,
-                "tokens": 7094
-              }
-            }
-          ],
+          "name": "researcher",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "message": "Run the Braintrust Eve instrumentation e2e scenario"
+          },
+          "output": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
+          "metadata": {
+            "scenario": "eve-instrumentation",
+            "testRunId": "<run:1>"
+          }
+        },
+        {
+          "name": "eve.step",
+          "type": "llm",
+          "children": [],
           "input": [
             {
-              "content": "Run the Braintrust Eve instrumentation e2e scenario again",
+              "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+              "role": "system"
+            },
+            {
+              "content": "Run the Braintrust Eve instrumentation e2e scenario",
               "role": "user"
+            },
+            {
+              "content": [
+                {
+                  "input": {
+                    "message": "Run the Braintrust Eve instrumentation e2e scenario"
+                  },
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:2>"
+                    }
+                  },
+                  "toolCallId": "<toolCallId:1>",
+                  "toolName": "researcher",
+                  "type": "tool-call"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "output": {
+                    "type": "text",
+                    "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+                  },
+                  "toolCallId": "<toolCallId:1>",
+                  "toolName": "researcher",
+                  "type": "tool-result"
+                }
+              ],
+              "role": "tool"
             }
           ],
-          "output": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+          "output": [
+            {
+              "finish_reason": "tool_calls",
+              "index": 0,
+              "message": {
+                "content": null,
+                "role": "assistant",
+                "tool_calls": [
+                  {
+                    "function": {
+                      "arguments": "{\"url\":\"https://eve.dev/docs/guides/instrumentation\"}",
+                      "name": "read"
+                    },
+                    "id": "<span:1>",
+                    "type": "function"
+                  }
+                ]
+              }
+            }
+          ],
           "metadata": {
             "model": "gpt-5.4-mini",
             "provider": "openai",
@@ -1223,18 +137,1066 @@
             "testRunId": "<run:1>"
           },
           "metrics": {
-            "completion_tokens": 121,
-            "prompt_cached_tokens": 19584,
-            "prompt_tokens": 20864,
-            "tokens": 20985
+            "completion_tokens": 27,
+            "prompt_cached_tokens": 6528,
+            "prompt_tokens": 6724,
+            "tokens": 6751
+          }
+        },
+        {
+          "name": "read",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "url": "https://eve.dev/docs/guides/instrumentation"
+          },
+          "output": {
+            "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+            "section": "Runtime context",
+            "title": "Eve instrumentation",
+            "url": "https://eve.dev/docs/guides/instrumentation"
+          },
+          "metadata": {
+            "scenario": "eve-instrumentation",
+            "testRunId": "<run:1>"
+          }
+        },
+        {
+          "name": "eve.step",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+              "role": "system"
+            },
+            {
+              "content": "Run the Braintrust Eve instrumentation e2e scenario",
+              "role": "user"
+            },
+            {
+              "content": [
+                {
+                  "input": {
+                    "message": "Run the Braintrust Eve instrumentation e2e scenario"
+                  },
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:2>"
+                    }
+                  },
+                  "toolCallId": "<toolCallId:1>",
+                  "toolName": "researcher",
+                  "type": "tool-call"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "output": {
+                    "type": "text",
+                    "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+                  },
+                  "toolCallId": "<toolCallId:1>",
+                  "toolName": "researcher",
+                  "type": "tool-result"
+                }
+              ],
+              "role": "tool"
+            },
+            {
+              "content": [
+                {
+                  "input": {
+                    "url": "https://eve.dev/docs/guides/instrumentation"
+                  },
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:4>"
+                    }
+                  },
+                  "toolCallId": "<toolCallId:3>",
+                  "toolName": "read",
+                  "type": "tool-call"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "output": {
+                    "type": "json",
+                    "value": {
+                      "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+                      "section": "Runtime context",
+                      "title": "Eve instrumentation",
+                      "url": "https://eve.dev/docs/guides/instrumentation"
+                    }
+                  },
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:4>"
+                    }
+                  },
+                  "toolCallId": "<toolCallId:3>",
+                  "toolName": "read",
+                  "type": "tool-result"
+                }
+              ],
+              "role": "tool"
+            }
+          ],
+          "output": [
+            {
+              "finish_reason": "stop",
+              "index": 0,
+              "message": {
+                "content": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+                "role": "assistant"
+              }
+            }
+          ],
+          "metadata": {
+            "model": "gpt-5.4-mini",
+            "provider": "openai",
+            "scenario": "eve-instrumentation",
+            "testRunId": "<run:1>"
+          },
+          "metrics": {
+            "completion_tokens": 65,
+            "prompt_cached_tokens": 6528,
+            "prompt_tokens": 6806,
+            "tokens": 6871
           }
         }
       ],
+      "input": [
+        {
+          "content": "Run the Braintrust Eve instrumentation e2e scenario",
+          "role": "user"
+        }
+      ],
+      "output": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
       "metadata": {
         "model": "gpt-5.4-mini",
         "provider": "openai",
         "scenario": "eve-instrumentation",
         "testRunId": "<run:1>"
+      },
+      "metrics": {
+        "completion_tokens": 120,
+        "prompt_cached_tokens": 13056,
+        "prompt_tokens": 20196,
+        "tokens": 20316
+      }
+    },
+    {
+      "name": "eve.turn",
+      "type": "task",
+      "children": [
+        {
+          "name": "eve.step",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+              "role": "system"
+            },
+            {
+              "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
+              "role": "user"
+            }
+          ],
+          "output": [
+            {
+              "finish_reason": "tool_calls",
+              "index": 0,
+              "message": {
+                "content": null,
+                "role": "assistant",
+                "tool_calls": [
+                  {
+                    "function": {
+                      "arguments": "{\"query\":\"Run the Braintrust Eve instrumentation e2e scenario\"}",
+                      "name": "search"
+                    },
+                    "id": "<span:1>",
+                    "type": "function"
+                  }
+                ]
+              }
+            }
+          ],
+          "metadata": {
+            "model": "gpt-5.4-mini",
+            "provider": "openai",
+            "scenario": "eve-instrumentation",
+            "testRunId": "<run:1>"
+          },
+          "metrics": {
+            "completion_tokens": 26,
+            "prompt_cached_tokens": 0,
+            "prompt_tokens": 6554,
+            "tokens": 6580
+          }
+        },
+        {
+          "name": "search",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "query": "Run the Braintrust Eve instrumentation e2e scenario"
+          },
+          "output": {
+            "query": "Run the Braintrust Eve instrumentation e2e scenario",
+            "title": "Eve instrumentation",
+            "url": "https://eve.dev/docs/guides/instrumentation"
+          },
+          "metadata": {
+            "scenario": "eve-instrumentation",
+            "testRunId": "<run:1>"
+          }
+        },
+        {
+          "name": "eve.step",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+              "role": "system"
+            },
+            {
+              "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
+              "role": "user"
+            },
+            {
+              "content": [
+                {
+                  "input": {
+                    "query": "Run the Braintrust Eve instrumentation e2e scenario"
+                  },
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:2>"
+                    }
+                  },
+                  "toolCallId": "<toolCallId:1>",
+                  "toolName": "search",
+                  "type": "tool-call"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "output": {
+                    "type": "json",
+                    "value": {
+                      "query": "Run the Braintrust Eve instrumentation e2e scenario",
+                      "title": "Eve instrumentation",
+                      "url": "https://eve.dev/docs/guides/instrumentation"
+                    }
+                  },
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:2>"
+                    }
+                  },
+                  "toolCallId": "<toolCallId:1>",
+                  "toolName": "search",
+                  "type": "tool-result"
+                }
+              ],
+              "role": "tool"
+            }
+          ],
+          "output": [
+            {
+              "finish_reason": "stop",
+              "index": 0,
+              "message": {
+                "content": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
+                "role": "assistant"
+              }
+            }
+          ],
+          "metadata": {
+            "model": "gpt-5.4-mini",
+            "provider": "openai",
+            "scenario": "eve-instrumentation",
+            "testRunId": "<run:1>"
+          },
+          "metrics": {
+            "completion_tokens": 22,
+            "prompt_cached_tokens": 5504,
+            "prompt_tokens": 6624,
+            "tokens": 6646
+          }
+        }
+      ],
+      "input": [
+        {
+          "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
+          "role": "user"
+        }
+      ],
+      "output": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
+      "metadata": {
+        "model": "gpt-5.4-mini",
+        "provider": "openai",
+        "scenario": "eve-instrumentation",
+        "testRunId": "<run:1>"
+      },
+      "metrics": {
+        "completion_tokens": 48,
+        "prompt_cached_tokens": 5504,
+        "prompt_tokens": 13178,
+        "tokens": 13226
+      }
+    },
+    {
+      "name": "eve.turn",
+      "type": "task",
+      "children": [
+        {
+          "name": "eve.step",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+              "role": "system"
+            },
+            {
+              "content": "Run the Braintrust Eve instrumentation e2e scenario",
+              "role": "user"
+            },
+            {
+              "content": [
+                {
+                  "input": {
+                    "message": "Run the Braintrust Eve instrumentation e2e scenario"
+                  },
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:2>"
+                    }
+                  },
+                  "toolCallId": "<toolCallId:1>",
+                  "toolName": "researcher",
+                  "type": "tool-call"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "output": {
+                    "type": "text",
+                    "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+                  },
+                  "toolCallId": "<toolCallId:1>",
+                  "toolName": "researcher",
+                  "type": "tool-result"
+                }
+              ],
+              "role": "tool"
+            },
+            {
+              "content": [
+                {
+                  "input": {
+                    "url": "https://eve.dev/docs/guides/instrumentation"
+                  },
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:4>"
+                    }
+                  },
+                  "toolCallId": "<toolCallId:3>",
+                  "toolName": "read",
+                  "type": "tool-call"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "output": {
+                    "type": "json",
+                    "value": {
+                      "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+                      "section": "Runtime context",
+                      "title": "Eve instrumentation",
+                      "url": "https://eve.dev/docs/guides/instrumentation"
+                    }
+                  },
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:4>"
+                    }
+                  },
+                  "toolCallId": "<toolCallId:3>",
+                  "toolName": "read",
+                  "type": "tool-result"
+                }
+              ],
+              "role": "tool"
+            },
+            {
+              "content": [
+                {
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:5>",
+                      "phase": "final_answer"
+                    }
+                  },
+                  "text": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+                  "type": "text"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": "Run the Braintrust Eve instrumentation e2e scenario again",
+              "role": "user"
+            }
+          ],
+          "output": [
+            {
+              "finish_reason": "tool_calls",
+              "index": 0,
+              "message": {
+                "content": null,
+                "role": "assistant",
+                "tool_calls": [
+                  {
+                    "function": {
+                      "arguments": "{\"message\":\"Run the Braintrust Eve instrumentation e2e scenario again\"}",
+                      "name": "researcher"
+                    },
+                    "id": "<span:1>",
+                    "type": "function"
+                  }
+                ]
+              }
+            }
+          ],
+          "metadata": {
+            "model": "gpt-5.4-mini",
+            "provider": "openai",
+            "scenario": "eve-instrumentation",
+            "testRunId": "<run:1>"
+          },
+          "metrics": {
+            "completion_tokens": 29,
+            "prompt_cached_tokens": 6528,
+            "prompt_tokens": 6888,
+            "tokens": 6917
+          }
+        },
+        {
+          "name": "researcher",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "message": "Run the Braintrust Eve instrumentation e2e scenario again"
+          },
+          "output": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
+          "metadata": {
+            "scenario": "eve-instrumentation",
+            "testRunId": "<run:1>"
+          }
+        },
+        {
+          "name": "eve.step",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+              "role": "system"
+            },
+            {
+              "content": "Run the Braintrust Eve instrumentation e2e scenario",
+              "role": "user"
+            },
+            {
+              "content": [
+                {
+                  "input": {
+                    "message": "Run the Braintrust Eve instrumentation e2e scenario"
+                  },
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:2>"
+                    }
+                  },
+                  "toolCallId": "<toolCallId:1>",
+                  "toolName": "researcher",
+                  "type": "tool-call"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "output": {
+                    "type": "text",
+                    "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+                  },
+                  "toolCallId": "<toolCallId:1>",
+                  "toolName": "researcher",
+                  "type": "tool-result"
+                }
+              ],
+              "role": "tool"
+            },
+            {
+              "content": [
+                {
+                  "input": {
+                    "url": "https://eve.dev/docs/guides/instrumentation"
+                  },
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:4>"
+                    }
+                  },
+                  "toolCallId": "<toolCallId:3>",
+                  "toolName": "read",
+                  "type": "tool-call"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "output": {
+                    "type": "json",
+                    "value": {
+                      "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+                      "section": "Runtime context",
+                      "title": "Eve instrumentation",
+                      "url": "https://eve.dev/docs/guides/instrumentation"
+                    }
+                  },
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:4>"
+                    }
+                  },
+                  "toolCallId": "<toolCallId:3>",
+                  "toolName": "read",
+                  "type": "tool-result"
+                }
+              ],
+              "role": "tool"
+            },
+            {
+              "content": [
+                {
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:5>",
+                      "phase": "final_answer"
+                    }
+                  },
+                  "text": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+                  "type": "text"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": "Run the Braintrust Eve instrumentation e2e scenario again",
+              "role": "user"
+            },
+            {
+              "content": [
+                {
+                  "input": {
+                    "message": "Run the Braintrust Eve instrumentation e2e scenario again"
+                  },
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:7>"
+                    }
+                  },
+                  "toolCallId": "<toolCallId:6>",
+                  "toolName": "researcher",
+                  "type": "tool-call"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "output": {
+                    "type": "text",
+                    "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+                  },
+                  "toolCallId": "<toolCallId:6>",
+                  "toolName": "researcher",
+                  "type": "tool-result"
+                }
+              ],
+              "role": "tool"
+            }
+          ],
+          "output": [
+            {
+              "finish_reason": "tool_calls",
+              "index": 0,
+              "message": {
+                "content": null,
+                "role": "assistant",
+                "tool_calls": [
+                  {
+                    "function": {
+                      "arguments": "{\"url\":\"https://eve.dev/docs/guides/instrumentation\"}",
+                      "name": "read"
+                    },
+                    "id": "<span:1>",
+                    "type": "function"
+                  }
+                ]
+              }
+            }
+          ],
+          "metadata": {
+            "model": "gpt-5.4-mini",
+            "provider": "openai",
+            "scenario": "eve-instrumentation",
+            "testRunId": "<run:1>"
+          },
+          "metrics": {
+            "completion_tokens": 27,
+            "prompt_cached_tokens": 6528,
+            "prompt_tokens": 6947,
+            "tokens": 6974
+          }
+        },
+        {
+          "name": "read",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "url": "https://eve.dev/docs/guides/instrumentation"
+          },
+          "output": {
+            "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+            "section": "Runtime context",
+            "title": "Eve instrumentation",
+            "url": "https://eve.dev/docs/guides/instrumentation"
+          },
+          "metadata": {
+            "scenario": "eve-instrumentation",
+            "testRunId": "<run:1>"
+          }
+        },
+        {
+          "name": "eve.step",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+              "role": "system"
+            },
+            {
+              "content": "Run the Braintrust Eve instrumentation e2e scenario",
+              "role": "user"
+            },
+            {
+              "content": [
+                {
+                  "input": {
+                    "message": "Run the Braintrust Eve instrumentation e2e scenario"
+                  },
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:2>"
+                    }
+                  },
+                  "toolCallId": "<toolCallId:1>",
+                  "toolName": "researcher",
+                  "type": "tool-call"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "output": {
+                    "type": "text",
+                    "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+                  },
+                  "toolCallId": "<toolCallId:1>",
+                  "toolName": "researcher",
+                  "type": "tool-result"
+                }
+              ],
+              "role": "tool"
+            },
+            {
+              "content": [
+                {
+                  "input": {
+                    "url": "https://eve.dev/docs/guides/instrumentation"
+                  },
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:4>"
+                    }
+                  },
+                  "toolCallId": "<toolCallId:3>",
+                  "toolName": "read",
+                  "type": "tool-call"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "output": {
+                    "type": "json",
+                    "value": {
+                      "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+                      "section": "Runtime context",
+                      "title": "Eve instrumentation",
+                      "url": "https://eve.dev/docs/guides/instrumentation"
+                    }
+                  },
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:4>"
+                    }
+                  },
+                  "toolCallId": "<toolCallId:3>",
+                  "toolName": "read",
+                  "type": "tool-result"
+                }
+              ],
+              "role": "tool"
+            },
+            {
+              "content": [
+                {
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:5>",
+                      "phase": "final_answer"
+                    }
+                  },
+                  "text": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+                  "type": "text"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": "Run the Braintrust Eve instrumentation e2e scenario again",
+              "role": "user"
+            },
+            {
+              "content": [
+                {
+                  "input": {
+                    "message": "Run the Braintrust Eve instrumentation e2e scenario again"
+                  },
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:7>"
+                    }
+                  },
+                  "toolCallId": "<toolCallId:6>",
+                  "toolName": "researcher",
+                  "type": "tool-call"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "output": {
+                    "type": "text",
+                    "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+                  },
+                  "toolCallId": "<toolCallId:6>",
+                  "toolName": "researcher",
+                  "type": "tool-result"
+                }
+              ],
+              "role": "tool"
+            },
+            {
+              "content": [
+                {
+                  "input": {
+                    "url": "https://eve.dev/docs/guides/instrumentation"
+                  },
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:9>"
+                    }
+                  },
+                  "toolCallId": "<toolCallId:8>",
+                  "toolName": "read",
+                  "type": "tool-call"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "output": {
+                    "type": "json",
+                    "value": {
+                      "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+                      "section": "Runtime context",
+                      "title": "Eve instrumentation",
+                      "url": "https://eve.dev/docs/guides/instrumentation"
+                    }
+                  },
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:9>"
+                    }
+                  },
+                  "toolCallId": "<toolCallId:8>",
+                  "toolName": "read",
+                  "type": "tool-result"
+                }
+              ],
+              "role": "tool"
+            }
+          ],
+          "output": [
+            {
+              "finish_reason": "stop",
+              "index": 0,
+              "message": {
+                "content": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+                "role": "assistant"
+              }
+            }
+          ],
+          "metadata": {
+            "model": "gpt-5.4-mini",
+            "provider": "openai",
+            "scenario": "eve-instrumentation",
+            "testRunId": "<run:1>"
+          },
+          "metrics": {
+            "completion_tokens": 65,
+            "prompt_cached_tokens": 6528,
+            "prompt_tokens": 7029,
+            "tokens": 7094
+          }
+        }
+      ],
+      "input": [
+        {
+          "content": "Run the Braintrust Eve instrumentation e2e scenario again",
+          "role": "user"
+        }
+      ],
+      "output": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+      "metadata": {
+        "model": "gpt-5.4-mini",
+        "provider": "openai",
+        "scenario": "eve-instrumentation",
+        "testRunId": "<run:1>"
+      },
+      "metrics": {
+        "completion_tokens": 121,
+        "prompt_cached_tokens": 19584,
+        "prompt_tokens": 20864,
+        "tokens": 20985
+      }
+    },
+    {
+      "name": "eve.turn",
+      "type": "task",
+      "children": [
+        {
+          "name": "eve.step",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+              "role": "system"
+            },
+            {
+              "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
+              "role": "user"
+            }
+          ],
+          "output": [
+            {
+              "finish_reason": "tool_calls",
+              "index": 0,
+              "message": {
+                "content": null,
+                "role": "assistant",
+                "tool_calls": [
+                  {
+                    "function": {
+                      "arguments": "{\"query\":\"Run the Braintrust Eve instrumentation e2e scenario again\"}",
+                      "name": "search"
+                    },
+                    "id": "<span:1>",
+                    "type": "function"
+                  }
+                ]
+              }
+            }
+          ],
+          "metadata": {
+            "model": "gpt-5.4-mini",
+            "provider": "openai",
+            "scenario": "eve-instrumentation",
+            "testRunId": "<run:1>"
+          },
+          "metrics": {
+            "completion_tokens": 27,
+            "prompt_cached_tokens": 6528,
+            "prompt_tokens": 6555,
+            "tokens": 6582
+          }
+        },
+        {
+          "name": "search",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "query": "Run the Braintrust Eve instrumentation e2e scenario again"
+          },
+          "output": {
+            "query": "Run the Braintrust Eve instrumentation e2e scenario again",
+            "title": "Eve instrumentation",
+            "url": "https://eve.dev/docs/guides/instrumentation"
+          },
+          "metadata": {
+            "scenario": "eve-instrumentation",
+            "testRunId": "<run:1>"
+          }
+        },
+        {
+          "name": "eve.step",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+              "role": "system"
+            },
+            {
+              "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
+              "role": "user"
+            },
+            {
+              "content": [
+                {
+                  "input": {
+                    "query": "Run the Braintrust Eve instrumentation e2e scenario again"
+                  },
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:2>"
+                    }
+                  },
+                  "toolCallId": "<toolCallId:1>",
+                  "toolName": "search",
+                  "type": "tool-call"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "output": {
+                    "type": "json",
+                    "value": {
+                      "query": "Run the Braintrust Eve instrumentation e2e scenario again",
+                      "title": "Eve instrumentation",
+                      "url": "https://eve.dev/docs/guides/instrumentation"
+                    }
+                  },
+                  "providerOptions": {
+                    "openai": {
+                      "itemId": "<itemId:2>"
+                    }
+                  },
+                  "toolCallId": "<toolCallId:1>",
+                  "toolName": "search",
+                  "type": "tool-result"
+                }
+              ],
+              "role": "tool"
+            }
+          ],
+          "output": [
+            {
+              "finish_reason": "stop",
+              "index": 0,
+              "message": {
+                "content": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
+                "role": "assistant"
+              }
+            }
+          ],
+          "metadata": {
+            "model": "gpt-5.4-mini",
+            "provider": "openai",
+            "scenario": "eve-instrumentation",
+            "testRunId": "<run:1>"
+          },
+          "metrics": {
+            "completion_tokens": 22,
+            "prompt_cached_tokens": 6528,
+            "prompt_tokens": 6627,
+            "tokens": 6649
+          }
+        }
+      ],
+      "input": [
+        {
+          "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
+          "role": "user"
+        }
+      ],
+      "output": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
+      "metadata": {
+        "model": "gpt-5.4-mini",
+        "provider": "openai",
+        "scenario": "eve-instrumentation",
+        "testRunId": "<run:1>"
+      },
+      "metrics": {
+        "completion_tokens": 49,
+        "prompt_cached_tokens": 13056,
+        "prompt_tokens": 13182,
+        "tokens": 13231
       }
     }
   ]

--- a/e2e/scenarios/eve-instrumentation/__snapshots__/eve-instrumentation.span-tree.txt
+++ b/e2e/scenarios/eve-instrumentation/__snapshots__/eve-instrumentation.span-tree.txt
@@ -8,6 +8,7 @@ span_tree:
 │   ]
 │   output: "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace."
 │   metadata: {
+│     "eve.session_id": "<eve.session_id:1>",
 │     "model": "gpt-5.4-mini",
 │     "provider": "openai",
 │     "scenario": "eve-instrumentation",
@@ -51,6 +52,7 @@ span_tree:
 │   │     }
 │   │   ]
 │   │   metadata: {
+│   │     "eve.session_id": "<eve.session_id:1>",
 │   │     "model": "gpt-5.4-mini",
 │   │     "provider": "openai",
 │   │     "scenario": "eve-instrumentation",
@@ -68,6 +70,7 @@ span_tree:
 │   │   }
 │   │   output: "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
 │   │   metadata: {
+│   │     "eve.session_id": "<eve.session_id:1>",
 │   │     "scenario": "eve-instrumentation",
 │   │     "testRunId": "<run:1>"
 │   │   }
@@ -80,6 +83,7 @@ span_tree:
 │   │       ]
 │   │       output: "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
 │   │       metadata: {
+│   │         "eve.session_id": "<eve.session_id:1>",
 │   │         "model": "gpt-5.4-mini",
 │   │         "provider": "openai",
 │   │         "scenario": "eve-instrumentation",
@@ -123,6 +127,7 @@ span_tree:
 │   │       │     }
 │   │       │   ]
 │   │       │   metadata: {
+│   │       │     "eve.session_id": "<eve.session_id:1>",
 │   │       │     "model": "gpt-5.4-mini",
 │   │       │     "provider": "openai",
 │   │       │     "scenario": "eve-instrumentation",
@@ -144,6 +149,7 @@ span_tree:
 │   │       │     "url": "https://eve.dev/docs/guides/instrumentation"
 │   │       │   }
 │   │       │   metadata: {
+│   │       │     "eve.session_id": "<eve.session_id:1>",
 │   │       │     "scenario": "eve-instrumentation",
 │   │       │     "testRunId": "<run:1>"
 │   │       │   }
@@ -210,6 +216,7 @@ span_tree:
 │   │             }
 │   │           ]
 │   │           metadata: {
+│   │             "eve.session_id": "<eve.session_id:1>",
 │   │             "model": "gpt-5.4-mini",
 │   │             "provider": "openai",
 │   │             "scenario": "eve-instrumentation",
@@ -285,6 +292,7 @@ span_tree:
 │   │     }
 │   │   ]
 │   │   metadata: {
+│   │     "eve.session_id": "<eve.session_id:1>",
 │   │     "model": "gpt-5.4-mini",
 │   │     "provider": "openai",
 │   │     "scenario": "eve-instrumentation",
@@ -307,6 +315,7 @@ span_tree:
 │   │     "url": "https://eve.dev/docs/guides/instrumentation"
 │   │   }
 │   │   metadata: {
+│   │     "eve.session_id": "<eve.session_id:1>",
 │   │     "scenario": "eve-instrumentation",
 │   │     "testRunId": "<run:1>"
 │   │   }
@@ -406,6 +415,7 @@ span_tree:
 │         }
 │       ]
 │       metadata: {
+│         "eve.session_id": "<eve.session_id:1>",
 │         "model": "gpt-5.4-mini",
 │         "provider": "openai",
 │         "scenario": "eve-instrumentation",
@@ -426,6 +436,7 @@ span_tree:
     ]
     output: "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace."
     metadata: {
+      "eve.session_id": "<eve.session_id:1>",
       "model": "gpt-5.4-mini",
       "provider": "openai",
       "scenario": "eve-instrumentation",
@@ -562,6 +573,7 @@ span_tree:
     │     }
     │   ]
     │   metadata: {
+    │     "eve.session_id": "<eve.session_id:1>",
     │     "model": "gpt-5.4-mini",
     │     "provider": "openai",
     │     "scenario": "eve-instrumentation",
@@ -579,6 +591,7 @@ span_tree:
     │   }
     │   output: "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
     │   metadata: {
+    │     "eve.session_id": "<eve.session_id:1>",
     │     "scenario": "eve-instrumentation",
     │     "testRunId": "<run:1>"
     │   }
@@ -591,6 +604,7 @@ span_tree:
     │       ]
     │       output: "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
     │       metadata: {
+    │         "eve.session_id": "<eve.session_id:1>",
     │         "model": "gpt-5.4-mini",
     │         "provider": "openai",
     │         "scenario": "eve-instrumentation",
@@ -634,6 +648,7 @@ span_tree:
     │       │     }
     │       │   ]
     │       │   metadata: {
+    │       │     "eve.session_id": "<eve.session_id:1>",
     │       │     "model": "gpt-5.4-mini",
     │       │     "provider": "openai",
     │       │     "scenario": "eve-instrumentation",
@@ -655,6 +670,7 @@ span_tree:
     │       │     "url": "https://eve.dev/docs/guides/instrumentation"
     │       │   }
     │       │   metadata: {
+    │       │     "eve.session_id": "<eve.session_id:1>",
     │       │     "scenario": "eve-instrumentation",
     │       │     "testRunId": "<run:1>"
     │       │   }
@@ -721,6 +737,7 @@ span_tree:
     │             }
     │           ]
     │           metadata: {
+    │             "eve.session_id": "<eve.session_id:1>",
     │             "model": "gpt-5.4-mini",
     │             "provider": "openai",
     │             "scenario": "eve-instrumentation",
@@ -889,6 +906,7 @@ span_tree:
     │     }
     │   ]
     │   metadata: {
+    │     "eve.session_id": "<eve.session_id:1>",
     │     "model": "gpt-5.4-mini",
     │     "provider": "openai",
     │     "scenario": "eve-instrumentation",
@@ -911,6 +929,7 @@ span_tree:
     │     "url": "https://eve.dev/docs/guides/instrumentation"
     │   }
     │   metadata: {
+    │     "eve.session_id": "<eve.session_id:1>",
     │     "scenario": "eve-instrumentation",
     │     "testRunId": "<run:1>"
     │   }
@@ -1103,6 +1122,7 @@ span_tree:
           }
         ]
         metadata: {
+          "eve.session_id": "<eve.session_id:1>",
           "model": "gpt-5.4-mini",
           "provider": "openai",
           "scenario": "eve-instrumentation",

--- a/e2e/scenarios/eve-instrumentation/__snapshots__/eve-instrumentation.span-tree.txt
+++ b/e2e/scenarios/eve-instrumentation/__snapshots__/eve-instrumentation.span-tree.txt
@@ -71,6 +71,156 @@ span_tree:
 │   │     "scenario": "eve-instrumentation",
 │   │     "testRunId": "<run:1>"
 │   │   }
+│   │   └── eve.turn [task]
+│   │       input: [
+│   │         {
+│   │           "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
+│   │           "role": "user"
+│   │         }
+│   │       ]
+│   │       output: "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+│   │       metadata: {
+│   │         "model": "gpt-5.4-mini",
+│   │         "provider": "openai",
+│   │         "scenario": "eve-instrumentation",
+│   │         "testRunId": "<run:1>"
+│   │       }
+│   │       metrics: {
+│   │         "completion_tokens": 48,
+│   │         "prompt_cached_tokens": 5504,
+│   │         "prompt_tokens": 13178,
+│   │         "tokens": 13226
+│   │       }
+│   │       ├── eve.step [llm]
+│   │       │   input: [
+│   │       │     {
+│   │       │       "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+│   │       │       "role": "system"
+│   │       │     },
+│   │       │     {
+│   │       │       "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
+│   │       │       "role": "user"
+│   │       │     }
+│   │       │   ]
+│   │       │   output: [
+│   │       │     {
+│   │       │       "finish_reason": "tool_calls",
+│   │       │       "index": 0,
+│   │       │       "message": {
+│   │       │         "content": null,
+│   │       │         "role": "assistant",
+│   │       │         "tool_calls": [
+│   │       │           {
+│   │       │             "function": {
+│   │       │               "arguments": "{\"query\":\"Run the Braintrust Eve instrumentation e2e scenario\"}",
+│   │       │               "name": "search"
+│   │       │             },
+│   │       │             "id": "<span:1>",
+│   │       │             "type": "function"
+│   │       │           }
+│   │       │         ]
+│   │       │       }
+│   │       │     }
+│   │       │   ]
+│   │       │   metadata: {
+│   │       │     "model": "gpt-5.4-mini",
+│   │       │     "provider": "openai",
+│   │       │     "scenario": "eve-instrumentation",
+│   │       │     "testRunId": "<run:1>"
+│   │       │   }
+│   │       │   metrics: {
+│   │       │     "completion_tokens": 26,
+│   │       │     "prompt_cached_tokens": 0,
+│   │       │     "prompt_tokens": 6554,
+│   │       │     "tokens": 6580
+│   │       │   }
+│   │       ├── search [tool]
+│   │       │   input: {
+│   │       │     "query": "Run the Braintrust Eve instrumentation e2e scenario"
+│   │       │   }
+│   │       │   output: {
+│   │       │     "query": "Run the Braintrust Eve instrumentation e2e scenario",
+│   │       │     "title": "Eve instrumentation",
+│   │       │     "url": "https://eve.dev/docs/guides/instrumentation"
+│   │       │   }
+│   │       │   metadata: {
+│   │       │     "scenario": "eve-instrumentation",
+│   │       │     "testRunId": "<run:1>"
+│   │       │   }
+│   │       └── eve.step [llm]
+│   │           input: [
+│   │             {
+│   │               "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+│   │               "role": "system"
+│   │             },
+│   │             {
+│   │               "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
+│   │               "role": "user"
+│   │             },
+│   │             {
+│   │               "content": [
+│   │                 {
+│   │                   "input": {
+│   │                     "query": "Run the Braintrust Eve instrumentation e2e scenario"
+│   │                   },
+│   │                   "providerOptions": {
+│   │                     "openai": {
+│   │                       "itemId": "<itemId:2>"
+│   │                     }
+│   │                   },
+│   │                   "toolCallId": "<toolCallId:1>",
+│   │                   "toolName": "search",
+│   │                   "type": "tool-call"
+│   │                 }
+│   │               ],
+│   │               "role": "assistant"
+│   │             },
+│   │             {
+│   │               "content": [
+│   │                 {
+│   │                   "output": {
+│   │                     "type": "json",
+│   │                     "value": {
+│   │                       "query": "Run the Braintrust Eve instrumentation e2e scenario",
+│   │                       "title": "Eve instrumentation",
+│   │                       "url": "https://eve.dev/docs/guides/instrumentation"
+│   │                     }
+│   │                   },
+│   │                   "providerOptions": {
+│   │                     "openai": {
+│   │                       "itemId": "<itemId:2>"
+│   │                     }
+│   │                   },
+│   │                   "toolCallId": "<toolCallId:1>",
+│   │                   "toolName": "search",
+│   │                   "type": "tool-result"
+│   │                 }
+│   │               ],
+│   │               "role": "tool"
+│   │             }
+│   │           ]
+│   │           output: [
+│   │             {
+│   │               "finish_reason": "stop",
+│   │               "index": 0,
+│   │               "message": {
+│   │                 "content": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
+│   │                 "role": "assistant"
+│   │               }
+│   │             }
+│   │           ]
+│   │           metadata: {
+│   │             "model": "gpt-5.4-mini",
+│   │             "provider": "openai",
+│   │             "scenario": "eve-instrumentation",
+│   │             "testRunId": "<run:1>"
+│   │           }
+│   │           metrics: {
+│   │             "completion_tokens": 22,
+│   │             "prompt_cached_tokens": 5504,
+│   │             "prompt_tokens": 6624,
+│   │             "tokens": 6646
+│   │           }
 │   ├── eve.step [llm]
 │   │   input: [
 │   │     {
@@ -267,711 +417,14 @@ span_tree:
 │         "prompt_tokens": 6806,
 │         "tokens": 6871
 │       }
-├── eve.turn [task]
-│   input: [
-│     {
-│       "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
-│       "role": "user"
-│     }
-│   ]
-│   output: "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-│   metadata: {
-│     "model": "gpt-5.4-mini",
-│     "provider": "openai",
-│     "scenario": "eve-instrumentation",
-│     "testRunId": "<run:1>"
-│   }
-│   metrics: {
-│     "completion_tokens": 48,
-│     "prompt_cached_tokens": 5504,
-│     "prompt_tokens": 13178,
-│     "tokens": 13226
-│   }
-│   ├── eve.step [llm]
-│   │   input: [
-│   │     {
-│   │       "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-│   │       "role": "system"
-│   │     },
-│   │     {
-│   │       "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
-│   │       "role": "user"
-│   │     }
-│   │   ]
-│   │   output: [
-│   │     {
-│   │       "finish_reason": "tool_calls",
-│   │       "index": 0,
-│   │       "message": {
-│   │         "content": null,
-│   │         "role": "assistant",
-│   │         "tool_calls": [
-│   │           {
-│   │             "function": {
-│   │               "arguments": "{\"query\":\"Run the Braintrust Eve instrumentation e2e scenario\"}",
-│   │               "name": "search"
-│   │             },
-│   │             "id": "<span:1>",
-│   │             "type": "function"
-│   │           }
-│   │         ]
-│   │       }
-│   │     }
-│   │   ]
-│   │   metadata: {
-│   │     "model": "gpt-5.4-mini",
-│   │     "provider": "openai",
-│   │     "scenario": "eve-instrumentation",
-│   │     "testRunId": "<run:1>"
-│   │   }
-│   │   metrics: {
-│   │     "completion_tokens": 26,
-│   │     "prompt_cached_tokens": 0,
-│   │     "prompt_tokens": 6554,
-│   │     "tokens": 6580
-│   │   }
-│   ├── search [tool]
-│   │   input: {
-│   │     "query": "Run the Braintrust Eve instrumentation e2e scenario"
-│   │   }
-│   │   output: {
-│   │     "query": "Run the Braintrust Eve instrumentation e2e scenario",
-│   │     "title": "Eve instrumentation",
-│   │     "url": "https://eve.dev/docs/guides/instrumentation"
-│   │   }
-│   │   metadata: {
-│   │     "scenario": "eve-instrumentation",
-│   │     "testRunId": "<run:1>"
-│   │   }
-│   └── eve.step [llm]
-│       input: [
-│         {
-│           "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-│           "role": "system"
-│         },
-│         {
-│           "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
-│           "role": "user"
-│         },
-│         {
-│           "content": [
-│             {
-│               "input": {
-│                 "query": "Run the Braintrust Eve instrumentation e2e scenario"
-│               },
-│               "providerOptions": {
-│                 "openai": {
-│                   "itemId": "<itemId:2>"
-│                 }
-│               },
-│               "toolCallId": "<toolCallId:1>",
-│               "toolName": "search",
-│               "type": "tool-call"
-│             }
-│           ],
-│           "role": "assistant"
-│         },
-│         {
-│           "content": [
-│             {
-│               "output": {
-│                 "type": "json",
-│                 "value": {
-│                   "query": "Run the Braintrust Eve instrumentation e2e scenario",
-│                   "title": "Eve instrumentation",
-│                   "url": "https://eve.dev/docs/guides/instrumentation"
-│                 }
-│               },
-│               "providerOptions": {
-│                 "openai": {
-│                   "itemId": "<itemId:2>"
-│                 }
-│               },
-│               "toolCallId": "<toolCallId:1>",
-│               "toolName": "search",
-│               "type": "tool-result"
-│             }
-│           ],
-│           "role": "tool"
-│         }
-│       ]
-│       output: [
-│         {
-│           "finish_reason": "stop",
-│           "index": 0,
-│           "message": {
-│             "content": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
-│             "role": "assistant"
-│           }
-│         }
-│       ]
-│       metadata: {
-│         "model": "gpt-5.4-mini",
-│         "provider": "openai",
-│         "scenario": "eve-instrumentation",
-│         "testRunId": "<run:1>"
-│       }
-│       metrics: {
-│         "completion_tokens": 22,
-│         "prompt_cached_tokens": 5504,
-│         "prompt_tokens": 6624,
-│         "tokens": 6646
-│       }
-├── eve.turn [task]
-│   input: [
-│     {
-│       "content": "Run the Braintrust Eve instrumentation e2e scenario again",
-│       "role": "user"
-│     }
-│   ]
-│   output: "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace."
-│   metadata: {
-│     "model": "gpt-5.4-mini",
-│     "provider": "openai",
-│     "scenario": "eve-instrumentation",
-│     "testRunId": "<run:1>"
-│   }
-│   metrics: {
-│     "completion_tokens": 121,
-│     "prompt_cached_tokens": 19584,
-│     "prompt_tokens": 20864,
-│     "tokens": 20985
-│   }
-│   ├── eve.step [llm]
-│   │   input: [
-│   │     {
-│   │       "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-│   │       "role": "system"
-│   │     },
-│   │     {
-│   │       "content": "Run the Braintrust Eve instrumentation e2e scenario",
-│   │       "role": "user"
-│   │     },
-│   │     {
-│   │       "content": [
-│   │         {
-│   │           "input": {
-│   │             "message": "Run the Braintrust Eve instrumentation e2e scenario"
-│   │           },
-│   │           "providerOptions": {
-│   │             "openai": {
-│   │               "itemId": "<itemId:2>"
-│   │             }
-│   │           },
-│   │           "toolCallId": "<toolCallId:1>",
-│   │           "toolName": "researcher",
-│   │           "type": "tool-call"
-│   │         }
-│   │       ],
-│   │       "role": "assistant"
-│   │     },
-│   │     {
-│   │       "content": [
-│   │         {
-│   │           "output": {
-│   │             "type": "text",
-│   │             "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-│   │           },
-│   │           "toolCallId": "<toolCallId:1>",
-│   │           "toolName": "researcher",
-│   │           "type": "tool-result"
-│   │         }
-│   │       ],
-│   │       "role": "tool"
-│   │     },
-│   │     {
-│   │       "content": [
-│   │         {
-│   │           "input": {
-│   │             "url": "https://eve.dev/docs/guides/instrumentation"
-│   │           },
-│   │           "providerOptions": {
-│   │             "openai": {
-│   │               "itemId": "<itemId:4>"
-│   │             }
-│   │           },
-│   │           "toolCallId": "<toolCallId:3>",
-│   │           "toolName": "read",
-│   │           "type": "tool-call"
-│   │         }
-│   │       ],
-│   │       "role": "assistant"
-│   │     },
-│   │     {
-│   │       "content": [
-│   │         {
-│   │           "output": {
-│   │             "type": "json",
-│   │             "value": {
-│   │               "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-│   │               "section": "Runtime context",
-│   │               "title": "Eve instrumentation",
-│   │               "url": "https://eve.dev/docs/guides/instrumentation"
-│   │             }
-│   │           },
-│   │           "providerOptions": {
-│   │             "openai": {
-│   │               "itemId": "<itemId:4>"
-│   │             }
-│   │           },
-│   │           "toolCallId": "<toolCallId:3>",
-│   │           "toolName": "read",
-│   │           "type": "tool-result"
-│   │         }
-│   │       ],
-│   │       "role": "tool"
-│   │     },
-│   │     {
-│   │       "content": [
-│   │         {
-│   │           "providerOptions": {
-│   │             "openai": {
-│   │               "itemId": "<itemId:5>",
-│   │               "phase": "final_answer"
-│   │             }
-│   │           },
-│   │           "text": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-│   │           "type": "text"
-│   │         }
-│   │       ],
-│   │       "role": "assistant"
-│   │     },
-│   │     {
-│   │       "content": "Run the Braintrust Eve instrumentation e2e scenario again",
-│   │       "role": "user"
-│   │     }
-│   │   ]
-│   │   output: [
-│   │     {
-│   │       "finish_reason": "tool_calls",
-│   │       "index": 0,
-│   │       "message": {
-│   │         "content": null,
-│   │         "role": "assistant",
-│   │         "tool_calls": [
-│   │           {
-│   │             "function": {
-│   │               "arguments": "{\"message\":\"Run the Braintrust Eve instrumentation e2e scenario again\"}",
-│   │               "name": "researcher"
-│   │             },
-│   │             "id": "<span:1>",
-│   │             "type": "function"
-│   │           }
-│   │         ]
-│   │       }
-│   │     }
-│   │   ]
-│   │   metadata: {
-│   │     "model": "gpt-5.4-mini",
-│   │     "provider": "openai",
-│   │     "scenario": "eve-instrumentation",
-│   │     "testRunId": "<run:1>"
-│   │   }
-│   │   metrics: {
-│   │     "completion_tokens": 29,
-│   │     "prompt_cached_tokens": 6528,
-│   │     "prompt_tokens": 6888,
-│   │     "tokens": 6917
-│   │   }
-│   ├── researcher [tool]
-│   │   input: {
-│   │     "message": "Run the Braintrust Eve instrumentation e2e scenario again"
-│   │   }
-│   │   output: "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-│   │   metadata: {
-│   │     "scenario": "eve-instrumentation",
-│   │     "testRunId": "<run:1>"
-│   │   }
-│   ├── eve.step [llm]
-│   │   input: [
-│   │     {
-│   │       "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-│   │       "role": "system"
-│   │     },
-│   │     {
-│   │       "content": "Run the Braintrust Eve instrumentation e2e scenario",
-│   │       "role": "user"
-│   │     },
-│   │     {
-│   │       "content": [
-│   │         {
-│   │           "input": {
-│   │             "message": "Run the Braintrust Eve instrumentation e2e scenario"
-│   │           },
-│   │           "providerOptions": {
-│   │             "openai": {
-│   │               "itemId": "<itemId:2>"
-│   │             }
-│   │           },
-│   │           "toolCallId": "<toolCallId:1>",
-│   │           "toolName": "researcher",
-│   │           "type": "tool-call"
-│   │         }
-│   │       ],
-│   │       "role": "assistant"
-│   │     },
-│   │     {
-│   │       "content": [
-│   │         {
-│   │           "output": {
-│   │             "type": "text",
-│   │             "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-│   │           },
-│   │           "toolCallId": "<toolCallId:1>",
-│   │           "toolName": "researcher",
-│   │           "type": "tool-result"
-│   │         }
-│   │       ],
-│   │       "role": "tool"
-│   │     },
-│   │     {
-│   │       "content": [
-│   │         {
-│   │           "input": {
-│   │             "url": "https://eve.dev/docs/guides/instrumentation"
-│   │           },
-│   │           "providerOptions": {
-│   │             "openai": {
-│   │               "itemId": "<itemId:4>"
-│   │             }
-│   │           },
-│   │           "toolCallId": "<toolCallId:3>",
-│   │           "toolName": "read",
-│   │           "type": "tool-call"
-│   │         }
-│   │       ],
-│   │       "role": "assistant"
-│   │     },
-│   │     {
-│   │       "content": [
-│   │         {
-│   │           "output": {
-│   │             "type": "json",
-│   │             "value": {
-│   │               "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-│   │               "section": "Runtime context",
-│   │               "title": "Eve instrumentation",
-│   │               "url": "https://eve.dev/docs/guides/instrumentation"
-│   │             }
-│   │           },
-│   │           "providerOptions": {
-│   │             "openai": {
-│   │               "itemId": "<itemId:4>"
-│   │             }
-│   │           },
-│   │           "toolCallId": "<toolCallId:3>",
-│   │           "toolName": "read",
-│   │           "type": "tool-result"
-│   │         }
-│   │       ],
-│   │       "role": "tool"
-│   │     },
-│   │     {
-│   │       "content": [
-│   │         {
-│   │           "providerOptions": {
-│   │             "openai": {
-│   │               "itemId": "<itemId:5>",
-│   │               "phase": "final_answer"
-│   │             }
-│   │           },
-│   │           "text": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-│   │           "type": "text"
-│   │         }
-│   │       ],
-│   │       "role": "assistant"
-│   │     },
-│   │     {
-│   │       "content": "Run the Braintrust Eve instrumentation e2e scenario again",
-│   │       "role": "user"
-│   │     },
-│   │     {
-│   │       "content": [
-│   │         {
-│   │           "input": {
-│   │             "message": "Run the Braintrust Eve instrumentation e2e scenario again"
-│   │           },
-│   │           "providerOptions": {
-│   │             "openai": {
-│   │               "itemId": "<itemId:7>"
-│   │             }
-│   │           },
-│   │           "toolCallId": "<toolCallId:6>",
-│   │           "toolName": "researcher",
-│   │           "type": "tool-call"
-│   │         }
-│   │       ],
-│   │       "role": "assistant"
-│   │     },
-│   │     {
-│   │       "content": [
-│   │         {
-│   │           "output": {
-│   │             "type": "text",
-│   │             "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-│   │           },
-│   │           "toolCallId": "<toolCallId:6>",
-│   │           "toolName": "researcher",
-│   │           "type": "tool-result"
-│   │         }
-│   │       ],
-│   │       "role": "tool"
-│   │     }
-│   │   ]
-│   │   output: [
-│   │     {
-│   │       "finish_reason": "tool_calls",
-│   │       "index": 0,
-│   │       "message": {
-│   │         "content": null,
-│   │         "role": "assistant",
-│   │         "tool_calls": [
-│   │           {
-│   │             "function": {
-│   │               "arguments": "{\"url\":\"https://eve.dev/docs/guides/instrumentation\"}",
-│   │               "name": "read"
-│   │             },
-│   │             "id": "<span:1>",
-│   │             "type": "function"
-│   │           }
-│   │         ]
-│   │       }
-│   │     }
-│   │   ]
-│   │   metadata: {
-│   │     "model": "gpt-5.4-mini",
-│   │     "provider": "openai",
-│   │     "scenario": "eve-instrumentation",
-│   │     "testRunId": "<run:1>"
-│   │   }
-│   │   metrics: {
-│   │     "completion_tokens": 27,
-│   │     "prompt_cached_tokens": 6528,
-│   │     "prompt_tokens": 6947,
-│   │     "tokens": 6974
-│   │   }
-│   ├── read [tool]
-│   │   input: {
-│   │     "url": "https://eve.dev/docs/guides/instrumentation"
-│   │   }
-│   │   output: {
-│   │     "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-│   │     "section": "Runtime context",
-│   │     "title": "Eve instrumentation",
-│   │     "url": "https://eve.dev/docs/guides/instrumentation"
-│   │   }
-│   │   metadata: {
-│   │     "scenario": "eve-instrumentation",
-│   │     "testRunId": "<run:1>"
-│   │   }
-│   └── eve.step [llm]
-│       input: [
-│         {
-│           "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-│           "role": "system"
-│         },
-│         {
-│           "content": "Run the Braintrust Eve instrumentation e2e scenario",
-│           "role": "user"
-│         },
-│         {
-│           "content": [
-│             {
-│               "input": {
-│                 "message": "Run the Braintrust Eve instrumentation e2e scenario"
-│               },
-│               "providerOptions": {
-│                 "openai": {
-│                   "itemId": "<itemId:2>"
-│                 }
-│               },
-│               "toolCallId": "<toolCallId:1>",
-│               "toolName": "researcher",
-│               "type": "tool-call"
-│             }
-│           ],
-│           "role": "assistant"
-│         },
-│         {
-│           "content": [
-│             {
-│               "output": {
-│                 "type": "text",
-│                 "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-│               },
-│               "toolCallId": "<toolCallId:1>",
-│               "toolName": "researcher",
-│               "type": "tool-result"
-│             }
-│           ],
-│           "role": "tool"
-│         },
-│         {
-│           "content": [
-│             {
-│               "input": {
-│                 "url": "https://eve.dev/docs/guides/instrumentation"
-│               },
-│               "providerOptions": {
-│                 "openai": {
-│                   "itemId": "<itemId:4>"
-│                 }
-│               },
-│               "toolCallId": "<toolCallId:3>",
-│               "toolName": "read",
-│               "type": "tool-call"
-│             }
-│           ],
-│           "role": "assistant"
-│         },
-│         {
-│           "content": [
-│             {
-│               "output": {
-│                 "type": "json",
-│                 "value": {
-│                   "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-│                   "section": "Runtime context",
-│                   "title": "Eve instrumentation",
-│                   "url": "https://eve.dev/docs/guides/instrumentation"
-│                 }
-│               },
-│               "providerOptions": {
-│                 "openai": {
-│                   "itemId": "<itemId:4>"
-│                 }
-│               },
-│               "toolCallId": "<toolCallId:3>",
-│               "toolName": "read",
-│               "type": "tool-result"
-│             }
-│           ],
-│           "role": "tool"
-│         },
-│         {
-│           "content": [
-│             {
-│               "providerOptions": {
-│                 "openai": {
-│                   "itemId": "<itemId:5>",
-│                   "phase": "final_answer"
-│                 }
-│               },
-│               "text": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-│               "type": "text"
-│             }
-│           ],
-│           "role": "assistant"
-│         },
-│         {
-│           "content": "Run the Braintrust Eve instrumentation e2e scenario again",
-│           "role": "user"
-│         },
-│         {
-│           "content": [
-│             {
-│               "input": {
-│                 "message": "Run the Braintrust Eve instrumentation e2e scenario again"
-│               },
-│               "providerOptions": {
-│                 "openai": {
-│                   "itemId": "<itemId:7>"
-│                 }
-│               },
-│               "toolCallId": "<toolCallId:6>",
-│               "toolName": "researcher",
-│               "type": "tool-call"
-│             }
-│           ],
-│           "role": "assistant"
-│         },
-│         {
-│           "content": [
-│             {
-│               "output": {
-│                 "type": "text",
-│                 "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-│               },
-│               "toolCallId": "<toolCallId:6>",
-│               "toolName": "researcher",
-│               "type": "tool-result"
-│             }
-│           ],
-│           "role": "tool"
-│         },
-│         {
-│           "content": [
-│             {
-│               "input": {
-│                 "url": "https://eve.dev/docs/guides/instrumentation"
-│               },
-│               "providerOptions": {
-│                 "openai": {
-│                   "itemId": "<itemId:9>"
-│                 }
-│               },
-│               "toolCallId": "<toolCallId:8>",
-│               "toolName": "read",
-│               "type": "tool-call"
-│             }
-│           ],
-│           "role": "assistant"
-│         },
-│         {
-│           "content": [
-│             {
-│               "output": {
-│                 "type": "json",
-│                 "value": {
-│                   "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-│                   "section": "Runtime context",
-│                   "title": "Eve instrumentation",
-│                   "url": "https://eve.dev/docs/guides/instrumentation"
-│                 }
-│               },
-│               "providerOptions": {
-│                 "openai": {
-│                   "itemId": "<itemId:9>"
-│                 }
-│               },
-│               "toolCallId": "<toolCallId:8>",
-│               "toolName": "read",
-│               "type": "tool-result"
-│             }
-│           ],
-│           "role": "tool"
-│         }
-│       ]
-│       output: [
-│         {
-│           "finish_reason": "stop",
-│           "index": 0,
-│           "message": {
-│             "content": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-│             "role": "assistant"
-│           }
-│         }
-│       ]
-│       metadata: {
-│         "model": "gpt-5.4-mini",
-│         "provider": "openai",
-│         "scenario": "eve-instrumentation",
-│         "testRunId": "<run:1>"
-│       }
-│       metrics: {
-│         "completion_tokens": 65,
-│         "prompt_cached_tokens": 6528,
-│         "prompt_tokens": 7029,
-│         "tokens": 7094
-│       }
 └── eve.turn [task]
     input: [
       {
-        "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
+        "content": "Run the Braintrust Eve instrumentation e2e scenario again",
         "role": "user"
       }
     ]
-    output: "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+    output: "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace."
     metadata: {
       "model": "gpt-5.4-mini",
       "provider": "openai",
@@ -979,19 +432,112 @@ span_tree:
       "testRunId": "<run:1>"
     }
     metrics: {
-      "completion_tokens": 49,
-      "prompt_cached_tokens": 13056,
-      "prompt_tokens": 13182,
-      "tokens": 13231
+      "completion_tokens": 121,
+      "prompt_cached_tokens": 19584,
+      "prompt_tokens": 20864,
+      "tokens": 20985
     }
     ├── eve.step [llm]
     │   input: [
     │     {
-    │       "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+    │       "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
     │       "role": "system"
     │     },
     │     {
-    │       "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
+    │       "content": "Run the Braintrust Eve instrumentation e2e scenario",
+    │       "role": "user"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "input": {
+    │             "message": "Run the Braintrust Eve instrumentation e2e scenario"
+    │           },
+    │           "providerOptions": {
+    │             "openai": {
+    │               "itemId": "<itemId:2>"
+    │             }
+    │           },
+    │           "toolCallId": "<toolCallId:1>",
+    │           "toolName": "researcher",
+    │           "type": "tool-call"
+    │         }
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "output": {
+    │             "type": "text",
+    │             "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+    │           },
+    │           "toolCallId": "<toolCallId:1>",
+    │           "toolName": "researcher",
+    │           "type": "tool-result"
+    │         }
+    │       ],
+    │       "role": "tool"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "input": {
+    │             "url": "https://eve.dev/docs/guides/instrumentation"
+    │           },
+    │           "providerOptions": {
+    │             "openai": {
+    │               "itemId": "<itemId:4>"
+    │             }
+    │           },
+    │           "toolCallId": "<toolCallId:3>",
+    │           "toolName": "read",
+    │           "type": "tool-call"
+    │         }
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "output": {
+    │             "type": "json",
+    │             "value": {
+    │               "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+    │               "section": "Runtime context",
+    │               "title": "Eve instrumentation",
+    │               "url": "https://eve.dev/docs/guides/instrumentation"
+    │             }
+    │           },
+    │           "providerOptions": {
+    │             "openai": {
+    │               "itemId": "<itemId:4>"
+    │             }
+    │           },
+    │           "toolCallId": "<toolCallId:3>",
+    │           "toolName": "read",
+    │           "type": "tool-result"
+    │         }
+    │       ],
+    │       "role": "tool"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "providerOptions": {
+    │             "openai": {
+    │               "itemId": "<itemId:5>",
+    │               "phase": "final_answer"
+    │             }
+    │           },
+    │           "text": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+    │           "type": "text"
+    │         }
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": "Run the Braintrust Eve instrumentation e2e scenario again",
     │       "role": "user"
     │     }
     │   ]
@@ -1005,8 +551,335 @@ span_tree:
     │         "tool_calls": [
     │           {
     │             "function": {
-    │               "arguments": "{\"query\":\"Run the Braintrust Eve instrumentation e2e scenario again\"}",
-    │               "name": "search"
+    │               "arguments": "{\"message\":\"Run the Braintrust Eve instrumentation e2e scenario again\"}",
+    │               "name": "researcher"
+    │             },
+    │             "id": "<span:1>",
+    │             "type": "function"
+    │           }
+    │         ]
+    │       }
+    │     }
+    │   ]
+    │   metadata: {
+    │     "model": "gpt-5.4-mini",
+    │     "provider": "openai",
+    │     "scenario": "eve-instrumentation",
+    │     "testRunId": "<run:1>"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 29,
+    │     "prompt_cached_tokens": 6528,
+    │     "prompt_tokens": 6888,
+    │     "tokens": 6917
+    │   }
+    ├── researcher [tool]
+    │   input: {
+    │     "message": "Run the Braintrust Eve instrumentation e2e scenario again"
+    │   }
+    │   output: "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+    │   metadata: {
+    │     "scenario": "eve-instrumentation",
+    │     "testRunId": "<run:1>"
+    │   }
+    │   └── eve.turn [task]
+    │       input: [
+    │         {
+    │           "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
+    │           "role": "user"
+    │         }
+    │       ]
+    │       output: "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+    │       metadata: {
+    │         "model": "gpt-5.4-mini",
+    │         "provider": "openai",
+    │         "scenario": "eve-instrumentation",
+    │         "testRunId": "<run:1>"
+    │       }
+    │       metrics: {
+    │         "completion_tokens": 49,
+    │         "prompt_cached_tokens": 13056,
+    │         "prompt_tokens": 13182,
+    │         "tokens": 13231
+    │       }
+    │       ├── eve.step [llm]
+    │       │   input: [
+    │       │     {
+    │       │       "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+    │       │       "role": "system"
+    │       │     },
+    │       │     {
+    │       │       "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
+    │       │       "role": "user"
+    │       │     }
+    │       │   ]
+    │       │   output: [
+    │       │     {
+    │       │       "finish_reason": "tool_calls",
+    │       │       "index": 0,
+    │       │       "message": {
+    │       │         "content": null,
+    │       │         "role": "assistant",
+    │       │         "tool_calls": [
+    │       │           {
+    │       │             "function": {
+    │       │               "arguments": "{\"query\":\"Run the Braintrust Eve instrumentation e2e scenario again\"}",
+    │       │               "name": "search"
+    │       │             },
+    │       │             "id": "<span:1>",
+    │       │             "type": "function"
+    │       │           }
+    │       │         ]
+    │       │       }
+    │       │     }
+    │       │   ]
+    │       │   metadata: {
+    │       │     "model": "gpt-5.4-mini",
+    │       │     "provider": "openai",
+    │       │     "scenario": "eve-instrumentation",
+    │       │     "testRunId": "<run:1>"
+    │       │   }
+    │       │   metrics: {
+    │       │     "completion_tokens": 27,
+    │       │     "prompt_cached_tokens": 6528,
+    │       │     "prompt_tokens": 6555,
+    │       │     "tokens": 6582
+    │       │   }
+    │       ├── search [tool]
+    │       │   input: {
+    │       │     "query": "Run the Braintrust Eve instrumentation e2e scenario again"
+    │       │   }
+    │       │   output: {
+    │       │     "query": "Run the Braintrust Eve instrumentation e2e scenario again",
+    │       │     "title": "Eve instrumentation",
+    │       │     "url": "https://eve.dev/docs/guides/instrumentation"
+    │       │   }
+    │       │   metadata: {
+    │       │     "scenario": "eve-instrumentation",
+    │       │     "testRunId": "<run:1>"
+    │       │   }
+    │       └── eve.step [llm]
+    │           input: [
+    │             {
+    │               "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+    │               "role": "system"
+    │             },
+    │             {
+    │               "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
+    │               "role": "user"
+    │             },
+    │             {
+    │               "content": [
+    │                 {
+    │                   "input": {
+    │                     "query": "Run the Braintrust Eve instrumentation e2e scenario again"
+    │                   },
+    │                   "providerOptions": {
+    │                     "openai": {
+    │                       "itemId": "<itemId:2>"
+    │                     }
+    │                   },
+    │                   "toolCallId": "<toolCallId:1>",
+    │                   "toolName": "search",
+    │                   "type": "tool-call"
+    │                 }
+    │               ],
+    │               "role": "assistant"
+    │             },
+    │             {
+    │               "content": [
+    │                 {
+    │                   "output": {
+    │                     "type": "json",
+    │                     "value": {
+    │                       "query": "Run the Braintrust Eve instrumentation e2e scenario again",
+    │                       "title": "Eve instrumentation",
+    │                       "url": "https://eve.dev/docs/guides/instrumentation"
+    │                     }
+    │                   },
+    │                   "providerOptions": {
+    │                     "openai": {
+    │                       "itemId": "<itemId:2>"
+    │                     }
+    │                   },
+    │                   "toolCallId": "<toolCallId:1>",
+    │                   "toolName": "search",
+    │                   "type": "tool-result"
+    │                 }
+    │               ],
+    │               "role": "tool"
+    │             }
+    │           ]
+    │           output: [
+    │             {
+    │               "finish_reason": "stop",
+    │               "index": 0,
+    │               "message": {
+    │                 "content": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
+    │                 "role": "assistant"
+    │               }
+    │             }
+    │           ]
+    │           metadata: {
+    │             "model": "gpt-5.4-mini",
+    │             "provider": "openai",
+    │             "scenario": "eve-instrumentation",
+    │             "testRunId": "<run:1>"
+    │           }
+    │           metrics: {
+    │             "completion_tokens": 22,
+    │             "prompt_cached_tokens": 6528,
+    │             "prompt_tokens": 6627,
+    │             "tokens": 6649
+    │           }
+    ├── eve.step [llm]
+    │   input: [
+    │     {
+    │       "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+    │       "role": "system"
+    │     },
+    │     {
+    │       "content": "Run the Braintrust Eve instrumentation e2e scenario",
+    │       "role": "user"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "input": {
+    │             "message": "Run the Braintrust Eve instrumentation e2e scenario"
+    │           },
+    │           "providerOptions": {
+    │             "openai": {
+    │               "itemId": "<itemId:2>"
+    │             }
+    │           },
+    │           "toolCallId": "<toolCallId:1>",
+    │           "toolName": "researcher",
+    │           "type": "tool-call"
+    │         }
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "output": {
+    │             "type": "text",
+    │             "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+    │           },
+    │           "toolCallId": "<toolCallId:1>",
+    │           "toolName": "researcher",
+    │           "type": "tool-result"
+    │         }
+    │       ],
+    │       "role": "tool"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "input": {
+    │             "url": "https://eve.dev/docs/guides/instrumentation"
+    │           },
+    │           "providerOptions": {
+    │             "openai": {
+    │               "itemId": "<itemId:4>"
+    │             }
+    │           },
+    │           "toolCallId": "<toolCallId:3>",
+    │           "toolName": "read",
+    │           "type": "tool-call"
+    │         }
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "output": {
+    │             "type": "json",
+    │             "value": {
+    │               "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+    │               "section": "Runtime context",
+    │               "title": "Eve instrumentation",
+    │               "url": "https://eve.dev/docs/guides/instrumentation"
+    │             }
+    │           },
+    │           "providerOptions": {
+    │             "openai": {
+    │               "itemId": "<itemId:4>"
+    │             }
+    │           },
+    │           "toolCallId": "<toolCallId:3>",
+    │           "toolName": "read",
+    │           "type": "tool-result"
+    │         }
+    │       ],
+    │       "role": "tool"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "providerOptions": {
+    │             "openai": {
+    │               "itemId": "<itemId:5>",
+    │               "phase": "final_answer"
+    │             }
+    │           },
+    │           "text": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+    │           "type": "text"
+    │         }
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": "Run the Braintrust Eve instrumentation e2e scenario again",
+    │       "role": "user"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "input": {
+    │             "message": "Run the Braintrust Eve instrumentation e2e scenario again"
+    │           },
+    │           "providerOptions": {
+    │             "openai": {
+    │               "itemId": "<itemId:7>"
+    │             }
+    │           },
+    │           "toolCallId": "<toolCallId:6>",
+    │           "toolName": "researcher",
+    │           "type": "tool-call"
+    │         }
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "output": {
+    │             "type": "text",
+    │             "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+    │           },
+    │           "toolCallId": "<toolCallId:6>",
+    │           "toolName": "researcher",
+    │           "type": "tool-result"
+    │         }
+    │       ],
+    │       "role": "tool"
+    │     }
+    │   ]
+    │   output: [
+    │     {
+    │       "finish_reason": "tool_calls",
+    │       "index": 0,
+    │       "message": {
+    │         "content": null,
+    │         "role": "assistant",
+    │         "tool_calls": [
+    │           {
+    │             "function": {
+    │               "arguments": "{\"url\":\"https://eve.dev/docs/guides/instrumentation\"}",
+    │               "name": "read"
     │             },
     │             "id": "<span:1>",
     │             "type": "function"
@@ -1024,15 +897,16 @@ span_tree:
     │   metrics: {
     │     "completion_tokens": 27,
     │     "prompt_cached_tokens": 6528,
-    │     "prompt_tokens": 6555,
-    │     "tokens": 6582
+    │     "prompt_tokens": 6947,
+    │     "tokens": 6974
     │   }
-    ├── search [tool]
+    ├── read [tool]
     │   input: {
-    │     "query": "Run the Braintrust Eve instrumentation e2e scenario again"
+    │     "url": "https://eve.dev/docs/guides/instrumentation"
     │   }
     │   output: {
-    │     "query": "Run the Braintrust Eve instrumentation e2e scenario again",
+    │     "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+    │     "section": "Runtime context",
     │     "title": "Eve instrumentation",
     │     "url": "https://eve.dev/docs/guides/instrumentation"
     │   }
@@ -1043,18 +917,18 @@ span_tree:
     └── eve.step [llm]
         input: [
           {
-            "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+            "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
             "role": "system"
           },
           {
-            "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
+            "content": "Run the Braintrust Eve instrumentation e2e scenario",
             "role": "user"
           },
           {
             "content": [
               {
                 "input": {
-                  "query": "Run the Braintrust Eve instrumentation e2e scenario again"
+                  "message": "Run the Braintrust Eve instrumentation e2e scenario"
                 },
                 "providerOptions": {
                   "openai": {
@@ -1062,7 +936,39 @@ span_tree:
                   }
                 },
                 "toolCallId": "<toolCallId:1>",
-                "toolName": "search",
+                "toolName": "researcher",
+                "type": "tool-call"
+              }
+            ],
+            "role": "assistant"
+          },
+          {
+            "content": [
+              {
+                "output": {
+                  "type": "text",
+                  "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+                },
+                "toolCallId": "<toolCallId:1>",
+                "toolName": "researcher",
+                "type": "tool-result"
+              }
+            ],
+            "role": "tool"
+          },
+          {
+            "content": [
+              {
+                "input": {
+                  "url": "https://eve.dev/docs/guides/instrumentation"
+                },
+                "providerOptions": {
+                  "openai": {
+                    "itemId": "<itemId:4>"
+                  }
+                },
+                "toolCallId": "<toolCallId:3>",
+                "toolName": "read",
                 "type": "tool-call"
               }
             ],
@@ -1074,18 +980,112 @@ span_tree:
                 "output": {
                   "type": "json",
                   "value": {
-                    "query": "Run the Braintrust Eve instrumentation e2e scenario again",
+                    "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+                    "section": "Runtime context",
                     "title": "Eve instrumentation",
                     "url": "https://eve.dev/docs/guides/instrumentation"
                   }
                 },
                 "providerOptions": {
                   "openai": {
-                    "itemId": "<itemId:2>"
+                    "itemId": "<itemId:4>"
                   }
                 },
-                "toolCallId": "<toolCallId:1>",
-                "toolName": "search",
+                "toolCallId": "<toolCallId:3>",
+                "toolName": "read",
+                "type": "tool-result"
+              }
+            ],
+            "role": "tool"
+          },
+          {
+            "content": [
+              {
+                "providerOptions": {
+                  "openai": {
+                    "itemId": "<itemId:5>",
+                    "phase": "final_answer"
+                  }
+                },
+                "text": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+                "type": "text"
+              }
+            ],
+            "role": "assistant"
+          },
+          {
+            "content": "Run the Braintrust Eve instrumentation e2e scenario again",
+            "role": "user"
+          },
+          {
+            "content": [
+              {
+                "input": {
+                  "message": "Run the Braintrust Eve instrumentation e2e scenario again"
+                },
+                "providerOptions": {
+                  "openai": {
+                    "itemId": "<itemId:7>"
+                  }
+                },
+                "toolCallId": "<toolCallId:6>",
+                "toolName": "researcher",
+                "type": "tool-call"
+              }
+            ],
+            "role": "assistant"
+          },
+          {
+            "content": [
+              {
+                "output": {
+                  "type": "text",
+                  "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+                },
+                "toolCallId": "<toolCallId:6>",
+                "toolName": "researcher",
+                "type": "tool-result"
+              }
+            ],
+            "role": "tool"
+          },
+          {
+            "content": [
+              {
+                "input": {
+                  "url": "https://eve.dev/docs/guides/instrumentation"
+                },
+                "providerOptions": {
+                  "openai": {
+                    "itemId": "<itemId:9>"
+                  }
+                },
+                "toolCallId": "<toolCallId:8>",
+                "toolName": "read",
+                "type": "tool-call"
+              }
+            ],
+            "role": "assistant"
+          },
+          {
+            "content": [
+              {
+                "output": {
+                  "type": "json",
+                  "value": {
+                    "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+                    "section": "Runtime context",
+                    "title": "Eve instrumentation",
+                    "url": "https://eve.dev/docs/guides/instrumentation"
+                  }
+                },
+                "providerOptions": {
+                  "openai": {
+                    "itemId": "<itemId:9>"
+                  }
+                },
+                "toolCallId": "<toolCallId:8>",
+                "toolName": "read",
                 "type": "tool-result"
               }
             ],
@@ -1097,7 +1097,7 @@ span_tree:
             "finish_reason": "stop",
             "index": 0,
             "message": {
-              "content": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
+              "content": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
               "role": "assistant"
             }
           }
@@ -1109,8 +1109,8 @@ span_tree:
           "testRunId": "<run:1>"
         }
         metrics: {
-          "completion_tokens": 22,
+          "completion_tokens": 65,
           "prompt_cached_tokens": 6528,
-          "prompt_tokens": 6627,
-          "tokens": 6649
+          "prompt_tokens": 7029,
+          "tokens": 7094
         }

--- a/e2e/scenarios/eve-instrumentation/__snapshots__/eve-instrumentation.span-tree.txt
+++ b/e2e/scenarios/eve-instrumentation/__snapshots__/eve-instrumentation.span-tree.txt
@@ -1,19 +1,1020 @@
 span_tree:
-└── eve.session [task]
+├── eve.turn [task]
+│   input: [
+│     {
+│       "content": "Run the Braintrust Eve instrumentation e2e scenario",
+│       "role": "user"
+│     }
+│   ]
+│   output: "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace."
+│   metadata: {
+│     "model": "gpt-5.4-mini",
+│     "provider": "openai",
+│     "scenario": "eve-instrumentation",
+│     "testRunId": "<run:1>"
+│   }
+│   metrics: {
+│     "completion_tokens": 120,
+│     "prompt_cached_tokens": 13056,
+│     "prompt_tokens": 20196,
+│     "tokens": 20316
+│   }
+│   ├── eve.step [llm]
+│   │   input: [
+│   │     {
+│   │       "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+│   │       "role": "system"
+│   │     },
+│   │     {
+│   │       "content": "Run the Braintrust Eve instrumentation e2e scenario",
+│   │       "role": "user"
+│   │     }
+│   │   ]
+│   │   output: [
+│   │     {
+│   │       "finish_reason": "tool_calls",
+│   │       "index": 0,
+│   │       "message": {
+│   │         "content": null,
+│   │         "role": "assistant",
+│   │         "tool_calls": [
+│   │           {
+│   │             "function": {
+│   │               "arguments": "{\"message\":\"Run the Braintrust Eve instrumentation e2e scenario\"}",
+│   │               "name": "researcher"
+│   │             },
+│   │             "id": "<span:1>",
+│   │             "type": "function"
+│   │           }
+│   │         ]
+│   │       }
+│   │     }
+│   │   ]
+│   │   metadata: {
+│   │     "model": "gpt-5.4-mini",
+│   │     "provider": "openai",
+│   │     "scenario": "eve-instrumentation",
+│   │     "testRunId": "<run:1>"
+│   │   }
+│   │   metrics: {
+│   │     "completion_tokens": 28,
+│   │     "prompt_cached_tokens": 0,
+│   │     "prompt_tokens": 6666,
+│   │     "tokens": 6694
+│   │   }
+│   ├── researcher [tool]
+│   │   input: {
+│   │     "message": "Run the Braintrust Eve instrumentation e2e scenario"
+│   │   }
+│   │   output: "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+│   │   metadata: {
+│   │     "scenario": "eve-instrumentation",
+│   │     "testRunId": "<run:1>"
+│   │   }
+│   ├── eve.step [llm]
+│   │   input: [
+│   │     {
+│   │       "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+│   │       "role": "system"
+│   │     },
+│   │     {
+│   │       "content": "Run the Braintrust Eve instrumentation e2e scenario",
+│   │       "role": "user"
+│   │     },
+│   │     {
+│   │       "content": [
+│   │         {
+│   │           "input": {
+│   │             "message": "Run the Braintrust Eve instrumentation e2e scenario"
+│   │           },
+│   │           "providerOptions": {
+│   │             "openai": {
+│   │               "itemId": "<itemId:2>"
+│   │             }
+│   │           },
+│   │           "toolCallId": "<toolCallId:1>",
+│   │           "toolName": "researcher",
+│   │           "type": "tool-call"
+│   │         }
+│   │       ],
+│   │       "role": "assistant"
+│   │     },
+│   │     {
+│   │       "content": [
+│   │         {
+│   │           "output": {
+│   │             "type": "text",
+│   │             "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+│   │           },
+│   │           "toolCallId": "<toolCallId:1>",
+│   │           "toolName": "researcher",
+│   │           "type": "tool-result"
+│   │         }
+│   │       ],
+│   │       "role": "tool"
+│   │     }
+│   │   ]
+│   │   output: [
+│   │     {
+│   │       "finish_reason": "tool_calls",
+│   │       "index": 0,
+│   │       "message": {
+│   │         "content": null,
+│   │         "role": "assistant",
+│   │         "tool_calls": [
+│   │           {
+│   │             "function": {
+│   │               "arguments": "{\"url\":\"https://eve.dev/docs/guides/instrumentation\"}",
+│   │               "name": "read"
+│   │             },
+│   │             "id": "<span:1>",
+│   │             "type": "function"
+│   │           }
+│   │         ]
+│   │       }
+│   │     }
+│   │   ]
+│   │   metadata: {
+│   │     "model": "gpt-5.4-mini",
+│   │     "provider": "openai",
+│   │     "scenario": "eve-instrumentation",
+│   │     "testRunId": "<run:1>"
+│   │   }
+│   │   metrics: {
+│   │     "completion_tokens": 27,
+│   │     "prompt_cached_tokens": 6528,
+│   │     "prompt_tokens": 6724,
+│   │     "tokens": 6751
+│   │   }
+│   ├── read [tool]
+│   │   input: {
+│   │     "url": "https://eve.dev/docs/guides/instrumentation"
+│   │   }
+│   │   output: {
+│   │     "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+│   │     "section": "Runtime context",
+│   │     "title": "Eve instrumentation",
+│   │     "url": "https://eve.dev/docs/guides/instrumentation"
+│   │   }
+│   │   metadata: {
+│   │     "scenario": "eve-instrumentation",
+│   │     "testRunId": "<run:1>"
+│   │   }
+│   └── eve.step [llm]
+│       input: [
+│         {
+│           "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+│           "role": "system"
+│         },
+│         {
+│           "content": "Run the Braintrust Eve instrumentation e2e scenario",
+│           "role": "user"
+│         },
+│         {
+│           "content": [
+│             {
+│               "input": {
+│                 "message": "Run the Braintrust Eve instrumentation e2e scenario"
+│               },
+│               "providerOptions": {
+│                 "openai": {
+│                   "itemId": "<itemId:2>"
+│                 }
+│               },
+│               "toolCallId": "<toolCallId:1>",
+│               "toolName": "researcher",
+│               "type": "tool-call"
+│             }
+│           ],
+│           "role": "assistant"
+│         },
+│         {
+│           "content": [
+│             {
+│               "output": {
+│                 "type": "text",
+│                 "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+│               },
+│               "toolCallId": "<toolCallId:1>",
+│               "toolName": "researcher",
+│               "type": "tool-result"
+│             }
+│           ],
+│           "role": "tool"
+│         },
+│         {
+│           "content": [
+│             {
+│               "input": {
+│                 "url": "https://eve.dev/docs/guides/instrumentation"
+│               },
+│               "providerOptions": {
+│                 "openai": {
+│                   "itemId": "<itemId:4>"
+│                 }
+│               },
+│               "toolCallId": "<toolCallId:3>",
+│               "toolName": "read",
+│               "type": "tool-call"
+│             }
+│           ],
+│           "role": "assistant"
+│         },
+│         {
+│           "content": [
+│             {
+│               "output": {
+│                 "type": "json",
+│                 "value": {
+│                   "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+│                   "section": "Runtime context",
+│                   "title": "Eve instrumentation",
+│                   "url": "https://eve.dev/docs/guides/instrumentation"
+│                 }
+│               },
+│               "providerOptions": {
+│                 "openai": {
+│                   "itemId": "<itemId:4>"
+│                 }
+│               },
+│               "toolCallId": "<toolCallId:3>",
+│               "toolName": "read",
+│               "type": "tool-result"
+│             }
+│           ],
+│           "role": "tool"
+│         }
+│       ]
+│       output: [
+│         {
+│           "finish_reason": "stop",
+│           "index": 0,
+│           "message": {
+│             "content": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+│             "role": "assistant"
+│           }
+│         }
+│       ]
+│       metadata: {
+│         "model": "gpt-5.4-mini",
+│         "provider": "openai",
+│         "scenario": "eve-instrumentation",
+│         "testRunId": "<run:1>"
+│       }
+│       metrics: {
+│         "completion_tokens": 65,
+│         "prompt_cached_tokens": 6528,
+│         "prompt_tokens": 6806,
+│         "tokens": 6871
+│       }
+├── eve.turn [task]
+│   input: [
+│     {
+│       "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
+│       "role": "user"
+│     }
+│   ]
+│   output: "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+│   metadata: {
+│     "model": "gpt-5.4-mini",
+│     "provider": "openai",
+│     "scenario": "eve-instrumentation",
+│     "testRunId": "<run:1>"
+│   }
+│   metrics: {
+│     "completion_tokens": 48,
+│     "prompt_cached_tokens": 5504,
+│     "prompt_tokens": 13178,
+│     "tokens": 13226
+│   }
+│   ├── eve.step [llm]
+│   │   input: [
+│   │     {
+│   │       "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+│   │       "role": "system"
+│   │     },
+│   │     {
+│   │       "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
+│   │       "role": "user"
+│   │     }
+│   │   ]
+│   │   output: [
+│   │     {
+│   │       "finish_reason": "tool_calls",
+│   │       "index": 0,
+│   │       "message": {
+│   │         "content": null,
+│   │         "role": "assistant",
+│   │         "tool_calls": [
+│   │           {
+│   │             "function": {
+│   │               "arguments": "{\"query\":\"Run the Braintrust Eve instrumentation e2e scenario\"}",
+│   │               "name": "search"
+│   │             },
+│   │             "id": "<span:1>",
+│   │             "type": "function"
+│   │           }
+│   │         ]
+│   │       }
+│   │     }
+│   │   ]
+│   │   metadata: {
+│   │     "model": "gpt-5.4-mini",
+│   │     "provider": "openai",
+│   │     "scenario": "eve-instrumentation",
+│   │     "testRunId": "<run:1>"
+│   │   }
+│   │   metrics: {
+│   │     "completion_tokens": 26,
+│   │     "prompt_cached_tokens": 0,
+│   │     "prompt_tokens": 6554,
+│   │     "tokens": 6580
+│   │   }
+│   ├── search [tool]
+│   │   input: {
+│   │     "query": "Run the Braintrust Eve instrumentation e2e scenario"
+│   │   }
+│   │   output: {
+│   │     "query": "Run the Braintrust Eve instrumentation e2e scenario",
+│   │     "title": "Eve instrumentation",
+│   │     "url": "https://eve.dev/docs/guides/instrumentation"
+│   │   }
+│   │   metadata: {
+│   │     "scenario": "eve-instrumentation",
+│   │     "testRunId": "<run:1>"
+│   │   }
+│   └── eve.step [llm]
+│       input: [
+│         {
+│           "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+│           "role": "system"
+│         },
+│         {
+│           "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
+│           "role": "user"
+│         },
+│         {
+│           "content": [
+│             {
+│               "input": {
+│                 "query": "Run the Braintrust Eve instrumentation e2e scenario"
+│               },
+│               "providerOptions": {
+│                 "openai": {
+│                   "itemId": "<itemId:2>"
+│                 }
+│               },
+│               "toolCallId": "<toolCallId:1>",
+│               "toolName": "search",
+│               "type": "tool-call"
+│             }
+│           ],
+│           "role": "assistant"
+│         },
+│         {
+│           "content": [
+│             {
+│               "output": {
+│                 "type": "json",
+│                 "value": {
+│                   "query": "Run the Braintrust Eve instrumentation e2e scenario",
+│                   "title": "Eve instrumentation",
+│                   "url": "https://eve.dev/docs/guides/instrumentation"
+│                 }
+│               },
+│               "providerOptions": {
+│                 "openai": {
+│                   "itemId": "<itemId:2>"
+│                 }
+│               },
+│               "toolCallId": "<toolCallId:1>",
+│               "toolName": "search",
+│               "type": "tool-result"
+│             }
+│           ],
+│           "role": "tool"
+│         }
+│       ]
+│       output: [
+│         {
+│           "finish_reason": "stop",
+│           "index": 0,
+│           "message": {
+│             "content": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
+│             "role": "assistant"
+│           }
+│         }
+│       ]
+│       metadata: {
+│         "model": "gpt-5.4-mini",
+│         "provider": "openai",
+│         "scenario": "eve-instrumentation",
+│         "testRunId": "<run:1>"
+│       }
+│       metrics: {
+│         "completion_tokens": 22,
+│         "prompt_cached_tokens": 5504,
+│         "prompt_tokens": 6624,
+│         "tokens": 6646
+│       }
+├── eve.turn [task]
+│   input: [
+│     {
+│       "content": "Run the Braintrust Eve instrumentation e2e scenario again",
+│       "role": "user"
+│     }
+│   ]
+│   output: "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace."
+│   metadata: {
+│     "model": "gpt-5.4-mini",
+│     "provider": "openai",
+│     "scenario": "eve-instrumentation",
+│     "testRunId": "<run:1>"
+│   }
+│   metrics: {
+│     "completion_tokens": 121,
+│     "prompt_cached_tokens": 19584,
+│     "prompt_tokens": 20864,
+│     "tokens": 20985
+│   }
+│   ├── eve.step [llm]
+│   │   input: [
+│   │     {
+│   │       "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+│   │       "role": "system"
+│   │     },
+│   │     {
+│   │       "content": "Run the Braintrust Eve instrumentation e2e scenario",
+│   │       "role": "user"
+│   │     },
+│   │     {
+│   │       "content": [
+│   │         {
+│   │           "input": {
+│   │             "message": "Run the Braintrust Eve instrumentation e2e scenario"
+│   │           },
+│   │           "providerOptions": {
+│   │             "openai": {
+│   │               "itemId": "<itemId:2>"
+│   │             }
+│   │           },
+│   │           "toolCallId": "<toolCallId:1>",
+│   │           "toolName": "researcher",
+│   │           "type": "tool-call"
+│   │         }
+│   │       ],
+│   │       "role": "assistant"
+│   │     },
+│   │     {
+│   │       "content": [
+│   │         {
+│   │           "output": {
+│   │             "type": "text",
+│   │             "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+│   │           },
+│   │           "toolCallId": "<toolCallId:1>",
+│   │           "toolName": "researcher",
+│   │           "type": "tool-result"
+│   │         }
+│   │       ],
+│   │       "role": "tool"
+│   │     },
+│   │     {
+│   │       "content": [
+│   │         {
+│   │           "input": {
+│   │             "url": "https://eve.dev/docs/guides/instrumentation"
+│   │           },
+│   │           "providerOptions": {
+│   │             "openai": {
+│   │               "itemId": "<itemId:4>"
+│   │             }
+│   │           },
+│   │           "toolCallId": "<toolCallId:3>",
+│   │           "toolName": "read",
+│   │           "type": "tool-call"
+│   │         }
+│   │       ],
+│   │       "role": "assistant"
+│   │     },
+│   │     {
+│   │       "content": [
+│   │         {
+│   │           "output": {
+│   │             "type": "json",
+│   │             "value": {
+│   │               "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+│   │               "section": "Runtime context",
+│   │               "title": "Eve instrumentation",
+│   │               "url": "https://eve.dev/docs/guides/instrumentation"
+│   │             }
+│   │           },
+│   │           "providerOptions": {
+│   │             "openai": {
+│   │               "itemId": "<itemId:4>"
+│   │             }
+│   │           },
+│   │           "toolCallId": "<toolCallId:3>",
+│   │           "toolName": "read",
+│   │           "type": "tool-result"
+│   │         }
+│   │       ],
+│   │       "role": "tool"
+│   │     },
+│   │     {
+│   │       "content": [
+│   │         {
+│   │           "providerOptions": {
+│   │             "openai": {
+│   │               "itemId": "<itemId:5>",
+│   │               "phase": "final_answer"
+│   │             }
+│   │           },
+│   │           "text": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+│   │           "type": "text"
+│   │         }
+│   │       ],
+│   │       "role": "assistant"
+│   │     },
+│   │     {
+│   │       "content": "Run the Braintrust Eve instrumentation e2e scenario again",
+│   │       "role": "user"
+│   │     }
+│   │   ]
+│   │   output: [
+│   │     {
+│   │       "finish_reason": "tool_calls",
+│   │       "index": 0,
+│   │       "message": {
+│   │         "content": null,
+│   │         "role": "assistant",
+│   │         "tool_calls": [
+│   │           {
+│   │             "function": {
+│   │               "arguments": "{\"message\":\"Run the Braintrust Eve instrumentation e2e scenario again\"}",
+│   │               "name": "researcher"
+│   │             },
+│   │             "id": "<span:1>",
+│   │             "type": "function"
+│   │           }
+│   │         ]
+│   │       }
+│   │     }
+│   │   ]
+│   │   metadata: {
+│   │     "model": "gpt-5.4-mini",
+│   │     "provider": "openai",
+│   │     "scenario": "eve-instrumentation",
+│   │     "testRunId": "<run:1>"
+│   │   }
+│   │   metrics: {
+│   │     "completion_tokens": 29,
+│   │     "prompt_cached_tokens": 6528,
+│   │     "prompt_tokens": 6888,
+│   │     "tokens": 6917
+│   │   }
+│   ├── researcher [tool]
+│   │   input: {
+│   │     "message": "Run the Braintrust Eve instrumentation e2e scenario again"
+│   │   }
+│   │   output: "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+│   │   metadata: {
+│   │     "scenario": "eve-instrumentation",
+│   │     "testRunId": "<run:1>"
+│   │   }
+│   ├── eve.step [llm]
+│   │   input: [
+│   │     {
+│   │       "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+│   │       "role": "system"
+│   │     },
+│   │     {
+│   │       "content": "Run the Braintrust Eve instrumentation e2e scenario",
+│   │       "role": "user"
+│   │     },
+│   │     {
+│   │       "content": [
+│   │         {
+│   │           "input": {
+│   │             "message": "Run the Braintrust Eve instrumentation e2e scenario"
+│   │           },
+│   │           "providerOptions": {
+│   │             "openai": {
+│   │               "itemId": "<itemId:2>"
+│   │             }
+│   │           },
+│   │           "toolCallId": "<toolCallId:1>",
+│   │           "toolName": "researcher",
+│   │           "type": "tool-call"
+│   │         }
+│   │       ],
+│   │       "role": "assistant"
+│   │     },
+│   │     {
+│   │       "content": [
+│   │         {
+│   │           "output": {
+│   │             "type": "text",
+│   │             "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+│   │           },
+│   │           "toolCallId": "<toolCallId:1>",
+│   │           "toolName": "researcher",
+│   │           "type": "tool-result"
+│   │         }
+│   │       ],
+│   │       "role": "tool"
+│   │     },
+│   │     {
+│   │       "content": [
+│   │         {
+│   │           "input": {
+│   │             "url": "https://eve.dev/docs/guides/instrumentation"
+│   │           },
+│   │           "providerOptions": {
+│   │             "openai": {
+│   │               "itemId": "<itemId:4>"
+│   │             }
+│   │           },
+│   │           "toolCallId": "<toolCallId:3>",
+│   │           "toolName": "read",
+│   │           "type": "tool-call"
+│   │         }
+│   │       ],
+│   │       "role": "assistant"
+│   │     },
+│   │     {
+│   │       "content": [
+│   │         {
+│   │           "output": {
+│   │             "type": "json",
+│   │             "value": {
+│   │               "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+│   │               "section": "Runtime context",
+│   │               "title": "Eve instrumentation",
+│   │               "url": "https://eve.dev/docs/guides/instrumentation"
+│   │             }
+│   │           },
+│   │           "providerOptions": {
+│   │             "openai": {
+│   │               "itemId": "<itemId:4>"
+│   │             }
+│   │           },
+│   │           "toolCallId": "<toolCallId:3>",
+│   │           "toolName": "read",
+│   │           "type": "tool-result"
+│   │         }
+│   │       ],
+│   │       "role": "tool"
+│   │     },
+│   │     {
+│   │       "content": [
+│   │         {
+│   │           "providerOptions": {
+│   │             "openai": {
+│   │               "itemId": "<itemId:5>",
+│   │               "phase": "final_answer"
+│   │             }
+│   │           },
+│   │           "text": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+│   │           "type": "text"
+│   │         }
+│   │       ],
+│   │       "role": "assistant"
+│   │     },
+│   │     {
+│   │       "content": "Run the Braintrust Eve instrumentation e2e scenario again",
+│   │       "role": "user"
+│   │     },
+│   │     {
+│   │       "content": [
+│   │         {
+│   │           "input": {
+│   │             "message": "Run the Braintrust Eve instrumentation e2e scenario again"
+│   │           },
+│   │           "providerOptions": {
+│   │             "openai": {
+│   │               "itemId": "<itemId:7>"
+│   │             }
+│   │           },
+│   │           "toolCallId": "<toolCallId:6>",
+│   │           "toolName": "researcher",
+│   │           "type": "tool-call"
+│   │         }
+│   │       ],
+│   │       "role": "assistant"
+│   │     },
+│   │     {
+│   │       "content": [
+│   │         {
+│   │           "output": {
+│   │             "type": "text",
+│   │             "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+│   │           },
+│   │           "toolCallId": "<toolCallId:6>",
+│   │           "toolName": "researcher",
+│   │           "type": "tool-result"
+│   │         }
+│   │       ],
+│   │       "role": "tool"
+│   │     }
+│   │   ]
+│   │   output: [
+│   │     {
+│   │       "finish_reason": "tool_calls",
+│   │       "index": 0,
+│   │       "message": {
+│   │         "content": null,
+│   │         "role": "assistant",
+│   │         "tool_calls": [
+│   │           {
+│   │             "function": {
+│   │               "arguments": "{\"url\":\"https://eve.dev/docs/guides/instrumentation\"}",
+│   │               "name": "read"
+│   │             },
+│   │             "id": "<span:1>",
+│   │             "type": "function"
+│   │           }
+│   │         ]
+│   │       }
+│   │     }
+│   │   ]
+│   │   metadata: {
+│   │     "model": "gpt-5.4-mini",
+│   │     "provider": "openai",
+│   │     "scenario": "eve-instrumentation",
+│   │     "testRunId": "<run:1>"
+│   │   }
+│   │   metrics: {
+│   │     "completion_tokens": 27,
+│   │     "prompt_cached_tokens": 6528,
+│   │     "prompt_tokens": 6947,
+│   │     "tokens": 6974
+│   │   }
+│   ├── read [tool]
+│   │   input: {
+│   │     "url": "https://eve.dev/docs/guides/instrumentation"
+│   │   }
+│   │   output: {
+│   │     "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+│   │     "section": "Runtime context",
+│   │     "title": "Eve instrumentation",
+│   │     "url": "https://eve.dev/docs/guides/instrumentation"
+│   │   }
+│   │   metadata: {
+│   │     "scenario": "eve-instrumentation",
+│   │     "testRunId": "<run:1>"
+│   │   }
+│   └── eve.step [llm]
+│       input: [
+│         {
+│           "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+│           "role": "system"
+│         },
+│         {
+│           "content": "Run the Braintrust Eve instrumentation e2e scenario",
+│           "role": "user"
+│         },
+│         {
+│           "content": [
+│             {
+│               "input": {
+│                 "message": "Run the Braintrust Eve instrumentation e2e scenario"
+│               },
+│               "providerOptions": {
+│                 "openai": {
+│                   "itemId": "<itemId:2>"
+│                 }
+│               },
+│               "toolCallId": "<toolCallId:1>",
+│               "toolName": "researcher",
+│               "type": "tool-call"
+│             }
+│           ],
+│           "role": "assistant"
+│         },
+│         {
+│           "content": [
+│             {
+│               "output": {
+│                 "type": "text",
+│                 "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+│               },
+│               "toolCallId": "<toolCallId:1>",
+│               "toolName": "researcher",
+│               "type": "tool-result"
+│             }
+│           ],
+│           "role": "tool"
+│         },
+│         {
+│           "content": [
+│             {
+│               "input": {
+│                 "url": "https://eve.dev/docs/guides/instrumentation"
+│               },
+│               "providerOptions": {
+│                 "openai": {
+│                   "itemId": "<itemId:4>"
+│                 }
+│               },
+│               "toolCallId": "<toolCallId:3>",
+│               "toolName": "read",
+│               "type": "tool-call"
+│             }
+│           ],
+│           "role": "assistant"
+│         },
+│         {
+│           "content": [
+│             {
+│               "output": {
+│                 "type": "json",
+│                 "value": {
+│                   "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+│                   "section": "Runtime context",
+│                   "title": "Eve instrumentation",
+│                   "url": "https://eve.dev/docs/guides/instrumentation"
+│                 }
+│               },
+│               "providerOptions": {
+│                 "openai": {
+│                   "itemId": "<itemId:4>"
+│                 }
+│               },
+│               "toolCallId": "<toolCallId:3>",
+│               "toolName": "read",
+│               "type": "tool-result"
+│             }
+│           ],
+│           "role": "tool"
+│         },
+│         {
+│           "content": [
+│             {
+│               "providerOptions": {
+│                 "openai": {
+│                   "itemId": "<itemId:5>",
+│                   "phase": "final_answer"
+│                 }
+│               },
+│               "text": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+│               "type": "text"
+│             }
+│           ],
+│           "role": "assistant"
+│         },
+│         {
+│           "content": "Run the Braintrust Eve instrumentation e2e scenario again",
+│           "role": "user"
+│         },
+│         {
+│           "content": [
+│             {
+│               "input": {
+│                 "message": "Run the Braintrust Eve instrumentation e2e scenario again"
+│               },
+│               "providerOptions": {
+│                 "openai": {
+│                   "itemId": "<itemId:7>"
+│                 }
+│               },
+│               "toolCallId": "<toolCallId:6>",
+│               "toolName": "researcher",
+│               "type": "tool-call"
+│             }
+│           ],
+│           "role": "assistant"
+│         },
+│         {
+│           "content": [
+│             {
+│               "output": {
+│                 "type": "text",
+│                 "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
+│               },
+│               "toolCallId": "<toolCallId:6>",
+│               "toolName": "researcher",
+│               "type": "tool-result"
+│             }
+│           ],
+│           "role": "tool"
+│         },
+│         {
+│           "content": [
+│             {
+│               "input": {
+│                 "url": "https://eve.dev/docs/guides/instrumentation"
+│               },
+│               "providerOptions": {
+│                 "openai": {
+│                   "itemId": "<itemId:9>"
+│                 }
+│               },
+│               "toolCallId": "<toolCallId:8>",
+│               "toolName": "read",
+│               "type": "tool-call"
+│             }
+│           ],
+│           "role": "assistant"
+│         },
+│         {
+│           "content": [
+│             {
+│               "output": {
+│                 "type": "json",
+│                 "value": {
+│                   "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+│                   "section": "Runtime context",
+│                   "title": "Eve instrumentation",
+│                   "url": "https://eve.dev/docs/guides/instrumentation"
+│                 }
+│               },
+│               "providerOptions": {
+│                 "openai": {
+│                   "itemId": "<itemId:9>"
+│                 }
+│               },
+│               "toolCallId": "<toolCallId:8>",
+│               "toolName": "read",
+│               "type": "tool-result"
+│             }
+│           ],
+│           "role": "tool"
+│         }
+│       ]
+│       output: [
+│         {
+│           "finish_reason": "stop",
+│           "index": 0,
+│           "message": {
+│             "content": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
+│             "role": "assistant"
+│           }
+│         }
+│       ]
+│       metadata: {
+│         "model": "gpt-5.4-mini",
+│         "provider": "openai",
+│         "scenario": "eve-instrumentation",
+│         "testRunId": "<run:1>"
+│       }
+│       metrics: {
+│         "completion_tokens": 65,
+│         "prompt_cached_tokens": 6528,
+│         "prompt_tokens": 7029,
+│         "tokens": 7094
+│       }
+└── eve.turn [task]
+    input: [
+      {
+        "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
+        "role": "user"
+      }
+    ]
+    output: "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
     metadata: {
       "model": "gpt-5.4-mini",
       "provider": "openai",
       "scenario": "eve-instrumentation",
       "testRunId": "<run:1>"
     }
-    ├── eve.turn [task]
+    metrics: {
+      "completion_tokens": 49,
+      "prompt_cached_tokens": 13056,
+      "prompt_tokens": 13182,
+      "tokens": 13231
+    }
+    ├── eve.step [llm]
     │   input: [
     │     {
-    │       "content": "Run the Braintrust Eve instrumentation e2e scenario",
+    │       "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+    │       "role": "system"
+    │     },
+    │     {
+    │       "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
     │       "role": "user"
     │     }
     │   ]
-    │   output: "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace."
+    │   output: [
+    │     {
+    │       "finish_reason": "tool_calls",
+    │       "index": 0,
+    │       "message": {
+    │         "content": null,
+    │         "role": "assistant",
+    │         "tool_calls": [
+    │           {
+    │             "function": {
+    │               "arguments": "{\"query\":\"Run the Braintrust Eve instrumentation e2e scenario again\"}",
+    │               "name": "search"
+    │             },
+    │             "id": "<span:1>",
+    │             "type": "function"
+    │           }
+    │         ]
+    │       }
+    │     }
+    │   ]
     │   metadata: {
     │     "model": "gpt-5.4-mini",
     │     "provider": "openai",
@@ -21,424 +1022,86 @@ span_tree:
     │     "testRunId": "<run:1>"
     │   }
     │   metrics: {
-    │     "completion_tokens": 120,
-    │     "prompt_cached_tokens": 13056,
-    │     "prompt_tokens": 20196,
-    │     "tokens": 20316
+    │     "completion_tokens": 27,
+    │     "prompt_cached_tokens": 6528,
+    │     "prompt_tokens": 6555,
+    │     "tokens": 6582
     │   }
-    │   ├── eve.step [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-    │   │       "role": "system"
-    │   │     },
-    │   │     {
-    │   │       "content": "Run the Braintrust Eve instrumentation e2e scenario",
-    │   │       "role": "user"
-    │   │     }
-    │   │   ]
-    │   │   output: [
-    │   │     {
-    │   │       "finish_reason": "tool_calls",
-    │   │       "index": 0,
-    │   │       "message": {
-    │   │         "content": null,
-    │   │         "role": "assistant",
-    │   │         "tool_calls": [
-    │   │           {
-    │   │             "function": {
-    │   │               "arguments": "{\"message\":\"Run the Braintrust Eve instrumentation e2e scenario\"}",
-    │   │               "name": "researcher"
-    │   │             },
-    │   │             "id": "<span:1>",
-    │   │             "type": "function"
-    │   │           }
-    │   │         ]
-    │   │       }
-    │   │     }
-    │   │   ]
-    │   │   metadata: {
-    │   │     "model": "gpt-5.4-mini",
-    │   │     "provider": "openai",
-    │   │     "scenario": "eve-instrumentation",
-    │   │     "testRunId": "<run:1>"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 28,
-    │   │     "prompt_cached_tokens": 0,
-    │   │     "prompt_tokens": 6666,
-    │   │     "tokens": 6694
-    │   │   }
-    │   ├── researcher [tool]
-    │   │   input: {
-    │   │     "message": "Run the Braintrust Eve instrumentation e2e scenario"
-    │   │   }
-    │   │   output: "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-    │   │   metadata: {
-    │   │     "scenario": "eve-instrumentation",
-    │   │     "testRunId": "<run:1>"
-    │   │   }
-    │   │   └── eve.session [task]
-    │   │       metadata: {
-    │   │         "model": "gpt-5.4-mini",
-    │   │         "provider": "openai",
-    │   │         "scenario": "eve-instrumentation",
-    │   │         "testRunId": "<run:1>"
-    │   │       }
-    │   │       └── eve.turn [task]
-    │   │           input: [
-    │   │             {
-    │   │               "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
-    │   │               "role": "user"
-    │   │             }
-    │   │           ]
-    │   │           output: "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-    │   │           metadata: {
-    │   │             "model": "gpt-5.4-mini",
-    │   │             "provider": "openai",
-    │   │             "scenario": "eve-instrumentation",
-    │   │             "testRunId": "<run:1>"
-    │   │           }
-    │   │           metrics: {
-    │   │             "completion_tokens": 48,
-    │   │             "prompt_cached_tokens": 5504,
-    │   │             "prompt_tokens": 13178,
-    │   │             "tokens": 13226
-    │   │           }
-    │   │           ├── eve.step [llm]
-    │   │           │   input: [
-    │   │           │     {
-    │   │           │       "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-    │   │           │       "role": "system"
-    │   │           │     },
-    │   │           │     {
-    │   │           │       "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
-    │   │           │       "role": "user"
-    │   │           │     }
-    │   │           │   ]
-    │   │           │   output: [
-    │   │           │     {
-    │   │           │       "finish_reason": "tool_calls",
-    │   │           │       "index": 0,
-    │   │           │       "message": {
-    │   │           │         "content": null,
-    │   │           │         "role": "assistant",
-    │   │           │         "tool_calls": [
-    │   │           │           {
-    │   │           │             "function": {
-    │   │           │               "arguments": "{\"query\":\"Run the Braintrust Eve instrumentation e2e scenario\"}",
-    │   │           │               "name": "search"
-    │   │           │             },
-    │   │           │             "id": "<span:1>",
-    │   │           │             "type": "function"
-    │   │           │           }
-    │   │           │         ]
-    │   │           │       }
-    │   │           │     }
-    │   │           │   ]
-    │   │           │   metadata: {
-    │   │           │     "model": "gpt-5.4-mini",
-    │   │           │     "provider": "openai",
-    │   │           │     "scenario": "eve-instrumentation",
-    │   │           │     "testRunId": "<run:1>"
-    │   │           │   }
-    │   │           │   metrics: {
-    │   │           │     "completion_tokens": 26,
-    │   │           │     "prompt_cached_tokens": 0,
-    │   │           │     "prompt_tokens": 6554,
-    │   │           │     "tokens": 6580
-    │   │           │   }
-    │   │           ├── search [tool]
-    │   │           │   input: {
-    │   │           │     "query": "Run the Braintrust Eve instrumentation e2e scenario"
-    │   │           │   }
-    │   │           │   output: {
-    │   │           │     "query": "Run the Braintrust Eve instrumentation e2e scenario",
-    │   │           │     "title": "Eve instrumentation",
-    │   │           │     "url": "https://eve.dev/docs/guides/instrumentation"
-    │   │           │   }
-    │   │           │   metadata: {
-    │   │           │     "scenario": "eve-instrumentation",
-    │   │           │     "testRunId": "<run:1>"
-    │   │           │   }
-    │   │           └── eve.step [llm]
-    │   │               input: [
-    │   │                 {
-    │   │                   "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-    │   │                   "role": "system"
-    │   │                 },
-    │   │                 {
-    │   │                   "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario",
-    │   │                   "role": "user"
-    │   │                 },
-    │   │                 {
-    │   │                   "content": [
-    │   │                     {
-    │   │                       "input": {
-    │   │                         "query": "Run the Braintrust Eve instrumentation e2e scenario"
-    │   │                       },
-    │   │                       "providerOptions": {
-    │   │                         "openai": {
-    │   │                           "itemId": "<itemId:2>"
-    │   │                         }
-    │   │                       },
-    │   │                       "toolCallId": "<toolCallId:1>",
-    │   │                       "toolName": "search",
-    │   │                       "type": "tool-call"
-    │   │                     }
-    │   │                   ],
-    │   │                   "role": "assistant"
-    │   │                 },
-    │   │                 {
-    │   │                   "content": [
-    │   │                     {
-    │   │                       "output": {
-    │   │                         "type": "json",
-    │   │                         "value": {
-    │   │                           "query": "Run the Braintrust Eve instrumentation e2e scenario",
-    │   │                           "title": "Eve instrumentation",
-    │   │                           "url": "https://eve.dev/docs/guides/instrumentation"
-    │   │                         }
-    │   │                       },
-    │   │                       "providerOptions": {
-    │   │                         "openai": {
-    │   │                           "itemId": "<itemId:2>"
-    │   │                         }
-    │   │                       },
-    │   │                       "toolCallId": "<toolCallId:1>",
-    │   │                       "toolName": "search",
-    │   │                       "type": "tool-result"
-    │   │                     }
-    │   │                   ],
-    │   │                   "role": "tool"
-    │   │                 }
-    │   │               ]
-    │   │               output: [
-    │   │                 {
-    │   │                   "finish_reason": "stop",
-    │   │                   "index": 0,
-    │   │                   "message": {
-    │   │                     "content": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
-    │   │                     "role": "assistant"
-    │   │                   }
-    │   │                 }
-    │   │               ]
-    │   │               metadata: {
-    │   │                 "model": "gpt-5.4-mini",
-    │   │                 "provider": "openai",
-    │   │                 "scenario": "eve-instrumentation",
-    │   │                 "testRunId": "<run:1>"
-    │   │               }
-    │   │               metrics: {
-    │   │                 "completion_tokens": 22,
-    │   │                 "prompt_cached_tokens": 5504,
-    │   │                 "prompt_tokens": 6624,
-    │   │                 "tokens": 6646
-    │   │               }
-    │   ├── eve.step [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-    │   │       "role": "system"
-    │   │     },
-    │   │     {
-    │   │       "content": "Run the Braintrust Eve instrumentation e2e scenario",
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "input": {
-    │   │             "message": "Run the Braintrust Eve instrumentation e2e scenario"
-    │   │           },
-    │   │           "providerOptions": {
-    │   │             "openai": {
-    │   │               "itemId": "<itemId:2>"
-    │   │             }
-    │   │           },
-    │   │           "toolCallId": "<toolCallId:1>",
-    │   │           "toolName": "researcher",
-    │   │           "type": "tool-call"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "output": {
-    │   │             "type": "text",
-    │   │             "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-    │   │           },
-    │   │           "toolCallId": "<toolCallId:1>",
-    │   │           "toolName": "researcher",
-    │   │           "type": "tool-result"
-    │   │         }
-    │   │       ],
-    │   │       "role": "tool"
-    │   │     }
-    │   │   ]
-    │   │   output: [
-    │   │     {
-    │   │       "finish_reason": "tool_calls",
-    │   │       "index": 0,
-    │   │       "message": {
-    │   │         "content": null,
-    │   │         "role": "assistant",
-    │   │         "tool_calls": [
-    │   │           {
-    │   │             "function": {
-    │   │               "arguments": "{\"url\":\"https://eve.dev/docs/guides/instrumentation\"}",
-    │   │               "name": "read"
-    │   │             },
-    │   │             "id": "<span:1>",
-    │   │             "type": "function"
-    │   │           }
-    │   │         ]
-    │   │       }
-    │   │     }
-    │   │   ]
-    │   │   metadata: {
-    │   │     "model": "gpt-5.4-mini",
-    │   │     "provider": "openai",
-    │   │     "scenario": "eve-instrumentation",
-    │   │     "testRunId": "<run:1>"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 27,
-    │   │     "prompt_cached_tokens": 6528,
-    │   │     "prompt_tokens": 6724,
-    │   │     "tokens": 6751
-    │   │   }
-    │   ├── read [tool]
-    │   │   input: {
-    │   │     "url": "https://eve.dev/docs/guides/instrumentation"
-    │   │   }
-    │   │   output: {
-    │   │     "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-    │   │     "section": "Runtime context",
-    │   │     "title": "Eve instrumentation",
-    │   │     "url": "https://eve.dev/docs/guides/instrumentation"
-    │   │   }
-    │   │   metadata: {
-    │   │     "scenario": "eve-instrumentation",
-    │   │     "testRunId": "<run:1>"
-    │   │   }
-    │   └── eve.step [llm]
-    │       input: [
-    │         {
-    │           "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-    │           "role": "system"
-    │         },
-    │         {
-    │           "content": "Run the Braintrust Eve instrumentation e2e scenario",
-    │           "role": "user"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "input": {
-    │                 "message": "Run the Braintrust Eve instrumentation e2e scenario"
-    │               },
-    │               "providerOptions": {
-    │                 "openai": {
-    │                   "itemId": "<itemId:2>"
-    │                 }
-    │               },
-    │               "toolCallId": "<toolCallId:1>",
-    │               "toolName": "researcher",
-    │               "type": "tool-call"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "output": {
-    │                 "type": "text",
-    │                 "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-    │               },
-    │               "toolCallId": "<toolCallId:1>",
-    │               "toolName": "researcher",
-    │               "type": "tool-result"
-    │             }
-    │           ],
-    │           "role": "tool"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "input": {
-    │                 "url": "https://eve.dev/docs/guides/instrumentation"
-    │               },
-    │               "providerOptions": {
-    │                 "openai": {
-    │                   "itemId": "<itemId:4>"
-    │                 }
-    │               },
-    │               "toolCallId": "<toolCallId:3>",
-    │               "toolName": "read",
-    │               "type": "tool-call"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "output": {
-    │                 "type": "json",
-    │                 "value": {
-    │                   "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-    │                   "section": "Runtime context",
-    │                   "title": "Eve instrumentation",
-    │                   "url": "https://eve.dev/docs/guides/instrumentation"
-    │                 }
-    │               },
-    │               "providerOptions": {
-    │                 "openai": {
-    │                   "itemId": "<itemId:4>"
-    │                 }
-    │               },
-    │               "toolCallId": "<toolCallId:3>",
-    │               "toolName": "read",
-    │               "type": "tool-result"
-    │             }
-    │           ],
-    │           "role": "tool"
-    │         }
-    │       ]
-    │       output: [
-    │         {
-    │           "finish_reason": "stop",
-    │           "index": 0,
-    │           "message": {
-    │             "content": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-    │             "role": "assistant"
-    │           }
-    │         }
-    │       ]
-    │       metadata: {
-    │         "model": "gpt-5.4-mini",
-    │         "provider": "openai",
-    │         "scenario": "eve-instrumentation",
-    │         "testRunId": "<run:1>"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 65,
-    │         "prompt_cached_tokens": 6528,
-    │         "prompt_tokens": 6806,
-    │         "tokens": 6871
-    │       }
-    └── eve.turn [task]
+    ├── search [tool]
+    │   input: {
+    │     "query": "Run the Braintrust Eve instrumentation e2e scenario again"
+    │   }
+    │   output: {
+    │     "query": "Run the Braintrust Eve instrumentation e2e scenario again",
+    │     "title": "Eve instrumentation",
+    │     "url": "https://eve.dev/docs/guides/instrumentation"
+    │   }
+    │   metadata: {
+    │     "scenario": "eve-instrumentation",
+    │     "testRunId": "<run:1>"
+    │   }
+    └── eve.step [llm]
         input: [
           {
-            "content": "Run the Braintrust Eve instrumentation e2e scenario again",
+            "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
+            "role": "system"
+          },
+          {
+            "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
             "role": "user"
+          },
+          {
+            "content": [
+              {
+                "input": {
+                  "query": "Run the Braintrust Eve instrumentation e2e scenario again"
+                },
+                "providerOptions": {
+                  "openai": {
+                    "itemId": "<itemId:2>"
+                  }
+                },
+                "toolCallId": "<toolCallId:1>",
+                "toolName": "search",
+                "type": "tool-call"
+              }
+            ],
+            "role": "assistant"
+          },
+          {
+            "content": [
+              {
+                "output": {
+                  "type": "json",
+                  "value": {
+                    "query": "Run the Braintrust Eve instrumentation e2e scenario again",
+                    "title": "Eve instrumentation",
+                    "url": "https://eve.dev/docs/guides/instrumentation"
+                  }
+                },
+                "providerOptions": {
+                  "openai": {
+                    "itemId": "<itemId:2>"
+                  }
+                },
+                "toolCallId": "<toolCallId:1>",
+                "toolName": "search",
+                "type": "tool-result"
+              }
+            ],
+            "role": "tool"
           }
         ]
-        output: "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace."
+        output: [
+          {
+            "finish_reason": "stop",
+            "index": 0,
+            "message": {
+              "content": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
+              "role": "assistant"
+            }
+          }
+        ]
         metadata: {
           "model": "gpt-5.4-mini",
           "provider": "openai",
@@ -446,692 +1109,8 @@ span_tree:
           "testRunId": "<run:1>"
         }
         metrics: {
-          "completion_tokens": 121,
-          "prompt_cached_tokens": 19584,
-          "prompt_tokens": 20864,
-          "tokens": 20985
+          "completion_tokens": 22,
+          "prompt_cached_tokens": 6528,
+          "prompt_tokens": 6627,
+          "tokens": 6649
         }
-        ├── eve.step [llm]
-        │   input: [
-        │     {
-        │       "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-        │       "role": "system"
-        │     },
-        │     {
-        │       "content": "Run the Braintrust Eve instrumentation e2e scenario",
-        │       "role": "user"
-        │     },
-        │     {
-        │       "content": [
-        │         {
-        │           "input": {
-        │             "message": "Run the Braintrust Eve instrumentation e2e scenario"
-        │           },
-        │           "providerOptions": {
-        │             "openai": {
-        │               "itemId": "<itemId:2>"
-        │             }
-        │           },
-        │           "toolCallId": "<toolCallId:1>",
-        │           "toolName": "researcher",
-        │           "type": "tool-call"
-        │         }
-        │       ],
-        │       "role": "assistant"
-        │     },
-        │     {
-        │       "content": [
-        │         {
-        │           "output": {
-        │             "type": "text",
-        │             "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-        │           },
-        │           "toolCallId": "<toolCallId:1>",
-        │           "toolName": "researcher",
-        │           "type": "tool-result"
-        │         }
-        │       ],
-        │       "role": "tool"
-        │     },
-        │     {
-        │       "content": [
-        │         {
-        │           "input": {
-        │             "url": "https://eve.dev/docs/guides/instrumentation"
-        │           },
-        │           "providerOptions": {
-        │             "openai": {
-        │               "itemId": "<itemId:4>"
-        │             }
-        │           },
-        │           "toolCallId": "<toolCallId:3>",
-        │           "toolName": "read",
-        │           "type": "tool-call"
-        │         }
-        │       ],
-        │       "role": "assistant"
-        │     },
-        │     {
-        │       "content": [
-        │         {
-        │           "output": {
-        │             "type": "json",
-        │             "value": {
-        │               "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-        │               "section": "Runtime context",
-        │               "title": "Eve instrumentation",
-        │               "url": "https://eve.dev/docs/guides/instrumentation"
-        │             }
-        │           },
-        │           "providerOptions": {
-        │             "openai": {
-        │               "itemId": "<itemId:4>"
-        │             }
-        │           },
-        │           "toolCallId": "<toolCallId:3>",
-        │           "toolName": "read",
-        │           "type": "tool-result"
-        │         }
-        │       ],
-        │       "role": "tool"
-        │     },
-        │     {
-        │       "content": [
-        │         {
-        │           "providerOptions": {
-        │             "openai": {
-        │               "itemId": "<itemId:5>",
-        │               "phase": "final_answer"
-        │             }
-        │           },
-        │           "text": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-        │           "type": "text"
-        │         }
-        │       ],
-        │       "role": "assistant"
-        │     },
-        │     {
-        │       "content": "Run the Braintrust Eve instrumentation e2e scenario again",
-        │       "role": "user"
-        │     }
-        │   ]
-        │   output: [
-        │     {
-        │       "finish_reason": "tool_calls",
-        │       "index": 0,
-        │       "message": {
-        │         "content": null,
-        │         "role": "assistant",
-        │         "tool_calls": [
-        │           {
-        │             "function": {
-        │               "arguments": "{\"message\":\"Run the Braintrust Eve instrumentation e2e scenario again\"}",
-        │               "name": "researcher"
-        │             },
-        │             "id": "<span:1>",
-        │             "type": "function"
-        │           }
-        │         ]
-        │       }
-        │     }
-        │   ]
-        │   metadata: {
-        │     "model": "gpt-5.4-mini",
-        │     "provider": "openai",
-        │     "scenario": "eve-instrumentation",
-        │     "testRunId": "<run:1>"
-        │   }
-        │   metrics: {
-        │     "completion_tokens": 29,
-        │     "prompt_cached_tokens": 6528,
-        │     "prompt_tokens": 6888,
-        │     "tokens": 6917
-        │   }
-        ├── researcher [tool]
-        │   input: {
-        │     "message": "Run the Braintrust Eve instrumentation e2e scenario again"
-        │   }
-        │   output: "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-        │   metadata: {
-        │     "scenario": "eve-instrumentation",
-        │     "testRunId": "<run:1>"
-        │   }
-        │   └── eve.session [task]
-        │       metadata: {
-        │         "model": "gpt-5.4-mini",
-        │         "provider": "openai",
-        │         "scenario": "eve-instrumentation",
-        │         "testRunId": "<run:1>"
-        │       }
-        │       └── eve.turn [task]
-        │           input: [
-        │             {
-        │               "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
-        │               "role": "user"
-        │             }
-        │           ]
-        │           output: "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-        │           metadata: {
-        │             "model": "gpt-5.4-mini",
-        │             "provider": "openai",
-        │             "scenario": "eve-instrumentation",
-        │             "testRunId": "<run:1>"
-        │           }
-        │           metrics: {
-        │             "completion_tokens": 49,
-        │             "prompt_cached_tokens": 13056,
-        │             "prompt_tokens": 13182,
-        │             "tokens": 13231
-        │           }
-        │           ├── eve.step [llm]
-        │           │   input: [
-        │           │     {
-        │           │       "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-        │           │       "role": "system"
-        │           │     },
-        │           │     {
-        │           │       "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
-        │           │       "role": "user"
-        │           │     }
-        │           │   ]
-        │           │   output: [
-        │           │     {
-        │           │       "finish_reason": "tool_calls",
-        │           │       "index": 0,
-        │           │       "message": {
-        │           │         "content": null,
-        │           │         "role": "assistant",
-        │           │         "tool_calls": [
-        │           │           {
-        │           │             "function": {
-        │           │               "arguments": "{\"query\":\"Run the Braintrust Eve instrumentation e2e scenario again\"}",
-        │           │               "name": "search"
-        │           │             },
-        │           │             "id": "<span:1>",
-        │           │             "type": "function"
-        │           │           }
-        │           │         ]
-        │           │       }
-        │           │     }
-        │           │   ]
-        │           │   metadata: {
-        │           │     "model": "gpt-5.4-mini",
-        │           │     "provider": "openai",
-        │           │     "scenario": "eve-instrumentation",
-        │           │     "testRunId": "<run:1>"
-        │           │   }
-        │           │   metrics: {
-        │           │     "completion_tokens": 27,
-        │           │     "prompt_cached_tokens": 6528,
-        │           │     "prompt_tokens": 6555,
-        │           │     "tokens": 6582
-        │           │   }
-        │           ├── search [tool]
-        │           │   input: {
-        │           │     "query": "Run the Braintrust Eve instrumentation e2e scenario again"
-        │           │   }
-        │           │   output: {
-        │           │     "query": "Run the Braintrust Eve instrumentation e2e scenario again",
-        │           │     "title": "Eve instrumentation",
-        │           │     "url": "https://eve.dev/docs/guides/instrumentation"
-        │           │   }
-        │           │   metadata: {
-        │           │     "scenario": "eve-instrumentation",
-        │           │     "testRunId": "<run:1>"
-        │           │   }
-        │           └── eve.step [llm]
-        │               input: [
-        │                 {
-        │                   "content": "Instructions (instructions)\nYou are the deterministic researcher subagent for Braintrust Eve instrumentation tests.\n\nFor every task:\n\n1. Call the search tool exactly once with the full task as the query.\n2. After the search result is available, answer with a single sentence that starts\n   with \"Researcher result:\" and includes the search title and URL.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-        │                   "role": "system"
-        │                 },
-        │                 {
-        │                   "content": "You are the subagent \"researcher\".\nDescription: Research the Eve instrumentation documentation before the parent reads it.\n\nThe caller delegated the following task to you. Complete it and return the final result directly.\n\nCaller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
-        │                   "role": "user"
-        │                 },
-        │                 {
-        │                   "content": [
-        │                     {
-        │                       "input": {
-        │                         "query": "Run the Braintrust Eve instrumentation e2e scenario again"
-        │                       },
-        │                       "providerOptions": {
-        │                         "openai": {
-        │                           "itemId": "<itemId:2>"
-        │                         }
-        │                       },
-        │                       "toolCallId": "<toolCallId:1>",
-        │                       "toolName": "search",
-        │                       "type": "tool-call"
-        │                     }
-        │                   ],
-        │                   "role": "assistant"
-        │                 },
-        │                 {
-        │                   "content": [
-        │                     {
-        │                       "output": {
-        │                         "type": "json",
-        │                         "value": {
-        │                           "query": "Run the Braintrust Eve instrumentation e2e scenario again",
-        │                           "title": "Eve instrumentation",
-        │                           "url": "https://eve.dev/docs/guides/instrumentation"
-        │                         }
-        │                       },
-        │                       "providerOptions": {
-        │                         "openai": {
-        │                           "itemId": "<itemId:2>"
-        │                         }
-        │                       },
-        │                       "toolCallId": "<toolCallId:1>",
-        │                       "toolName": "search",
-        │                       "type": "tool-result"
-        │                     }
-        │                   ],
-        │                   "role": "tool"
-        │                 }
-        │               ]
-        │               output: [
-        │                 {
-        │                   "finish_reason": "stop",
-        │                   "index": 0,
-        │                   "message": {
-        │                     "content": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation",
-        │                     "role": "assistant"
-        │                   }
-        │                 }
-        │               ]
-        │               metadata: {
-        │                 "model": "gpt-5.4-mini",
-        │                 "provider": "openai",
-        │                 "scenario": "eve-instrumentation",
-        │                 "testRunId": "<run:1>"
-        │               }
-        │               metrics: {
-        │                 "completion_tokens": 22,
-        │                 "prompt_cached_tokens": 6528,
-        │                 "prompt_tokens": 6627,
-        │                 "tokens": 6649
-        │               }
-        ├── eve.step [llm]
-        │   input: [
-        │     {
-        │       "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-        │       "role": "system"
-        │     },
-        │     {
-        │       "content": "Run the Braintrust Eve instrumentation e2e scenario",
-        │       "role": "user"
-        │     },
-        │     {
-        │       "content": [
-        │         {
-        │           "input": {
-        │             "message": "Run the Braintrust Eve instrumentation e2e scenario"
-        │           },
-        │           "providerOptions": {
-        │             "openai": {
-        │               "itemId": "<itemId:2>"
-        │             }
-        │           },
-        │           "toolCallId": "<toolCallId:1>",
-        │           "toolName": "researcher",
-        │           "type": "tool-call"
-        │         }
-        │       ],
-        │       "role": "assistant"
-        │     },
-        │     {
-        │       "content": [
-        │         {
-        │           "output": {
-        │             "type": "text",
-        │             "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-        │           },
-        │           "toolCallId": "<toolCallId:1>",
-        │           "toolName": "researcher",
-        │           "type": "tool-result"
-        │         }
-        │       ],
-        │       "role": "tool"
-        │     },
-        │     {
-        │       "content": [
-        │         {
-        │           "input": {
-        │             "url": "https://eve.dev/docs/guides/instrumentation"
-        │           },
-        │           "providerOptions": {
-        │             "openai": {
-        │               "itemId": "<itemId:4>"
-        │             }
-        │           },
-        │           "toolCallId": "<toolCallId:3>",
-        │           "toolName": "read",
-        │           "type": "tool-call"
-        │         }
-        │       ],
-        │       "role": "assistant"
-        │     },
-        │     {
-        │       "content": [
-        │         {
-        │           "output": {
-        │             "type": "json",
-        │             "value": {
-        │               "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-        │               "section": "Runtime context",
-        │               "title": "Eve instrumentation",
-        │               "url": "https://eve.dev/docs/guides/instrumentation"
-        │             }
-        │           },
-        │           "providerOptions": {
-        │             "openai": {
-        │               "itemId": "<itemId:4>"
-        │             }
-        │           },
-        │           "toolCallId": "<toolCallId:3>",
-        │           "toolName": "read",
-        │           "type": "tool-result"
-        │         }
-        │       ],
-        │       "role": "tool"
-        │     },
-        │     {
-        │       "content": [
-        │         {
-        │           "providerOptions": {
-        │             "openai": {
-        │               "itemId": "<itemId:5>",
-        │               "phase": "final_answer"
-        │             }
-        │           },
-        │           "text": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-        │           "type": "text"
-        │         }
-        │       ],
-        │       "role": "assistant"
-        │     },
-        │     {
-        │       "content": "Run the Braintrust Eve instrumentation e2e scenario again",
-        │       "role": "user"
-        │     },
-        │     {
-        │       "content": [
-        │         {
-        │           "input": {
-        │             "message": "Run the Braintrust Eve instrumentation e2e scenario again"
-        │           },
-        │           "providerOptions": {
-        │             "openai": {
-        │               "itemId": "<itemId:7>"
-        │             }
-        │           },
-        │           "toolCallId": "<toolCallId:6>",
-        │           "toolName": "researcher",
-        │           "type": "tool-call"
-        │         }
-        │       ],
-        │       "role": "assistant"
-        │     },
-        │     {
-        │       "content": [
-        │         {
-        │           "output": {
-        │             "type": "text",
-        │             "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-        │           },
-        │           "toolCallId": "<toolCallId:6>",
-        │           "toolName": "researcher",
-        │           "type": "tool-result"
-        │         }
-        │       ],
-        │       "role": "tool"
-        │     }
-        │   ]
-        │   output: [
-        │     {
-        │       "finish_reason": "tool_calls",
-        │       "index": 0,
-        │       "message": {
-        │         "content": null,
-        │         "role": "assistant",
-        │         "tool_calls": [
-        │           {
-        │             "function": {
-        │               "arguments": "{\"url\":\"https://eve.dev/docs/guides/instrumentation\"}",
-        │               "name": "read"
-        │             },
-        │             "id": "<span:1>",
-        │             "type": "function"
-        │           }
-        │         ]
-        │       }
-        │     }
-        │   ]
-        │   metadata: {
-        │     "model": "gpt-5.4-mini",
-        │     "provider": "openai",
-        │     "scenario": "eve-instrumentation",
-        │     "testRunId": "<run:1>"
-        │   }
-        │   metrics: {
-        │     "completion_tokens": 27,
-        │     "prompt_cached_tokens": 6528,
-        │     "prompt_tokens": 6947,
-        │     "tokens": 6974
-        │   }
-        ├── read [tool]
-        │   input: {
-        │     "url": "https://eve.dev/docs/guides/instrumentation"
-        │   }
-        │   output: {
-        │     "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-        │     "section": "Runtime context",
-        │     "title": "Eve instrumentation",
-        │     "url": "https://eve.dev/docs/guides/instrumentation"
-        │   }
-        │   metadata: {
-        │     "scenario": "eve-instrumentation",
-        │     "testRunId": "<run:1>"
-        │   }
-        └── eve.step [llm]
-            input: [
-              {
-                "content": "Instructions (instructions)\nYou are a deterministic fixture agent for Braintrust Eve instrumentation tests.\n\nFor every user task:\n\n1. Call the researcher subagent exactly once with the full user message as the\n   message.\n2. After the researcher result is available, call the read tool exactly once with\n   the URL https://eve.dev/docs/guides/instrumentation.\n3. After the read result is available, answer with a single sentence that starts\n   with \"Final answer from read:\" and includes the researcher result, read title,\n   URL, and read excerpt.\n\nTool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
-                "role": "system"
-              },
-              {
-                "content": "Run the Braintrust Eve instrumentation e2e scenario",
-                "role": "user"
-              },
-              {
-                "content": [
-                  {
-                    "input": {
-                      "message": "Run the Braintrust Eve instrumentation e2e scenario"
-                    },
-                    "providerOptions": {
-                      "openai": {
-                        "itemId": "<itemId:2>"
-                      }
-                    },
-                    "toolCallId": "<toolCallId:1>",
-                    "toolName": "researcher",
-                    "type": "tool-call"
-                  }
-                ],
-                "role": "assistant"
-              },
-              {
-                "content": [
-                  {
-                    "output": {
-                      "type": "text",
-                      "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-                    },
-                    "toolCallId": "<toolCallId:1>",
-                    "toolName": "researcher",
-                    "type": "tool-result"
-                  }
-                ],
-                "role": "tool"
-              },
-              {
-                "content": [
-                  {
-                    "input": {
-                      "url": "https://eve.dev/docs/guides/instrumentation"
-                    },
-                    "providerOptions": {
-                      "openai": {
-                        "itemId": "<itemId:4>"
-                      }
-                    },
-                    "toolCallId": "<toolCallId:3>",
-                    "toolName": "read",
-                    "type": "tool-call"
-                  }
-                ],
-                "role": "assistant"
-              },
-              {
-                "content": [
-                  {
-                    "output": {
-                      "type": "json",
-                      "value": {
-                        "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-                        "section": "Runtime context",
-                        "title": "Eve instrumentation",
-                        "url": "https://eve.dev/docs/guides/instrumentation"
-                      }
-                    },
-                    "providerOptions": {
-                      "openai": {
-                        "itemId": "<itemId:4>"
-                      }
-                    },
-                    "toolCallId": "<toolCallId:3>",
-                    "toolName": "read",
-                    "type": "tool-result"
-                  }
-                ],
-                "role": "tool"
-              },
-              {
-                "content": [
-                  {
-                    "providerOptions": {
-                      "openai": {
-                        "itemId": "<itemId:5>",
-                        "phase": "final_answer"
-                      }
-                    },
-                    "text": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-                    "type": "text"
-                  }
-                ],
-                "role": "assistant"
-              },
-              {
-                "content": "Run the Braintrust Eve instrumentation e2e scenario again",
-                "role": "user"
-              },
-              {
-                "content": [
-                  {
-                    "input": {
-                      "message": "Run the Braintrust Eve instrumentation e2e scenario again"
-                    },
-                    "providerOptions": {
-                      "openai": {
-                        "itemId": "<itemId:7>"
-                      }
-                    },
-                    "toolCallId": "<toolCallId:6>",
-                    "toolName": "researcher",
-                    "type": "tool-call"
-                  }
-                ],
-                "role": "assistant"
-              },
-              {
-                "content": [
-                  {
-                    "output": {
-                      "type": "text",
-                      "value": "Researcher result: Eve instrumentation — https://eve.dev/docs/guides/instrumentation"
-                    },
-                    "toolCallId": "<toolCallId:6>",
-                    "toolName": "researcher",
-                    "type": "tool-result"
-                  }
-                ],
-                "role": "tool"
-              },
-              {
-                "content": [
-                  {
-                    "input": {
-                      "url": "https://eve.dev/docs/guides/instrumentation"
-                    },
-                    "providerOptions": {
-                      "openai": {
-                        "itemId": "<itemId:9>"
-                      }
-                    },
-                    "toolCallId": "<toolCallId:8>",
-                    "toolName": "read",
-                    "type": "tool-call"
-                  }
-                ],
-                "role": "assistant"
-              },
-              {
-                "content": [
-                  {
-                    "output": {
-                      "type": "json",
-                      "value": {
-                        "excerpt": "Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-                        "section": "Runtime context",
-                        "title": "Eve instrumentation",
-                        "url": "https://eve.dev/docs/guides/instrumentation"
-                      }
-                    },
-                    "providerOptions": {
-                      "openai": {
-                        "itemId": "<itemId:9>"
-                      }
-                    },
-                    "toolCallId": "<toolCallId:8>",
-                    "toolName": "read",
-                    "type": "tool-result"
-                  }
-                ],
-                "role": "tool"
-              }
-            ]
-            output: [
-              {
-                "finish_reason": "stop",
-                "index": 0,
-                "message": {
-                  "content": "Final answer from read: researcher result = Eve instrumentation — https://eve.dev/docs/guides/instrumentation; read title = Eve instrumentation; URL = https://eve.dev/docs/guides/instrumentation; excerpt = Eve hooks expose runtime stream events that Braintrust maps into a nested turn trace.",
-                  "role": "assistant"
-                }
-              }
-            ]
-            metadata: {
-              "model": "gpt-5.4-mini",
-              "provider": "openai",
-              "scenario": "eve-instrumentation",
-              "testRunId": "<run:1>"
-            }
-            metrics: {
-              "completion_tokens": 65,
-              "prompt_cached_tokens": 6528,
-              "prompt_tokens": 7029,
-              "tokens": 7094
-            }

--- a/e2e/scenarios/eve-instrumentation/scenario.test.ts
+++ b/e2e/scenarios/eve-instrumentation/scenario.test.ts
@@ -46,24 +46,30 @@ describe("eve instrumentation", () => {
     );
   }, TIMEOUT_MS);
 
-  test("captures multiple nested turns in one Eve session", async () => {
-    const session = findAllSpans(events, "eve.session").find(
-      (span) => span.span.parentIds.length === 0,
+  test("captures every Eve turn as an independent trace", async () => {
+    const turns = findAllSpans(events, "eve.turn");
+    const root = turns.find(
+      (turn) =>
+        Array.isArray(turn.input) &&
+        turn.input[0]?.content ===
+          "Run the Braintrust Eve instrumentation e2e scenario",
     );
-    const turns = findChildSpans(events, "eve.turn", session?.span.id);
-    const [root, secondRoot] = turns;
+    const secondRoot = turns.find(
+      (turn) =>
+        Array.isArray(turn.input) &&
+        turn.input[0]?.content ===
+          "Run the Braintrust Eve instrumentation e2e scenario again",
+    );
     const steps = findChildSpans(events, "eve.step", root?.span.id);
     const researcher = findChildSpans(events, "researcher", root?.span.id)[0];
-    const childSession = findChildSpans(
-      events,
-      "eve.session",
-      researcher?.span.id,
-    )[0];
-    const childTurn = findChildSpans(
-      events,
-      "eve.turn",
-      childSession?.span.id,
-    )[0];
+    const childTurn = turns.find(
+      (turn) =>
+        Array.isArray(turn.input) &&
+        String(turn.input[0]?.content).includes(
+          "Caller message:\nRun the Braintrust Eve instrumentation e2e scenario",
+        ) &&
+        !String(turn.input[0]?.content).includes("scenario again"),
+    );
     const childSteps = findChildSpans(events, "eve.step", childTurn?.span.id);
     const childSearch = findLatestChildSpan(
       events,
@@ -77,50 +83,23 @@ describe("eve instrumentation", () => {
       "researcher",
       secondRoot?.span.id,
     );
-    const secondChildSession = findLatestChildSpan(
-      events,
-      "eve.session",
-      secondResearcher?.span.id,
-    );
-    const secondChildTurn = findLatestChildSpan(
-      events,
-      "eve.turn",
-      secondChildSession?.span.id,
+    const secondChildTurn = turns.find(
+      (turn) =>
+        Array.isArray(turn.input) &&
+        String(turn.input[0]?.content).includes(
+          "Caller message:\nRun the Braintrust Eve instrumentation e2e scenario again",
+        ),
     );
     const secondRead = findLatestChildSpan(events, "read", secondRoot?.span.id);
 
-    expect(session).toBeDefined();
-    expect(session?.span.type).toBe("task");
-    expect(session?.span.parentIds).toEqual([]);
-    expect(session?.metadata).toMatchObject({
-      model: "gpt-5.4-mini",
-      provider: "openai",
-      scenario: "eve-instrumentation",
-      testRunId: expect.any(String),
-    });
-    expect(turns).toHaveLength(2);
-    expect(turns.map((turn) => turn.span.parentIds)).toEqual([
-      [session?.span.id],
-      [session?.span.id],
-    ]);
-    expect(turns.map((turn) => turn.input)).toEqual([
-      [
-        {
-          content: "Run the Braintrust Eve instrumentation e2e scenario",
-          role: "user",
-        },
-      ],
-      [
-        {
-          content: "Run the Braintrust Eve instrumentation e2e scenario again",
-          role: "user",
-        },
-      ],
-    ]);
+    expect(findAllSpans(events, "eve.session")).toEqual([]);
+    expect(turns).toHaveLength(4);
+    expect(turns.every((turn) => turn.span.parentIds.length === 0)).toBe(true);
+    expect(new Set(turns.map((turn) => turn.span.rootId)).size).toBe(4);
 
     expect(root).toBeDefined();
     expect(root?.span.type).toBe("task");
-    expect(root?.span.parentIds).toEqual([session?.span.id]);
+    expect(root?.span.parentIds).toEqual([]);
     expect(root?.metadata).toMatchObject({
       scenario: "eve-instrumentation",
       testRunId: expect.any(String),
@@ -160,13 +139,9 @@ describe("eve instrumentation", () => {
     });
     expect(researcher?.output).toContain("Researcher result");
 
-    expect(childSession).toBeDefined();
-    expect(childSession?.span.parentIds).toEqual([researcher?.span.id]);
-    expect(childSession?.span.rootId).toEqual(session?.span.rootId);
-
     expect(childTurn).toBeDefined();
-    expect(childTurn?.span.parentIds).toEqual([childSession?.span.id]);
-    expect(childTurn?.span.rootId).toEqual(root?.span.rootId);
+    expect(childTurn?.span.parentIds).toEqual([]);
+    expect(childTurn?.span.rootId).not.toEqual(root?.span.rootId);
     expect(childTurn?.metadata).toMatchObject({
       scenario: "eve-instrumentation",
       testRunId: expect.any(String),
@@ -224,12 +199,8 @@ describe("eve instrumentation", () => {
     expect(secondResearcher?.span.type).toBe("tool");
     expect(secondResearcher?.span.ended).toBe(true);
     expect(secondResearcher?.span.parentIds).toEqual([secondRoot?.span.id]);
-    expect(secondChildSession?.span.parentIds).toEqual([
-      secondResearcher?.span.id,
-    ]);
-    expect(secondChildTurn?.span.parentIds).toEqual([
-      secondChildSession?.span.id,
-    ]);
+    expect(secondChildTurn?.span.parentIds).toEqual([]);
+    expect(secondChildTurn?.span.rootId).not.toEqual(secondRoot?.span.rootId);
     expect(secondRead?.span.type).toBe("tool");
     expect(secondRead?.span.ended).toBe(true);
     expect(secondRead?.span.parentIds).toEqual([secondRoot?.span.id]);

--- a/e2e/scenarios/eve-instrumentation/scenario.test.ts
+++ b/e2e/scenarios/eve-instrumentation/scenario.test.ts
@@ -46,7 +46,7 @@ describe("eve instrumentation", () => {
     );
   }, TIMEOUT_MS);
 
-  test("captures every Eve turn as an independent trace", async () => {
+  test("captures user turns as traces with subagent turns attached", async () => {
     const turns = findAllSpans(events, "eve.turn");
     const root = turns.find(
       (turn) =>
@@ -94,8 +94,10 @@ describe("eve instrumentation", () => {
 
     expect(findAllSpans(events, "eve.session")).toEqual([]);
     expect(turns).toHaveLength(4);
-    expect(turns.every((turn) => turn.span.parentIds.length === 0)).toBe(true);
-    expect(new Set(turns.map((turn) => turn.span.rootId)).size).toBe(4);
+    expect(
+      turns.filter((turn) => turn.span.parentIds.length === 0),
+    ).toHaveLength(2);
+    expect(new Set(turns.map((turn) => turn.span.rootId)).size).toBe(2);
 
     expect(root).toBeDefined();
     expect(root?.span.type).toBe("task");
@@ -140,8 +142,8 @@ describe("eve instrumentation", () => {
     expect(researcher?.output).toContain("Researcher result");
 
     expect(childTurn).toBeDefined();
-    expect(childTurn?.span.parentIds).toEqual([]);
-    expect(childTurn?.span.rootId).not.toEqual(root?.span.rootId);
+    expect(childTurn?.span.parentIds).toEqual([researcher?.span.id]);
+    expect(childTurn?.span.rootId).toEqual(root?.span.rootId);
     expect(childTurn?.metadata).toMatchObject({
       scenario: "eve-instrumentation",
       testRunId: expect.any(String),
@@ -189,6 +191,8 @@ describe("eve instrumentation", () => {
 
     expect(secondRoot).toBeDefined();
     expect(secondRoot?.span.type).toBe("task");
+    expect(secondRoot?.span.parentIds).toEqual([]);
+    expect(secondRoot?.span.rootId).not.toEqual(root?.span.rootId);
     expect(secondRoot?.output).toContain("Final answer from read");
     expect(secondSteps).toHaveLength(3);
     expect(secondSteps.map((step) => step.span.type)).toEqual([
@@ -199,8 +203,10 @@ describe("eve instrumentation", () => {
     expect(secondResearcher?.span.type).toBe("tool");
     expect(secondResearcher?.span.ended).toBe(true);
     expect(secondResearcher?.span.parentIds).toEqual([secondRoot?.span.id]);
-    expect(secondChildTurn?.span.parentIds).toEqual([]);
-    expect(secondChildTurn?.span.rootId).not.toEqual(secondRoot?.span.rootId);
+    expect(secondChildTurn?.span.parentIds).toEqual([
+      secondResearcher?.span.id,
+    ]);
+    expect(secondChildTurn?.span.rootId).toEqual(secondRoot?.span.rootId);
     expect(secondRead?.span.type).toBe("tool");
     expect(secondRead?.span.ended).toBe(true);
     expect(secondRead?.span.parentIds).toEqual([secondRoot?.span.id]);

--- a/e2e/scenarios/eve-instrumentation/scenario.test.ts
+++ b/e2e/scenarios/eve-instrumentation/scenario.test.ts
@@ -103,6 +103,7 @@ describe("eve instrumentation", () => {
     expect(root?.span.type).toBe("task");
     expect(root?.span.parentIds).toEqual([]);
     expect(root?.metadata).toMatchObject({
+      "eve.session_id": expect.any(String),
       scenario: "eve-instrumentation",
       testRunId: expect.any(String),
     });
@@ -121,6 +122,7 @@ describe("eve instrumentation", () => {
       }
       expect(step.input[0]).toMatchObject({ role: "system" });
       expect(step.metadata).toMatchObject({
+        "eve.session_id": root?.metadata?.["eve.session_id"],
         model: "gpt-5.4-mini",
         provider: "openai",
         scenario: "eve-instrumentation",
@@ -136,6 +138,7 @@ describe("eve instrumentation", () => {
       message: expect.stringContaining("Braintrust Eve instrumentation"),
     });
     expect(researcher?.metadata).toMatchObject({
+      "eve.session_id": root?.metadata?.["eve.session_id"],
       scenario: "eve-instrumentation",
       testRunId: expect.any(String),
     });
@@ -145,9 +148,13 @@ describe("eve instrumentation", () => {
     expect(childTurn?.span.parentIds).toEqual([researcher?.span.id]);
     expect(childTurn?.span.rootId).toEqual(root?.span.rootId);
     expect(childTurn?.metadata).toMatchObject({
+      "eve.session_id": expect.any(String),
       scenario: "eve-instrumentation",
       testRunId: expect.any(String),
     });
+    expect(childTurn?.metadata?.["eve.session_id"]).not.toEqual(
+      root?.metadata?.["eve.session_id"],
+    );
 
     expect(childSteps).toHaveLength(2);
     for (const step of childSteps) {
@@ -159,6 +166,7 @@ describe("eve instrumentation", () => {
       }
       expect(step.input[0]).toMatchObject({ role: "system" });
       expect(step.metadata).toMatchObject({
+        "eve.session_id": childTurn?.metadata?.["eve.session_id"],
         model: "gpt-5.4-mini",
         provider: "openai",
         scenario: "eve-instrumentation",
@@ -170,6 +178,9 @@ describe("eve instrumentation", () => {
     expect(childSearch?.span.type).toBe("tool");
     expect(childSearch?.span.ended).toBe(true);
     expect(childSearch?.span.parentIds).toEqual([childTurn?.span.id]);
+    expect(childSearch?.metadata).toMatchObject({
+      "eve.session_id": childTurn?.metadata?.["eve.session_id"],
+    });
     expect(childSearch?.input).toMatchObject({
       query: expect.stringContaining("Braintrust Eve instrumentation"),
     });
@@ -181,6 +192,9 @@ describe("eve instrumentation", () => {
     expect(read?.span.type).toBe("tool");
     expect(read?.span.ended).toBe(true);
     expect(read?.span.parentIds).toEqual([root?.span.id]);
+    expect(read?.metadata).toMatchObject({
+      "eve.session_id": root?.metadata?.["eve.session_id"],
+    });
     expect(read?.input).toMatchObject({
       url: "https://eve.dev/docs/guides/instrumentation",
     });
@@ -193,6 +207,9 @@ describe("eve instrumentation", () => {
     expect(secondRoot?.span.type).toBe("task");
     expect(secondRoot?.span.parentIds).toEqual([]);
     expect(secondRoot?.span.rootId).not.toEqual(root?.span.rootId);
+    expect(secondRoot?.metadata).toMatchObject({
+      "eve.session_id": root?.metadata?.["eve.session_id"],
+    });
     expect(secondRoot?.output).toContain("Final answer from read");
     expect(secondSteps).toHaveLength(3);
     expect(secondSteps.map((step) => step.span.type)).toEqual([
@@ -203,14 +220,30 @@ describe("eve instrumentation", () => {
     expect(secondResearcher?.span.type).toBe("tool");
     expect(secondResearcher?.span.ended).toBe(true);
     expect(secondResearcher?.span.parentIds).toEqual([secondRoot?.span.id]);
+    expect(secondResearcher?.metadata).toMatchObject({
+      "eve.session_id": secondRoot?.metadata?.["eve.session_id"],
+    });
     expect(secondChildTurn?.span.parentIds).toEqual([
       secondResearcher?.span.id,
     ]);
     expect(secondChildTurn?.span.rootId).toEqual(secondRoot?.span.rootId);
+    expect(secondChildTurn?.metadata).toMatchObject({
+      "eve.session_id": expect.any(String),
+    });
+    expect(secondChildTurn?.metadata?.["eve.session_id"]).not.toEqual(
+      secondRoot?.metadata?.["eve.session_id"],
+    );
     expect(secondRead?.span.type).toBe("tool");
     expect(secondRead?.span.ended).toBe(true);
     expect(secondRead?.span.parentIds).toEqual([secondRoot?.span.id]);
+    expect(secondRead?.metadata).toMatchObject({
+      "eve.session_id": secondRoot?.metadata?.["eve.session_id"],
+    });
 
-    await matchSpanTreeSnapshot(events, spanTreeSnapshotPath);
+    await matchSpanTreeSnapshot(events, spanTreeSnapshotPath, {
+      normalize: {
+        additionalProviderIdKeys: ["eve.session_id"],
+      },
+    });
   });
 });

--- a/js/src/instrumentation/plugins/eve-plugin.test.ts
+++ b/js/src/instrumentation/plugins/eve-plugin.test.ts
@@ -344,8 +344,6 @@ describe("braintrustEveHook", () => {
     expect(wildcard).toBeDefined();
 
     const ctx: EveHookContext = {
-      agent: { name: "eve-test-agent" },
-      channel: { kind: "http" },
       session: { id: "session-flat-tree" },
     };
     const emit = (event: EveHandleMessageStreamEvent) => wildcard?.(event, ctx);
@@ -633,8 +631,6 @@ describe("braintrustEveHook", () => {
     expect(wildcard).toBeDefined();
 
     const ctx: EveHookContext = {
-      agent: { name: "eve-test-agent" },
-      channel: { kind: "http" },
       session: { id: "session-incremental-tools" },
     };
     const emit = (event: EveHandleMessageStreamEvent) => wildcard?.(event, ctx);
@@ -784,8 +780,6 @@ describe("braintrustEveHook", () => {
     expect(wildcard).toBeDefined();
 
     const ctx: EveHookContext = {
-      agent: { name: "eve-test-agent" },
-      channel: { kind: "http" },
       session: { id: "session-late-tool-result" },
     };
     const emit = (event: EveHandleMessageStreamEvent) => wildcard?.(event, ctx);
@@ -1016,8 +1010,6 @@ describe("braintrustEveHook", () => {
     expect(wildcard).toBeDefined();
 
     const ctx: EveHookContext = {
-      agent: { name: "eve-test-agent" },
-      channel: { kind: "http" },
       session: { id: "session-late-after-session" },
     };
     const emit = (event: EveHandleMessageStreamEvent) => wildcard?.(event, ctx);
@@ -1081,8 +1073,6 @@ describe("braintrustEveHook", () => {
     expect(wildcard).toBeDefined();
 
     const ctx: EveHookContext = {
-      agent: { name: "eve-test-agent" },
-      channel: { kind: "http" },
       session: { id: "session-result-only" },
     };
     const emit = (event: EveHandleMessageStreamEvent) => wildcard?.(event, ctx);
@@ -1294,22 +1284,10 @@ describe("braintrustEveHook", () => {
     expect(childWildcard).toBeDefined();
 
     const parentCtx: EveHookContext = {
-      agent: { name: "eve-parent-agent" },
-      channel: { kind: "http" },
       session: { id: "session-parent" },
     };
     const childCtx: EveHookContext = {
-      agent: { name: "eve-child-agent", nodeId: "researcher-node" },
-      channel: { kind: "subagent" },
-      session: {
-        id: "session-child",
-        parent: {
-          callId: "call-researcher",
-          rootSessionId: "session-parent",
-          sessionId: "session-parent",
-          turn: { id: "turn-parent", sequence: 0 },
-        },
-      },
+      session: { id: "session-child" },
     };
     const emitParent = (event: EveHandleMessageStreamEvent) =>
       parentWildcard?.(event, parentCtx);

--- a/js/src/instrumentation/plugins/eve-plugin.test.ts
+++ b/js/src/instrumentation/plugins/eve-plugin.test.ts
@@ -1271,7 +1271,7 @@ describe("braintrustEveHook", () => {
     expect(queuedEventFinished).toBe(true);
   });
 
-  it("uses deterministic ids and gives local subagent turns independent roots", async () => {
+  it("uses deterministic ids and attaches local subagent turns to their tool span", async () => {
     const parentEveState = createFakeDefineState();
     const childEveState = createFakeDefineState();
     const parentWildcard = braintrustEveHook({
@@ -1287,7 +1287,14 @@ describe("braintrustEveHook", () => {
       session: { id: "session-parent" },
     };
     const childCtx: EveHookContext = {
-      session: { id: "session-child" },
+      session: {
+        id: "session-child",
+        parent: {
+          callId: "call-researcher",
+          sessionId: "session-parent",
+          turn: { id: "turn-parent" },
+        },
+      },
     };
     const emitParent = (event: EveHandleMessageStreamEvent) =>
       parentWildcard?.(event, parentCtx);
@@ -1577,11 +1584,8 @@ describe("braintrustEveHook", () => {
       deterministicEveIdForTest("eve:root", "session-parent", "turn-parent"),
     );
     expect(subagentSpans[0]?.span_parents).toEqual([parentTurn?.span_id]);
-    expect(childTurn?.span_parents).toEqual([]);
-    expect(childTurn?.root_span_id).toBe(
-      deterministicEveIdForTest("eve:root", "session-child", "turn-child"),
-    );
-    expect(childTurn?.root_span_id).not.toBe(parentTurn?.root_span_id);
+    expect(childTurn?.span_parents).toEqual([subagentSpanId]);
+    expect(childTurn?.root_span_id).toBe(parentTurn?.root_span_id);
     expect(childTurn?.metadata ?? {}).toEqual({});
     expect(subagentSpans[0]?.metadata ?? {}).toEqual({});
     expect(childSearch?.span_parents).toEqual([childTurn?.span_id]);

--- a/js/src/instrumentation/plugins/eve-plugin.test.ts
+++ b/js/src/instrumentation/plugins/eve-plugin.test.ts
@@ -313,6 +313,26 @@ describe("braintrustEveHook", () => {
     expect(state.stepStarts).toHaveLength(10_000);
   });
 
+  it("does not emit a span for session lifecycle metadata alone", async () => {
+    const wildcard = braintrustEveHook({ defineState }).events?.["*"];
+
+    await wildcard?.(
+      {
+        data: {
+          runtime: {
+            agentId: "agent-session-only",
+            eveVersion: "0.20.0",
+            modelId: "openai/gpt-5.4-mini",
+          },
+        },
+        type: "session.started",
+      },
+      { session: { id: "session-only" } },
+    );
+
+    expect(await backgroundLogger.drain()).toEqual([]);
+  });
+
   it("records a flat Eve turn with session model metadata", async () => {
     const wildcard = braintrustEveHook({
       defineState,
@@ -455,9 +475,6 @@ describe("braintrustEveHook", () => {
     const spans = (await backgroundLogger.drain()) as Array<
       Record<string, any>
     >;
-    const session = spans.find(
-      (span) => span.span_attributes?.name === "eve.session",
-    );
     const root = spans.find(
       (span) => span.span_attributes?.name === "eve.turn",
     );
@@ -467,24 +484,11 @@ describe("braintrustEveHook", () => {
     const tool = spans.find((span) => span.span_attributes?.name === "search");
 
     expect(spans.map((span) => span.span_attributes?.name)).toEqual([
-      "eve.session",
       "eve.turn",
       "eve.step",
       "search",
       "eve.step",
     ]);
-    expect(session).toMatchObject({
-      metadata: {
-        ...expectedModelMetadata,
-        scenario: "eve-plugin-unit",
-        testRunId: "test-run-flat-tree",
-      },
-      span_attributes: {
-        name: "eve.session",
-        type: "task",
-      },
-      span_parents: [],
-    });
     expect(root).toMatchObject({
       input: [{ content: "Search then read", role: "user" }],
       metadata: {
@@ -505,7 +509,12 @@ describe("braintrustEveHook", () => {
         name: "eve.turn",
         type: "task",
       },
-      span_parents: [session?.span_id],
+      root_span_id: deterministicEveIdForTest(
+        "eve:root",
+        "session-flat-tree",
+        "turn-flat-tree",
+      ),
+      span_parents: [],
     });
     expect(steps).toHaveLength(2);
     expect(steps.map((span) => span.span_attributes?.name)).toEqual([
@@ -599,19 +608,20 @@ describe("braintrustEveHook", () => {
     const spans = (await backgroundLogger.drain()) as Array<
       Record<string, any>
     >;
-    const session = spans.find(
-      (span) => span.span_attributes?.name === "eve.session",
-    );
     const turns = spans.filter(
       (span) => span.span_attributes?.name === "eve.turn",
     );
 
-    expect(session?.span_parents).toEqual([]);
+    expect(
+      spans.some((span) => span.span_attributes?.name === "eve.session"),
+    ).toBe(false);
     expect(turns).toHaveLength(2);
-    expect(turns.map((turn) => turn.span_parents)).toEqual([
-      [session?.span_id],
-      [session?.span_id],
+    expect(turns.map((turn) => turn.span_parents)).toEqual([[], []]);
+    expect(turns.map((turn) => turn.root_span_id)).toEqual([
+      deterministicEveIdForTest("eve:root", "session-multi-turn", "turn-0"),
+      deterministicEveIdForTest("eve:root", "session-multi-turn", "turn-1"),
     ]);
+    expect(turns[0]?.root_span_id).not.toBe(turns[1]?.root_span_id);
     expect(turns.map((turn) => turn.input)).toEqual([
       [{ content: "First user message", role: "user" }],
       [{ content: "Second user message", role: "user" }],
@@ -819,6 +829,7 @@ describe("braintrustEveHook", () => {
           rootSpanId: deterministicEveIdForTest(
             "eve:root",
             "session-late-tool-result",
+            "turn-late-tool-result",
           ),
           rowId: deterministicEveIdForTest(
             "eve:row:tool",
@@ -1270,7 +1281,7 @@ describe("braintrustEveHook", () => {
     expect(queuedEventFinished).toBe(true);
   });
 
-  it("uses deterministic ids and nests local subagent sessions from Eve lineage", async () => {
+  it("uses deterministic ids and gives local subagent turns independent roots", async () => {
     const parentEveState = createFakeDefineState();
     const childEveState = createFakeDefineState();
     const parentWildcard = braintrustEveHook({
@@ -1527,18 +1538,10 @@ describe("braintrustEveHook", () => {
       "session-parent",
       "turn-parent",
     );
-    const parentSessionId = deterministicEveIdForTest(
-      "eve:session",
-      "session-parent",
-    );
     const childTurnId = deterministicEveIdForTest(
       "eve:turn",
       "session-child",
       "turn-child",
-    );
-    const childSessionId = deterministicEveIdForTest(
-      "eve:session",
-      "session-child",
     );
     const subagentSpanId = deterministicEveIdForTest(
       "eve:subagent",
@@ -1550,11 +1553,6 @@ describe("braintrustEveHook", () => {
         span.span_attributes?.name === "eve.turn" &&
         span.span_id === parentTurnId,
     );
-    const parentSession = spans.find(
-      (span) =>
-        span.span_attributes?.name === "eve.session" &&
-        span.span_id === parentSessionId,
-    );
     const subagentSpans = spans.filter(
       (span) => span.span_attributes?.name === "researcher",
     );
@@ -1562,11 +1560,6 @@ describe("braintrustEveHook", () => {
       (span) =>
         span.span_attributes?.name === "eve.turn" &&
         span.span_id === childTurnId,
-    );
-    const childSession = spans.find(
-      (span) =>
-        span.span_attributes?.name === "eve.session" &&
-        span.span_id === childSessionId,
     );
     const childSearch = spans.find(
       (span) =>
@@ -1584,7 +1577,6 @@ describe("braintrustEveHook", () => {
         span.span_parents?.[0] === parentTurnId,
     );
 
-    expect(parentSession).toBeDefined();
     expect(parentTurn).toBeDefined();
     expect(subagentSpans).toHaveLength(1);
     expect(subagentSpans[0]?.span_id).toBe(subagentSpanId);
@@ -1595,8 +1587,7 @@ describe("braintrustEveHook", () => {
     expect(childSearch).toBeDefined();
     expect(parentRead).toBeDefined();
     expect(parentSteps).toHaveLength(3);
-    expect(parentSession?.span_parents ?? []).toEqual([]);
-    expect(parentTurn?.span_parents).toEqual([parentSession?.span_id]);
+    expect(parentTurn?.span_parents).toEqual([]);
     expect(parentTurn?.span_id).toBe(parentTurnId);
     expect(parentTurn?.span_id).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
@@ -1604,10 +1595,15 @@ describe("braintrustEveHook", () => {
     expect(parentTurn?.root_span_id).toMatch(
       /^([0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/,
     );
+    expect(parentTurn?.root_span_id).toBe(
+      deterministicEveIdForTest("eve:root", "session-parent", "turn-parent"),
+    );
     expect(subagentSpans[0]?.span_parents).toEqual([parentTurn?.span_id]);
-    expect(childSession?.span_parents).toEqual([subagentSpans[0]?.span_id]);
-    expect(childTurn?.span_parents).toEqual([childSession?.span_id]);
-    expect(childTurn?.root_span_id).toBe(parentTurn?.root_span_id);
+    expect(childTurn?.span_parents).toEqual([]);
+    expect(childTurn?.root_span_id).toBe(
+      deterministicEveIdForTest("eve:root", "session-child", "turn-child"),
+    );
+    expect(childTurn?.root_span_id).not.toBe(parentTurn?.root_span_id);
     expect(childTurn?.metadata ?? {}).toEqual({});
     expect(subagentSpans[0]?.metadata ?? {}).toEqual({});
     expect(childSearch?.span_parents).toEqual([childTurn?.span_id]);
@@ -1648,11 +1644,9 @@ describe("braintrustEveHook", () => {
       ),
     ]);
     expect(spans.map((span) => span.span_attributes?.name)).toEqual([
-      "eve.session",
       "eve.turn",
       "eve.step",
       "researcher",
-      "eve.session",
       "eve.turn",
       "eve.step",
       "search",
@@ -1687,14 +1681,11 @@ describe("braintrustEveHook", () => {
       Record<string, any>
     >;
     expect(
-      replaySpans.find((span) => span.span_id === parentSession?.span_id),
-    ).toMatchObject({ _is_merge: true });
-    expect(
       replaySpans.find((span) => span.span_id === parentTurn?.span_id),
     ).toMatchObject({ _is_merge: true });
   });
 
-  it("parents root Eve sessions under the active Braintrust span", async () => {
+  it("does not parent an Eve turn under the active Braintrust span", async () => {
     const wildcard = braintrustEveHook({ defineState }).events?.["*"];
     expect(wildcard).toBeDefined();
 
@@ -1726,20 +1717,14 @@ describe("braintrustEveHook", () => {
     const turn = spans.find(
       (span) => span.span_attributes?.name === "eve.turn",
     );
-    const session = spans.find(
-      (span) => span.span_attributes?.name === "eve.session",
-    );
-
-    expect(session?.span_id).toBe(
-      deterministicEveIdForTest("eve:session", "session-wrapped"),
-    );
-    expect(session?.span_parents).toEqual([parent.spanId]);
-    expect(session?.root_span_id).toBe(parent.rootSpanId);
     expect(turn?.span_id).toBe(
       deterministicEveIdForTest("eve:turn", "session-wrapped", "turn-wrapped"),
     );
-    expect(turn?.span_parents).toEqual([session?.span_id]);
-    expect(turn?.root_span_id).toBe(parent.rootSpanId);
+    expect(turn?.span_parents).toEqual([]);
+    expect(turn?.root_span_id).toBe(
+      deterministicEveIdForTest("eve:root", "session-wrapped", "turn-wrapped"),
+    );
+    expect(turn?.root_span_id).not.toBe(parent.rootSpanId);
   });
 
   it("does not throw when Eve emits malformed events or failures", async () => {
@@ -1777,11 +1762,6 @@ describe("braintrustEveHook", () => {
     const spans = (await backgroundLogger.drain()) as Array<
       Record<string, any>
     >;
-    expect(spans).toHaveLength(1);
-    expect(spans[0]).toMatchObject({
-      metadata: {},
-      span_attributes: { name: "eve.session", type: "task" },
-      span_parents: [],
-    });
+    expect(spans).toEqual([]);
   });
 });

--- a/js/src/instrumentation/plugins/eve-plugin.test.ts
+++ b/js/src/instrumentation/plugins/eve-plugin.test.ts
@@ -491,6 +491,7 @@ describe("braintrustEveHook", () => {
       input: [{ content: "Search then read", role: "user" }],
       metadata: {
         ...expectedModelMetadata,
+        "eve.session_id": "session-flat-tree",
         scenario: "eve-plugin-unit",
         testRunId: "test-run-flat-tree",
       },
@@ -530,6 +531,7 @@ describe("braintrustEveHook", () => {
     for (const step of steps) {
       expect(step.metadata).toEqual({
         ...expectedModelMetadata,
+        "eve.session_id": "session-flat-tree",
         scenario: "eve-plugin-unit",
         testRunId: "test-run-flat-tree",
       });
@@ -539,6 +541,7 @@ describe("braintrustEveHook", () => {
     expect(tool).toMatchObject({
       input: { query: "Eve instrumentation" },
       metadata: {
+        "eve.session_id": "session-flat-tree",
         scenario: "eve-plugin-unit",
         testRunId: "test-run-flat-tree",
       },
@@ -1586,8 +1589,21 @@ describe("braintrustEveHook", () => {
     expect(subagentSpans[0]?.span_parents).toEqual([parentTurn?.span_id]);
     expect(childTurn?.span_parents).toEqual([subagentSpanId]);
     expect(childTurn?.root_span_id).toBe(parentTurn?.root_span_id);
-    expect(childTurn?.metadata ?? {}).toEqual({});
-    expect(subagentSpans[0]?.metadata ?? {}).toEqual({});
+    expect(parentTurn?.metadata).toEqual({
+      "eve.session_id": "session-parent",
+    });
+    expect(subagentSpans[0]?.metadata).toEqual({
+      "eve.session_id": "session-parent",
+    });
+    expect(childTurn?.metadata).toEqual({
+      "eve.session_id": "session-child",
+    });
+    expect(childSearch?.metadata).toEqual({
+      "eve.session_id": "session-child",
+    });
+    expect(parentRead?.metadata).toEqual({
+      "eve.session_id": "session-parent",
+    });
     expect(childSearch?.span_parents).toEqual([childTurn?.span_id]);
     expect(childSearch?.span_id).toBe(
       deterministicEveIdForTest(

--- a/js/src/instrumentation/plugins/eve-plugin.ts
+++ b/js/src/instrumentation/plugins/eve-plugin.ts
@@ -491,6 +491,7 @@ class EveBridge {
     const metadata = {
       ...readEveTraceState(this.state).metadata,
       ...(hookMetadata ?? {}),
+      "eve.session_id": sessionId,
     };
     const existing = this.turnsByKey.get(key);
     if (existing) {
@@ -1137,6 +1138,7 @@ class EveBridge {
     const metadata = {
       ...readEveTraceState(this.state).metadata,
       ...(hookMetadata ?? {}),
+      "eve.session_id": sessionId,
     };
     const span = await this.startTurnSpan(sessionId, event, ctx, metadata);
     span.log({ metadata });

--- a/js/src/instrumentation/plugins/eve-plugin.ts
+++ b/js/src/instrumentation/plugins/eve-plugin.ts
@@ -390,7 +390,7 @@ class EveBridge {
   ): Promise<boolean> {
     switch (event.type) {
       case "session.started":
-        await this.handleSessionStarted(event, ctx, hookMetadata);
+        this.handleSessionStarted(event, ctx, hookMetadata);
         return true;
       case "turn.started":
         await this.handleTurnStarted(event, ctx, hookMetadata);
@@ -426,27 +426,27 @@ class EveBridge {
         this.handleStepFailed(event, ctx);
         return true;
       case "turn.completed":
-        await this.handleTurnCompleted(event, ctx);
+        this.handleTurnCompleted(event, ctx);
         return true;
       case "turn.failed":
-        await this.handleTurnFailed(event, ctx);
+        this.handleTurnFailed(event, ctx);
         return true;
       case "session.failed":
-        await this.handleSessionFailed(event, ctx);
+        this.handleSessionFailed(event, ctx);
         return true;
       case "session.completed":
-        await this.handleSessionCompleted(event, ctx);
+        this.handleSessionCompleted(event, ctx);
         return true;
       default:
         return false;
     }
   }
 
-  private async handleSessionStarted(
+  private handleSessionStarted(
     event: Extract<EveHandleMessageStreamEvent, { type: "session.started" }>,
     ctx: unknown,
     hookMetadata?: Record<string, unknown>,
-  ): Promise<void> {
+  ): void {
     const sessionId = sessionIdFromContext(ctx);
     if (!sessionId) {
       return;
@@ -1368,12 +1368,10 @@ class EveBridge {
     >,
     metadata: Record<string, unknown>,
   ): Promise<EveSpan> {
-    const { rowId: eventId, spanId } = await generateEveIds(
-      "turn",
-      sessionId,
-      event.data.turnId,
-    );
-    const rootSpanId = await rootSpanIdForTurn(sessionId, event.data.turnId);
+    const [{ rowId: eventId, spanId }, rootSpanId] = await Promise.all([
+      generateEveIds("turn", sessionId, event.data.turnId),
+      deterministicEveId("eve:root", sessionId, event.data.turnId),
+    ]);
 
     return await this.startEveSpan({
       event: {
@@ -1891,13 +1889,6 @@ function turnKey(sessionId: string, turnId: string): string {
 
 function toolKey(sessionId: string, callId: string): string {
   return `${sessionId}:${callId}`;
-}
-
-async function rootSpanIdForTurn(
-  sessionId: string,
-  turnId: string,
-): Promise<string> {
-  return deterministicEveId("eve:root", sessionId, turnId);
 }
 
 async function generateEveIds(

--- a/js/src/instrumentation/plugins/eve-plugin.ts
+++ b/js/src/instrumentation/plugins/eve-plugin.ts
@@ -499,7 +499,7 @@ class EveBridge {
       return;
     }
 
-    const span = await this.startTurnSpan(sessionId, event, metadata);
+    const span = await this.startTurnSpan(sessionId, event, ctx, metadata);
     span.log({ metadata });
     this.turnsByKey.set(key, {
       key,
@@ -1138,7 +1138,7 @@ class EveBridge {
       ...readEveTraceState(this.state).metadata,
       ...(hookMetadata ?? {}),
     };
-    const span = await this.startTurnSpan(sessionId, event, metadata);
+    const span = await this.startTurnSpan(sessionId, event, ctx, metadata);
     span.log({ metadata });
     const state = {
       key,
@@ -1366,12 +1366,40 @@ class EveBridge {
       EveHandleMessageStreamEvent,
       { data: { readonly sequence: number; readonly turnId: string } }
     >,
+    ctx: unknown,
     metadata: Record<string, unknown>,
   ): Promise<EveSpan> {
-    const [{ rowId: eventId, spanId }, rootSpanId] = await Promise.all([
-      generateEveIds("turn", sessionId, event.data.turnId),
-      deterministicEveId("eve:root", sessionId, event.data.turnId),
-    ]);
+    const session = isObject(ctx) ? ctx["session"] : undefined;
+    const parent = isObject(session) ? session["parent"] : undefined;
+    const parentTurn = isObject(parent) ? parent["turn"] : undefined;
+    const parentLineage =
+      isObject(parent) &&
+      typeof parent["callId"] === "string" &&
+      typeof parent["sessionId"] === "string" &&
+      isObject(parentTurn) &&
+      typeof parentTurn["id"] === "string"
+        ? {
+            callId: parent["callId"],
+            sessionId: parent["sessionId"],
+            turnId: parentTurn["id"],
+          }
+        : undefined;
+    const [{ rowId: eventId, spanId }, rootSpanId, parentSpanId] =
+      await Promise.all([
+        generateEveIds("turn", sessionId, event.data.turnId),
+        deterministicEveId(
+          "eve:root",
+          parentLineage?.sessionId ?? sessionId,
+          parentLineage?.turnId ?? event.data.turnId,
+        ),
+        parentLineage
+          ? deterministicEveId(
+              "eve:subagent",
+              parentLineage.sessionId,
+              parentLineage.callId,
+            )
+          : Promise.resolve(undefined),
+      ]);
 
     return await this.startEveSpan({
       event: {
@@ -1379,10 +1407,9 @@ class EveBridge {
         metadata,
       },
       name: "eve.turn",
-      parentSpanIds: {
-        parentSpanIds: [],
-        rootSpanId,
-      },
+      parentSpanIds: parentSpanId
+        ? { rootSpanId, spanId: parentSpanId }
+        : { parentSpanIds: [], rootSpanId },
       spanAttributes: { type: SpanTypeAttribute.TASK },
       spanId,
       startTime: eventTime(event),

--- a/js/src/instrumentation/plugins/eve-plugin.ts
+++ b/js/src/instrumentation/plugins/eve-plugin.ts
@@ -2,7 +2,6 @@ import { debugLogger } from "../../debug-logger";
 import {
   NOOP_SPAN,
   _internalStartSpanWithInitialMerge,
-  currentSpan,
   flush,
   updateSpan,
   withCurrent,
@@ -48,10 +47,6 @@ type EveSpanReference = {
   readonly startEvent?: EveSpanStartEvent;
 };
 
-type SessionState = SpanState & {
-  sessionId: string;
-};
-
 type StepState = SpanState & {
   input?: unknown;
   metrics: Record<string, number>;
@@ -71,13 +66,7 @@ type ToolState = SpanState & {
   turnKey: string;
 };
 
-type ParentLineage = {
-  callId: string;
-  rootSessionId: string;
-  sessionId: string;
-};
-
-type EveEntityKind = "session" | "step" | "subagent" | "tool" | "turn";
+type EveEntityKind = "step" | "subagent" | "tool" | "turn";
 
 type EveStateHandle<T> = {
   get(): T;
@@ -195,9 +184,6 @@ class EveBridge {
   constructor(private readonly state: EveStateHandle<EveTraceState>) {}
 
   private eventQueuesBySession = new Map<string, Promise<void>>();
-  private sessionsById = new LRUCache<string, SessionState>({
-    max: MAX_EVE_CACHE_ENTRIES,
-  });
   private completedToolKeys = new LRUCache<string, true>({
     max: MAX_EVE_CACHE_ENTRIES,
   });
@@ -477,7 +463,6 @@ class EveBridge {
         metadata: { ...normalized.metadata, ...metadata },
       };
     });
-    await this.ensureSession(sessionId, ctx, metadata, eventTime(event));
     for (const [key, turn] of this.turnsByKey) {
       if (!key.startsWith(`${sessionId}:`)) {
         continue;
@@ -502,14 +487,11 @@ class EveBridge {
       return;
     }
 
-    const session = await this.ensureSession(
-      sessionId,
-      ctx,
-      hookMetadata ?? {},
-      eventTime(event),
-    );
     const key = turnKey(sessionId, event.data.turnId);
-    const metadata = { ...session.metadata };
+    const metadata = {
+      ...readEveTraceState(this.state).metadata,
+      ...(hookMetadata ?? {}),
+    };
     const existing = this.turnsByKey.get(key);
     if (existing) {
       existing.metadata = { ...existing.metadata, ...metadata };
@@ -517,7 +499,7 @@ class EveBridge {
       return;
     }
 
-    const span = await this.startTurnSpan(session, event, metadata);
+    const span = await this.startTurnSpan(sessionId, event, metadata);
     span.log({ metadata });
     this.turnsByKey.set(key, {
       key,
@@ -568,10 +550,7 @@ class EveBridge {
     }
 
     const stepOrdinal = this.stepOrdinal(event);
-    const metadata = {
-      ...turn.metadata,
-      ...(this.sessionsById.get(sessionId)?.metadata ?? {}),
-    };
+    const metadata = { ...turn.metadata };
     const input = consumeCapturedEveModelInput(
       this.state,
       sessionId,
@@ -1072,21 +1051,14 @@ class EveBridge {
     });
   }
 
-  private async handleSessionFailed(
+  private handleSessionFailed(
     event: Extract<EveHandleMessageStreamEvent, { type: "session.failed" }>,
     ctx: unknown,
-  ): Promise<void> {
+  ): void {
     const sessionId = event.data.sessionId || sessionIdFromContext(ctx);
     if (!sessionId) {
       return;
     }
-    const session = await this.ensureSession(
-      sessionId,
-      ctx,
-      {},
-      eventTime(event),
-    );
-
     const error = errorFromMessage(
       event.data.message,
       event.data.code,
@@ -1112,27 +1084,16 @@ class EveBridge {
         }
       }
     }
-
-    session.span.log({ error });
-    const endTime = eventTime(event);
-    session.span.end(endTime === undefined ? undefined : { endTime });
   }
 
-  private async handleSessionCompleted(
+  private handleSessionCompleted(
     event: Extract<EveHandleMessageStreamEvent, { type: "session.completed" }>,
     ctx: unknown,
-  ): Promise<void> {
+  ): void {
     const sessionId = sessionIdFromContext(ctx);
     if (!sessionId) {
       return;
     }
-    const session = await this.ensureSession(
-      sessionId,
-      ctx,
-      {},
-      eventTime(event),
-    );
-
     for (const [key, turn] of this.turnsByKey) {
       if (!key.startsWith(`${sessionId}:`)) {
         continue;
@@ -1150,78 +1111,6 @@ class EveBridge {
         tool.endedByTurn = true;
       }
     }
-    session.span.log({ metadata: session.metadata });
-    const endTime = eventTime(event);
-    session.span.end(endTime === undefined ? undefined : { endTime });
-  }
-
-  private async ensureSession(
-    sessionId: string,
-    ctx: unknown,
-    metadata: Record<string, unknown>,
-    startTime?: number,
-  ): Promise<SessionState> {
-    metadata = {
-      ...readEveTraceState(this.state).metadata,
-      ...metadata,
-    };
-    const existing = this.sessionsById.get(sessionId);
-    if (existing) {
-      existing.metadata = { ...existing.metadata, ...metadata };
-      existing.span.log({ metadata: existing.metadata });
-      return existing;
-    }
-
-    const lineage = parentLineageFromContext(ctx);
-    // A child session has its own durable Eve context. It can link to the
-    // deterministic parent subagent span, but must not upsert that row itself.
-    const parentSubagent = lineage
-      ? this.toolsByCallKey.get(toolKey(lineage.sessionId, lineage.callId))
-      : undefined;
-    const activeParent = currentSpan();
-    const [
-      { rowId: eventId, spanId },
-      parentSubagentSpanId,
-      fallbackRootSpanId,
-    ] = await Promise.all([
-      generateEveIds("session", sessionId),
-      lineage
-        ? spanIdForSubagent(lineage.sessionId, lineage.callId)
-        : Promise.resolve(undefined),
-      lineage
-        ? rootSpanIdForSession(lineage.rootSessionId)
-        : rootSpanIdForSession(sessionId),
-    ]);
-
-    const span = await this.startEveSpan({
-      event: {
-        id: eventId,
-        metadata,
-      },
-      name: "eve.session",
-      parentSpanIds:
-        lineage && parentSubagentSpanId
-          ? {
-              rootSpanId: parentSubagent?.span.rootSpanId ?? fallbackRootSpanId,
-              spanId: parentSubagentSpanId,
-            }
-          : !Object.is(activeParent, NOOP_SPAN)
-            ? {
-                rootSpanId: activeParent.rootSpanId,
-                spanId: activeParent.spanId,
-              }
-            : {
-                parentSpanIds: [],
-                rootSpanId: fallbackRootSpanId,
-              },
-      spanAttributes: { type: SpanTypeAttribute.TASK },
-      spanId,
-      startTime,
-    });
-    span.log({ metadata });
-    const session = { metadata, sessionId, span };
-    this.sessionsById.set(sessionId, session);
-    return session;
   }
 
   private async ensureTurn(
@@ -1239,20 +1128,17 @@ class EveBridge {
       return undefined;
     }
 
-    const session = await this.ensureSession(
-      sessionId,
-      ctx,
-      hookMetadata ?? {},
-      eventTime(event),
-    );
     const key = turnKey(sessionId, event.data.turnId);
     const existing = this.turnsByKey.get(key);
     if (existing) {
       return existing;
     }
 
-    const metadata = { ...session.metadata };
-    const span = await this.startTurnSpan(session, event, metadata);
+    const metadata = {
+      ...readEveTraceState(this.state).metadata,
+      ...(hookMetadata ?? {}),
+    };
+    const span = await this.startTurnSpan(sessionId, event, metadata);
     span.log({ metadata });
     const state = {
       key,
@@ -1475,7 +1361,7 @@ class EveBridge {
   }
 
   private async startTurnSpan(
-    session: SessionState,
+    sessionId: string,
     event: Extract<
       EveHandleMessageStreamEvent,
       { data: { readonly sequence: number; readonly turnId: string } }
@@ -1484,9 +1370,10 @@ class EveBridge {
   ): Promise<EveSpan> {
     const { rowId: eventId, spanId } = await generateEveIds(
       "turn",
-      session.sessionId,
+      sessionId,
       event.data.turnId,
     );
+    const rootSpanId = await rootSpanIdForTurn(sessionId, event.data.turnId);
 
     return await this.startEveSpan({
       event: {
@@ -1495,8 +1382,8 @@ class EveBridge {
       },
       name: "eve.turn",
       parentSpanIds: {
-        rootSpanId: session.span.rootSpanId,
-        spanId: session.span.spanId,
+        parentSpanIds: [],
+        rootSpanId,
       },
       spanAttributes: { type: SpanTypeAttribute.TASK },
       spanId,
@@ -1581,7 +1468,6 @@ class EveBridge {
 
   private cleanupSession(sessionId: string): void {
     const keyPrefix = `${sessionId}:`;
-    this.sessionsById.delete(sessionId);
     for (const key of this.turnsByKey.keys()) {
       if (key.startsWith(keyPrefix)) {
         this.turnsByKey.delete(key);
@@ -1897,33 +1783,6 @@ function toolMetadataFromTurn(turn: TurnState): Record<string, unknown> {
   return metadata;
 }
 
-function parentLineageFromContext(ctx: unknown): ParentLineage | undefined {
-  if (!isObject(ctx)) {
-    return undefined;
-  }
-  const session = ctx.session;
-  if (!isObject(session)) {
-    return undefined;
-  }
-  const parent = session["parent"];
-  if (!isObject(parent)) {
-    return undefined;
-  }
-
-  const callId = parent["callId"];
-  const rootSessionId = parent["rootSessionId"];
-  const sessionId = parent["sessionId"];
-  if (
-    typeof callId !== "string" ||
-    typeof rootSessionId !== "string" ||
-    typeof sessionId !== "string"
-  ) {
-    return undefined;
-  }
-
-  return { callId, rootSessionId, sessionId };
-}
-
 function isToolCallAction(
   action: unknown,
 ): action is EveRuntimeToolCallActionRequest {
@@ -2034,8 +1893,11 @@ function toolKey(sessionId: string, callId: string): string {
   return `${sessionId}:${callId}`;
 }
 
-async function rootSpanIdForSession(sessionId: string): Promise<string> {
-  return deterministicEveId("eve:root", sessionId);
+async function rootSpanIdForTurn(
+  sessionId: string,
+  turnId: string,
+): Promise<string> {
+  return deterministicEveId("eve:root", sessionId, turnId);
 }
 
 async function generateEveIds(
@@ -2047,13 +1909,6 @@ async function generateEveIds(
     deterministicEveId(`eve:${kind}`, ...parts),
   ]);
   return { rowId, spanId };
-}
-
-async function spanIdForSubagent(
-  sessionId: string,
-  callId: string,
-): Promise<string> {
-  return deterministicEveId("eve:subagent", sessionId, callId);
 }
 
 async function deterministicEveId(...parts: string[]): Promise<string> {

--- a/js/src/vendor-sdk-types/eve.ts
+++ b/js/src/vendor-sdk-types/eve.ts
@@ -16,25 +16,8 @@ export type EveJsonValue =
 export type EveJsonObject = { readonly [key: string]: EveJsonValue };
 
 export interface EveHookContext {
-  readonly agent?: {
-    readonly name?: string;
-    readonly nodeId?: string;
-  };
-  readonly channel?: {
-    readonly kind?: string;
-    readonly continuationToken?: string;
-  };
   readonly session?: {
     readonly id?: string;
-    readonly parent?: {
-      readonly callId?: string;
-      readonly rootSessionId?: string;
-      readonly sessionId?: string;
-      readonly turn?: {
-        readonly id?: string;
-        readonly sequence?: number;
-      };
-    };
   };
 }
 

--- a/js/src/vendor-sdk-types/eve.ts
+++ b/js/src/vendor-sdk-types/eve.ts
@@ -18,6 +18,13 @@ export type EveJsonObject = { readonly [key: string]: EveJsonValue };
 export interface EveHookContext {
   readonly session?: {
     readonly id?: string;
+    readonly parent?: {
+      readonly callId?: string;
+      readonly sessionId?: string;
+      readonly turn?: {
+        readonly id?: string;
+      };
+    };
   };
 }
 


### PR DESCRIPTION
Currently we attach turns to existing traces as a "session". Going forward we generally want to have a trace per turn.