### PR TITLE
feat(vitest-evals): Add `meta.eval.input`

### DIFF
--- a/.changeset/vitest-evals-direct-input.md
+++ b/.changeset/vitest-evals-direct-input.md
@@ -2,7 +2,7 @@
 "braintrust": minor
 ---
 
-feat(vitest-evals): support a direct `input` on eval task meta, mirroring `output`
+feat: `BraintrustVitestEvalsReporter` accepts a direct `input` on eval task meta
 
 Previously the only way to populate an eval row's `input` field was via
 `harness.run.session.messages` (the first message with `role: "user"`), which

--- a/.changeset/vitest-evals-direct-input.md
+++ b/.changeset/vitest-evals-direct-input.md
@@ -2,12 +2,4 @@
 "braintrust": minor
 ---
 
-feat: `BraintrustVitestEvalsReporter` accepts a direct `input` on eval task meta
-
-Previously the only way to populate an eval row's `input` field was via
-`harness.run.session.messages` (the first message with `role: "user"`), which
-forces non-conversational harnesses to fabricate a synthetic message just to
-surface their real input. `meta.eval.input` now works exactly like the
-existing `meta.eval.output`: a direct passthrough that takes precedence over
-`session.messages` when present, falling back to the previous behavior when
-it's not set.
+feat(vitest-evals): Add `meta.eval.input`

--- a/.changeset/vitest-evals-direct-input.md
+++ b/.changeset/vitest-evals-direct-input.md
@@ -1,0 +1,13 @@
+---
+"braintrust": minor
+---
+
+feat(vitest-evals): support a direct `input` on eval task meta, mirroring `output`
+
+Previously the only way to populate an eval row's `input` field was via
+`harness.run.session.messages` (the first message with `role: "user"`), which
+forces non-conversational harnesses to fabricate a synthetic message just to
+surface their real input. `meta.eval.input` now works exactly like the
+existing `meta.eval.output`: a direct passthrough that takes precedence over
+`session.messages` when present, falling back to the previous behavior when
+it's not set.

--- a/js/src/wrappers/vitest-evals/reporter.test.ts
+++ b/js/src/wrappers/vitest-evals/reporter.test.ts
@@ -1,11 +1,11 @@
 import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import BraintrustVitestEvalsReporter from "./reporter";
-import { configureNode } from "../../node/config";
 import {
   _exportsForTestingOnly,
   type TestBackgroundLogger,
 } from "../../logger";
 import * as logger from "../../logger";
+import { configureNode } from "../../node/config";
 
 configureNode();
 
