### PR TITLE
ref: remove simple-git dependency

### DIFF
--- a/.changeset/direct-git-commands.md
+++ b/.changeset/direct-git-commands.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+Remove the `simple-git` dependency by collecting Git metadata through the Git CLI.

--- a/e2e/scenarios/git-metadata/scenario.test.ts
+++ b/e2e/scenarios/git-metadata/scenario.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "vitest";
+import {
+  prepareScenarioDir,
+  resolveScenarioDir,
+  withScenarioHarness,
+} from "../../helpers/scenario-harness";
+
+const scenarioDir = await prepareScenarioDir({
+  scenarioDir: resolveScenarioDir(import.meta.url),
+});
+
+test("preserves git metadata on experiment spans", async () => {
+  await withScenarioHarness(
+    async ({ requestsAfter, runScenarioDir, testRunEvents }) => {
+      const result = await runScenarioDir({ scenarioDir });
+      const { baseCommit, featureCommit } = JSON.parse(result.stdout) as {
+        baseCommit: string;
+        featureCommit: string;
+      };
+
+      const registrationRequests = requestsAfter(
+        0,
+        (request) => request.path === "/api/experiment/register",
+      );
+      expect(registrationRequests).toHaveLength(2);
+
+      expect(registrationRequests[0]?.jsonBody).toEqual(
+        expect.objectContaining({
+          ancestor_commits: [baseCommit],
+          experiment_name: "git-metadata-base",
+          repo_info: {
+            author_email: "git-regression@braintrust.dev",
+            author_name: "Braintrust Git Regression",
+            branch: "main",
+            commit: baseCommit,
+            commit_message: "Deterministic base commit",
+            commit_time: "2024-02-01T12:00:00Z",
+            dirty: false,
+            tag: "git-regression-base",
+          },
+        }),
+      );
+
+      expect(registrationRequests[1]?.jsonBody).toEqual(
+        expect.objectContaining({
+          ancestor_commits: [featureCommit],
+          experiment_name: "git-metadata-feature",
+          repo_info: {
+            author_email: "git-regression@braintrust.dev",
+            author_name: "Braintrust Git Regression",
+            branch: "feature/git-metadata-regression",
+            commit: featureCommit,
+            commit_message: "Deterministic feature commit",
+            commit_time: "2024-02-02T12:00:00Z",
+            dirty: true,
+            tag: "git-regression-feature",
+          },
+        }),
+      );
+
+      const spans = testRunEvents(
+        (event) =>
+          event.span.name === "git-metadata-regression" &&
+          event.output !== undefined,
+      );
+      expect(spans).toHaveLength(2);
+      expect(
+        spans.map((event) => ({
+          input: event.input,
+          metadata: event.metadata,
+          output: event.output,
+        })),
+      ).toEqual([
+        {
+          input: { case: "base" },
+          metadata: expect.objectContaining({ gitRegressionCase: "base" }),
+          output: { status: "recorded" },
+        },
+        {
+          input: { case: "feature-dirty" },
+          metadata: expect.objectContaining({
+            gitRegressionCase: "feature-dirty",
+          }),
+          output: { status: "recorded" },
+        },
+      ]);
+    },
+  );
+});

