### PR TITLE
chore: Fix gitleaks toml

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -4,6 +4,22 @@ title = "Braintrust SDK gitleaks config"
 # Use the default gitleaks ruleset as the base
 useDefault = true
 
+[[rules]]
+id = "braintrust-api-key"
+description = "Braintrust API key"
+regex = '''\bsk-[a-zA-Z0-9]{40,}\b'''
+tags = ["key", "braintrust"]
+
+[[allowlists]]
+description = "E2E scenario variant keys are cassette/snapshot identifiers, not secrets"
+condition = "AND"
+regexTarget = "line"
+paths = [
+  '''e2e/config/pr-comment-scenarios\.json''',
+  '''e2e/scenarios/.*/scenario\.test\.ts''',
+]
+regexes = ['''variantKey"?\s*:\s*"[a-z0-9-]+"''']
+
 [[allowlists]]
 description = "LangSmith E2E variant identifiers are not API keys"
 condition = "AND"
@@ -13,19 +29,3 @@ paths = [
   '''^e2e/config/pr-comment-scenarios\.json$''',
   '''^e2e/scenarios/langsmith-instrumentation/scenario\.test\.ts$''',
 ]
-
-[[rules]]
-id = "braintrust-api-key"
-description = "Braintrust API key"
-regex = '''\bsk-[a-zA-Z0-9]{40,}\b'''
-tags = ["key", "braintrust"]
-
-[allowlist]
-description = "E2E scenario variant keys are cassette/snapshot identifiers, not secrets"
-condition = "AND"
-regexTarget = "line"
-paths = [
-  '''e2e/config/pr-comment-scenarios\.json''',
-  '''e2e/scenarios/.*/scenario\.test\.ts''',
-]
-regexes = ['''variantKey"?\s*:\s*"[a-z0-9-]+"''']


### PR DESCRIPTION
emitted a warning about the two allowlist variants not being able to be used together