@@ -218,6 +218,65 @@ describe("Braintrust vitest-evals reporter", () => {
       Date.parse("2026-01-01T00:00:00.100Z") / 1000 + 0.012,
       6,
     );
+  });
+
+  test("meta.eval.input is a direct passthrough that takes precedence over session.messages", async () => {
+    const reporter = new BraintrustVitestEvalsReporter({
+      displaySummary: false,
+      projectName: "vitest-evals-tests",
+    });
+
+    await reporter.onTestRunEnd([
+      fakeModule([
+        fakeTest({
+          meta: {
+            eval: {
+              avgScore: 1,
+              input: { memberUuid: "member-1", payPeriodEnd: "2026-06-15" },
+              output: { status: "approved" },
+            },
+            harness: {
+              run: {
+                session: {
+                  messages: [
+                    {
+                      role: "user",
+                      content: "ignored in favor of meta.eval.input",
+                    },
+                  ],
+                },
+                usage: {},
+              },
+            },
+          },
+          name: "structured input",
+        }),
+        fakeTest({
+          meta: {
+            eval: { avgScore: 1 },
+            harness: { run: { session: { messages: [] }, usage: {} } },
+          },
+          name: "falls back to session when meta.eval.input is absent",
+        }),
+      ]),
+    ] as any);
+
+    await backgroundLogger.flush();
+    const rows = (await backgroundLogger.drain()) as any[];
+
+    const structured = rows.find(
+      (row: any) => row.metadata?.fullName === "structured input",
+    );
+    expect(structured?.input).toMatchObject({
+      input: { memberUuid: "member-1", payPeriodEnd: "2026-06-15" },
+    });
+
+    const fallback = rows.find(
+      (row: any) =>
+        row.metadata?.fullName ===
+        "falls back to session when meta.eval.input is absent",
+    );
+    expect(fallback?.input?.input).toBeUndefined();
   });
 
   test("logs failed eval scores and failure metadata", async () => {

--- a/js/src/wrappers/vitest-evals/reporter.test.ts
+++ b/js/src/wrappers/vitest-evals/reporter.test.ts
@@ -232,7 +232,7 @@ describe("Braintrust vitest-evals reporter", () => {
           meta: {
             eval: {
               avgScore: 1,
-              input: { memberUuid: "member-1", payPeriodEnd: "2026-06-15" },
+              input: { invoiceId: "inv_123", amount: 42 },
               output: { status: "approved" },
             },
             harness: {
@@ -268,7 +268,7 @@ describe("Braintrust vitest-evals reporter", () => {
       (row: any) => row.metadata?.fullName === "structured input",
     );
     expect(structured?.input).toMatchObject({
-      input: { memberUuid: "member-1", payPeriodEnd: "2026-06-15" },
+      input: { invoiceId: "inv_123", amount: 42 },
     });
 
     const fallback = rows.find(

--- a/js/src/wrappers/vitest-evals/reporter.ts
+++ b/js/src/wrappers/vitest-evals/reporter.ts
@@ -232,10 +232,6 @@ function logEvalTest(
   const result = test.result();
   const diagnostic = test.diagnostic();
   const run = meta.harness?.run;
-  // meta.eval.input is a direct passthrough (mirrors meta.eval.output below) for
-  // harnesses whose input isn't a conversation, so they don't need to fabricate a
-  // session.messages entry just to populate this field. Falls back to the first
-  // user message for harnesses that only report a session.
   const input = meta.eval?.input ?? firstUserMessageContent(run);
   const output = meta.eval?.output ?? run?.output;
   const scores = buildScores(result.state, meta.eval);

--- a/js/src/wrappers/vitest-evals/reporter.ts
+++ b/js/src/wrappers/vitest-evals/reporter.ts
@@ -1,12 +1,12 @@
 import type { Reporter, TestCase, TestModule, Vitest } from "vitest/node";
-import { configureNode } from "../../node/config";
+import { SpanTypeAttribute, isObject } from "../../../util";
 import {
   initExperiment,
   logError,
   type Experiment,
   type Span,
 } from "../../logger";
-import { SpanTypeAttribute, isObject } from "../../../util";
+import { configureNode } from "../../node/config";
 import { summarizeAndFlush } from "../shared/flush";
 
 configureNode();
@@ -31,6 +31,7 @@ type EvalScore = {
 type EvalMeta = {
   scores?: EvalScore[];
   avgScore?: number | null;
+  input?: unknown;
   output?: unknown;
   thresholdFailed?: boolean;
   toolCalls?: ToolCallRecord[];
@@ -231,6 +232,11 @@ function logEvalTest(
   const result = test.result();
   const diagnostic = test.diagnostic();
   const run = meta.harness?.run;
+  // meta.eval.input is a direct passthrough (mirrors meta.eval.output below) for
+  // harnesses whose input isn't a conversation, so they don't need to fabricate a
+  // session.messages entry just to populate this field. Falls back to the first
+  // user message for harnesses that only report a session.
+  const input = meta.eval?.input ?? firstUserMessageContent(run);
   const output = meta.eval?.output ?? run?.output;
   const scores = buildScores(result.state, meta.eval);
   const metrics = buildMetrics(diagnostic?.duration, run);
@@ -247,7 +253,7 @@ function logEvalTest(
     event: {
       input: {
         test: test.fullName || test.name,
-        input: firstUserMessageContent(run),
+        input,
       },
       ...(output !== undefined ? { output } : {}),
       scores,
@@ -519,6 +525,7 @@ function readEvalMeta(input: unknown): EvalMeta | undefined {
   return {
     ...(scores ? { scores } : {}),
     ...(avgScore !== undefined ? { avgScore } : {}),
+    ...(input.input !== undefined ? { input: input.input } : {}),
     ...(input.output !== undefined ? { output: input.output } : {}),
     ...(typeof input.thresholdFailed === "boolean"
       ? { thresholdFailed: input.thresholdFailed }


### PR DESCRIPTION
## What this PR does

Adds `meta.eval.input` to the `vitest-evals` reporter, as a direct passthrough for an eval row's `input` field — the same way `meta.eval.output` already works.

## Why

Today the eval-level root span's `input` can *only* be populated via `harness.run.session.messages`, specifically the first entry with `role: "user"` (`firstUserMessageContent()`). That's a reasonable default for conversational harnesses, but it forces any harness whose input isn't a conversation (e.g. a structured payload, a single scalar) to fabricate a synthetic `{ role: "user", content: ... }` message just to get anything into `input` at all.

This is inconsistent with the rest of this same file:
- `meta.eval.output` already supports a direct passthrough (`input.output !== undefined ? { output: input.output } : {}` in `readEvalMeta`) — there's no equivalent for `input`.
- `logToolCallSpans` in this file sets `event: { input: call.arguments }` directly, no message-shape required.
- The classic `Eval()` framework (`js/src/framework.ts`) does `event: { input: datum.input }` — a direct, arbitrary passthrough, which is the norm for the rest of the SDK.

## Changes

- `EvalMeta` gains an `input?: unknown` field, alongside the existing `output?: unknown`.
- `readEvalMeta` reads `input.input` the same way it already reads `input.output`.
- `logEvalTest` computes `const input = meta.eval?.input ?? firstUserMessageContent(run);` — `meta.eval.input` takes precedence when present, falling back to the existing session-derived behavior when it's not. Fully backward compatible: nothing changes for consumers that only set `harness.run.session.messages`.
- Adds a test covering both the direct-passthrough case and the fallback case.

## Testing

- `pnpm vitest run src/wrappers/vitest-evals/reporter.test.ts` — all 6 tests pass (5 existing + 1 new).
- `pnpm run fix:formatting` — clean.
- Added a changeset (`minor`, per the existing convention for new fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)