--- a/e2e/scenarios/git-metadata/scenario.ts
+++ b/e2e/scenarios/git-metadata/scenario.ts
@@ -1,0 +1,137 @@
+import { execFile } from "node:child_process";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import * as path from "node:path";
+import { promisify } from "node:util";
+import { init } from "braintrust";
+import { getTestRunId, runMain } from "../../helpers/scenario-runtime";
+
+const execFileAsync = promisify(execFile);
+const gitMetadataSettings = {
+  collect: "some" as const,
+  fields: [
+    "commit" as const,
+    "branch" as const,
+    "tag" as const,
+    "dirty" as const,
+    "author_name" as const,
+    "author_email" as const,
+    "commit_message" as const,
+    "commit_time" as const,
+  ],
+};
+
+async function git(
+  cwd: string,
+  args: string[],
+  env?: Record<string, string>,
+): Promise<string> {
+  const { stdout } = await execFileAsync("git", args, {
+    cwd,
+    env: {
+      ...process.env,
+      ...env,
+    },
+  });
+  return stdout.trim();
+}
+
+async function commit(
+  repoDir: string,
+  message: string,
+  timestamp: string,
+): Promise<string> {
+  await git(repoDir, ["add", "."]);
+  await git(repoDir, ["commit", "-m", message], {
+    GIT_AUTHOR_DATE: timestamp,
+    GIT_COMMITTER_DATE: timestamp,
+  });
+  return await git(repoDir, ["rev-parse", "HEAD"]);
+}
+
+async function initializeRepository(): Promise<{
+  baseCommit: string;
+  repoDir: string;
+}> {
+  const fixtureDir = path.join(process.cwd(), ".git-metadata-fixture");
+  const repoDir = path.join(fixtureDir, "repo");
+  const remoteDir = path.join(fixtureDir, "remote.git");
+
+  await rm(fixtureDir, { recursive: true, force: true });
+  await mkdir(repoDir, { recursive: true });
+  await mkdir(remoteDir, { recursive: true });
+
+  await git(repoDir, ["init"]);
+  await git(repoDir, ["symbolic-ref", "HEAD", "refs/heads/main"]);
+  await git(repoDir, ["config", "user.name", "Braintrust Git Regression"]);
+  await git(repoDir, ["config", "user.email", "git-regression@braintrust.dev"]);
+
+  await writeFile(path.join(repoDir, "application.txt"), "seed\n");
+  await commit(
+    repoDir,
+    "Deterministic seed commit",
+    "2024-01-31T12:00:00+00:00",
+  );
+
+  await writeFile(path.join(repoDir, "application.txt"), "base\n");
+  const baseCommit = await commit(
+    repoDir,
+    "Deterministic base commit",
+    "2024-02-01T12:00:00+00:00",
+  );
+  await git(repoDir, ["tag", "git-regression-base"]);
+
+  await git(remoteDir, ["init", "--bare"]);
+  await git(remoteDir, ["symbolic-ref", "HEAD", "refs/heads/main"]);
+  await git(repoDir, ["remote", "add", "origin", remoteDir]);
+  await git(repoDir, ["push", "--set-upstream", "origin", "main"]);
+
+  return { baseCommit, repoDir };
+}
+
+async function logRegressionSpan(
+  experimentName: string,
+  testRunId: string,
+  gitRegressionCase: string,
+): Promise<void> {
+  const experiment = init({
+    project: "e2e-git-metadata",
+    experiment: experimentName,
+    gitMetadataSettings,
+    setCurrent: false,
+    update: true,
+  });
+  const span = experiment.startSpan({
+    name: "git-metadata-regression",
+    event: {
+      input: { case: gitRegressionCase },
+      metadata: { gitRegressionCase, testRunId },
+    },
+  });
+  span.log({ output: { status: "recorded" } });
+  span.end();
+  await experiment.flush();
+}
+
+async function main() {
+  const testRunId = getTestRunId();
+  const { baseCommit, repoDir } = await initializeRepository();
+  process.chdir(repoDir);
+
+  await logRegressionSpan("git-metadata-base", testRunId, "base");
+
+  await git(repoDir, ["checkout", "-b", "feature/git-metadata-regression"]);
+  await writeFile(path.join(repoDir, "application.txt"), "feature\n");
+  const featureCommit = await commit(
+    repoDir,
+    "Deterministic feature commit",
+    "2024-02-02T12:00:00+00:00",
+  );
+  await git(repoDir, ["tag", "git-regression-feature"]);
+  await writeFile(path.join(repoDir, "application.txt"), "dirty feature\n");
+
+  await logRegressionSpan("git-metadata-feature", testRunId, "feature-dirty");
+
+  console.log(JSON.stringify({ baseCommit, featureCommit }));
+}
+
+runMain(main);

--- a/integrations/otel-js/otel-v1/pnpm-lock.yaml
+++ b/integrations/otel-js/otel-v1/pnpm-lock.yaml
@@ -518,12 +518,6 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
-  '@kwsites/file-exists@1.1.1':
-    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
-
-  '@kwsites/promise-deferred@1.1.1':
-    resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
-
   '@mswjs/interceptors@0.41.9':
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
     engines: {node: '>=18'}
@@ -994,12 +988,6 @@ packages:
     resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
     cpu: [x64]
     os: [win32]
-
-  '@simple-git/args-pathspec@1.0.3':
-    resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
-
-  '@simple-git/argv-parser@1.1.1':
-    resolution: {integrity: sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1820,9 +1808,6 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  simple-git@3.36.0:
-    resolution: {integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2383,14 +2368,6 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@kwsites/file-exists@1.1.1':
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@kwsites/promise-deferred@1.1.1': {}
-
   '@mswjs/interceptors@0.41.9':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -2784,12 +2761,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
 
-  '@simple-git/args-pathspec@1.0.3': {}
-
-  '@simple-git/argv-parser@1.1.1':
-    dependencies:
-      '@simple-git/args-pathspec': 1.0.3
-
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.2':
@@ -2941,7 +2912,6 @@ snapshots:
       mustache: 4.2.0
       pluralize: 8.0.0
       semifies: 1.0.0
-      simple-git: 3.36.0
       source-map: 0.7.6
       termi-link: 1.1.0
       unplugin: 2.3.11
@@ -3697,16 +3667,6 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
-
-  simple-git@3.36.0:
-    dependencies:
-      '@kwsites/file-exists': 1.1.1
-      '@kwsites/promise-deferred': 1.1.1
-      '@simple-git/args-pathspec': 1.0.3
-      '@simple-git/argv-parser': 1.1.1
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   source-map-js@1.2.1: {}
 

--- a/integrations/otel-js/otel-v2/pnpm-lock.yaml
+++ b/integrations/otel-js/otel-v2/pnpm-lock.yaml
@@ -507,12 +507,6 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
-  '@kwsites/file-exists@1.1.1':
-    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
-
-  '@kwsites/promise-deferred@1.1.1':
-    resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
-
   '@mswjs/interceptors@0.41.9':
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
     engines: {node: '>=18'}
@@ -971,12 +965,6 @@ packages:
     resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
     cpu: [x64]
     os: [win32]
-
-  '@simple-git/args-pathspec@1.0.3':
-    resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
-
-  '@simple-git/argv-parser@1.1.1':
-    resolution: {integrity: sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1761,9 +1749,6 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  simple-git@3.36.0:
-    resolution: {integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2302,14 +2287,6 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@kwsites/file-exists@1.1.1':
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@kwsites/promise-deferred@1.1.1': {}
-
   '@mswjs/interceptors@0.41.9':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -2720,12 +2697,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
 
-  '@simple-git/args-pathspec@1.0.3': {}
-
-  '@simple-git/argv-parser@1.1.1':
-    dependencies:
-      '@simple-git/args-pathspec': 1.0.3
-
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.2':
@@ -2877,7 +2848,6 @@ snapshots:
       mustache: 4.2.0
       pluralize: 8.0.0
       semifies: 1.0.0
-      simple-git: 3.36.0
       source-map: 0.7.6
       termi-link: 1.1.0
       unplugin: 2.3.11
@@ -3601,16 +3571,6 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
-
-  simple-git@3.36.0:
-    dependencies:
-      '@kwsites/file-exists': 1.1.1
-      '@kwsites/promise-deferred': 1.1.1
-      '@simple-git/args-pathspec': 1.0.3
-      '@simple-git/argv-parser': 1.1.1
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   source-map-js@1.2.1: {}
 

--- a/js/package.json
+++ b/js/package.json
@@ -236,7 +236,6 @@
     "mustache": "^4.2.0",
     "pluralize": "^8.0.0",
     "semifies": "^1.0.0",
-    "simple-git": "^3.36.0",
     "source-map": "^0.7.4",
     "termi-link": "^1.0.1",
     "unplugin": "^2.3.5",

--- a/js/src/cli/util/pull.ts
+++ b/js/src/cli/util/pull.ts
@@ -13,7 +13,8 @@ import fs from "node:fs/promises";
 import util from "node:util";
 import { slugify } from "../../../util/string_util";
 import path from "node:path";
-import { currentRepo } from "../../gitutil";
+import { runGitCommand } from "../../git-command";
+import { currentRepoPath } from "../../gitutil";
 import { isEmpty, loadPrettyXact, prettifyXact } from "../../../util/index";
 import {
   ProjectNameIdMap,
@@ -71,16 +72,17 @@ export async function pullCommand(args: PullArgs) {
   const outputDir = args.output_dir ?? "./braintrust";
   await fs.mkdir(outputDir, { recursive: true });
 
-  const git = await currentRepo();
-  const diffSummary = await git?.diffSummary("HEAD");
-
-  // Get the root directory of the Git repository
-  const repoRoot = await git?.revparse(["--show-toplevel"]);
-
+  const repoRoot = await currentRepoPath();
+  const dirtyFileOutput = repoRoot
+    ? await runGitCommand(["diff", "--name-only", "-z", "HEAD"], {
+        cwd: repoRoot,
+      })
+    : "";
   const dirtyFiles = new Set(
-    (diffSummary?.files ?? []).map((f) =>
-      path.resolve(repoRoot ?? ".", f.file),
-    ),
+    dirtyFileOutput
+      .split("\0")
+      .filter(Boolean)
+      .map((file) => path.resolve(repoRoot ?? ".", file)),
   );
 
   for (const projectName of Object.keys(projectNameToFunctions)) {
@@ -111,7 +113,7 @@ export async function pullCommand(args: PullArgs) {
       );
       continue;
     } else if (fileExists) {
-      if (!git) {
+      if (!repoRoot) {
         // eslint-disable-next-line no-restricted-properties -- preserving intentional console usage.
         console.warn(
           warning(

--- a/js/src/git-command.test.ts
+++ b/js/src/git-command.test.ts
@@ -1,0 +1,24 @@
+import * as path from "node:path";
+import { afterEach, expect, test } from "vitest";
+import {
+  findGitExecutable,
+  resetGitExecutableCacheForTests,
+  resolveGitExecutable,
+  runGitCommand,
+} from "./git-command";
+
+afterEach(() => {
+  resetGitExecutableCacheForTests();
+});
+
+test("resolves git to an absolute executable path", async () => {
+  const executable = await resolveGitExecutable();
+
+  expect(executable).toBeDefined();
+  expect(path.isAbsolute(executable!)).toBe(true);
+  await expect(runGitCommand(["--version"])).resolves.toMatch(/^git version /);
+});
+
+test("ignores relative PATH entries", async () => {
+  await expect(findGitExecutable(".")).resolves.toBeUndefined();
+});

--- a/js/src/git-command.ts
+++ b/js/src/git-command.ts
@@ -1,0 +1,84 @@
+import { execFile } from "node:child_process";
+import { constants } from "node:fs";
+import { access } from "node:fs/promises";
+import * as path from "node:path";
+
+const GIT_EXECUTABLE_NAMES =
+  process.platform === "win32" ? ["git.exe", "git"] : ["git"];
+const GIT_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+
+let gitExecutablePromise: Promise<string | undefined> | undefined;
+
+function executableSearchPath(): string | undefined {
+  return Object.entries(process.env).find(
+    ([name]) => name.toUpperCase() === "PATH",
+  )?.[1];
+}
+
+export async function findGitExecutable(
+  searchPath = executableSearchPath(),
+): Promise<string | undefined> {
+  if (!searchPath) {
+    return undefined;
+  }
+
+  for (const rawSearchDir of searchPath.split(path.delimiter)) {
+    const searchDir = rawSearchDir.trim().replace(/^"(.*)"$/, "$1");
+    if (!path.isAbsolute(searchDir)) {
+      continue;
+    }
+
+    for (const executableName of GIT_EXECUTABLE_NAMES) {
+      const candidate = path.join(searchDir, executableName);
+      try {
+        await access(
+          candidate,
+          process.platform === "win32" ? constants.F_OK : constants.X_OK,
+        );
+        return candidate;
+      } catch {
+        // Keep searching PATH.
+      }
+    }
+  }
+
+  return undefined;
+}
+
+export async function resolveGitExecutable(): Promise<string | undefined> {
+  gitExecutablePromise ??= findGitExecutable();
+  return await gitExecutablePromise;
+}
+
+export async function runGitCommand(
+  args: string[],
+  options: { cwd?: string } = {},
+): Promise<string> {
+  const executable = await resolveGitExecutable();
+  if (!executable) {
+    throw new Error("Could not find a git executable on PATH");
+  }
+
+  return await new Promise<string>((resolve, reject) => {
+    execFile(
+      executable,
+      args,
+      {
+        cwd: options.cwd,
+        encoding: "utf8",
+        maxBuffer: GIT_MAX_BUFFER_BYTES,
+      },
+      (error, stdout) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(stdout);
+        }
+      },
+    );
+  });
+}
+
+export function resetGitExecutableCacheForTests(): void {
+  gitExecutablePromise = undefined;
+}

--- a/js/src/gitutil.ts
+++ b/js/src/gitutil.ts
@@ -3,6 +3,7 @@ import {
   type RepoInfoType as RepoInfo,
 } from "./generated_types";
 import { debugLogger } from "./debug-logger";
+import { runGitCommand } from "./git-command";
 import { simpleGit } from "simple-git";
 
 const COMMON_BASE_BRANCHES = ["main", "master", "develop"];
@@ -166,9 +167,15 @@ export async function getRepoInfo(settings?: GitMetadataSettings) {
   return sanitized;
 }
 
+async function currentRepoPath(): Promise<string | undefined> {
+  return await attempt(async () =>
+    (await runGitCommand(["rev-parse", "--show-toplevel"])).trim(),
+  );
+}
+
 async function repoInfo() {
-  const git = await currentRepo();
-  if (git === null) {
+  const repoPath = await currentRepoPath();
+  if (!repoPath) {
     return undefined;
   }
 
@@ -181,32 +188,36 @@ async function repoInfo() {
   let branch = undefined;
   let git_diff = undefined;
 
-  const dirty = (await git.diffSummary()).files.length > 0;
+  const runGit = async (args: string[]) =>
+    await runGitCommand(args, { cwd: repoPath });
+  const dirty = (await runGit(["diff", "--name-only"])).trim().length > 0;
 
-  commit = await attempt(async () => await git.revparse(["HEAD"]));
+  commit = await attempt(async () =>
+    (await runGit(["rev-parse", "HEAD"])).trim(),
+  );
   commit_message = await attempt(async () =>
-    (await git.raw(["log", "-1", "--pretty=%B"])).trim(),
+    (await runGit(["log", "-1", "--pretty=%B"])).trim(),
   );
   commit_time = await attempt(async () =>
-    (await git.raw(["log", "-1", "--pretty=%cI"])).trim(),
+    (await runGit(["log", "-1", "--pretty=%cI"])).trim(),
   );
   author_name = await attempt(async () =>
-    (await git.raw(["log", "-1", "--pretty=%aN"])).trim(),
+    (await runGit(["log", "-1", "--pretty=%aN"])).trim(),
   );
   author_email = await attempt(async () =>
-    (await git.raw(["log", "-1", "--pretty=%aE"])).trim(),
+    (await runGit(["log", "-1", "--pretty=%aE"])).trim(),
   );
   tag = await attempt(async () =>
-    (await git.raw(["describe", "--tags", "--exact-match", "--always"])).trim(),
+    (await runGit(["describe", "--tags", "--exact-match", "--always"])).trim(),
   );
 
   branch = await attempt(async () =>
-    (await git.raw(["rev-parse", "--abbrev-ref", "HEAD"])).trim(),
+    (await runGit(["rev-parse", "--abbrev-ref", "HEAD"])).trim(),
   );
 
   if (dirty) {
     git_diff = await attempt(async () =>
-      truncateToByteLimit(await git.raw(["--no-ext-diff", "diff", "HEAD"])),
+      truncateToByteLimit(await runGit(["diff", "--no-ext-diff", "HEAD"])),
     );
   }
 

--- a/js/src/gitutil.ts
+++ b/js/src/gitutil.ts
@@ -31,12 +31,15 @@ let _baseBranch: {
 
 async function getBaseBranch(remote: string | undefined = undefined) {
   if (_baseBranch === null) {
-    const git = await currentRepo();
-    if (git === null) {
+    const repoPath = await currentRepoPath();
+    if (!repoPath) {
       throw new Error("Not in a git repo");
     }
 
-    const remoteName = remote ?? (await git.getRemotes())[0]?.name;
+    const runGit = async (args: string[]) =>
+      await runGitCommand(args, { cwd: repoPath });
+    const remoteName =
+      remote ?? (await runGit(["remote"])).trim().split(/\r?\n/)[0];
     if (!remoteName) {
       throw new Error("No remote found");
     }
@@ -48,7 +51,17 @@ async function getBaseBranch(remote: string | undefined = undefined) {
 
     // To speed this up in the short term, we pick from a list of common names
     // and only fall back to the remote origin if required.
-    const repoBranches = new Set((await git.branchLocal()).all);
+    const repoBranches = new Set(
+      (
+        await runGit([
+          "for-each-ref",
+          "--format=%(refname:short)",
+          "refs/heads/",
+        ])
+      )
+        .trim()
+        .split(/\r?\n/),
+    );
     const matchingBaseBranches = COMMON_BASE_BRANCHES.filter((b) =>
       repoBranches.has(b),
     );
@@ -56,7 +69,7 @@ async function getBaseBranch(remote: string | undefined = undefined) {
       branch = matchingBaseBranches[0];
     } else {
       try {
-        const remoteInfo = await git.remote(["show", remoteName]);
+        const remoteInfo = await runGit(["remote", "show", remoteName]);
         if (!remoteInfo) {
           throw new Error(`Could not find remote ${remoteName}`);
         }
@@ -77,23 +90,27 @@ async function getBaseBranch(remote: string | undefined = undefined) {
 }
 
 async function getBaseBranchAncestor(remote: string | undefined = undefined) {
-  const git = await currentRepo();
-  if (git === null) {
+  const repoPath = await currentRepoPath();
+  if (!repoPath) {
     throw new Error("Not in a git repo");
   }
 
   const { remote: remoteName, branch: baseBranch } =
     await getBaseBranch(remote);
 
-  const isDirty = (await git.diffSummary()).files.length > 0;
+  const isDirty =
+    (
+      await runGitCommand(["diff", "--name-only"], {
+        cwd: repoPath,
+      })
+    ).trim().length > 0;
   const head = isDirty ? "HEAD" : "HEAD^";
 
   try {
-    const ancestor = await git.raw([
-      "merge-base",
-      head,
-      `${remoteName}/${baseBranch}`,
-    ]);
+    const ancestor = await runGitCommand(
+      ["merge-base", head, `${remoteName}/${baseBranch}`],
+      { cwd: repoPath },
+    );
     return ancestor.trim();
   } catch {
     /*
@@ -109,8 +126,8 @@ export async function getPastNAncestors(
   n: number = 1000,
   remote: string | undefined = undefined,
 ) {
-  const git = await currentRepo();
-  if (git === null) {
+  const repoPath = await currentRepoPath();
+  if (!repoPath) {
     return [];
   }
 
@@ -126,8 +143,12 @@ export async function getPastNAncestors(
   if (!ancestor) {
     return [];
   }
-  const commits = await git.log({ from: ancestor, to: "HEAD", maxCount: n });
-  return commits.all.slice(0, n).map((c) => c.hash);
+  const commits = (
+    await runGitCommand(["rev-list", `--max-count=${n}`, `${ancestor}..HEAD`], {
+      cwd: repoPath,
+    })
+  ).trim();
+  return commits ? commits.split(/\r?\n/).slice(0, n) : [];
 }
 
 async function attempt<T>(fn: () => Promise<T>): Promise<T | undefined> {

--- a/js/src/gitutil.ts
+++ b/js/src/gitutil.ts
@@ -4,25 +4,8 @@ import {
 } from "./generated_types";
 import { debugLogger } from "./debug-logger";
 import { runGitCommand } from "./git-command";
-import { simpleGit } from "simple-git";
 
 const COMMON_BASE_BRANCHES = ["main", "master", "develop"];
-
-/**
- * Information about the current HEAD of the repo.
- */
-export async function currentRepo() {
-  try {
-    const git = simpleGit();
-    if (await git.checkIsRepo()) {
-      return git;
-    } else {
-      return null;
-    }
-  } catch {
-    return null;
-  }
-}
 
 let _baseBranch: {
   remote: string;
@@ -188,7 +171,7 @@ export async function getRepoInfo(settings?: GitMetadataSettings) {
   return sanitized;
 }
 
-async function currentRepoPath(): Promise<string | undefined> {
+export async function currentRepoPath(): Promise<string | undefined> {
   return await attempt(async () =>
     (await runGitCommand(["rev-parse", "--show-toplevel"])).trim(),
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,9 +413,6 @@ importers:
       semifies:
         specifier: ^1.0.0
         version: 1.0.0
-      simple-git:
-        specifier: ^3.36.0
-        version: 3.36.0
       source-map:
         specifier: ^0.7.4
         version: 0.7.6
@@ -1119,12 +1116,6 @@ packages:
     peerDependencies:
       tslib: '2'
 
-  '@kwsites/file-exists@1.1.1':
-    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
-
-  '@kwsites/promise-deferred@1.1.1':
-    resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
-
   '@langchain/anthropic@1.3.5':
     resolution: {integrity: sha512-oB+sfcBujxW/E3cRhGfR5K23+TwZKPPZPjatEadQOZllyPoen0xefIuNoi0oLWfobz3/LPwoNixGU4si3oyGBQ==}
     engines: {node: '>=20'}
@@ -1736,12 +1727,6 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
-
-  '@simple-git/args-pathspec@1.0.3':
-    resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
-
-  '@simple-git/argv-parser@1.1.1':
-    resolution: {integrity: sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -3886,9 +3871,6 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  simple-git@3.36.0:
-    resolution: {integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==}
-
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -5109,14 +5091,6 @@ snapshots:
       '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@kwsites/file-exists@1.1.1':
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@kwsites/promise-deferred@1.1.1': {}
-
   '@langchain/anthropic@1.3.5(@langchain/core@1.1.10(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1))':
     dependencies:
       '@anthropic-ai/sdk': 0.71.2(zod@3.25.76)
@@ -5656,12 +5630,6 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
-
-  '@simple-git/args-pathspec@1.0.3': {}
-
-  '@simple-git/argv-parser@1.1.1':
-    dependencies:
-      '@simple-git/args-pathspec': 1.0.3
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -7959,16 +7927,6 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
-
-  simple-git@3.36.0:
-    dependencies:
-      '@kwsites/file-exists': 1.1.1
-      '@kwsites/promise-deferred': 1.1.1
-      '@simple-git/args-pathspec': 1.0.3
-      '@simple-git/argv-parser': 1.1.1
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   sisteransi@1.0.5: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
         version: 9.1.7
       knip:
         specifier: ^5.85.0
-        version: 5.85.0(@types/node@24.12.4)(typescript@5.9.3)
+        version: 5.85.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(typescript@5.9.3)
       lint-staged:
         specifier: ^16.2.7
         version: 16.2.7
@@ -759,17 +759,8 @@ packages:
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/core@1.8.1':
-    resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
-
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
-
-  '@emnapi/runtime@1.8.1':
-    resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
-
-  '@emnapi/wasi-threads@1.1.0':
-    resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
@@ -1182,9 +1173,6 @@ packages:
   '@mswjs/interceptors@0.41.6':
     resolution: {integrity: sha512-qmDvJIjcNsZ6tXWy2G9yuCgMPTTn35GMA3dPpSLm7QJVpbQzYdw0ALy1bKoivXnEM3U93/OrK+/M719b+fg84Q==}
     engines: {node: '>=18'}
-
-  '@napi-rs/wasm-runtime@1.1.1':
-    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -1871,9 +1859,6 @@ packages:
     resolution: {integrity: sha512-fVdCsnmYoKICsycbWuuGp6Jvi51/3G/UluFWuAUCvR8PIW5IJkAk5BM9UF8PSm0Q2IphWHFZjYEgjHsh3B9y/g==}
     cpu: [arm64]
     os: [win32]
-
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -3622,10 +3607,6 @@ packages:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
@@ -4186,10 +4167,6 @@ packages:
   type-fest@5.6.0:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
     engines: {node: '>=20'}
-
-  type-is@2.0.1:
-    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
-    engines: {node: '>= 0.6'}
 
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
@@ -4765,23 +4742,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.8.1':
-    dependencies:
-      '@emnapi/wasi-threads': 1.1.0
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/runtime@1.11.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.8.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.1.0':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -5201,13 +5162,6 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
-  '@napi-rs/wasm-runtime@1.1.1':
-    dependencies:
-      '@emnapi/core': 1.8.1
-      '@emnapi/runtime': 1.8.1
-      '@tybys/wasm-util': 0.10.1
-    optional: true
-
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -5436,9 +5390,12 @@ snapshots:
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     optional: true
 
-  '@oxc-resolver/binding-wasm32-wasi@11.19.1':
+  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
     optional: true
 
   '@oxc-resolver/binding-win32-arm64-msvc@11.19.1':
@@ -5787,11 +5744,6 @@ snapshots:
     optional: true
 
   '@turbo/windows-arm64@2.9.14':
-    optional: true
-
-  '@tybys/wasm-util@0.10.1':
-    dependencies:
-      tslib: 2.8.1
     optional: true
 
   '@tybys/wasm-util@0.10.3':
@@ -6751,7 +6703,7 @@ snapshots:
       send: 1.2.0
       serve-static: 2.2.0
       statuses: 2.0.2
-      type-is: 2.0.1
+      type-is: 2.1.0
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -6792,9 +6744,9 @@ snapshots:
     dependencies:
       walk-up-path: 4.0.0
 
-  fdir@6.5.0(picomatch@4.0.4):
+  fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -7115,7 +7067,7 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  knip@5.85.0(@types/node@24.12.4)(typescript@5.9.3):
+  knip@5.85.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(typescript@5.9.3):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
       '@types/node': 24.12.4
@@ -7124,13 +7076,16 @@ snapshots:
       jiti: 2.6.1
       js-yaml: 4.3.0
       minimist: 1.2.8
-      oxc-resolver: 11.19.1
+      oxc-resolver: 11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       picocolors: 1.1.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       smol-toml: 1.6.0
       strip-json-comments: 5.0.3
       typescript: 5.9.3
       zod: 4.3.6
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   langsmith@0.7.1(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.32.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1):
     dependencies:
@@ -7541,7 +7496,7 @@ snapshots:
 
   outvariant@1.4.3: {}
 
-  oxc-resolver@11.19.1:
+  oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
     optionalDependencies:
       '@oxc-resolver/binding-android-arm-eabi': 11.19.1
       '@oxc-resolver/binding-android-arm64': 11.19.1
@@ -7559,10 +7514,13 @@ snapshots:
       '@oxc-resolver/binding-linux-x64-gnu': 11.19.1
       '@oxc-resolver/binding-linux-x64-musl': 11.19.1
       '@oxc-resolver/binding-openharmony-arm64': 11.19.1
-      '@oxc-resolver/binding-wasm32-wasi': 11.19.1
+      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@oxc-resolver/binding-win32-arm64-msvc': 11.19.1
       '@oxc-resolver/binding-win32-ia32-msvc': 11.19.1
       '@oxc-resolver/binding-win32-x64-msvc': 11.19.1
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   p-filter@2.1.0:
     dependencies:
@@ -7638,8 +7596,6 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
-
-  picomatch@4.0.4: {}
 
   picomatch@4.0.5: {}
 
@@ -8091,8 +8047,8 @@ snapshots:
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinyrainbow@3.1.0: {}
 
@@ -8128,7 +8084,7 @@ snapshots:
 
   ts-declaration-location@1.0.7(typescript@5.4.4):
     dependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       typescript: 5.4.4
 
   ts-interface-checker@0.1.13: {}
@@ -8250,12 +8206,6 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
-  type-is@2.0.1:
-    dependencies:
-      content-type: 1.0.5
-      media-typer: 1.1.0
-      mime-types: 3.0.1
-
   type-is@2.1.0:
     dependencies:
       content-type: 2.0.0
@@ -8321,7 +8271,7 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       acorn: 8.16.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
 
   until-async@3.0.2: {}
@@ -8397,7 +8347,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.2
@@ -8425,7 +8375,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.2
@@ -8453,7 +8403,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.2
@@ -8481,7 +8431,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.2


### PR DESCRIPTION
Remove the `simple-git` dependency by collecting Git metadata through the Git CLI

resolves https://linear.app/braintrustdata/issue/SDK-220/remove-usage-of-simple-git-from-js-sdk