### PR TITLE
fix: Reduce flue instrumentation memory footprint

### DIFF
--- a/.changeset/reduce-flue-memory.md
+++ b/.changeset/reduce-flue-memory.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+fix: Reduce flue instrumentation memory footprint

--- a/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-0-auto-hook.span-tree.json
+++ b/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-0-auto-hook.span-tree.json
@@ -5,541 +5,6 @@
       "type": "task",
       "children": [
         {
-          "name": "flue.prompt",
-          "type": "task",
-          "children": [
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-                    "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-                    "type": "thinking"
-                  },
-                  {
-                    "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-                    "type": "text"
-                  },
-                  {
-                    "arguments": {
-                      "query": "flue instrumentation"
-                    },
-                    "id": "<span:1>",
-                    "name": "lookup",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "anthropic-messages",
-                "flue.model": "claude-sonnet-4-5-20250929",
-                "flue.provider": "anthropic",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "claude-sonnet-4-5-20250929",
-                "provider": "anthropic"
-              },
-              "metrics": {
-                "completion_tokens": 196,
-                "duration_ms": 0,
-                "estimated_cost": 0.0113025,
-                "prompt_cache_creation_tokens": 2222,
-                "prompt_cached_tokens": 0,
-                "prompt_tokens": 10,
-                "tokens": 2428
-              }
-            },
-            {
-              "name": "tool:lookup",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "query": "flue instrumentation"
-              },
-              "output": {
-                "content": [
-                  {
-                    "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                    "type": "text"
-                  }
-                ],
-                "details": {
-                  "customTool": "lookup"
-                }
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "lookup",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-                      "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-                    "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
-                    "type": "thinking"
-                  },
-                  {
-                    "text": "Now proceeding to Step 2:",
-                    "type": "text"
-                  },
-                  {
-                    "arguments": {
-                      "lookupId": "flue-session-2026",
-                      "query": "Braintrust Flue reasoning stream instrumentation"
-                    },
-                    "id": "<span:1>",
-                    "name": "web_search",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "anthropic-messages",
-                "flue.model": "claude-sonnet-4-5-20250929",
-                "flue.provider": "anthropic",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "claude-sonnet-4-5-20250929",
-                "provider": "anthropic"
-              },
-              "metrics": {
-                "completion_tokens": 158,
-                "duration_ms": 0,
-                "estimated_cost": 0.0039606,
-                "prompt_cache_creation_tokens": 236,
-                "prompt_cached_tokens": 2222,
-                "prompt_tokens": 13,
-                "tokens": 2629
-              }
-            },
-            {
-              "name": "tool:web_search",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "lookupId": "flue-session-2026",
-                "query": "Braintrust Flue reasoning stream instrumentation"
-              },
-              "output": {
-                "content": [
-                  {
-                    "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-                    "type": "text"
-                  }
-                ],
-                "details": {
-                  "customTool": "web_search"
-                }
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "web_search",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-                      "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-                      "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "Now proceeding to Step 2:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "lookupId": "flue-session-2026",
-                        "query": "Braintrust Flue reasoning stream instrumentation"
-                      },
-                      "id": "<span:2>",
-                      "name": "web_search",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:2>",
-                  "toolName": "web_search"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
-                    "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
-                    "type": "thinking"
-                  },
-                  {
-                    "text": "Now proceeding to Step 3:",
-                    "type": "text"
-                  },
-                  {
-                    "arguments": {
-                      "url": "https://example.test/flue/reasoning-streams"
-                    },
-                    "id": "<span:1>",
-                    "name": "summarize_source",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "anthropic-messages",
-                "flue.model": "claude-sonnet-4-5-20250929",
-                "flue.provider": "anthropic",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "claude-sonnet-4-5-20250929",
-                "provider": "anthropic"
-              },
-              "metrics": {
-                "completion_tokens": 138,
-                "duration_ms": 0,
-                "estimated_cost": 0.0037239000000000005,
-                "prompt_cache_creation_tokens": 234,
-                "prompt_cached_tokens": 2458,
-                "prompt_tokens": 13,
-                "tokens": 2843
-              }
-            },
-            {
-              "name": "tool:summarize_source",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "url": "https://example.test/flue/reasoning-streams"
-              },
-              "output": {
-                "content": [
-                  {
-                    "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-                    "type": "text"
-                  }
-                ],
-                "details": {
-                  "customTool": "summarize_source"
-                }
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "summarize_source",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-                      "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-                      "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "Now proceeding to Step 2:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "lookupId": "flue-session-2026",
-                        "query": "Braintrust Flue reasoning stream instrumentation"
-                      },
-                      "id": "<span:2>",
-                      "name": "web_search",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:2>",
-                  "toolName": "web_search"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
-                      "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "Now proceeding to Step 3:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "url": "https://example.test/flue/reasoning-streams"
-                      },
-                      "id": "<span:3>",
-                      "name": "summarize_source",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:3>",
-                  "toolName": "summarize_source"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "thinking": "Perfect! The summarize_source call has completed successfully. According to the instructions, I should now reply with exactly \"PROMPT_DONE\" and no other text.",
-                    "thinkingSignature": "Eu8CCm4IDhgCKkAn2QOIIlYfvcs6ynsmhCslHDtBsrTA4CfmimK7zyz6+k6dZldV2JBtEBET41It0gFcGEKC0n0mAhaYVuLutpDDMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIM1xfLptxSF8rKzou8GgwRLuVmfiBYOT4CZIsiMAYz8TpvchMAWodP+T9uZ+dJ47MVdNv+p86nZXmT5d5EWlCroiAOFHHzJH2o0UjJQSquAX6wu+jIC8/DXwurGIIf2ToldPuJWF5HGj8kHMnwh777XS1NUFl1irM24rvP7kTAv3Dp8YEwb8t3g1EsicY7j+C5DzgwxVsPYCVOCgdMqQjtsqpL7AX5KQ9+hR1gK1DQjshv4Gze3hw/+C+9iptd3RlDIuwO0cm8NY+sVqeWVh3TtQujQlVt1rW/HfWjclrtT0LZSGwc6RypmfMMQi6lncIk/EPgy0XbS1plKW0tLBgB",
-                    "type": "thinking"
-                  },
-                  {
-                    "text": "PROMPT_DONE",
-                    "type": "text"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "anthropic-messages",
-                "flue.model": "claude-sonnet-4-5-20250929",
-                "flue.provider": "anthropic",
-                "flue.session": "main",
-                "flue.stop_reason": "stop",
-                "flue.turn_purpose": "agent",
-                "model": "claude-sonnet-4-5-20250929",
-                "provider": "anthropic"
-              },
-              "metrics": {
-                "completion_tokens": 51,
-                "duration_ms": 0,
-                "estimated_cost": 0.0023391,
-                "prompt_cache_creation_tokens": 194,
-                "prompt_cached_tokens": 2692,
-                "prompt_tokens": 13,
-                "tokens": 2950
-              }
-            }
-          ],
-          "input": [
-            {
-              "content": [
-                {
-                  "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                  "type": "text"
-                }
-              ],
-              "role": "user"
-            }
-          ],
-          "output": "PROMPT_DONE",
-          "metadata": {
-            "flue.operation": "prompt",
-            "flue.session": "main",
-            "provider": "flue"
-          },
-          "metrics": {
-            "duration_ms": 0
-          }
-        },
-        {
           "name": "flue.skill",
           "type": "task",
           "children": [
@@ -1383,7 +848,9 @@
           "metadata": {
             "flue.operation": "skill",
             "flue.session": "skill",
-            "provider": "flue"
+            "flue.workflow_name": "instrumentation",
+            "provider": "flue",
+            "scenario": "flue-instrumentation"
           },
           "metrics": {
             "duration_ms": 0
@@ -1420,6 +887,7 @@
               },
               "metadata": {
                 "flue.api": "openai-responses",
+                "flue.input_mode": "full",
                 "flue.model": "gpt-4o-mini",
                 "flue.provider": "openai",
                 "flue.session": "task:task:<uuid:1>",
@@ -1533,7 +1001,9 @@
           "metadata": {
             "flue.operation": "compact",
             "flue.session": "main",
-            "provider": "flue"
+            "flue.workflow_name": "instrumentation",
+            "provider": "flue",
+            "scenario": "flue-instrumentation"
           },
           "metrics": {
             "duration_ms": 0
@@ -1552,6 +1022,420 @@
         "status": "done"
       },
       "metadata": {
+        "flue.workflow_name": "instrumentation",
+        "provider": "flue",
+        "scenario": "flue-instrumentation"
+      },
+      "metrics": {
+        "duration_ms": 0
+      }
+    },
+    {
+      "name": "flue.prompt",
+      "type": "task",
+      "children": [
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+                  "type": "text"
+                }
+              ],
+              "role": "user"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
+                "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
+                "type": "thinking"
+              },
+              {
+                "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
+                "type": "text"
+              },
+              {
+                "arguments": {
+                  "query": "flue instrumentation"
+                },
+                "id": "<span:1>",
+                "name": "lookup",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "anthropic-messages",
+            "flue.input_mode": "full",
+            "flue.model": "claude-sonnet-4-5-20250929",
+            "flue.provider": "anthropic",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "claude-sonnet-4-5-20250929",
+            "provider": "anthropic"
+          },
+          "metrics": {
+            "completion_tokens": 196,
+            "duration_ms": 0,
+            "estimated_cost": 0.0113025,
+            "prompt_cache_creation_tokens": 2222,
+            "prompt_cached_tokens": 0,
+            "prompt_tokens": 10,
+            "tokens": 2428
+          }
+        },
+        {
+          "name": "tool:lookup",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "query": "flue instrumentation"
+          },
+          "output": {
+            "content": [
+              {
+                "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
+                "type": "text"
+              }
+            ],
+            "details": {
+              "customTool": "lookup"
+            }
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "lookup",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
+                  "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
+                  "type": "thinking"
+                },
+                {
+                  "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
+                  "type": "text"
+                },
+                {
+                  "arguments": {
+                    "query": "flue instrumentation"
+                  },
+                  "id": "<span:1>",
+                  "name": "lookup",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "lookup"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
+                "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
+                "type": "thinking"
+              },
+              {
+                "text": "Now proceeding to Step 2:",
+                "type": "text"
+              },
+              {
+                "arguments": {
+                  "lookupId": "flue-session-2026",
+                  "query": "Braintrust Flue reasoning stream instrumentation"
+                },
+                "id": "<span:1>",
+                "name": "web_search",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "anthropic-messages",
+            "flue.input_message_offset": 1,
+            "flue.input_mode": "delta",
+            "flue.model": "claude-sonnet-4-5-20250929",
+            "flue.provider": "anthropic",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "claude-sonnet-4-5-20250929",
+            "provider": "anthropic"
+          },
+          "metrics": {
+            "completion_tokens": 158,
+            "duration_ms": 0,
+            "estimated_cost": 0.0039606,
+            "prompt_cache_creation_tokens": 236,
+            "prompt_cached_tokens": 2222,
+            "prompt_tokens": 13,
+            "tokens": 2629
+          }
+        },
+        {
+          "name": "tool:web_search",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "lookupId": "flue-session-2026",
+            "query": "Braintrust Flue reasoning stream instrumentation"
+          },
+          "output": {
+            "content": [
+              {
+                "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+                "type": "text"
+              }
+            ],
+            "details": {
+              "customTool": "web_search"
+            }
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "web_search",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
+                  "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
+                  "type": "thinking"
+                },
+                {
+                  "text": "Now proceeding to Step 2:",
+                  "type": "text"
+                },
+                {
+                  "arguments": {
+                    "lookupId": "flue-session-2026",
+                    "query": "Braintrust Flue reasoning stream instrumentation"
+                  },
+                  "id": "<span:1>",
+                  "name": "web_search",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "web_search"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
+                "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
+                "type": "thinking"
+              },
+              {
+                "text": "Now proceeding to Step 3:",
+                "type": "text"
+              },
+              {
+                "arguments": {
+                  "url": "https://example.test/flue/reasoning-streams"
+                },
+                "id": "<span:1>",
+                "name": "summarize_source",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "anthropic-messages",
+            "flue.input_message_offset": 3,
+            "flue.input_mode": "delta",
+            "flue.model": "claude-sonnet-4-5-20250929",
+            "flue.provider": "anthropic",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "claude-sonnet-4-5-20250929",
+            "provider": "anthropic"
+          },
+          "metrics": {
+            "completion_tokens": 138,
+            "duration_ms": 0,
+            "estimated_cost": 0.0037239000000000005,
+            "prompt_cache_creation_tokens": 234,
+            "prompt_cached_tokens": 2458,
+            "prompt_tokens": 13,
+            "tokens": 2843
+          }
+        },
+        {
+          "name": "tool:summarize_source",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "url": "https://example.test/flue/reasoning-streams"
+          },
+          "output": {
+            "content": [
+              {
+                "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+                "type": "text"
+              }
+            ],
+            "details": {
+              "customTool": "summarize_source"
+            }
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "summarize_source",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
+                  "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
+                  "type": "thinking"
+                },
+                {
+                  "text": "Now proceeding to Step 3:",
+                  "type": "text"
+                },
+                {
+                  "arguments": {
+                    "url": "https://example.test/flue/reasoning-streams"
+                  },
+                  "id": "<span:1>",
+                  "name": "summarize_source",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "summarize_source"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "thinking": "Perfect! The summarize_source call has completed successfully. According to the instructions, I should now reply with exactly \"PROMPT_DONE\" and no other text.",
+                "thinkingSignature": "Eu8CCm4IDhgCKkAn2QOIIlYfvcs6ynsmhCslHDtBsrTA4CfmimK7zyz6+k6dZldV2JBtEBET41It0gFcGEKC0n0mAhaYVuLutpDDMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIM1xfLptxSF8rKzou8GgwRLuVmfiBYOT4CZIsiMAYz8TpvchMAWodP+T9uZ+dJ47MVdNv+p86nZXmT5d5EWlCroiAOFHHzJH2o0UjJQSquAX6wu+jIC8/DXwurGIIf2ToldPuJWF5HGj8kHMnwh777XS1NUFl1irM24rvP7kTAv3Dp8YEwb8t3g1EsicY7j+C5DzgwxVsPYCVOCgdMqQjtsqpL7AX5KQ9+hR1gK1DQjshv4Gze3hw/+C+9iptd3RlDIuwO0cm8NY+sVqeWVh3TtQujQlVt1rW/HfWjclrtT0LZSGwc6RypmfMMQi6lncIk/EPgy0XbS1plKW0tLBgB",
+                "type": "thinking"
+              },
+              {
+                "text": "PROMPT_DONE",
+                "type": "text"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "anthropic-messages",
+            "flue.input_message_offset": 5,
+            "flue.input_mode": "delta",
+            "flue.model": "claude-sonnet-4-5-20250929",
+            "flue.provider": "anthropic",
+            "flue.session": "main",
+            "flue.stop_reason": "stop",
+            "flue.turn_purpose": "agent",
+            "model": "claude-sonnet-4-5-20250929",
+            "provider": "anthropic"
+          },
+          "metrics": {
+            "completion_tokens": 51,
+            "duration_ms": 0,
+            "estimated_cost": 0.0023391,
+            "prompt_cache_creation_tokens": 194,
+            "prompt_cached_tokens": 2692,
+            "prompt_tokens": 13,
+            "tokens": 2950
+          }
+        }
+      ],
+      "input": [
+        {
+          "content": [
+            {
+              "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+              "type": "text"
+            }
+          ],
+          "role": "user"
+        }
+      ],
+      "output": "PROMPT_DONE",
+      "metadata": {
+        "flue.operation": "prompt",
+        "flue.session": "main",
         "flue.workflow_name": "instrumentation",
         "provider": "flue",
         "scenario": "flue-instrumentation"

--- a/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-0-auto-hook.span-tree.txt
+++ b/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-0-auto-hook.span-tree.txt
@@ -1,17 +1,973 @@
 span_tree:
-└── workflow:instrumentation [task]
-    input: {
-      "metadata": {
-        "scenario": "flue-instrumentation",
-        "testRunId": "<run:1>"
-      },
-      "scenario": "flue-instrumentation"
-    }
-    output: {
-      "scenario": "flue-instrumentation",
-      "status": "done"
-    }
+├── workflow:instrumentation [task]
+│   input: {
+│     "metadata": {
+│       "scenario": "flue-instrumentation",
+│       "testRunId": "<run:1>"
+│     },
+│     "scenario": "flue-instrumentation"
+│   }
+│   output: {
+│     "scenario": "flue-instrumentation",
+│     "status": "done"
+│   }
+│   metadata: {
+│     "flue.workflow_name": "instrumentation",
+│     "provider": "flue",
+│     "scenario": "flue-instrumentation"
+│   }
+│   metrics: {
+│     "duration_ms": 0
+│   }
+│   ├── flue.skill [task]
+│   │   input: [
+│   │     {
+│   │       "content": [
+│   │         {
+│   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │           "type": "text"
+│   │         }
+│   │       ],
+│   │       "role": "user"
+│   │     }
+│   │   ]
+│   │   output: "SKILL_DONE"
+│   │   metadata: {
+│   │     "flue.operation": "skill",
+│   │     "flue.session": "skill",
+│   │     "flue.workflow_name": "instrumentation",
+│   │     "provider": "flue",
+│   │     "scenario": "flue-instrumentation"
+│   │   }
+│   │   metrics: {
+│   │     "duration_ms": 0
+│   │   }
+│   │   ├── flue.turn [llm]
+│   │   │   input: [
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "user"
+│   │   │     }
+│   │   │   ]
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
+│   │   │         "type": "text"
+│   │   │       },
+│   │   │       {
+│   │   │         "arguments": {
+│   │   │           "path": ".agents/e2e-flue-skill.md"
+│   │   │         },
+│   │   │         "id": "<span:1>",
+│   │   │         "name": "read",
+│   │   │         "type": "toolCall"
+│   │   │       }
+│   │   │     ],
+│   │   │     "role": "assistant"
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.api": "anthropic-messages",
+│   │   │     "flue.model": "claude-sonnet-4-5-20250929",
+│   │   │     "flue.provider": "anthropic",
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.stop_reason": "toolUse",
+│   │   │     "flue.turn_purpose": "agent",
+│   │   │     "model": "claude-sonnet-4-5-20250929",
+│   │   │     "provider": "anthropic"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "completion_tokens": 89,
+│   │   │     "duration_ms": 0,
+│   │   │     "estimated_cost": 0.0041862,
+│   │   │     "prompt_cache_creation_tokens": 670,
+│   │   │     "prompt_cached_tokens": 1099,
+│   │   │     "prompt_tokens": 3,
+│   │   │     "tokens": 1861
+│   │   │   }
+│   │   ├── tool:read [tool]
+│   │   │   input: {
+│   │   │     "path": ".agents/e2e-flue-skill.md"
+│   │   │   }
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
+│   │   │         "type": "text"
+│   │   │       }
+│   │   │     ],
+│   │   │     "details": {}
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.tool_name": "read",
+│   │   │     "provider": "flue"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "duration_ms": 0
+│   │   │   }
+│   │   │   error: "{\"content\":[{\"type\":\"text\",\"text\":\"ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'\"}],\"details\":{}}"
+│   │   ├── flue.turn [llm]
+│   │   │   input: [
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "user"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
+│   │   │           "type": "text"
+│   │   │         },
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents/e2e-flue-skill.md"
+│   │   │           },
+│   │   │           "id": "<span:1>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": true,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:1>",
+│   │   │       "toolName": "read"
+│   │   │     }
+│   │   │   ]
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "arguments": {
+│   │   │           "path": ".agents"
+│   │   │         },
+│   │   │         "id": "<span:1>",
+│   │   │         "name": "read",
+│   │   │         "type": "toolCall"
+│   │   │       }
+│   │   │     ],
+│   │   │     "role": "assistant"
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.api": "anthropic-messages",
+│   │   │     "flue.model": "claude-sonnet-4-5-20250929",
+│   │   │     "flue.provider": "anthropic",
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.stop_reason": "toolUse",
+│   │   │     "flue.turn_purpose": "agent",
+│   │   │     "model": "claude-sonnet-4-5-20250929",
+│   │   │     "provider": "anthropic"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "completion_tokens": 52,
+│   │   │     "duration_ms": 0,
+│   │   │     "estimated_cost": 0.00201795,
+│   │   │     "prompt_cache_creation_tokens": 183,
+│   │   │     "prompt_cached_tokens": 1769,
+│   │   │     "prompt_tokens": 7,
+│   │   │     "tokens": 2011
+│   │   │   }
+│   │   ├── tool:read [tool]
+│   │   │   input: {
+│   │   │     "path": ".agents"
+│   │   │   }
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "text": "skills",
+│   │   │         "type": "text"
+│   │   │       }
+│   │   │     ],
+│   │   │     "details": {
+│   │   │       "entries": 1,
+│   │   │       "isDirectory": true,
+│   │   │       "path": ".agents"
+│   │   │     }
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.tool_name": "read",
+│   │   │     "provider": "flue"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "duration_ms": 0
+│   │   │   }
+│   │   ├── flue.turn [llm]
+│   │   │   input: [
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "user"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
+│   │   │           "type": "text"
+│   │   │         },
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents/e2e-flue-skill.md"
+│   │   │           },
+│   │   │           "id": "<span:1>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": true,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:1>",
+│   │   │       "toolName": "read"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents"
+│   │   │           },
+│   │   │           "id": "<span:2>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "skills",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": false,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:2>",
+│   │   │       "toolName": "read"
+│   │   │     }
+│   │   │   ]
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "arguments": {
+│   │   │           "path": ".agents/skills"
+│   │   │         },
+│   │   │         "id": "<span:1>",
+│   │   │         "name": "read",
+│   │   │         "type": "toolCall"
+│   │   │       }
+│   │   │     ],
+│   │   │     "role": "assistant"
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.api": "anthropic-messages",
+│   │   │     "flue.model": "claude-sonnet-4-5-20250929",
+│   │   │     "flue.provider": "anthropic",
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.stop_reason": "toolUse",
+│   │   │     "flue.turn_purpose": "agent",
+│   │   │     "model": "claude-sonnet-4-5-20250929",
+│   │   │     "provider": "anthropic"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "completion_tokens": 54,
+│   │   │     "duration_ms": 0,
+│   │   │     "estimated_cost": 0.0016611,
+│   │   │     "prompt_cache_creation_tokens": 66,
+│   │   │     "prompt_cached_tokens": 1952,
+│   │   │     "prompt_tokens": 6,
+│   │   │     "tokens": 2078
+│   │   │   }
+│   │   ├── tool:read [tool]
+│   │   │   input: {
+│   │   │     "path": ".agents/skills"
+│   │   │   }
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "text": "e2e-flue-skill",
+│   │   │         "type": "text"
+│   │   │       }
+│   │   │     ],
+│   │   │     "details": {
+│   │   │       "entries": 1,
+│   │   │       "isDirectory": true,
+│   │   │       "path": ".agents/skills"
+│   │   │     }
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.tool_name": "read",
+│   │   │     "provider": "flue"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "duration_ms": 0
+│   │   │   }
+│   │   ├── flue.turn [llm]
+│   │   │   input: [
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "user"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
+│   │   │           "type": "text"
+│   │   │         },
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents/e2e-flue-skill.md"
+│   │   │           },
+│   │   │           "id": "<span:1>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": true,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:1>",
+│   │   │       "toolName": "read"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents"
+│   │   │           },
+│   │   │           "id": "<span:2>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "skills",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": false,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:2>",
+│   │   │       "toolName": "read"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents/skills"
+│   │   │           },
+│   │   │           "id": "<span:3>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "e2e-flue-skill",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": false,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:3>",
+│   │   │       "toolName": "read"
+│   │   │     }
+│   │   │   ]
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "arguments": {
+│   │   │           "path": ".agents/skills/e2e-flue-skill"
+│   │   │         },
+│   │   │         "id": "<span:1>",
+│   │   │         "name": "read",
+│   │   │         "type": "toolCall"
+│   │   │       }
+│   │   │     ],
+│   │   │     "role": "assistant"
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.api": "anthropic-messages",
+│   │   │     "flue.model": "claude-sonnet-4-5-20250929",
+│   │   │     "flue.provider": "anthropic",
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.stop_reason": "toolUse",
+│   │   │     "flue.turn_purpose": "agent",
+│   │   │     "model": "claude-sonnet-4-5-20250929",
+│   │   │     "provider": "anthropic"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "completion_tokens": 63,
+│   │   │     "duration_ms": 0,
+│   │   │     "estimated_cost": 0.0018459,
+│   │   │     "prompt_cache_creation_tokens": 74,
+│   │   │     "prompt_cached_tokens": 2018,
+│   │   │     "prompt_tokens": 6,
+│   │   │     "tokens": 2161
+│   │   │   }
+│   │   ├── tool:read [tool]
+│   │   │   input: {
+│   │   │     "path": ".agents/skills/e2e-flue-skill"
+│   │   │   }
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "text": "SKILL.md",
+│   │   │         "type": "text"
+│   │   │       }
+│   │   │     ],
+│   │   │     "details": {
+│   │   │       "entries": 1,
+│   │   │       "isDirectory": true,
+│   │   │       "path": ".agents/skills/e2e-flue-skill"
+│   │   │     }
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.tool_name": "read",
+│   │   │     "provider": "flue"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "duration_ms": 0
+│   │   │   }
+│   │   ├── flue.turn [llm]
+│   │   │   input: [
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "user"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
+│   │   │           "type": "text"
+│   │   │         },
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents/e2e-flue-skill.md"
+│   │   │           },
+│   │   │           "id": "<span:1>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": true,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:1>",
+│   │   │       "toolName": "read"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents"
+│   │   │           },
+│   │   │           "id": "<span:2>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "skills",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": false,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:2>",
+│   │   │       "toolName": "read"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents/skills"
+│   │   │           },
+│   │   │           "id": "<span:3>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "e2e-flue-skill",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": false,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:3>",
+│   │   │       "toolName": "read"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents/skills/e2e-flue-skill"
+│   │   │           },
+│   │   │           "id": "<span:4>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "SKILL.md",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": false,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:4>",
+│   │   │       "toolName": "read"
+│   │   │     }
+│   │   │   ]
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "arguments": {
+│   │   │           "path": ".agents/skills/e2e-flue-skill/SKILL.md"
+│   │   │         },
+│   │   │         "id": "<span:1>",
+│   │   │         "name": "read",
+│   │   │         "type": "toolCall"
+│   │   │       }
+│   │   │     ],
+│   │   │     "role": "assistant"
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.api": "anthropic-messages",
+│   │   │     "flue.model": "claude-sonnet-4-5-20250929",
+│   │   │     "flue.provider": "anthropic",
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.stop_reason": "toolUse",
+│   │   │     "flue.turn_purpose": "agent",
+│   │   │     "model": "claude-sonnet-4-5-20250929",
+│   │   │     "provider": "anthropic"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "completion_tokens": 68,
+│   │   │     "duration_ms": 0,
+│   │   │     "estimated_cost": 0.0019618500000000002,
+│   │   │     "prompt_cache_creation_tokens": 79,
+│   │   │     "prompt_cached_tokens": 2092,
+│   │   │     "prompt_tokens": 6,
+│   │   │     "tokens": 2245
+│   │   │   }
+│   │   ├── tool:read [tool]
+│   │   │   input: {
+│   │   │     "path": ".agents/skills/e2e-flue-skill/SKILL.md"
+│   │   │   }
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
+│   │   │         "type": "text"
+│   │   │       }
+│   │   │     ],
+│   │   │     "details": {
+│   │   │       "lines": 7,
+│   │   │       "path": ".agents/skills/e2e-flue-skill/SKILL.md"
+│   │   │     }
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.tool_name": "read",
+│   │   │     "provider": "flue"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "duration_ms": 0
+│   │   │   }
+│   │   └── flue.turn [llm]
+│   │       input: [
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "role": "user"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
+│   │               "type": "text"
+│   │             },
+│   │             {
+│   │               "arguments": {
+│   │                 "path": ".agents/e2e-flue-skill.md"
+│   │               },
+│   │               "id": "<span:1>",
+│   │               "name": "read",
+│   │               "type": "toolCall"
+│   │             }
+│   │           ],
+│   │           "role": "assistant"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "isError": true,
+│   │           "role": "toolResult",
+│   │           "toolCallId": "<span:1>",
+│   │           "toolName": "read"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "arguments": {
+│   │                 "path": ".agents"
+│   │               },
+│   │               "id": "<span:2>",
+│   │               "name": "read",
+│   │               "type": "toolCall"
+│   │             }
+│   │           ],
+│   │           "role": "assistant"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "skills",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "isError": false,
+│   │           "role": "toolResult",
+│   │           "toolCallId": "<span:2>",
+│   │           "toolName": "read"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "arguments": {
+│   │                 "path": ".agents/skills"
+│   │               },
+│   │               "id": "<span:3>",
+│   │               "name": "read",
+│   │               "type": "toolCall"
+│   │             }
+│   │           ],
+│   │           "role": "assistant"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "e2e-flue-skill",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "isError": false,
+│   │           "role": "toolResult",
+│   │           "toolCallId": "<span:3>",
+│   │           "toolName": "read"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "arguments": {
+│   │                 "path": ".agents/skills/e2e-flue-skill"
+│   │               },
+│   │               "id": "<span:4>",
+│   │               "name": "read",
+│   │               "type": "toolCall"
+│   │             }
+│   │           ],
+│   │           "role": "assistant"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "SKILL.md",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "isError": false,
+│   │           "role": "toolResult",
+│   │           "toolCallId": "<span:4>",
+│   │           "toolName": "read"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "arguments": {
+│   │                 "path": ".agents/skills/e2e-flue-skill/SKILL.md"
+│   │               },
+│   │               "id": "<span:5>",
+│   │               "name": "read",
+│   │               "type": "toolCall"
+│   │             }
+│   │           ],
+│   │           "role": "assistant"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "isError": false,
+│   │           "role": "toolResult",
+│   │           "toolCallId": "<span:5>",
+│   │           "toolName": "read"
+│   │         }
+│   │       ]
+│   │       output: {
+│   │         "content": [
+│   │           {
+│   │             "text": "SKILL_DONE",
+│   │             "type": "text"
+│   │           }
+│   │         ],
+│   │         "role": "assistant"
+│   │       }
+│   │       metadata: {
+│   │         "flue.api": "anthropic-messages",
+│   │         "flue.model": "claude-sonnet-4-5-20250929",
+│   │         "flue.provider": "anthropic",
+│   │         "flue.session": "skill",
+│   │         "flue.stop_reason": "stop",
+│   │         "flue.turn_purpose": "agent",
+│   │         "model": "claude-sonnet-4-5-20250929",
+│   │         "provider": "anthropic"
+│   │       }
+│   │       metrics: {
+│   │         "completion_tokens": 8,
+│   │         "duration_ms": 0,
+│   │         "estimated_cost": 0.00129555,
+│   │         "prompt_cache_creation_tokens": 135,
+│   │         "prompt_cached_tokens": 2171,
+│   │         "prompt_tokens": 6,
+│   │         "tokens": 2320
+│   │       }
+│   ├── flue.task [task]
+│   │   input: "Reply with exactly TASK_DONE and no other text."
+│   │   output: "TASK_DONE"
+│   │   metadata: {
+│   │     "flue.session": "task",
+│   │     "provider": "flue"
+│   │   }
+│   │   metrics: {
+│   │     "duration_ms": 0
+│   │   }
+│   │   └── flue.turn [llm]
+│   │       input: [
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "Reply with exactly TASK_DONE and no other text.",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "role": "user"
+│   │         }
+│   │       ]
+│   │       output: {
+│   │         "content": [
+│   │           {
+│   │             "text": "TASK_DONE",
+│   │             "textSignature": "{\"v\":1,\"id\":\"msg_09b32b2821e9a4d8016a184600019081929d34bb7d4c6a246f\"}",
+│   │             "type": "text"
+│   │           }
+│   │         ],
+│   │         "role": "assistant"
+│   │       }
+│   │       metadata: {
+│   │         "flue.api": "openai-responses",
+│   │         "flue.input_mode": "full",
+│   │         "flue.model": "gpt-4o-mini",
+│   │         "flue.provider": "openai",
+│   │         "flue.session": "task:task:<uuid:1>",
+│   │         "flue.stop_reason": "stop",
+│   │         "flue.turn_purpose": "agent",
+│   │         "model": "gpt-4o-mini",
+│   │         "provider": "openai"
+│   │       }
+│   │       metrics: {
+│   │         "completion_tokens": 4,
+│   │         "duration_ms": 0,
+│   │         "estimated_cost": 0.00012299999999999998,
+│   │         "prompt_cache_creation_tokens": 0,
+│   │         "prompt_cached_tokens": 0,
+│   │         "prompt_tokens": 804,
+│   │         "tokens": 808
+│   │       }
+│   └── flue.compact [task]
+│       input: {
+│         "estimatedTokens": 2950,
+│         "reason": "manual"
+│       }
+│       output: {
+│         "completed": true
+│       }
+│       metadata: {
+│         "flue.operation": "compact",
+│         "flue.session": "main",
+│         "flue.workflow_name": "instrumentation",
+│         "provider": "flue",
+│         "scenario": "flue-instrumentation"
+│       }
+│       metrics: {
+│         "duration_ms": 0
+│       }
+│       └── compaction:manual [task]
+│           input: {
+│             "estimatedTokens": 2950,
+│             "reason": "manual"
+│           }
+│           output: {
+│             "messagesAfter": 2,
+│             "messagesBefore": 8
+│           }
+│           metadata: {
+│             "flue.compaction_reason": "manual",
+│             "flue.session": "main",
+│             "provider": "flue"
+│           }
+│           metrics: {
+│             "duration_ms": 0,
+│             "messages_after": 2,
+│             "messages_before": 8
+│           }
+│           └── flue.turn [llm]
+│               input: [
+│                 {
+│                   "content": [
+│                     {
+│                       "text": "<conversation>\n[User]: Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.\n\n[Assistant thinking]: The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.\n\n[Assistant]: I'll complete this instrumented research flow step by step. Starting with Step 1:\n\n[Assistant tool calls]: lookup(query=\"flue instrumentation\")\n\n[Tool result]: {\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}\n\n[Assistant thinking]: Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".\n\n[Assistant]: Now proceeding to Step 2:\n\n[Assistant tool calls]: web_search(lookupId=\"flue-session-2026\", query=\"Braintrust Flue reasoning stream instrumentation\")\n\n[Tool result]: {\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}\n\n[Assistant thinking]: Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.\n\n[Assistant]: Now proceeding to Step 3:\n\n[Assistant tool calls]: summarize_source(url=\"https://example.test/flue/reasoning-streams\")\n\n[Tool result]: {\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}\n</conversation>\n\nThis is the PREFIX of a turn that was too large to keep. The SUFFIX (recent work) is retained.\n\nSummarize the prefix to provide context for the retained suffix:\n\n## Original Request\n[What did the user ask for in this turn?]\n\n## Early Progress\n- [Key decisions and work done in the prefix]\n\n## Context for Suffix\n- [Information needed to understand the retained recent work]\n\nBe concise. Focus on what's needed to understand the kept suffix.",
+│                       "type": "text"
+│                     }
+│                   ],
+│                   "role": "user"
+│                 }
+│               ]
+│               output: {
+│                 "content": [
+│                   {
+│                     "text": "## Original Request\nThe user requested to complete an instrumented research flow consisting of three specific steps, involving calling various tools in a sequential manner.\n\n## Early Progress",
+│                     "textSignature": "{\"v\":1,\"id\":\"msg_01ecf68325f9e202016a184601309081a0878ef4054e950d32\"}",
+│                     "type": "text"
+│                   }
+│                 ],
+│                 "role": "assistant"
+│               }
+│               metadata: {
+│                 "flue.api": "openai-responses",
+│                 "flue.model": "gpt-4o-mini",
+│                 "flue.provider": "openai",
+│                 "flue.session": "main",
+│                 "flue.stop_reason": "stop",
+│                 "flue.turn_purpose": "compaction_prefix",
+│                 "model": "gpt-4o-mini",
+│                 "provider": "openai"
+│               }
+│               metrics: {
+│                 "completion_tokens": 0,
+│                 "duration_ms": 0,
+│                 "estimated_cost": 0,
+│                 "prompt_cache_creation_tokens": 0,
+│                 "prompt_cached_tokens": 0,
+│                 "prompt_tokens": 0,
+│                 "tokens": 0
+│               }
+└── flue.prompt [task]
+    input: [
+      {
+        "content": [
+          {
+            "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+            "type": "text"
+          }
+        ],
+        "role": "user"
+      }
+    ]
+    output: "PROMPT_DONE"
     metadata: {
+      "flue.operation": "prompt",
+      "flue.session": "main",
       "flue.workflow_name": "instrumentation",
       "provider": "flue",
       "scenario": "flue-instrumentation"
@@ -19,7 +975,7 @@ span_tree:
     metrics: {
       "duration_ms": 0
     }
-    ├── flue.prompt [task]
+    ├── flue.turn [llm]
     │   input: [
     │     {
     │       "content": [
@@ -31,1421 +987,349 @@ span_tree:
     │       "role": "user"
     │     }
     │   ]
-    │   output: "PROMPT_DONE"
+    │   output: {
+    │     "content": [
+    │       {
+    │         "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
+    │         "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
+    │         "type": "thinking"
+    │       },
+    │       {
+    │         "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
+    │         "type": "text"
+    │       },
+    │       {
+    │         "arguments": {
+    │           "query": "flue instrumentation"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "lookup",
+    │         "type": "toolCall"
+    │       }
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.operation": "prompt",
+    │     "flue.api": "anthropic-messages",
+    │     "flue.input_mode": "full",
+    │     "flue.model": "claude-sonnet-4-5-20250929",
+    │     "flue.provider": "anthropic",
     │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "claude-sonnet-4-5-20250929",
+    │     "provider": "anthropic"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 196,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.0113025,
+    │     "prompt_cache_creation_tokens": 2222,
+    │     "prompt_cached_tokens": 0,
+    │     "prompt_tokens": 10,
+    │     "tokens": 2428
+    │   }
+    ├── tool:lookup [tool]
+    │   input: {
+    │     "query": "flue instrumentation"
+    │   }
+    │   output: {
+    │     "content": [
+    │       {
+    │         "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
+    │         "type": "text"
+    │       }
+    │     ],
+    │     "details": {
+    │       "customTool": "lookup"
+    │     }
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "lookup",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-    │   │         "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-    │   │         "type": "thinking"
-    │   │       },
-    │   │       {
-    │   │         "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-    │   │         "type": "text"
-    │   │       },
-    │   │       {
-    │   │         "arguments": {
-    │   │           "query": "flue instrumentation"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "lookup",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 196,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0113025,
-    │   │     "prompt_cache_creation_tokens": 2222,
-    │   │     "prompt_cached_tokens": 0,
-    │   │     "prompt_tokens": 10,
-    │   │     "tokens": 2428
-    │   │   }
-    │   ├── tool:lookup [tool]
-    │   │   input: {
-    │   │     "query": "flue instrumentation"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "customTool": "lookup"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "lookup",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-    │   │           "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-    │   │           "type": "thinking"
-    │   │         },
-    │   │         {
-    │   │           "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "query": "flue instrumentation"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "lookup",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "lookup"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-    │   │         "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
-    │   │         "type": "thinking"
-    │   │       },
-    │   │       {
-    │   │         "text": "Now proceeding to Step 2:",
-    │   │         "type": "text"
-    │   │       },
-    │   │       {
-    │   │         "arguments": {
-    │   │           "lookupId": "flue-session-2026",
-    │   │           "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "web_search",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 158,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0039606,
-    │   │     "prompt_cache_creation_tokens": 236,
-    │   │     "prompt_cached_tokens": 2222,
-    │   │     "prompt_tokens": 13,
-    │   │     "tokens": 2629
-    │   │   }
-    │   ├── tool:web_search [tool]
-    │   │   input: {
-    │   │     "lookupId": "flue-session-2026",
-    │   │     "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "customTool": "web_search"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "web_search",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-    │   │           "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-    │   │           "type": "thinking"
-    │   │         },
-    │   │         {
-    │   │           "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "query": "flue instrumentation"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "lookup",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "lookup"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-    │   │           "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
-    │   │           "type": "thinking"
-    │   │         },
-    │   │         {
-    │   │           "text": "Now proceeding to Step 2:",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "lookupId": "flue-session-2026",
-    │   │             "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │           },
-    │   │           "id": "<span:2>",
-    │   │           "name": "web_search",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:2>",
-    │   │       "toolName": "web_search"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
-    │   │         "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
-    │   │         "type": "thinking"
-    │   │       },
-    │   │       {
-    │   │         "text": "Now proceeding to Step 3:",
-    │   │         "type": "text"
-    │   │       },
-    │   │       {
-    │   │         "arguments": {
-    │   │           "url": "https://example.test/flue/reasoning-streams"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "summarize_source",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 138,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0037239000000000005,
-    │   │     "prompt_cache_creation_tokens": 234,
-    │   │     "prompt_cached_tokens": 2458,
-    │   │     "prompt_tokens": 13,
-    │   │     "tokens": 2843
-    │   │   }
-    │   ├── tool:summarize_source [tool]
-    │   │   input: {
-    │   │     "url": "https://example.test/flue/reasoning-streams"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "customTool": "summarize_source"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "summarize_source",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   └── flue.turn [llm]
-    │       input: [
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-    │               "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-    │               "type": "thinking"
-    │             },
-    │             {
-    │               "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-    │               "type": "text"
-    │             },
-    │             {
-    │               "arguments": {
-    │                 "query": "flue instrumentation"
-    │               },
-    │               "id": "<span:1>",
-    │               "name": "lookup",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:1>",
-    │           "toolName": "lookup"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-    │               "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
-    │               "type": "thinking"
-    │             },
-    │             {
-    │               "text": "Now proceeding to Step 2:",
-    │               "type": "text"
-    │             },
-    │             {
-    │               "arguments": {
-    │                 "lookupId": "flue-session-2026",
-    │                 "query": "Braintrust Flue reasoning stream instrumentation"
-    │               },
-    │               "id": "<span:2>",
-    │               "name": "web_search",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:2>",
-    │           "toolName": "web_search"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
-    │               "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
-    │               "type": "thinking"
-    │             },
-    │             {
-    │               "text": "Now proceeding to Step 3:",
-    │               "type": "text"
-    │             },
-    │             {
-    │               "arguments": {
-    │                 "url": "https://example.test/flue/reasoning-streams"
-    │               },
-    │               "id": "<span:3>",
-    │               "name": "summarize_source",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:3>",
-    │           "toolName": "summarize_source"
-    │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "thinking": "Perfect! The summarize_source call has completed successfully. According to the instructions, I should now reply with exactly \"PROMPT_DONE\" and no other text.",
-    │             "thinkingSignature": "Eu8CCm4IDhgCKkAn2QOIIlYfvcs6ynsmhCslHDtBsrTA4CfmimK7zyz6+k6dZldV2JBtEBET41It0gFcGEKC0n0mAhaYVuLutpDDMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIM1xfLptxSF8rKzou8GgwRLuVmfiBYOT4CZIsiMAYz8TpvchMAWodP+T9uZ+dJ47MVdNv+p86nZXmT5d5EWlCroiAOFHHzJH2o0UjJQSquAX6wu+jIC8/DXwurGIIf2ToldPuJWF5HGj8kHMnwh777XS1NUFl1irM24rvP7kTAv3Dp8YEwb8t3g1EsicY7j+C5DzgwxVsPYCVOCgdMqQjtsqpL7AX5KQ9+hR1gK1DQjshv4Gze3hw/+C+9iptd3RlDIuwO0cm8NY+sVqeWVh3TtQujQlVt1rW/HfWjclrtT0LZSGwc6RypmfMMQi6lncIk/EPgy0XbS1plKW0tLBgB",
-    │             "type": "thinking"
-    │           },
-    │           {
-    │             "text": "PROMPT_DONE",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
-    │       }
-    │       metadata: {
-    │         "flue.api": "anthropic-messages",
-    │         "flue.model": "claude-sonnet-4-5-20250929",
-    │         "flue.provider": "anthropic",
-    │         "flue.session": "main",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "claude-sonnet-4-5-20250929",
-    │         "provider": "anthropic"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 51,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.0023391,
-    │         "prompt_cache_creation_tokens": 194,
-    │         "prompt_cached_tokens": 2692,
-    │         "prompt_tokens": 13,
-    │         "tokens": 2950
-    │       }
-    ├── flue.skill [task]
+    ├── flue.turn [llm]
     │   input: [
     │     {
     │       "content": [
     │         {
-    │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+    │           "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
+    │           "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
+    │           "type": "thinking"
+    │         },
+    │         {
+    │           "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
+    │           "type": "text"
+    │         },
+    │         {
+    │           "arguments": {
+    │             "query": "flue instrumentation"
+    │           },
+    │           "id": "<span:1>",
+    │           "name": "lookup",
+    │           "type": "toolCall"
+    │         }
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
     │           "type": "text"
     │         }
     │       ],
-    │       "role": "user"
+    │       "isError": false,
+    │       "role": "toolResult",
+    │       "toolCallId": "<span:1>",
+    │       "toolName": "lookup"
     │     }
     │   ]
-    │   output: "SKILL_DONE"
+    │   output: {
+    │     "content": [
+    │       {
+    │         "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
+    │         "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
+    │         "type": "thinking"
+    │       },
+    │       {
+    │         "text": "Now proceeding to Step 2:",
+    │         "type": "text"
+    │       },
+    │       {
+    │         "arguments": {
+    │           "lookupId": "flue-session-2026",
+    │           "query": "Braintrust Flue reasoning stream instrumentation"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "web_search",
+    │         "type": "toolCall"
+    │       }
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.operation": "skill",
-    │     "flue.session": "skill",
+    │     "flue.api": "anthropic-messages",
+    │     "flue.input_message_offset": 1,
+    │     "flue.input_mode": "delta",
+    │     "flue.model": "claude-sonnet-4-5-20250929",
+    │     "flue.provider": "anthropic",
+    │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "claude-sonnet-4-5-20250929",
+    │     "provider": "anthropic"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 158,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.0039606,
+    │     "prompt_cache_creation_tokens": 236,
+    │     "prompt_cached_tokens": 2222,
+    │     "prompt_tokens": 13,
+    │     "tokens": 2629
+    │   }
+    ├── tool:web_search [tool]
+    │   input: {
+    │     "lookupId": "flue-session-2026",
+    │     "query": "Braintrust Flue reasoning stream instrumentation"
+    │   }
+    │   output: {
+    │     "content": [
+    │       {
+    │         "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+    │         "type": "text"
+    │       }
+    │     ],
+    │     "details": {
+    │       "customTool": "web_search"
+    │     }
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "web_search",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
-    │   │         "type": "text"
-    │   │       },
-    │   │       {
-    │   │         "arguments": {
-    │   │           "path": ".agents/e2e-flue-skill.md"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "read",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "skill",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 89,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0041862,
-    │   │     "prompt_cache_creation_tokens": 670,
-    │   │     "prompt_cached_tokens": 1099,
-    │   │     "prompt_tokens": 3,
-    │   │     "tokens": 1861
-    │   │   }
-    │   ├── tool:read [tool]
-    │   │   input: {
-    │   │     "path": ".agents/e2e-flue-skill.md"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {}
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "skill",
-    │   │     "flue.tool_name": "read",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   │   error: "{\"content\":[{\"type\":\"text\",\"text\":\"ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'\"}],\"details\":{}}"
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents/e2e-flue-skill.md"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": true,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "read"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "path": ".agents"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "read",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "skill",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 52,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.00201795,
-    │   │     "prompt_cache_creation_tokens": 183,
-    │   │     "prompt_cached_tokens": 1769,
-    │   │     "prompt_tokens": 7,
-    │   │     "tokens": 2011
-    │   │   }
-    │   ├── tool:read [tool]
-    │   │   input: {
-    │   │     "path": ".agents"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "skills",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "entries": 1,
-    │   │       "isDirectory": true,
-    │   │       "path": ".agents"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "skill",
-    │   │     "flue.tool_name": "read",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents/e2e-flue-skill.md"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": true,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "read"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents"
-    │   │           },
-    │   │           "id": "<span:2>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "skills",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:2>",
-    │   │       "toolName": "read"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "path": ".agents/skills"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "read",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "skill",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 54,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0016611,
-    │   │     "prompt_cache_creation_tokens": 66,
-    │   │     "prompt_cached_tokens": 1952,
-    │   │     "prompt_tokens": 6,
-    │   │     "tokens": 2078
-    │   │   }
-    │   ├── tool:read [tool]
-    │   │   input: {
-    │   │     "path": ".agents/skills"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "e2e-flue-skill",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "entries": 1,
-    │   │       "isDirectory": true,
-    │   │       "path": ".agents/skills"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "skill",
-    │   │     "flue.tool_name": "read",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents/e2e-flue-skill.md"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": true,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "read"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents"
-    │   │           },
-    │   │           "id": "<span:2>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "skills",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:2>",
-    │   │       "toolName": "read"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents/skills"
-    │   │           },
-    │   │           "id": "<span:3>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "e2e-flue-skill",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:3>",
-    │   │       "toolName": "read"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "path": ".agents/skills/e2e-flue-skill"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "read",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "skill",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 63,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0018459,
-    │   │     "prompt_cache_creation_tokens": 74,
-    │   │     "prompt_cached_tokens": 2018,
-    │   │     "prompt_tokens": 6,
-    │   │     "tokens": 2161
-    │   │   }
-    │   ├── tool:read [tool]
-    │   │   input: {
-    │   │     "path": ".agents/skills/e2e-flue-skill"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "SKILL.md",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "entries": 1,
-    │   │       "isDirectory": true,
-    │   │       "path": ".agents/skills/e2e-flue-skill"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "skill",
-    │   │     "flue.tool_name": "read",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents/e2e-flue-skill.md"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": true,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "read"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents"
-    │   │           },
-    │   │           "id": "<span:2>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "skills",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:2>",
-    │   │       "toolName": "read"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents/skills"
-    │   │           },
-    │   │           "id": "<span:3>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "e2e-flue-skill",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:3>",
-    │   │       "toolName": "read"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents/skills/e2e-flue-skill"
-    │   │           },
-    │   │           "id": "<span:4>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "SKILL.md",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:4>",
-    │   │       "toolName": "read"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "path": ".agents/skills/e2e-flue-skill/SKILL.md"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "read",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "skill",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 68,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0019618500000000002,
-    │   │     "prompt_cache_creation_tokens": 79,
-    │   │     "prompt_cached_tokens": 2092,
-    │   │     "prompt_tokens": 6,
-    │   │     "tokens": 2245
-    │   │   }
-    │   ├── tool:read [tool]
-    │   │   input: {
-    │   │     "path": ".agents/skills/e2e-flue-skill/SKILL.md"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "lines": 7,
-    │   │       "path": ".agents/skills/e2e-flue-skill/SKILL.md"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "skill",
-    │   │     "flue.tool_name": "read",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   └── flue.turn [llm]
-    │       input: [
+    ├── flue.turn [llm]
+    │   input: [
+    │     {
+    │       "content": [
     │         {
-    │           "content": [
-    │             {
-    │               "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
+    │           "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
+    │           "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
+    │           "type": "thinking"
     │         },
     │         {
-    │           "content": [
-    │             {
-    │               "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
-    │               "type": "text"
-    │             },
-    │             {
-    │               "arguments": {
-    │                 "path": ".agents/e2e-flue-skill.md"
-    │               },
-    │               "id": "<span:1>",
-    │               "name": "read",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
+    │           "text": "Now proceeding to Step 2:",
+    │           "type": "text"
     │         },
     │         {
-    │           "content": [
-    │             {
-    │               "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": true,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:1>",
-    │           "toolName": "read"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "path": ".agents"
-    │               },
-    │               "id": "<span:2>",
-    │               "name": "read",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "skills",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:2>",
-    │           "toolName": "read"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "path": ".agents/skills"
-    │               },
-    │               "id": "<span:3>",
-    │               "name": "read",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "e2e-flue-skill",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:3>",
-    │           "toolName": "read"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "path": ".agents/skills/e2e-flue-skill"
-    │               },
-    │               "id": "<span:4>",
-    │               "name": "read",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "SKILL.md",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:4>",
-    │           "toolName": "read"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "path": ".agents/skills/e2e-flue-skill/SKILL.md"
-    │               },
-    │               "id": "<span:5>",
-    │               "name": "read",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:5>",
-    │           "toolName": "read"
+    │           "arguments": {
+    │             "lookupId": "flue-session-2026",
+    │             "query": "Braintrust Flue reasoning stream instrumentation"
+    │           },
+    │           "id": "<span:1>",
+    │           "name": "web_search",
+    │           "type": "toolCall"
     │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "text": "SKILL_DONE",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+    │           "type": "text"
+    │         }
+    │       ],
+    │       "isError": false,
+    │       "role": "toolResult",
+    │       "toolCallId": "<span:1>",
+    │       "toolName": "web_search"
+    │     }
+    │   ]
+    │   output: {
+    │     "content": [
+    │       {
+    │         "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
+    │         "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
+    │         "type": "thinking"
+    │       },
+    │       {
+    │         "text": "Now proceeding to Step 3:",
+    │         "type": "text"
+    │       },
+    │       {
+    │         "arguments": {
+    │           "url": "https://example.test/flue/reasoning-streams"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "summarize_source",
+    │         "type": "toolCall"
     │       }
-    │       metadata: {
-    │         "flue.api": "anthropic-messages",
-    │         "flue.model": "claude-sonnet-4-5-20250929",
-    │         "flue.provider": "anthropic",
-    │         "flue.session": "skill",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "claude-sonnet-4-5-20250929",
-    │         "provider": "anthropic"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 8,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.00129555,
-    │         "prompt_cache_creation_tokens": 135,
-    │         "prompt_cached_tokens": 2171,
-    │         "prompt_tokens": 6,
-    │         "tokens": 2320
-    │       }
-    ├── flue.task [task]
-    │   input: "Reply with exactly TASK_DONE and no other text."
-    │   output: "TASK_DONE"
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.session": "task",
+    │     "flue.api": "anthropic-messages",
+    │     "flue.input_message_offset": 3,
+    │     "flue.input_mode": "delta",
+    │     "flue.model": "claude-sonnet-4-5-20250929",
+    │     "flue.provider": "anthropic",
+    │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "claude-sonnet-4-5-20250929",
+    │     "provider": "anthropic"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 138,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.0037239000000000005,
+    │     "prompt_cache_creation_tokens": 234,
+    │     "prompt_cached_tokens": 2458,
+    │     "prompt_tokens": 13,
+    │     "tokens": 2843
+    │   }
+    ├── tool:summarize_source [tool]
+    │   input: {
+    │     "url": "https://example.test/flue/reasoning-streams"
+    │   }
+    │   output: {
+    │     "content": [
+    │       {
+    │         "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+    │         "type": "text"
+    │       }
+    │     ],
+    │     "details": {
+    │       "customTool": "summarize_source"
+    │     }
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "summarize_source",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   └── flue.turn [llm]
-    │       input: [
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "Reply with exactly TASK_DONE and no other text.",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
-    │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "text": "TASK_DONE",
-    │             "textSignature": "{\"v\":1,\"id\":\"msg_09b32b2821e9a4d8016a184600019081929d34bb7d4c6a246f\"}",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
-    │       }
-    │       metadata: {
-    │         "flue.api": "openai-responses",
-    │         "flue.model": "gpt-4o-mini",
-    │         "flue.provider": "openai",
-    │         "flue.session": "task:task:<uuid:1>",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "gpt-4o-mini",
-    │         "provider": "openai"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 4,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.00012299999999999998,
-    │         "prompt_cache_creation_tokens": 0,
-    │         "prompt_cached_tokens": 0,
-    │         "prompt_tokens": 804,
-    │         "tokens": 808
-    │       }
-    └── flue.compact [task]
-        input: {
-          "estimatedTokens": 2950,
-          "reason": "manual"
-        }
+    └── flue.turn [llm]
+        input: [
+          {
+            "content": [
+              {
+                "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
+                "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
+                "type": "thinking"
+              },
+              {
+                "text": "Now proceeding to Step 3:",
+                "type": "text"
+              },
+              {
+                "arguments": {
+                  "url": "https://example.test/flue/reasoning-streams"
+                },
+                "id": "<span:1>",
+                "name": "summarize_source",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          {
+            "content": [
+              {
+                "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+                "type": "text"
+              }
+            ],
+            "isError": false,
+            "role": "toolResult",
+            "toolCallId": "<span:1>",
+            "toolName": "summarize_source"
+          }
+        ]
         output: {
-          "completed": true
+          "content": [
+            {
+              "thinking": "Perfect! The summarize_source call has completed successfully. According to the instructions, I should now reply with exactly \"PROMPT_DONE\" and no other text.",
+              "thinkingSignature": "Eu8CCm4IDhgCKkAn2QOIIlYfvcs6ynsmhCslHDtBsrTA4CfmimK7zyz6+k6dZldV2JBtEBET41It0gFcGEKC0n0mAhaYVuLutpDDMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIM1xfLptxSF8rKzou8GgwRLuVmfiBYOT4CZIsiMAYz8TpvchMAWodP+T9uZ+dJ47MVdNv+p86nZXmT5d5EWlCroiAOFHHzJH2o0UjJQSquAX6wu+jIC8/DXwurGIIf2ToldPuJWF5HGj8kHMnwh777XS1NUFl1irM24rvP7kTAv3Dp8YEwb8t3g1EsicY7j+C5DzgwxVsPYCVOCgdMqQjtsqpL7AX5KQ9+hR1gK1DQjshv4Gze3hw/+C+9iptd3RlDIuwO0cm8NY+sVqeWVh3TtQujQlVt1rW/HfWjclrtT0LZSGwc6RypmfMMQi6lncIk/EPgy0XbS1plKW0tLBgB",
+              "type": "thinking"
+            },
+            {
+              "text": "PROMPT_DONE",
+              "type": "text"
+            }
+          ],
+          "role": "assistant"
         }
         metadata: {
-          "flue.operation": "compact",
+          "flue.api": "anthropic-messages",
+          "flue.input_message_offset": 5,
+          "flue.input_mode": "delta",
+          "flue.model": "claude-sonnet-4-5-20250929",
+          "flue.provider": "anthropic",
           "flue.session": "main",
-          "provider": "flue"
+          "flue.stop_reason": "stop",
+          "flue.turn_purpose": "agent",
+          "model": "claude-sonnet-4-5-20250929",
+          "provider": "anthropic"
         }
         metrics: {
-          "duration_ms": 0
+          "completion_tokens": 51,
+          "duration_ms": 0,
+          "estimated_cost": 0.0023391,
+          "prompt_cache_creation_tokens": 194,
+          "prompt_cached_tokens": 2692,
+          "prompt_tokens": 13,
+          "tokens": 2950
         }
-        └── compaction:manual [task]
-            input: {
-              "estimatedTokens": 2950,
-              "reason": "manual"
-            }
-            output: {
-              "messagesAfter": 2,
-              "messagesBefore": 8
-            }
-            metadata: {
-              "flue.compaction_reason": "manual",
-              "flue.session": "main",
-              "provider": "flue"
-            }
-            metrics: {
-              "duration_ms": 0,
-              "messages_after": 2,
-              "messages_before": 8
-            }
-            └── flue.turn [llm]
-                input: [
-                  {
-                    "content": [
-                      {
-                        "text": "<conversation>\n[User]: Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.\n\n[Assistant thinking]: The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.\n\n[Assistant]: I'll complete this instrumented research flow step by step. Starting with Step 1:\n\n[Assistant tool calls]: lookup(query=\"flue instrumentation\")\n\n[Tool result]: {\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}\n\n[Assistant thinking]: Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".\n\n[Assistant]: Now proceeding to Step 2:\n\n[Assistant tool calls]: web_search(lookupId=\"flue-session-2026\", query=\"Braintrust Flue reasoning stream instrumentation\")\n\n[Tool result]: {\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}\n\n[Assistant thinking]: Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.\n\n[Assistant]: Now proceeding to Step 3:\n\n[Assistant tool calls]: summarize_source(url=\"https://example.test/flue/reasoning-streams\")\n\n[Tool result]: {\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}\n</conversation>\n\nThis is the PREFIX of a turn that was too large to keep. The SUFFIX (recent work) is retained.\n\nSummarize the prefix to provide context for the retained suffix:\n\n## Original Request\n[What did the user ask for in this turn?]\n\n## Early Progress\n- [Key decisions and work done in the prefix]\n\n## Context for Suffix\n- [Information needed to understand the retained recent work]\n\nBe concise. Focus on what's needed to understand the kept suffix.",
-                        "type": "text"
-                      }
-                    ],
-                    "role": "user"
-                  }
-                ]
-                output: {
-                  "content": [
-                    {
-                      "text": "## Original Request\nThe user requested to complete an instrumented research flow consisting of three specific steps, involving calling various tools in a sequential manner.\n\n## Early Progress",
-                      "textSignature": "{\"v\":1,\"id\":\"msg_01ecf68325f9e202016a184601309081a0878ef4054e950d32\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "assistant"
-                }
-                metadata: {
-                  "flue.api": "openai-responses",
-                  "flue.model": "gpt-4o-mini",
-                  "flue.provider": "openai",
-                  "flue.session": "main",
-                  "flue.stop_reason": "stop",
-                  "flue.turn_purpose": "compaction_prefix",
-                  "model": "gpt-4o-mini",
-                  "provider": "openai"
-                }
-                metrics: {
-                  "completion_tokens": 0,
-                  "duration_ms": 0,
-                  "estimated_cost": 0,
-                  "prompt_cache_creation_tokens": 0,
-                  "prompt_cached_tokens": 0,
-                  "prompt_tokens": 0,
-                  "tokens": 0
-                }

--- a/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-0-cli.span-tree.json
+++ b/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-0-cli.span-tree.json
@@ -5,541 +5,6 @@
       "type": "task",
       "children": [
         {
-          "name": "flue.prompt",
-          "type": "task",
-          "children": [
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-                    "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-                    "type": "thinking"
-                  },
-                  {
-                    "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-                    "type": "text"
-                  },
-                  {
-                    "arguments": {
-                      "query": "flue instrumentation"
-                    },
-                    "id": "<span:1>",
-                    "name": "lookup",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "anthropic-messages",
-                "flue.model": "claude-sonnet-4-5-20250929",
-                "flue.provider": "anthropic",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "claude-sonnet-4-5-20250929",
-                "provider": "anthropic"
-              },
-              "metrics": {
-                "completion_tokens": 196,
-                "duration_ms": 0,
-                "estimated_cost": 0.0113025,
-                "prompt_cache_creation_tokens": 2222,
-                "prompt_cached_tokens": 0,
-                "prompt_tokens": 10,
-                "tokens": 2428
-              }
-            },
-            {
-              "name": "tool:lookup",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "query": "flue instrumentation"
-              },
-              "output": {
-                "content": [
-                  {
-                    "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                    "type": "text"
-                  }
-                ],
-                "details": {
-                  "customTool": "lookup"
-                }
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "lookup",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-                      "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-                    "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
-                    "type": "thinking"
-                  },
-                  {
-                    "text": "Now proceeding to Step 2:",
-                    "type": "text"
-                  },
-                  {
-                    "arguments": {
-                      "lookupId": "flue-session-2026",
-                      "query": "Braintrust Flue reasoning stream instrumentation"
-                    },
-                    "id": "<span:1>",
-                    "name": "web_search",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "anthropic-messages",
-                "flue.model": "claude-sonnet-4-5-20250929",
-                "flue.provider": "anthropic",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "claude-sonnet-4-5-20250929",
-                "provider": "anthropic"
-              },
-              "metrics": {
-                "completion_tokens": 158,
-                "duration_ms": 0,
-                "estimated_cost": 0.0039606,
-                "prompt_cache_creation_tokens": 236,
-                "prompt_cached_tokens": 2222,
-                "prompt_tokens": 13,
-                "tokens": 2629
-              }
-            },
-            {
-              "name": "tool:web_search",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "lookupId": "flue-session-2026",
-                "query": "Braintrust Flue reasoning stream instrumentation"
-              },
-              "output": {
-                "content": [
-                  {
-                    "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-                    "type": "text"
-                  }
-                ],
-                "details": {
-                  "customTool": "web_search"
-                }
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "web_search",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-                      "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-                      "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "Now proceeding to Step 2:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "lookupId": "flue-session-2026",
-                        "query": "Braintrust Flue reasoning stream instrumentation"
-                      },
-                      "id": "<span:2>",
-                      "name": "web_search",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:2>",
-                  "toolName": "web_search"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
-                    "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
-                    "type": "thinking"
-                  },
-                  {
-                    "text": "Now proceeding to Step 3:",
-                    "type": "text"
-                  },
-                  {
-                    "arguments": {
-                      "url": "https://example.test/flue/reasoning-streams"
-                    },
-                    "id": "<span:1>",
-                    "name": "summarize_source",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "anthropic-messages",
-                "flue.model": "claude-sonnet-4-5-20250929",
-                "flue.provider": "anthropic",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "claude-sonnet-4-5-20250929",
-                "provider": "anthropic"
-              },
-              "metrics": {
-                "completion_tokens": 138,
-                "duration_ms": 0,
-                "estimated_cost": 0.0037239000000000005,
-                "prompt_cache_creation_tokens": 234,
-                "prompt_cached_tokens": 2458,
-                "prompt_tokens": 13,
-                "tokens": 2843
-              }
-            },
-            {
-              "name": "tool:summarize_source",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "url": "https://example.test/flue/reasoning-streams"
-              },
-              "output": {
-                "content": [
-                  {
-                    "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-                    "type": "text"
-                  }
-                ],
-                "details": {
-                  "customTool": "summarize_source"
-                }
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "summarize_source",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-                      "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-                      "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "Now proceeding to Step 2:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "lookupId": "flue-session-2026",
-                        "query": "Braintrust Flue reasoning stream instrumentation"
-                      },
-                      "id": "<span:2>",
-                      "name": "web_search",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:2>",
-                  "toolName": "web_search"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
-                      "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "Now proceeding to Step 3:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "url": "https://example.test/flue/reasoning-streams"
-                      },
-                      "id": "<span:3>",
-                      "name": "summarize_source",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:3>",
-                  "toolName": "summarize_source"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "thinking": "Perfect! The summarize_source call has completed successfully. According to the instructions, I should now reply with exactly \"PROMPT_DONE\" and no other text.",
-                    "thinkingSignature": "Eu8CCm4IDhgCKkAn2QOIIlYfvcs6ynsmhCslHDtBsrTA4CfmimK7zyz6+k6dZldV2JBtEBET41It0gFcGEKC0n0mAhaYVuLutpDDMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIM1xfLptxSF8rKzou8GgwRLuVmfiBYOT4CZIsiMAYz8TpvchMAWodP+T9uZ+dJ47MVdNv+p86nZXmT5d5EWlCroiAOFHHzJH2o0UjJQSquAX6wu+jIC8/DXwurGIIf2ToldPuJWF5HGj8kHMnwh777XS1NUFl1irM24rvP7kTAv3Dp8YEwb8t3g1EsicY7j+C5DzgwxVsPYCVOCgdMqQjtsqpL7AX5KQ9+hR1gK1DQjshv4Gze3hw/+C+9iptd3RlDIuwO0cm8NY+sVqeWVh3TtQujQlVt1rW/HfWjclrtT0LZSGwc6RypmfMMQi6lncIk/EPgy0XbS1plKW0tLBgB",
-                    "type": "thinking"
-                  },
-                  {
-                    "text": "PROMPT_DONE",
-                    "type": "text"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "anthropic-messages",
-                "flue.model": "claude-sonnet-4-5-20250929",
-                "flue.provider": "anthropic",
-                "flue.session": "main",
-                "flue.stop_reason": "stop",
-                "flue.turn_purpose": "agent",
-                "model": "claude-sonnet-4-5-20250929",
-                "provider": "anthropic"
-              },
-              "metrics": {
-                "completion_tokens": 51,
-                "duration_ms": 0,
-                "estimated_cost": 0.0023391,
-                "prompt_cache_creation_tokens": 194,
-                "prompt_cached_tokens": 2692,
-                "prompt_tokens": 13,
-                "tokens": 2950
-              }
-            }
-          ],
-          "input": [
-            {
-              "content": [
-                {
-                  "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                  "type": "text"
-                }
-              ],
-              "role": "user"
-            }
-          ],
-          "output": "PROMPT_DONE",
-          "metadata": {
-            "flue.operation": "prompt",
-            "flue.session": "main",
-            "provider": "flue"
-          },
-          "metrics": {
-            "duration_ms": 0
-          }
-        },
-        {
           "name": "flue.skill",
           "type": "task",
           "children": [
@@ -1383,7 +848,9 @@
           "metadata": {
             "flue.operation": "skill",
             "flue.session": "skill",
-            "provider": "flue"
+            "flue.workflow_name": "instrumentation",
+            "provider": "flue",
+            "scenario": "flue-instrumentation"
           },
           "metrics": {
             "duration_ms": 0
@@ -1420,6 +887,7 @@
               },
               "metadata": {
                 "flue.api": "openai-responses",
+                "flue.input_mode": "full",
                 "flue.model": "gpt-4o-mini",
                 "flue.provider": "openai",
                 "flue.session": "task:task:<uuid:1>",
@@ -1533,7 +1001,9 @@
           "metadata": {
             "flue.operation": "compact",
             "flue.session": "main",
-            "provider": "flue"
+            "flue.workflow_name": "instrumentation",
+            "provider": "flue",
+            "scenario": "flue-instrumentation"
           },
           "metrics": {
             "duration_ms": 0
@@ -1552,6 +1022,420 @@
         "status": "done"
       },
       "metadata": {
+        "flue.workflow_name": "instrumentation",
+        "provider": "flue",
+        "scenario": "flue-instrumentation"
+      },
+      "metrics": {
+        "duration_ms": 0
+      }
+    },
+    {
+      "name": "flue.prompt",
+      "type": "task",
+      "children": [
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+                  "type": "text"
+                }
+              ],
+              "role": "user"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
+                "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
+                "type": "thinking"
+              },
+              {
+                "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
+                "type": "text"
+              },
+              {
+                "arguments": {
+                  "query": "flue instrumentation"
+                },
+                "id": "<span:1>",
+                "name": "lookup",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "anthropic-messages",
+            "flue.input_mode": "full",
+            "flue.model": "claude-sonnet-4-5-20250929",
+            "flue.provider": "anthropic",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "claude-sonnet-4-5-20250929",
+            "provider": "anthropic"
+          },
+          "metrics": {
+            "completion_tokens": 196,
+            "duration_ms": 0,
+            "estimated_cost": 0.0113025,
+            "prompt_cache_creation_tokens": 2222,
+            "prompt_cached_tokens": 0,
+            "prompt_tokens": 10,
+            "tokens": 2428
+          }
+        },
+        {
+          "name": "tool:lookup",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "query": "flue instrumentation"
+          },
+          "output": {
+            "content": [
+              {
+                "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
+                "type": "text"
+              }
+            ],
+            "details": {
+              "customTool": "lookup"
+            }
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "lookup",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
+                  "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
+                  "type": "thinking"
+                },
+                {
+                  "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
+                  "type": "text"
+                },
+                {
+                  "arguments": {
+                    "query": "flue instrumentation"
+                  },
+                  "id": "<span:1>",
+                  "name": "lookup",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "lookup"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
+                "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
+                "type": "thinking"
+              },
+              {
+                "text": "Now proceeding to Step 2:",
+                "type": "text"
+              },
+              {
+                "arguments": {
+                  "lookupId": "flue-session-2026",
+                  "query": "Braintrust Flue reasoning stream instrumentation"
+                },
+                "id": "<span:1>",
+                "name": "web_search",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "anthropic-messages",
+            "flue.input_message_offset": 1,
+            "flue.input_mode": "delta",
+            "flue.model": "claude-sonnet-4-5-20250929",
+            "flue.provider": "anthropic",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "claude-sonnet-4-5-20250929",
+            "provider": "anthropic"
+          },
+          "metrics": {
+            "completion_tokens": 158,
+            "duration_ms": 0,
+            "estimated_cost": 0.0039606,
+            "prompt_cache_creation_tokens": 236,
+            "prompt_cached_tokens": 2222,
+            "prompt_tokens": 13,
+            "tokens": 2629
+          }
+        },
+        {
+          "name": "tool:web_search",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "lookupId": "flue-session-2026",
+            "query": "Braintrust Flue reasoning stream instrumentation"
+          },
+          "output": {
+            "content": [
+              {
+                "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+                "type": "text"
+              }
+            ],
+            "details": {
+              "customTool": "web_search"
+            }
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "web_search",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
+                  "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
+                  "type": "thinking"
+                },
+                {
+                  "text": "Now proceeding to Step 2:",
+                  "type": "text"
+                },
+                {
+                  "arguments": {
+                    "lookupId": "flue-session-2026",
+                    "query": "Braintrust Flue reasoning stream instrumentation"
+                  },
+                  "id": "<span:1>",
+                  "name": "web_search",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "web_search"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
+                "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
+                "type": "thinking"
+              },
+              {
+                "text": "Now proceeding to Step 3:",
+                "type": "text"
+              },
+              {
+                "arguments": {
+                  "url": "https://example.test/flue/reasoning-streams"
+                },
+                "id": "<span:1>",
+                "name": "summarize_source",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "anthropic-messages",
+            "flue.input_message_offset": 3,
+            "flue.input_mode": "delta",
+            "flue.model": "claude-sonnet-4-5-20250929",
+            "flue.provider": "anthropic",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "claude-sonnet-4-5-20250929",
+            "provider": "anthropic"
+          },
+          "metrics": {
+            "completion_tokens": 138,
+            "duration_ms": 0,
+            "estimated_cost": 0.0037239000000000005,
+            "prompt_cache_creation_tokens": 234,
+            "prompt_cached_tokens": 2458,
+            "prompt_tokens": 13,
+            "tokens": 2843
+          }
+        },
+        {
+          "name": "tool:summarize_source",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "url": "https://example.test/flue/reasoning-streams"
+          },
+          "output": {
+            "content": [
+              {
+                "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+                "type": "text"
+              }
+            ],
+            "details": {
+              "customTool": "summarize_source"
+            }
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "summarize_source",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
+                  "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
+                  "type": "thinking"
+                },
+                {
+                  "text": "Now proceeding to Step 3:",
+                  "type": "text"
+                },
+                {
+                  "arguments": {
+                    "url": "https://example.test/flue/reasoning-streams"
+                  },
+                  "id": "<span:1>",
+                  "name": "summarize_source",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "summarize_source"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "thinking": "Perfect! The summarize_source call has completed successfully. According to the instructions, I should now reply with exactly \"PROMPT_DONE\" and no other text.",
+                "thinkingSignature": "Eu8CCm4IDhgCKkAn2QOIIlYfvcs6ynsmhCslHDtBsrTA4CfmimK7zyz6+k6dZldV2JBtEBET41It0gFcGEKC0n0mAhaYVuLutpDDMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIM1xfLptxSF8rKzou8GgwRLuVmfiBYOT4CZIsiMAYz8TpvchMAWodP+T9uZ+dJ47MVdNv+p86nZXmT5d5EWlCroiAOFHHzJH2o0UjJQSquAX6wu+jIC8/DXwurGIIf2ToldPuJWF5HGj8kHMnwh777XS1NUFl1irM24rvP7kTAv3Dp8YEwb8t3g1EsicY7j+C5DzgwxVsPYCVOCgdMqQjtsqpL7AX5KQ9+hR1gK1DQjshv4Gze3hw/+C+9iptd3RlDIuwO0cm8NY+sVqeWVh3TtQujQlVt1rW/HfWjclrtT0LZSGwc6RypmfMMQi6lncIk/EPgy0XbS1plKW0tLBgB",
+                "type": "thinking"
+              },
+              {
+                "text": "PROMPT_DONE",
+                "type": "text"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "anthropic-messages",
+            "flue.input_message_offset": 5,
+            "flue.input_mode": "delta",
+            "flue.model": "claude-sonnet-4-5-20250929",
+            "flue.provider": "anthropic",
+            "flue.session": "main",
+            "flue.stop_reason": "stop",
+            "flue.turn_purpose": "agent",
+            "model": "claude-sonnet-4-5-20250929",
+            "provider": "anthropic"
+          },
+          "metrics": {
+            "completion_tokens": 51,
+            "duration_ms": 0,
+            "estimated_cost": 0.0023391,
+            "prompt_cache_creation_tokens": 194,
+            "prompt_cached_tokens": 2692,
+            "prompt_tokens": 13,
+            "tokens": 2950
+          }
+        }
+      ],
+      "input": [
+        {
+          "content": [
+            {
+              "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+              "type": "text"
+            }
+          ],
+          "role": "user"
+        }
+      ],
+      "output": "PROMPT_DONE",
+      "metadata": {
+        "flue.operation": "prompt",
+        "flue.session": "main",
         "flue.workflow_name": "instrumentation",
         "provider": "flue",
         "scenario": "flue-instrumentation"

--- a/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-0-cli.span-tree.txt
+++ b/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-0-cli.span-tree.txt
@@ -1,17 +1,973 @@
 span_tree:
-└── workflow:instrumentation [task]
-    input: {
-      "metadata": {
-        "scenario": "flue-instrumentation",
-        "testRunId": "<run:1>"
-      },
-      "scenario": "flue-instrumentation"
-    }
-    output: {
-      "scenario": "flue-instrumentation",
-      "status": "done"
-    }
+├── workflow:instrumentation [task]
+│   input: {
+│     "metadata": {
+│       "scenario": "flue-instrumentation",
+│       "testRunId": "<run:1>"
+│     },
+│     "scenario": "flue-instrumentation"
+│   }
+│   output: {
+│     "scenario": "flue-instrumentation",
+│     "status": "done"
+│   }
+│   metadata: {
+│     "flue.workflow_name": "instrumentation",
+│     "provider": "flue",
+│     "scenario": "flue-instrumentation"
+│   }
+│   metrics: {
+│     "duration_ms": 0
+│   }
+│   ├── flue.skill [task]
+│   │   input: [
+│   │     {
+│   │       "content": [
+│   │         {
+│   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │           "type": "text"
+│   │         }
+│   │       ],
+│   │       "role": "user"
+│   │     }
+│   │   ]
+│   │   output: "SKILL_DONE"
+│   │   metadata: {
+│   │     "flue.operation": "skill",
+│   │     "flue.session": "skill",
+│   │     "flue.workflow_name": "instrumentation",
+│   │     "provider": "flue",
+│   │     "scenario": "flue-instrumentation"
+│   │   }
+│   │   metrics: {
+│   │     "duration_ms": 0
+│   │   }
+│   │   ├── flue.turn [llm]
+│   │   │   input: [
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "user"
+│   │   │     }
+│   │   │   ]
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
+│   │   │         "type": "text"
+│   │   │       },
+│   │   │       {
+│   │   │         "arguments": {
+│   │   │           "path": ".agents/e2e-flue-skill.md"
+│   │   │         },
+│   │   │         "id": "<span:1>",
+│   │   │         "name": "read",
+│   │   │         "type": "toolCall"
+│   │   │       }
+│   │   │     ],
+│   │   │     "role": "assistant"
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.api": "anthropic-messages",
+│   │   │     "flue.model": "claude-sonnet-4-5-20250929",
+│   │   │     "flue.provider": "anthropic",
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.stop_reason": "toolUse",
+│   │   │     "flue.turn_purpose": "agent",
+│   │   │     "model": "claude-sonnet-4-5-20250929",
+│   │   │     "provider": "anthropic"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "completion_tokens": 89,
+│   │   │     "duration_ms": 0,
+│   │   │     "estimated_cost": 0.0041862,
+│   │   │     "prompt_cache_creation_tokens": 670,
+│   │   │     "prompt_cached_tokens": 1099,
+│   │   │     "prompt_tokens": 3,
+│   │   │     "tokens": 1861
+│   │   │   }
+│   │   ├── tool:read [tool]
+│   │   │   input: {
+│   │   │     "path": ".agents/e2e-flue-skill.md"
+│   │   │   }
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
+│   │   │         "type": "text"
+│   │   │       }
+│   │   │     ],
+│   │   │     "details": {}
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.tool_name": "read",
+│   │   │     "provider": "flue"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "duration_ms": 0
+│   │   │   }
+│   │   │   error: "{\"content\":[{\"type\":\"text\",\"text\":\"ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'\"}],\"details\":{}}"
+│   │   ├── flue.turn [llm]
+│   │   │   input: [
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "user"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
+│   │   │           "type": "text"
+│   │   │         },
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents/e2e-flue-skill.md"
+│   │   │           },
+│   │   │           "id": "<span:1>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": true,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:1>",
+│   │   │       "toolName": "read"
+│   │   │     }
+│   │   │   ]
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "arguments": {
+│   │   │           "path": ".agents"
+│   │   │         },
+│   │   │         "id": "<span:1>",
+│   │   │         "name": "read",
+│   │   │         "type": "toolCall"
+│   │   │       }
+│   │   │     ],
+│   │   │     "role": "assistant"
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.api": "anthropic-messages",
+│   │   │     "flue.model": "claude-sonnet-4-5-20250929",
+│   │   │     "flue.provider": "anthropic",
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.stop_reason": "toolUse",
+│   │   │     "flue.turn_purpose": "agent",
+│   │   │     "model": "claude-sonnet-4-5-20250929",
+│   │   │     "provider": "anthropic"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "completion_tokens": 52,
+│   │   │     "duration_ms": 0,
+│   │   │     "estimated_cost": 0.00201795,
+│   │   │     "prompt_cache_creation_tokens": 183,
+│   │   │     "prompt_cached_tokens": 1769,
+│   │   │     "prompt_tokens": 7,
+│   │   │     "tokens": 2011
+│   │   │   }
+│   │   ├── tool:read [tool]
+│   │   │   input: {
+│   │   │     "path": ".agents"
+│   │   │   }
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "text": "skills",
+│   │   │         "type": "text"
+│   │   │       }
+│   │   │     ],
+│   │   │     "details": {
+│   │   │       "entries": 1,
+│   │   │       "isDirectory": true,
+│   │   │       "path": ".agents"
+│   │   │     }
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.tool_name": "read",
+│   │   │     "provider": "flue"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "duration_ms": 0
+│   │   │   }
+│   │   ├── flue.turn [llm]
+│   │   │   input: [
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "user"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
+│   │   │           "type": "text"
+│   │   │         },
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents/e2e-flue-skill.md"
+│   │   │           },
+│   │   │           "id": "<span:1>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": true,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:1>",
+│   │   │       "toolName": "read"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents"
+│   │   │           },
+│   │   │           "id": "<span:2>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "skills",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": false,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:2>",
+│   │   │       "toolName": "read"
+│   │   │     }
+│   │   │   ]
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "arguments": {
+│   │   │           "path": ".agents/skills"
+│   │   │         },
+│   │   │         "id": "<span:1>",
+│   │   │         "name": "read",
+│   │   │         "type": "toolCall"
+│   │   │       }
+│   │   │     ],
+│   │   │     "role": "assistant"
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.api": "anthropic-messages",
+│   │   │     "flue.model": "claude-sonnet-4-5-20250929",
+│   │   │     "flue.provider": "anthropic",
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.stop_reason": "toolUse",
+│   │   │     "flue.turn_purpose": "agent",
+│   │   │     "model": "claude-sonnet-4-5-20250929",
+│   │   │     "provider": "anthropic"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "completion_tokens": 54,
+│   │   │     "duration_ms": 0,
+│   │   │     "estimated_cost": 0.0016611,
+│   │   │     "prompt_cache_creation_tokens": 66,
+│   │   │     "prompt_cached_tokens": 1952,
+│   │   │     "prompt_tokens": 6,
+│   │   │     "tokens": 2078
+│   │   │   }
+│   │   ├── tool:read [tool]
+│   │   │   input: {
+│   │   │     "path": ".agents/skills"
+│   │   │   }
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "text": "e2e-flue-skill",
+│   │   │         "type": "text"
+│   │   │       }
+│   │   │     ],
+│   │   │     "details": {
+│   │   │       "entries": 1,
+│   │   │       "isDirectory": true,
+│   │   │       "path": ".agents/skills"
+│   │   │     }
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.tool_name": "read",
+│   │   │     "provider": "flue"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "duration_ms": 0
+│   │   │   }
+│   │   ├── flue.turn [llm]
+│   │   │   input: [
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "user"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
+│   │   │           "type": "text"
+│   │   │         },
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents/e2e-flue-skill.md"
+│   │   │           },
+│   │   │           "id": "<span:1>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": true,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:1>",
+│   │   │       "toolName": "read"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents"
+│   │   │           },
+│   │   │           "id": "<span:2>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "skills",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": false,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:2>",
+│   │   │       "toolName": "read"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents/skills"
+│   │   │           },
+│   │   │           "id": "<span:3>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "e2e-flue-skill",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": false,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:3>",
+│   │   │       "toolName": "read"
+│   │   │     }
+│   │   │   ]
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "arguments": {
+│   │   │           "path": ".agents/skills/e2e-flue-skill"
+│   │   │         },
+│   │   │         "id": "<span:1>",
+│   │   │         "name": "read",
+│   │   │         "type": "toolCall"
+│   │   │       }
+│   │   │     ],
+│   │   │     "role": "assistant"
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.api": "anthropic-messages",
+│   │   │     "flue.model": "claude-sonnet-4-5-20250929",
+│   │   │     "flue.provider": "anthropic",
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.stop_reason": "toolUse",
+│   │   │     "flue.turn_purpose": "agent",
+│   │   │     "model": "claude-sonnet-4-5-20250929",
+│   │   │     "provider": "anthropic"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "completion_tokens": 63,
+│   │   │     "duration_ms": 0,
+│   │   │     "estimated_cost": 0.0018459,
+│   │   │     "prompt_cache_creation_tokens": 74,
+│   │   │     "prompt_cached_tokens": 2018,
+│   │   │     "prompt_tokens": 6,
+│   │   │     "tokens": 2161
+│   │   │   }
+│   │   ├── tool:read [tool]
+│   │   │   input: {
+│   │   │     "path": ".agents/skills/e2e-flue-skill"
+│   │   │   }
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "text": "SKILL.md",
+│   │   │         "type": "text"
+│   │   │       }
+│   │   │     ],
+│   │   │     "details": {
+│   │   │       "entries": 1,
+│   │   │       "isDirectory": true,
+│   │   │       "path": ".agents/skills/e2e-flue-skill"
+│   │   │     }
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.tool_name": "read",
+│   │   │     "provider": "flue"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "duration_ms": 0
+│   │   │   }
+│   │   ├── flue.turn [llm]
+│   │   │   input: [
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "user"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
+│   │   │           "type": "text"
+│   │   │         },
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents/e2e-flue-skill.md"
+│   │   │           },
+│   │   │           "id": "<span:1>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": true,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:1>",
+│   │   │       "toolName": "read"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents"
+│   │   │           },
+│   │   │           "id": "<span:2>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "skills",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": false,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:2>",
+│   │   │       "toolName": "read"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents/skills"
+│   │   │           },
+│   │   │           "id": "<span:3>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "e2e-flue-skill",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": false,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:3>",
+│   │   │       "toolName": "read"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents/skills/e2e-flue-skill"
+│   │   │           },
+│   │   │           "id": "<span:4>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "SKILL.md",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": false,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:4>",
+│   │   │       "toolName": "read"
+│   │   │     }
+│   │   │   ]
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "arguments": {
+│   │   │           "path": ".agents/skills/e2e-flue-skill/SKILL.md"
+│   │   │         },
+│   │   │         "id": "<span:1>",
+│   │   │         "name": "read",
+│   │   │         "type": "toolCall"
+│   │   │       }
+│   │   │     ],
+│   │   │     "role": "assistant"
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.api": "anthropic-messages",
+│   │   │     "flue.model": "claude-sonnet-4-5-20250929",
+│   │   │     "flue.provider": "anthropic",
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.stop_reason": "toolUse",
+│   │   │     "flue.turn_purpose": "agent",
+│   │   │     "model": "claude-sonnet-4-5-20250929",
+│   │   │     "provider": "anthropic"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "completion_tokens": 68,
+│   │   │     "duration_ms": 0,
+│   │   │     "estimated_cost": 0.0019618500000000002,
+│   │   │     "prompt_cache_creation_tokens": 79,
+│   │   │     "prompt_cached_tokens": 2092,
+│   │   │     "prompt_tokens": 6,
+│   │   │     "tokens": 2245
+│   │   │   }
+│   │   ├── tool:read [tool]
+│   │   │   input: {
+│   │   │     "path": ".agents/skills/e2e-flue-skill/SKILL.md"
+│   │   │   }
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
+│   │   │         "type": "text"
+│   │   │       }
+│   │   │     ],
+│   │   │     "details": {
+│   │   │       "lines": 7,
+│   │   │       "path": ".agents/skills/e2e-flue-skill/SKILL.md"
+│   │   │     }
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.tool_name": "read",
+│   │   │     "provider": "flue"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "duration_ms": 0
+│   │   │   }
+│   │   └── flue.turn [llm]
+│   │       input: [
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "role": "user"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
+│   │               "type": "text"
+│   │             },
+│   │             {
+│   │               "arguments": {
+│   │                 "path": ".agents/e2e-flue-skill.md"
+│   │               },
+│   │               "id": "<span:1>",
+│   │               "name": "read",
+│   │               "type": "toolCall"
+│   │             }
+│   │           ],
+│   │           "role": "assistant"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "isError": true,
+│   │           "role": "toolResult",
+│   │           "toolCallId": "<span:1>",
+│   │           "toolName": "read"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "arguments": {
+│   │                 "path": ".agents"
+│   │               },
+│   │               "id": "<span:2>",
+│   │               "name": "read",
+│   │               "type": "toolCall"
+│   │             }
+│   │           ],
+│   │           "role": "assistant"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "skills",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "isError": false,
+│   │           "role": "toolResult",
+│   │           "toolCallId": "<span:2>",
+│   │           "toolName": "read"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "arguments": {
+│   │                 "path": ".agents/skills"
+│   │               },
+│   │               "id": "<span:3>",
+│   │               "name": "read",
+│   │               "type": "toolCall"
+│   │             }
+│   │           ],
+│   │           "role": "assistant"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "e2e-flue-skill",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "isError": false,
+│   │           "role": "toolResult",
+│   │           "toolCallId": "<span:3>",
+│   │           "toolName": "read"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "arguments": {
+│   │                 "path": ".agents/skills/e2e-flue-skill"
+│   │               },
+│   │               "id": "<span:4>",
+│   │               "name": "read",
+│   │               "type": "toolCall"
+│   │             }
+│   │           ],
+│   │           "role": "assistant"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "SKILL.md",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "isError": false,
+│   │           "role": "toolResult",
+│   │           "toolCallId": "<span:4>",
+│   │           "toolName": "read"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "arguments": {
+│   │                 "path": ".agents/skills/e2e-flue-skill/SKILL.md"
+│   │               },
+│   │               "id": "<span:5>",
+│   │               "name": "read",
+│   │               "type": "toolCall"
+│   │             }
+│   │           ],
+│   │           "role": "assistant"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "isError": false,
+│   │           "role": "toolResult",
+│   │           "toolCallId": "<span:5>",
+│   │           "toolName": "read"
+│   │         }
+│   │       ]
+│   │       output: {
+│   │         "content": [
+│   │           {
+│   │             "text": "SKILL_DONE",
+│   │             "type": "text"
+│   │           }
+│   │         ],
+│   │         "role": "assistant"
+│   │       }
+│   │       metadata: {
+│   │         "flue.api": "anthropic-messages",
+│   │         "flue.model": "claude-sonnet-4-5-20250929",
+│   │         "flue.provider": "anthropic",
+│   │         "flue.session": "skill",
+│   │         "flue.stop_reason": "stop",
+│   │         "flue.turn_purpose": "agent",
+│   │         "model": "claude-sonnet-4-5-20250929",
+│   │         "provider": "anthropic"
+│   │       }
+│   │       metrics: {
+│   │         "completion_tokens": 8,
+│   │         "duration_ms": 0,
+│   │         "estimated_cost": 0.00129555,
+│   │         "prompt_cache_creation_tokens": 135,
+│   │         "prompt_cached_tokens": 2171,
+│   │         "prompt_tokens": 6,
+│   │         "tokens": 2320
+│   │       }
+│   ├── flue.task [task]
+│   │   input: "Reply with exactly TASK_DONE and no other text."
+│   │   output: "TASK_DONE"
+│   │   metadata: {
+│   │     "flue.session": "task",
+│   │     "provider": "flue"
+│   │   }
+│   │   metrics: {
+│   │     "duration_ms": 0
+│   │   }
+│   │   └── flue.turn [llm]
+│   │       input: [
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "Reply with exactly TASK_DONE and no other text.",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "role": "user"
+│   │         }
+│   │       ]
+│   │       output: {
+│   │         "content": [
+│   │           {
+│   │             "text": "TASK_DONE",
+│   │             "textSignature": "{\"v\":1,\"id\":\"msg_09b32b2821e9a4d8016a184600019081929d34bb7d4c6a246f\"}",
+│   │             "type": "text"
+│   │           }
+│   │         ],
+│   │         "role": "assistant"
+│   │       }
+│   │       metadata: {
+│   │         "flue.api": "openai-responses",
+│   │         "flue.input_mode": "full",
+│   │         "flue.model": "gpt-4o-mini",
+│   │         "flue.provider": "openai",
+│   │         "flue.session": "task:task:<uuid:1>",
+│   │         "flue.stop_reason": "stop",
+│   │         "flue.turn_purpose": "agent",
+│   │         "model": "gpt-4o-mini",
+│   │         "provider": "openai"
+│   │       }
+│   │       metrics: {
+│   │         "completion_tokens": 4,
+│   │         "duration_ms": 0,
+│   │         "estimated_cost": 0.00012299999999999998,
+│   │         "prompt_cache_creation_tokens": 0,
+│   │         "prompt_cached_tokens": 0,
+│   │         "prompt_tokens": 804,
+│   │         "tokens": 808
+│   │       }
+│   └── flue.compact [task]
+│       input: {
+│         "estimatedTokens": 2950,
+│         "reason": "manual"
+│       }
+│       output: {
+│         "completed": true
+│       }
+│       metadata: {
+│         "flue.operation": "compact",
+│         "flue.session": "main",
+│         "flue.workflow_name": "instrumentation",
+│         "provider": "flue",
+│         "scenario": "flue-instrumentation"
+│       }
+│       metrics: {
+│         "duration_ms": 0
+│       }
+│       └── compaction:manual [task]
+│           input: {
+│             "estimatedTokens": 2950,
+│             "reason": "manual"
+│           }
+│           output: {
+│             "messagesAfter": 2,
+│             "messagesBefore": 8
+│           }
+│           metadata: {
+│             "flue.compaction_reason": "manual",
+│             "flue.session": "main",
+│             "provider": "flue"
+│           }
+│           metrics: {
+│             "duration_ms": 0,
+│             "messages_after": 2,
+│             "messages_before": 8
+│           }
+│           └── flue.turn [llm]
+│               input: [
+│                 {
+│                   "content": [
+│                     {
+│                       "text": "<conversation>\n[User]: Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.\n\n[Assistant thinking]: The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.\n\n[Assistant]: I'll complete this instrumented research flow step by step. Starting with Step 1:\n\n[Assistant tool calls]: lookup(query=\"flue instrumentation\")\n\n[Tool result]: {\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}\n\n[Assistant thinking]: Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".\n\n[Assistant]: Now proceeding to Step 2:\n\n[Assistant tool calls]: web_search(lookupId=\"flue-session-2026\", query=\"Braintrust Flue reasoning stream instrumentation\")\n\n[Tool result]: {\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}\n\n[Assistant thinking]: Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.\n\n[Assistant]: Now proceeding to Step 3:\n\n[Assistant tool calls]: summarize_source(url=\"https://example.test/flue/reasoning-streams\")\n\n[Tool result]: {\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}\n</conversation>\n\nThis is the PREFIX of a turn that was too large to keep. The SUFFIX (recent work) is retained.\n\nSummarize the prefix to provide context for the retained suffix:\n\n## Original Request\n[What did the user ask for in this turn?]\n\n## Early Progress\n- [Key decisions and work done in the prefix]\n\n## Context for Suffix\n- [Information needed to understand the retained recent work]\n\nBe concise. Focus on what's needed to understand the kept suffix.",
+│                       "type": "text"
+│                     }
+│                   ],
+│                   "role": "user"
+│                 }
+│               ]
+│               output: {
+│                 "content": [
+│                   {
+│                     "text": "## Original Request\nThe user requested to complete an instrumented research flow consisting of three specific steps, involving calling various tools in a sequential manner.\n\n## Early Progress",
+│                     "textSignature": "{\"v\":1,\"id\":\"msg_01ecf68325f9e202016a184601309081a0878ef4054e950d32\"}",
+│                     "type": "text"
+│                   }
+│                 ],
+│                 "role": "assistant"
+│               }
+│               metadata: {
+│                 "flue.api": "openai-responses",
+│                 "flue.model": "gpt-4o-mini",
+│                 "flue.provider": "openai",
+│                 "flue.session": "main",
+│                 "flue.stop_reason": "stop",
+│                 "flue.turn_purpose": "compaction_prefix",
+│                 "model": "gpt-4o-mini",
+│                 "provider": "openai"
+│               }
+│               metrics: {
+│                 "completion_tokens": 0,
+│                 "duration_ms": 0,
+│                 "estimated_cost": 0,
+│                 "prompt_cache_creation_tokens": 0,
+│                 "prompt_cached_tokens": 0,
+│                 "prompt_tokens": 0,
+│                 "tokens": 0
+│               }
+└── flue.prompt [task]
+    input: [
+      {
+        "content": [
+          {
+            "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+            "type": "text"
+          }
+        ],
+        "role": "user"
+      }
+    ]
+    output: "PROMPT_DONE"
     metadata: {
+      "flue.operation": "prompt",
+      "flue.session": "main",
       "flue.workflow_name": "instrumentation",
       "provider": "flue",
       "scenario": "flue-instrumentation"
@@ -19,7 +975,7 @@ span_tree:
     metrics: {
       "duration_ms": 0
     }
-    ├── flue.prompt [task]
+    ├── flue.turn [llm]
     │   input: [
     │     {
     │       "content": [
@@ -31,1421 +987,349 @@ span_tree:
     │       "role": "user"
     │     }
     │   ]
-    │   output: "PROMPT_DONE"
+    │   output: {
+    │     "content": [
+    │       {
+    │         "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
+    │         "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
+    │         "type": "thinking"
+    │       },
+    │       {
+    │         "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
+    │         "type": "text"
+    │       },
+    │       {
+    │         "arguments": {
+    │           "query": "flue instrumentation"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "lookup",
+    │         "type": "toolCall"
+    │       }
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.operation": "prompt",
+    │     "flue.api": "anthropic-messages",
+    │     "flue.input_mode": "full",
+    │     "flue.model": "claude-sonnet-4-5-20250929",
+    │     "flue.provider": "anthropic",
     │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "claude-sonnet-4-5-20250929",
+    │     "provider": "anthropic"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 196,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.0113025,
+    │     "prompt_cache_creation_tokens": 2222,
+    │     "prompt_cached_tokens": 0,
+    │     "prompt_tokens": 10,
+    │     "tokens": 2428
+    │   }
+    ├── tool:lookup [tool]
+    │   input: {
+    │     "query": "flue instrumentation"
+    │   }
+    │   output: {
+    │     "content": [
+    │       {
+    │         "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
+    │         "type": "text"
+    │       }
+    │     ],
+    │     "details": {
+    │       "customTool": "lookup"
+    │     }
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "lookup",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-    │   │         "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-    │   │         "type": "thinking"
-    │   │       },
-    │   │       {
-    │   │         "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-    │   │         "type": "text"
-    │   │       },
-    │   │       {
-    │   │         "arguments": {
-    │   │           "query": "flue instrumentation"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "lookup",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 196,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0113025,
-    │   │     "prompt_cache_creation_tokens": 2222,
-    │   │     "prompt_cached_tokens": 0,
-    │   │     "prompt_tokens": 10,
-    │   │     "tokens": 2428
-    │   │   }
-    │   ├── tool:lookup [tool]
-    │   │   input: {
-    │   │     "query": "flue instrumentation"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "customTool": "lookup"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "lookup",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-    │   │           "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-    │   │           "type": "thinking"
-    │   │         },
-    │   │         {
-    │   │           "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "query": "flue instrumentation"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "lookup",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "lookup"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-    │   │         "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
-    │   │         "type": "thinking"
-    │   │       },
-    │   │       {
-    │   │         "text": "Now proceeding to Step 2:",
-    │   │         "type": "text"
-    │   │       },
-    │   │       {
-    │   │         "arguments": {
-    │   │           "lookupId": "flue-session-2026",
-    │   │           "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "web_search",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 158,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0039606,
-    │   │     "prompt_cache_creation_tokens": 236,
-    │   │     "prompt_cached_tokens": 2222,
-    │   │     "prompt_tokens": 13,
-    │   │     "tokens": 2629
-    │   │   }
-    │   ├── tool:web_search [tool]
-    │   │   input: {
-    │   │     "lookupId": "flue-session-2026",
-    │   │     "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "customTool": "web_search"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "web_search",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-    │   │           "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-    │   │           "type": "thinking"
-    │   │         },
-    │   │         {
-    │   │           "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "query": "flue instrumentation"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "lookup",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "lookup"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-    │   │           "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
-    │   │           "type": "thinking"
-    │   │         },
-    │   │         {
-    │   │           "text": "Now proceeding to Step 2:",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "lookupId": "flue-session-2026",
-    │   │             "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │           },
-    │   │           "id": "<span:2>",
-    │   │           "name": "web_search",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:2>",
-    │   │       "toolName": "web_search"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
-    │   │         "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
-    │   │         "type": "thinking"
-    │   │       },
-    │   │       {
-    │   │         "text": "Now proceeding to Step 3:",
-    │   │         "type": "text"
-    │   │       },
-    │   │       {
-    │   │         "arguments": {
-    │   │           "url": "https://example.test/flue/reasoning-streams"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "summarize_source",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 138,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0037239000000000005,
-    │   │     "prompt_cache_creation_tokens": 234,
-    │   │     "prompt_cached_tokens": 2458,
-    │   │     "prompt_tokens": 13,
-    │   │     "tokens": 2843
-    │   │   }
-    │   ├── tool:summarize_source [tool]
-    │   │   input: {
-    │   │     "url": "https://example.test/flue/reasoning-streams"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "customTool": "summarize_source"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "summarize_source",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   └── flue.turn [llm]
-    │       input: [
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-    │               "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-    │               "type": "thinking"
-    │             },
-    │             {
-    │               "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-    │               "type": "text"
-    │             },
-    │             {
-    │               "arguments": {
-    │                 "query": "flue instrumentation"
-    │               },
-    │               "id": "<span:1>",
-    │               "name": "lookup",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:1>",
-    │           "toolName": "lookup"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-    │               "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
-    │               "type": "thinking"
-    │             },
-    │             {
-    │               "text": "Now proceeding to Step 2:",
-    │               "type": "text"
-    │             },
-    │             {
-    │               "arguments": {
-    │                 "lookupId": "flue-session-2026",
-    │                 "query": "Braintrust Flue reasoning stream instrumentation"
-    │               },
-    │               "id": "<span:2>",
-    │               "name": "web_search",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:2>",
-    │           "toolName": "web_search"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
-    │               "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
-    │               "type": "thinking"
-    │             },
-    │             {
-    │               "text": "Now proceeding to Step 3:",
-    │               "type": "text"
-    │             },
-    │             {
-    │               "arguments": {
-    │                 "url": "https://example.test/flue/reasoning-streams"
-    │               },
-    │               "id": "<span:3>",
-    │               "name": "summarize_source",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:3>",
-    │           "toolName": "summarize_source"
-    │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "thinking": "Perfect! The summarize_source call has completed successfully. According to the instructions, I should now reply with exactly \"PROMPT_DONE\" and no other text.",
-    │             "thinkingSignature": "Eu8CCm4IDhgCKkAn2QOIIlYfvcs6ynsmhCslHDtBsrTA4CfmimK7zyz6+k6dZldV2JBtEBET41It0gFcGEKC0n0mAhaYVuLutpDDMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIM1xfLptxSF8rKzou8GgwRLuVmfiBYOT4CZIsiMAYz8TpvchMAWodP+T9uZ+dJ47MVdNv+p86nZXmT5d5EWlCroiAOFHHzJH2o0UjJQSquAX6wu+jIC8/DXwurGIIf2ToldPuJWF5HGj8kHMnwh777XS1NUFl1irM24rvP7kTAv3Dp8YEwb8t3g1EsicY7j+C5DzgwxVsPYCVOCgdMqQjtsqpL7AX5KQ9+hR1gK1DQjshv4Gze3hw/+C+9iptd3RlDIuwO0cm8NY+sVqeWVh3TtQujQlVt1rW/HfWjclrtT0LZSGwc6RypmfMMQi6lncIk/EPgy0XbS1plKW0tLBgB",
-    │             "type": "thinking"
-    │           },
-    │           {
-    │             "text": "PROMPT_DONE",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
-    │       }
-    │       metadata: {
-    │         "flue.api": "anthropic-messages",
-    │         "flue.model": "claude-sonnet-4-5-20250929",
-    │         "flue.provider": "anthropic",
-    │         "flue.session": "main",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "claude-sonnet-4-5-20250929",
-    │         "provider": "anthropic"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 51,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.0023391,
-    │         "prompt_cache_creation_tokens": 194,
-    │         "prompt_cached_tokens": 2692,
-    │         "prompt_tokens": 13,
-    │         "tokens": 2950
-    │       }
-    ├── flue.skill [task]
+    ├── flue.turn [llm]
     │   input: [
     │     {
     │       "content": [
     │         {
-    │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+    │           "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
+    │           "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
+    │           "type": "thinking"
+    │         },
+    │         {
+    │           "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
+    │           "type": "text"
+    │         },
+    │         {
+    │           "arguments": {
+    │             "query": "flue instrumentation"
+    │           },
+    │           "id": "<span:1>",
+    │           "name": "lookup",
+    │           "type": "toolCall"
+    │         }
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
     │           "type": "text"
     │         }
     │       ],
-    │       "role": "user"
+    │       "isError": false,
+    │       "role": "toolResult",
+    │       "toolCallId": "<span:1>",
+    │       "toolName": "lookup"
     │     }
     │   ]
-    │   output: "SKILL_DONE"
+    │   output: {
+    │     "content": [
+    │       {
+    │         "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
+    │         "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
+    │         "type": "thinking"
+    │       },
+    │       {
+    │         "text": "Now proceeding to Step 2:",
+    │         "type": "text"
+    │       },
+    │       {
+    │         "arguments": {
+    │           "lookupId": "flue-session-2026",
+    │           "query": "Braintrust Flue reasoning stream instrumentation"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "web_search",
+    │         "type": "toolCall"
+    │       }
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.operation": "skill",
-    │     "flue.session": "skill",
+    │     "flue.api": "anthropic-messages",
+    │     "flue.input_message_offset": 1,
+    │     "flue.input_mode": "delta",
+    │     "flue.model": "claude-sonnet-4-5-20250929",
+    │     "flue.provider": "anthropic",
+    │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "claude-sonnet-4-5-20250929",
+    │     "provider": "anthropic"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 158,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.0039606,
+    │     "prompt_cache_creation_tokens": 236,
+    │     "prompt_cached_tokens": 2222,
+    │     "prompt_tokens": 13,
+    │     "tokens": 2629
+    │   }
+    ├── tool:web_search [tool]
+    │   input: {
+    │     "lookupId": "flue-session-2026",
+    │     "query": "Braintrust Flue reasoning stream instrumentation"
+    │   }
+    │   output: {
+    │     "content": [
+    │       {
+    │         "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+    │         "type": "text"
+    │       }
+    │     ],
+    │     "details": {
+    │       "customTool": "web_search"
+    │     }
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "web_search",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
-    │   │         "type": "text"
-    │   │       },
-    │   │       {
-    │   │         "arguments": {
-    │   │           "path": ".agents/e2e-flue-skill.md"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "read",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "skill",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 89,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0041862,
-    │   │     "prompt_cache_creation_tokens": 670,
-    │   │     "prompt_cached_tokens": 1099,
-    │   │     "prompt_tokens": 3,
-    │   │     "tokens": 1861
-    │   │   }
-    │   ├── tool:read [tool]
-    │   │   input: {
-    │   │     "path": ".agents/e2e-flue-skill.md"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {}
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "skill",
-    │   │     "flue.tool_name": "read",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   │   error: "{\"content\":[{\"type\":\"text\",\"text\":\"ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'\"}],\"details\":{}}"
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents/e2e-flue-skill.md"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": true,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "read"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "path": ".agents"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "read",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "skill",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 52,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.00201795,
-    │   │     "prompt_cache_creation_tokens": 183,
-    │   │     "prompt_cached_tokens": 1769,
-    │   │     "prompt_tokens": 7,
-    │   │     "tokens": 2011
-    │   │   }
-    │   ├── tool:read [tool]
-    │   │   input: {
-    │   │     "path": ".agents"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "skills",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "entries": 1,
-    │   │       "isDirectory": true,
-    │   │       "path": ".agents"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "skill",
-    │   │     "flue.tool_name": "read",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents/e2e-flue-skill.md"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": true,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "read"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents"
-    │   │           },
-    │   │           "id": "<span:2>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "skills",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:2>",
-    │   │       "toolName": "read"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "path": ".agents/skills"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "read",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "skill",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 54,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0016611,
-    │   │     "prompt_cache_creation_tokens": 66,
-    │   │     "prompt_cached_tokens": 1952,
-    │   │     "prompt_tokens": 6,
-    │   │     "tokens": 2078
-    │   │   }
-    │   ├── tool:read [tool]
-    │   │   input: {
-    │   │     "path": ".agents/skills"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "e2e-flue-skill",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "entries": 1,
-    │   │       "isDirectory": true,
-    │   │       "path": ".agents/skills"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "skill",
-    │   │     "flue.tool_name": "read",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents/e2e-flue-skill.md"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": true,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "read"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents"
-    │   │           },
-    │   │           "id": "<span:2>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "skills",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:2>",
-    │   │       "toolName": "read"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents/skills"
-    │   │           },
-    │   │           "id": "<span:3>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "e2e-flue-skill",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:3>",
-    │   │       "toolName": "read"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "path": ".agents/skills/e2e-flue-skill"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "read",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "skill",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 63,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0018459,
-    │   │     "prompt_cache_creation_tokens": 74,
-    │   │     "prompt_cached_tokens": 2018,
-    │   │     "prompt_tokens": 6,
-    │   │     "tokens": 2161
-    │   │   }
-    │   ├── tool:read [tool]
-    │   │   input: {
-    │   │     "path": ".agents/skills/e2e-flue-skill"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "SKILL.md",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "entries": 1,
-    │   │       "isDirectory": true,
-    │   │       "path": ".agents/skills/e2e-flue-skill"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "skill",
-    │   │     "flue.tool_name": "read",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents/e2e-flue-skill.md"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": true,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "read"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents"
-    │   │           },
-    │   │           "id": "<span:2>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "skills",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:2>",
-    │   │       "toolName": "read"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents/skills"
-    │   │           },
-    │   │           "id": "<span:3>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "e2e-flue-skill",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:3>",
-    │   │       "toolName": "read"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents/skills/e2e-flue-skill"
-    │   │           },
-    │   │           "id": "<span:4>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "SKILL.md",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:4>",
-    │   │       "toolName": "read"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "path": ".agents/skills/e2e-flue-skill/SKILL.md"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "read",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "skill",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 68,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0019618500000000002,
-    │   │     "prompt_cache_creation_tokens": 79,
-    │   │     "prompt_cached_tokens": 2092,
-    │   │     "prompt_tokens": 6,
-    │   │     "tokens": 2245
-    │   │   }
-    │   ├── tool:read [tool]
-    │   │   input: {
-    │   │     "path": ".agents/skills/e2e-flue-skill/SKILL.md"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "lines": 7,
-    │   │       "path": ".agents/skills/e2e-flue-skill/SKILL.md"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "skill",
-    │   │     "flue.tool_name": "read",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   └── flue.turn [llm]
-    │       input: [
+    ├── flue.turn [llm]
+    │   input: [
+    │     {
+    │       "content": [
     │         {
-    │           "content": [
-    │             {
-    │               "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
+    │           "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
+    │           "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
+    │           "type": "thinking"
     │         },
     │         {
-    │           "content": [
-    │             {
-    │               "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
-    │               "type": "text"
-    │             },
-    │             {
-    │               "arguments": {
-    │                 "path": ".agents/e2e-flue-skill.md"
-    │               },
-    │               "id": "<span:1>",
-    │               "name": "read",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
+    │           "text": "Now proceeding to Step 2:",
+    │           "type": "text"
     │         },
     │         {
-    │           "content": [
-    │             {
-    │               "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": true,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:1>",
-    │           "toolName": "read"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "path": ".agents"
-    │               },
-    │               "id": "<span:2>",
-    │               "name": "read",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "skills",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:2>",
-    │           "toolName": "read"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "path": ".agents/skills"
-    │               },
-    │               "id": "<span:3>",
-    │               "name": "read",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "e2e-flue-skill",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:3>",
-    │           "toolName": "read"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "path": ".agents/skills/e2e-flue-skill"
-    │               },
-    │               "id": "<span:4>",
-    │               "name": "read",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "SKILL.md",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:4>",
-    │           "toolName": "read"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "path": ".agents/skills/e2e-flue-skill/SKILL.md"
-    │               },
-    │               "id": "<span:5>",
-    │               "name": "read",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:5>",
-    │           "toolName": "read"
+    │           "arguments": {
+    │             "lookupId": "flue-session-2026",
+    │             "query": "Braintrust Flue reasoning stream instrumentation"
+    │           },
+    │           "id": "<span:1>",
+    │           "name": "web_search",
+    │           "type": "toolCall"
     │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "text": "SKILL_DONE",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+    │           "type": "text"
+    │         }
+    │       ],
+    │       "isError": false,
+    │       "role": "toolResult",
+    │       "toolCallId": "<span:1>",
+    │       "toolName": "web_search"
+    │     }
+    │   ]
+    │   output: {
+    │     "content": [
+    │       {
+    │         "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
+    │         "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
+    │         "type": "thinking"
+    │       },
+    │       {
+    │         "text": "Now proceeding to Step 3:",
+    │         "type": "text"
+    │       },
+    │       {
+    │         "arguments": {
+    │           "url": "https://example.test/flue/reasoning-streams"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "summarize_source",
+    │         "type": "toolCall"
     │       }
-    │       metadata: {
-    │         "flue.api": "anthropic-messages",
-    │         "flue.model": "claude-sonnet-4-5-20250929",
-    │         "flue.provider": "anthropic",
-    │         "flue.session": "skill",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "claude-sonnet-4-5-20250929",
-    │         "provider": "anthropic"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 8,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.00129555,
-    │         "prompt_cache_creation_tokens": 135,
-    │         "prompt_cached_tokens": 2171,
-    │         "prompt_tokens": 6,
-    │         "tokens": 2320
-    │       }
-    ├── flue.task [task]
-    │   input: "Reply with exactly TASK_DONE and no other text."
-    │   output: "TASK_DONE"
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.session": "task",
+    │     "flue.api": "anthropic-messages",
+    │     "flue.input_message_offset": 3,
+    │     "flue.input_mode": "delta",
+    │     "flue.model": "claude-sonnet-4-5-20250929",
+    │     "flue.provider": "anthropic",
+    │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "claude-sonnet-4-5-20250929",
+    │     "provider": "anthropic"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 138,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.0037239000000000005,
+    │     "prompt_cache_creation_tokens": 234,
+    │     "prompt_cached_tokens": 2458,
+    │     "prompt_tokens": 13,
+    │     "tokens": 2843
+    │   }
+    ├── tool:summarize_source [tool]
+    │   input: {
+    │     "url": "https://example.test/flue/reasoning-streams"
+    │   }
+    │   output: {
+    │     "content": [
+    │       {
+    │         "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+    │         "type": "text"
+    │       }
+    │     ],
+    │     "details": {
+    │       "customTool": "summarize_source"
+    │     }
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "summarize_source",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   └── flue.turn [llm]
-    │       input: [
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "Reply with exactly TASK_DONE and no other text.",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
-    │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "text": "TASK_DONE",
-    │             "textSignature": "{\"v\":1,\"id\":\"msg_09b32b2821e9a4d8016a184600019081929d34bb7d4c6a246f\"}",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
-    │       }
-    │       metadata: {
-    │         "flue.api": "openai-responses",
-    │         "flue.model": "gpt-4o-mini",
-    │         "flue.provider": "openai",
-    │         "flue.session": "task:task:<uuid:1>",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "gpt-4o-mini",
-    │         "provider": "openai"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 4,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.00012299999999999998,
-    │         "prompt_cache_creation_tokens": 0,
-    │         "prompt_cached_tokens": 0,
-    │         "prompt_tokens": 804,
-    │         "tokens": 808
-    │       }
-    └── flue.compact [task]
-        input: {
-          "estimatedTokens": 2950,
-          "reason": "manual"
-        }
+    └── flue.turn [llm]
+        input: [
+          {
+            "content": [
+              {
+                "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
+                "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
+                "type": "thinking"
+              },
+              {
+                "text": "Now proceeding to Step 3:",
+                "type": "text"
+              },
+              {
+                "arguments": {
+                  "url": "https://example.test/flue/reasoning-streams"
+                },
+                "id": "<span:1>",
+                "name": "summarize_source",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          {
+            "content": [
+              {
+                "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+                "type": "text"
+              }
+            ],
+            "isError": false,
+            "role": "toolResult",
+            "toolCallId": "<span:1>",
+            "toolName": "summarize_source"
+          }
+        ]
         output: {
-          "completed": true
+          "content": [
+            {
+              "thinking": "Perfect! The summarize_source call has completed successfully. According to the instructions, I should now reply with exactly \"PROMPT_DONE\" and no other text.",
+              "thinkingSignature": "Eu8CCm4IDhgCKkAn2QOIIlYfvcs6ynsmhCslHDtBsrTA4CfmimK7zyz6+k6dZldV2JBtEBET41It0gFcGEKC0n0mAhaYVuLutpDDMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIM1xfLptxSF8rKzou8GgwRLuVmfiBYOT4CZIsiMAYz8TpvchMAWodP+T9uZ+dJ47MVdNv+p86nZXmT5d5EWlCroiAOFHHzJH2o0UjJQSquAX6wu+jIC8/DXwurGIIf2ToldPuJWF5HGj8kHMnwh777XS1NUFl1irM24rvP7kTAv3Dp8YEwb8t3g1EsicY7j+C5DzgwxVsPYCVOCgdMqQjtsqpL7AX5KQ9+hR1gK1DQjshv4Gze3hw/+C+9iptd3RlDIuwO0cm8NY+sVqeWVh3TtQujQlVt1rW/HfWjclrtT0LZSGwc6RypmfMMQi6lncIk/EPgy0XbS1plKW0tLBgB",
+              "type": "thinking"
+            },
+            {
+              "text": "PROMPT_DONE",
+              "type": "text"
+            }
+          ],
+          "role": "assistant"
         }
         metadata: {
-          "flue.operation": "compact",
+          "flue.api": "anthropic-messages",
+          "flue.input_message_offset": 5,
+          "flue.input_mode": "delta",
+          "flue.model": "claude-sonnet-4-5-20250929",
+          "flue.provider": "anthropic",
           "flue.session": "main",
-          "provider": "flue"
+          "flue.stop_reason": "stop",
+          "flue.turn_purpose": "agent",
+          "model": "claude-sonnet-4-5-20250929",
+          "provider": "anthropic"
         }
         metrics: {
-          "duration_ms": 0
+          "completion_tokens": 51,
+          "duration_ms": 0,
+          "estimated_cost": 0.0023391,
+          "prompt_cache_creation_tokens": 194,
+          "prompt_cached_tokens": 2692,
+          "prompt_tokens": 13,
+          "tokens": 2950
         }
-        └── compaction:manual [task]
-            input: {
-              "estimatedTokens": 2950,
-              "reason": "manual"
-            }
-            output: {
-              "messagesAfter": 2,
-              "messagesBefore": 8
-            }
-            metadata: {
-              "flue.compaction_reason": "manual",
-              "flue.session": "main",
-              "provider": "flue"
-            }
-            metrics: {
-              "duration_ms": 0,
-              "messages_after": 2,
-              "messages_before": 8
-            }
-            └── flue.turn [llm]
-                input: [
-                  {
-                    "content": [
-                      {
-                        "text": "<conversation>\n[User]: Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.\n\n[Assistant thinking]: The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.\n\n[Assistant]: I'll complete this instrumented research flow step by step. Starting with Step 1:\n\n[Assistant tool calls]: lookup(query=\"flue instrumentation\")\n\n[Tool result]: {\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}\n\n[Assistant thinking]: Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".\n\n[Assistant]: Now proceeding to Step 2:\n\n[Assistant tool calls]: web_search(lookupId=\"flue-session-2026\", query=\"Braintrust Flue reasoning stream instrumentation\")\n\n[Tool result]: {\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}\n\n[Assistant thinking]: Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.\n\n[Assistant]: Now proceeding to Step 3:\n\n[Assistant tool calls]: summarize_source(url=\"https://example.test/flue/reasoning-streams\")\n\n[Tool result]: {\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}\n</conversation>\n\nThis is the PREFIX of a turn that was too large to keep. The SUFFIX (recent work) is retained.\n\nSummarize the prefix to provide context for the retained suffix:\n\n## Original Request\n[What did the user ask for in this turn?]\n\n## Early Progress\n- [Key decisions and work done in the prefix]\n\n## Context for Suffix\n- [Information needed to understand the retained recent work]\n\nBe concise. Focus on what's needed to understand the kept suffix.",
-                        "type": "text"
-                      }
-                    ],
-                    "role": "user"
-                  }
-                ]
-                output: {
-                  "content": [
-                    {
-                      "text": "## Original Request\nThe user requested to complete an instrumented research flow consisting of three specific steps, involving calling various tools in a sequential manner.\n\n## Early Progress",
-                      "textSignature": "{\"v\":1,\"id\":\"msg_01ecf68325f9e202016a184601309081a0878ef4054e950d32\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "assistant"
-                }
-                metadata: {
-                  "flue.api": "openai-responses",
-                  "flue.model": "gpt-4o-mini",
-                  "flue.provider": "openai",
-                  "flue.session": "main",
-                  "flue.stop_reason": "stop",
-                  "flue.turn_purpose": "compaction_prefix",
-                  "model": "gpt-4o-mini",
-                  "provider": "openai"
-                }
-                metrics: {
-                  "completion_tokens": 0,
-                  "duration_ms": 0,
-                  "estimated_cost": 0,
-                  "prompt_cache_creation_tokens": 0,
-                  "prompt_cached_tokens": 0,
-                  "prompt_tokens": 0,
-                  "tokens": 0
-                }

--- a/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-0-explicit.span-tree.json
+++ b/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-0-explicit.span-tree.json
@@ -5,541 +5,6 @@
       "type": "task",
       "children": [
         {
-          "name": "flue.prompt",
-          "type": "task",
-          "children": [
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-                    "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-                    "type": "thinking"
-                  },
-                  {
-                    "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-                    "type": "text"
-                  },
-                  {
-                    "arguments": {
-                      "query": "flue instrumentation"
-                    },
-                    "id": "<span:1>",
-                    "name": "lookup",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "anthropic-messages",
-                "flue.model": "claude-sonnet-4-5-20250929",
-                "flue.provider": "anthropic",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "claude-sonnet-4-5-20250929",
-                "provider": "anthropic"
-              },
-              "metrics": {
-                "completion_tokens": 196,
-                "duration_ms": 0,
-                "estimated_cost": 0.0113025,
-                "prompt_cache_creation_tokens": 2222,
-                "prompt_cached_tokens": 0,
-                "prompt_tokens": 10,
-                "tokens": 2428
-              }
-            },
-            {
-              "name": "tool:lookup",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "query": "flue instrumentation"
-              },
-              "output": {
-                "content": [
-                  {
-                    "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                    "type": "text"
-                  }
-                ],
-                "details": {
-                  "customTool": "lookup"
-                }
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "lookup",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-                      "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-                    "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
-                    "type": "thinking"
-                  },
-                  {
-                    "text": "Now proceeding to Step 2:",
-                    "type": "text"
-                  },
-                  {
-                    "arguments": {
-                      "lookupId": "flue-session-2026",
-                      "query": "Braintrust Flue reasoning stream instrumentation"
-                    },
-                    "id": "<span:1>",
-                    "name": "web_search",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "anthropic-messages",
-                "flue.model": "claude-sonnet-4-5-20250929",
-                "flue.provider": "anthropic",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "claude-sonnet-4-5-20250929",
-                "provider": "anthropic"
-              },
-              "metrics": {
-                "completion_tokens": 158,
-                "duration_ms": 0,
-                "estimated_cost": 0.0039606,
-                "prompt_cache_creation_tokens": 236,
-                "prompt_cached_tokens": 2222,
-                "prompt_tokens": 13,
-                "tokens": 2629
-              }
-            },
-            {
-              "name": "tool:web_search",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "lookupId": "flue-session-2026",
-                "query": "Braintrust Flue reasoning stream instrumentation"
-              },
-              "output": {
-                "content": [
-                  {
-                    "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-                    "type": "text"
-                  }
-                ],
-                "details": {
-                  "customTool": "web_search"
-                }
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "web_search",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-                      "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-                      "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "Now proceeding to Step 2:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "lookupId": "flue-session-2026",
-                        "query": "Braintrust Flue reasoning stream instrumentation"
-                      },
-                      "id": "<span:2>",
-                      "name": "web_search",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:2>",
-                  "toolName": "web_search"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
-                    "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
-                    "type": "thinking"
-                  },
-                  {
-                    "text": "Now proceeding to Step 3:",
-                    "type": "text"
-                  },
-                  {
-                    "arguments": {
-                      "url": "https://example.test/flue/reasoning-streams"
-                    },
-                    "id": "<span:1>",
-                    "name": "summarize_source",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "anthropic-messages",
-                "flue.model": "claude-sonnet-4-5-20250929",
-                "flue.provider": "anthropic",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "claude-sonnet-4-5-20250929",
-                "provider": "anthropic"
-              },
-              "metrics": {
-                "completion_tokens": 138,
-                "duration_ms": 0,
-                "estimated_cost": 0.0037239000000000005,
-                "prompt_cache_creation_tokens": 234,
-                "prompt_cached_tokens": 2458,
-                "prompt_tokens": 13,
-                "tokens": 2843
-              }
-            },
-            {
-              "name": "tool:summarize_source",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "url": "https://example.test/flue/reasoning-streams"
-              },
-              "output": {
-                "content": [
-                  {
-                    "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-                    "type": "text"
-                  }
-                ],
-                "details": {
-                  "customTool": "summarize_source"
-                }
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "summarize_source",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-                      "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-                      "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "Now proceeding to Step 2:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "lookupId": "flue-session-2026",
-                        "query": "Braintrust Flue reasoning stream instrumentation"
-                      },
-                      "id": "<span:2>",
-                      "name": "web_search",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:2>",
-                  "toolName": "web_search"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
-                      "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "Now proceeding to Step 3:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "url": "https://example.test/flue/reasoning-streams"
-                      },
-                      "id": "<span:3>",
-                      "name": "summarize_source",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:3>",
-                  "toolName": "summarize_source"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "thinking": "Perfect! The summarize_source call has completed successfully. According to the instructions, I should now reply with exactly \"PROMPT_DONE\" and no other text.",
-                    "thinkingSignature": "Eu8CCm4IDhgCKkAn2QOIIlYfvcs6ynsmhCslHDtBsrTA4CfmimK7zyz6+k6dZldV2JBtEBET41It0gFcGEKC0n0mAhaYVuLutpDDMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIM1xfLptxSF8rKzou8GgwRLuVmfiBYOT4CZIsiMAYz8TpvchMAWodP+T9uZ+dJ47MVdNv+p86nZXmT5d5EWlCroiAOFHHzJH2o0UjJQSquAX6wu+jIC8/DXwurGIIf2ToldPuJWF5HGj8kHMnwh777XS1NUFl1irM24rvP7kTAv3Dp8YEwb8t3g1EsicY7j+C5DzgwxVsPYCVOCgdMqQjtsqpL7AX5KQ9+hR1gK1DQjshv4Gze3hw/+C+9iptd3RlDIuwO0cm8NY+sVqeWVh3TtQujQlVt1rW/HfWjclrtT0LZSGwc6RypmfMMQi6lncIk/EPgy0XbS1plKW0tLBgB",
-                    "type": "thinking"
-                  },
-                  {
-                    "text": "PROMPT_DONE",
-                    "type": "text"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "anthropic-messages",
-                "flue.model": "claude-sonnet-4-5-20250929",
-                "flue.provider": "anthropic",
-                "flue.session": "main",
-                "flue.stop_reason": "stop",
-                "flue.turn_purpose": "agent",
-                "model": "claude-sonnet-4-5-20250929",
-                "provider": "anthropic"
-              },
-              "metrics": {
-                "completion_tokens": 51,
-                "duration_ms": 0,
-                "estimated_cost": 0.0023391,
-                "prompt_cache_creation_tokens": 194,
-                "prompt_cached_tokens": 2692,
-                "prompt_tokens": 13,
-                "tokens": 2950
-              }
-            }
-          ],
-          "input": [
-            {
-              "content": [
-                {
-                  "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                  "type": "text"
-                }
-              ],
-              "role": "user"
-            }
-          ],
-          "output": "PROMPT_DONE",
-          "metadata": {
-            "flue.operation": "prompt",
-            "flue.session": "main",
-            "provider": "flue"
-          },
-          "metrics": {
-            "duration_ms": 0
-          }
-        },
-        {
           "name": "flue.skill",
           "type": "task",
           "children": [
@@ -1383,7 +848,9 @@
           "metadata": {
             "flue.operation": "skill",
             "flue.session": "skill",
-            "provider": "flue"
+            "flue.workflow_name": "instrumentation",
+            "provider": "flue",
+            "scenario": "flue-instrumentation"
           },
           "metrics": {
             "duration_ms": 0
@@ -1420,6 +887,7 @@
               },
               "metadata": {
                 "flue.api": "openai-responses",
+                "flue.input_mode": "full",
                 "flue.model": "gpt-4o-mini",
                 "flue.provider": "openai",
                 "flue.session": "task:task:<uuid:1>",
@@ -1533,7 +1001,9 @@
           "metadata": {
             "flue.operation": "compact",
             "flue.session": "main",
-            "provider": "flue"
+            "flue.workflow_name": "instrumentation",
+            "provider": "flue",
+            "scenario": "flue-instrumentation"
           },
           "metrics": {
             "duration_ms": 0
@@ -1552,6 +1022,420 @@
         "status": "done"
       },
       "metadata": {
+        "flue.workflow_name": "instrumentation",
+        "provider": "flue",
+        "scenario": "flue-instrumentation"
+      },
+      "metrics": {
+        "duration_ms": 0
+      }
+    },
+    {
+      "name": "flue.prompt",
+      "type": "task",
+      "children": [
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+                  "type": "text"
+                }
+              ],
+              "role": "user"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
+                "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
+                "type": "thinking"
+              },
+              {
+                "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
+                "type": "text"
+              },
+              {
+                "arguments": {
+                  "query": "flue instrumentation"
+                },
+                "id": "<span:1>",
+                "name": "lookup",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "anthropic-messages",
+            "flue.input_mode": "full",
+            "flue.model": "claude-sonnet-4-5-20250929",
+            "flue.provider": "anthropic",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "claude-sonnet-4-5-20250929",
+            "provider": "anthropic"
+          },
+          "metrics": {
+            "completion_tokens": 196,
+            "duration_ms": 0,
+            "estimated_cost": 0.0113025,
+            "prompt_cache_creation_tokens": 2222,
+            "prompt_cached_tokens": 0,
+            "prompt_tokens": 10,
+            "tokens": 2428
+          }
+        },
+        {
+          "name": "tool:lookup",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "query": "flue instrumentation"
+          },
+          "output": {
+            "content": [
+              {
+                "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
+                "type": "text"
+              }
+            ],
+            "details": {
+              "customTool": "lookup"
+            }
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "lookup",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
+                  "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
+                  "type": "thinking"
+                },
+                {
+                  "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
+                  "type": "text"
+                },
+                {
+                  "arguments": {
+                    "query": "flue instrumentation"
+                  },
+                  "id": "<span:1>",
+                  "name": "lookup",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "lookup"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
+                "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
+                "type": "thinking"
+              },
+              {
+                "text": "Now proceeding to Step 2:",
+                "type": "text"
+              },
+              {
+                "arguments": {
+                  "lookupId": "flue-session-2026",
+                  "query": "Braintrust Flue reasoning stream instrumentation"
+                },
+                "id": "<span:1>",
+                "name": "web_search",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "anthropic-messages",
+            "flue.input_message_offset": 1,
+            "flue.input_mode": "delta",
+            "flue.model": "claude-sonnet-4-5-20250929",
+            "flue.provider": "anthropic",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "claude-sonnet-4-5-20250929",
+            "provider": "anthropic"
+          },
+          "metrics": {
+            "completion_tokens": 158,
+            "duration_ms": 0,
+            "estimated_cost": 0.0039606,
+            "prompt_cache_creation_tokens": 236,
+            "prompt_cached_tokens": 2222,
+            "prompt_tokens": 13,
+            "tokens": 2629
+          }
+        },
+        {
+          "name": "tool:web_search",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "lookupId": "flue-session-2026",
+            "query": "Braintrust Flue reasoning stream instrumentation"
+          },
+          "output": {
+            "content": [
+              {
+                "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+                "type": "text"
+              }
+            ],
+            "details": {
+              "customTool": "web_search"
+            }
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "web_search",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
+                  "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
+                  "type": "thinking"
+                },
+                {
+                  "text": "Now proceeding to Step 2:",
+                  "type": "text"
+                },
+                {
+                  "arguments": {
+                    "lookupId": "flue-session-2026",
+                    "query": "Braintrust Flue reasoning stream instrumentation"
+                  },
+                  "id": "<span:1>",
+                  "name": "web_search",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "web_search"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
+                "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
+                "type": "thinking"
+              },
+              {
+                "text": "Now proceeding to Step 3:",
+                "type": "text"
+              },
+              {
+                "arguments": {
+                  "url": "https://example.test/flue/reasoning-streams"
+                },
+                "id": "<span:1>",
+                "name": "summarize_source",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "anthropic-messages",
+            "flue.input_message_offset": 3,
+            "flue.input_mode": "delta",
+            "flue.model": "claude-sonnet-4-5-20250929",
+            "flue.provider": "anthropic",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "claude-sonnet-4-5-20250929",
+            "provider": "anthropic"
+          },
+          "metrics": {
+            "completion_tokens": 138,
+            "duration_ms": 0,
+            "estimated_cost": 0.0037239000000000005,
+            "prompt_cache_creation_tokens": 234,
+            "prompt_cached_tokens": 2458,
+            "prompt_tokens": 13,
+            "tokens": 2843
+          }
+        },
+        {
+          "name": "tool:summarize_source",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "url": "https://example.test/flue/reasoning-streams"
+          },
+          "output": {
+            "content": [
+              {
+                "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+                "type": "text"
+              }
+            ],
+            "details": {
+              "customTool": "summarize_source"
+            }
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "summarize_source",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
+                  "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
+                  "type": "thinking"
+                },
+                {
+                  "text": "Now proceeding to Step 3:",
+                  "type": "text"
+                },
+                {
+                  "arguments": {
+                    "url": "https://example.test/flue/reasoning-streams"
+                  },
+                  "id": "<span:1>",
+                  "name": "summarize_source",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "summarize_source"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "thinking": "Perfect! The summarize_source call has completed successfully. According to the instructions, I should now reply with exactly \"PROMPT_DONE\" and no other text.",
+                "thinkingSignature": "Eu8CCm4IDhgCKkAn2QOIIlYfvcs6ynsmhCslHDtBsrTA4CfmimK7zyz6+k6dZldV2JBtEBET41It0gFcGEKC0n0mAhaYVuLutpDDMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIM1xfLptxSF8rKzou8GgwRLuVmfiBYOT4CZIsiMAYz8TpvchMAWodP+T9uZ+dJ47MVdNv+p86nZXmT5d5EWlCroiAOFHHzJH2o0UjJQSquAX6wu+jIC8/DXwurGIIf2ToldPuJWF5HGj8kHMnwh777XS1NUFl1irM24rvP7kTAv3Dp8YEwb8t3g1EsicY7j+C5DzgwxVsPYCVOCgdMqQjtsqpL7AX5KQ9+hR1gK1DQjshv4Gze3hw/+C+9iptd3RlDIuwO0cm8NY+sVqeWVh3TtQujQlVt1rW/HfWjclrtT0LZSGwc6RypmfMMQi6lncIk/EPgy0XbS1plKW0tLBgB",
+                "type": "thinking"
+              },
+              {
+                "text": "PROMPT_DONE",
+                "type": "text"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "anthropic-messages",
+            "flue.input_message_offset": 5,
+            "flue.input_mode": "delta",
+            "flue.model": "claude-sonnet-4-5-20250929",
+            "flue.provider": "anthropic",
+            "flue.session": "main",
+            "flue.stop_reason": "stop",
+            "flue.turn_purpose": "agent",
+            "model": "claude-sonnet-4-5-20250929",
+            "provider": "anthropic"
+          },
+          "metrics": {
+            "completion_tokens": 51,
+            "duration_ms": 0,
+            "estimated_cost": 0.0023391,
+            "prompt_cache_creation_tokens": 194,
+            "prompt_cached_tokens": 2692,
+            "prompt_tokens": 13,
+            "tokens": 2950
+          }
+        }
+      ],
+      "input": [
+        {
+          "content": [
+            {
+              "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+              "type": "text"
+            }
+          ],
+          "role": "user"
+        }
+      ],
+      "output": "PROMPT_DONE",
+      "metadata": {
+        "flue.operation": "prompt",
+        "flue.session": "main",
         "flue.workflow_name": "instrumentation",
         "provider": "flue",
         "scenario": "flue-instrumentation"

--- a/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-0-explicit.span-tree.txt
+++ b/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-0-explicit.span-tree.txt
@@ -1,17 +1,973 @@
 span_tree:
-└── workflow:instrumentation [task]
-    input: {
-      "metadata": {
-        "scenario": "flue-instrumentation",
-        "testRunId": "<run:1>"
-      },
-      "scenario": "flue-instrumentation"
-    }
-    output: {
-      "scenario": "flue-instrumentation",
-      "status": "done"
-    }
+├── workflow:instrumentation [task]
+│   input: {
+│     "metadata": {
+│       "scenario": "flue-instrumentation",
+│       "testRunId": "<run:1>"
+│     },
+│     "scenario": "flue-instrumentation"
+│   }
+│   output: {
+│     "scenario": "flue-instrumentation",
+│     "status": "done"
+│   }
+│   metadata: {
+│     "flue.workflow_name": "instrumentation",
+│     "provider": "flue",
+│     "scenario": "flue-instrumentation"
+│   }
+│   metrics: {
+│     "duration_ms": 0
+│   }
+│   ├── flue.skill [task]
+│   │   input: [
+│   │     {
+│   │       "content": [
+│   │         {
+│   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │           "type": "text"
+│   │         }
+│   │       ],
+│   │       "role": "user"
+│   │     }
+│   │   ]
+│   │   output: "SKILL_DONE"
+│   │   metadata: {
+│   │     "flue.operation": "skill",
+│   │     "flue.session": "skill",
+│   │     "flue.workflow_name": "instrumentation",
+│   │     "provider": "flue",
+│   │     "scenario": "flue-instrumentation"
+│   │   }
+│   │   metrics: {
+│   │     "duration_ms": 0
+│   │   }
+│   │   ├── flue.turn [llm]
+│   │   │   input: [
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "user"
+│   │   │     }
+│   │   │   ]
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
+│   │   │         "type": "text"
+│   │   │       },
+│   │   │       {
+│   │   │         "arguments": {
+│   │   │           "path": ".agents/e2e-flue-skill.md"
+│   │   │         },
+│   │   │         "id": "<span:1>",
+│   │   │         "name": "read",
+│   │   │         "type": "toolCall"
+│   │   │       }
+│   │   │     ],
+│   │   │     "role": "assistant"
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.api": "anthropic-messages",
+│   │   │     "flue.model": "claude-sonnet-4-5-20250929",
+│   │   │     "flue.provider": "anthropic",
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.stop_reason": "toolUse",
+│   │   │     "flue.turn_purpose": "agent",
+│   │   │     "model": "claude-sonnet-4-5-20250929",
+│   │   │     "provider": "anthropic"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "completion_tokens": 89,
+│   │   │     "duration_ms": 0,
+│   │   │     "estimated_cost": 0.0041862,
+│   │   │     "prompt_cache_creation_tokens": 670,
+│   │   │     "prompt_cached_tokens": 1099,
+│   │   │     "prompt_tokens": 3,
+│   │   │     "tokens": 1861
+│   │   │   }
+│   │   ├── tool:read [tool]
+│   │   │   input: {
+│   │   │     "path": ".agents/e2e-flue-skill.md"
+│   │   │   }
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
+│   │   │         "type": "text"
+│   │   │       }
+│   │   │     ],
+│   │   │     "details": {}
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.tool_name": "read",
+│   │   │     "provider": "flue"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "duration_ms": 0
+│   │   │   }
+│   │   │   error: "{\"content\":[{\"type\":\"text\",\"text\":\"ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'\"}],\"details\":{}}"
+│   │   ├── flue.turn [llm]
+│   │   │   input: [
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "user"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
+│   │   │           "type": "text"
+│   │   │         },
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents/e2e-flue-skill.md"
+│   │   │           },
+│   │   │           "id": "<span:1>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": true,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:1>",
+│   │   │       "toolName": "read"
+│   │   │     }
+│   │   │   ]
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "arguments": {
+│   │   │           "path": ".agents"
+│   │   │         },
+│   │   │         "id": "<span:1>",
+│   │   │         "name": "read",
+│   │   │         "type": "toolCall"
+│   │   │       }
+│   │   │     ],
+│   │   │     "role": "assistant"
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.api": "anthropic-messages",
+│   │   │     "flue.model": "claude-sonnet-4-5-20250929",
+│   │   │     "flue.provider": "anthropic",
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.stop_reason": "toolUse",
+│   │   │     "flue.turn_purpose": "agent",
+│   │   │     "model": "claude-sonnet-4-5-20250929",
+│   │   │     "provider": "anthropic"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "completion_tokens": 52,
+│   │   │     "duration_ms": 0,
+│   │   │     "estimated_cost": 0.00201795,
+│   │   │     "prompt_cache_creation_tokens": 183,
+│   │   │     "prompt_cached_tokens": 1769,
+│   │   │     "prompt_tokens": 7,
+│   │   │     "tokens": 2011
+│   │   │   }
+│   │   ├── tool:read [tool]
+│   │   │   input: {
+│   │   │     "path": ".agents"
+│   │   │   }
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "text": "skills",
+│   │   │         "type": "text"
+│   │   │       }
+│   │   │     ],
+│   │   │     "details": {
+│   │   │       "entries": 1,
+│   │   │       "isDirectory": true,
+│   │   │       "path": ".agents"
+│   │   │     }
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.tool_name": "read",
+│   │   │     "provider": "flue"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "duration_ms": 0
+│   │   │   }
+│   │   ├── flue.turn [llm]
+│   │   │   input: [
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "user"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
+│   │   │           "type": "text"
+│   │   │         },
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents/e2e-flue-skill.md"
+│   │   │           },
+│   │   │           "id": "<span:1>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": true,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:1>",
+│   │   │       "toolName": "read"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents"
+│   │   │           },
+│   │   │           "id": "<span:2>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "skills",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": false,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:2>",
+│   │   │       "toolName": "read"
+│   │   │     }
+│   │   │   ]
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "arguments": {
+│   │   │           "path": ".agents/skills"
+│   │   │         },
+│   │   │         "id": "<span:1>",
+│   │   │         "name": "read",
+│   │   │         "type": "toolCall"
+│   │   │       }
+│   │   │     ],
+│   │   │     "role": "assistant"
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.api": "anthropic-messages",
+│   │   │     "flue.model": "claude-sonnet-4-5-20250929",
+│   │   │     "flue.provider": "anthropic",
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.stop_reason": "toolUse",
+│   │   │     "flue.turn_purpose": "agent",
+│   │   │     "model": "claude-sonnet-4-5-20250929",
+│   │   │     "provider": "anthropic"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "completion_tokens": 54,
+│   │   │     "duration_ms": 0,
+│   │   │     "estimated_cost": 0.0016611,
+│   │   │     "prompt_cache_creation_tokens": 66,
+│   │   │     "prompt_cached_tokens": 1952,
+│   │   │     "prompt_tokens": 6,
+│   │   │     "tokens": 2078
+│   │   │   }
+│   │   ├── tool:read [tool]
+│   │   │   input: {
+│   │   │     "path": ".agents/skills"
+│   │   │   }
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "text": "e2e-flue-skill",
+│   │   │         "type": "text"
+│   │   │       }
+│   │   │     ],
+│   │   │     "details": {
+│   │   │       "entries": 1,
+│   │   │       "isDirectory": true,
+│   │   │       "path": ".agents/skills"
+│   │   │     }
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.tool_name": "read",
+│   │   │     "provider": "flue"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "duration_ms": 0
+│   │   │   }
+│   │   ├── flue.turn [llm]
+│   │   │   input: [
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "user"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
+│   │   │           "type": "text"
+│   │   │         },
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents/e2e-flue-skill.md"
+│   │   │           },
+│   │   │           "id": "<span:1>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": true,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:1>",
+│   │   │       "toolName": "read"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents"
+│   │   │           },
+│   │   │           "id": "<span:2>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "skills",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": false,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:2>",
+│   │   │       "toolName": "read"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents/skills"
+│   │   │           },
+│   │   │           "id": "<span:3>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "e2e-flue-skill",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": false,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:3>",
+│   │   │       "toolName": "read"
+│   │   │     }
+│   │   │   ]
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "arguments": {
+│   │   │           "path": ".agents/skills/e2e-flue-skill"
+│   │   │         },
+│   │   │         "id": "<span:1>",
+│   │   │         "name": "read",
+│   │   │         "type": "toolCall"
+│   │   │       }
+│   │   │     ],
+│   │   │     "role": "assistant"
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.api": "anthropic-messages",
+│   │   │     "flue.model": "claude-sonnet-4-5-20250929",
+│   │   │     "flue.provider": "anthropic",
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.stop_reason": "toolUse",
+│   │   │     "flue.turn_purpose": "agent",
+│   │   │     "model": "claude-sonnet-4-5-20250929",
+│   │   │     "provider": "anthropic"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "completion_tokens": 63,
+│   │   │     "duration_ms": 0,
+│   │   │     "estimated_cost": 0.0018459,
+│   │   │     "prompt_cache_creation_tokens": 74,
+│   │   │     "prompt_cached_tokens": 2018,
+│   │   │     "prompt_tokens": 6,
+│   │   │     "tokens": 2161
+│   │   │   }
+│   │   ├── tool:read [tool]
+│   │   │   input: {
+│   │   │     "path": ".agents/skills/e2e-flue-skill"
+│   │   │   }
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "text": "SKILL.md",
+│   │   │         "type": "text"
+│   │   │       }
+│   │   │     ],
+│   │   │     "details": {
+│   │   │       "entries": 1,
+│   │   │       "isDirectory": true,
+│   │   │       "path": ".agents/skills/e2e-flue-skill"
+│   │   │     }
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.tool_name": "read",
+│   │   │     "provider": "flue"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "duration_ms": 0
+│   │   │   }
+│   │   ├── flue.turn [llm]
+│   │   │   input: [
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "user"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
+│   │   │           "type": "text"
+│   │   │         },
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents/e2e-flue-skill.md"
+│   │   │           },
+│   │   │           "id": "<span:1>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": true,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:1>",
+│   │   │       "toolName": "read"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents"
+│   │   │           },
+│   │   │           "id": "<span:2>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "skills",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": false,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:2>",
+│   │   │       "toolName": "read"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents/skills"
+│   │   │           },
+│   │   │           "id": "<span:3>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "e2e-flue-skill",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": false,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:3>",
+│   │   │       "toolName": "read"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "arguments": {
+│   │   │             "path": ".agents/skills/e2e-flue-skill"
+│   │   │           },
+│   │   │           "id": "<span:4>",
+│   │   │           "name": "read",
+│   │   │           "type": "toolCall"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "assistant"
+│   │   │     },
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "SKILL.md",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "isError": false,
+│   │   │       "role": "toolResult",
+│   │   │       "toolCallId": "<span:4>",
+│   │   │       "toolName": "read"
+│   │   │     }
+│   │   │   ]
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "arguments": {
+│   │   │           "path": ".agents/skills/e2e-flue-skill/SKILL.md"
+│   │   │         },
+│   │   │         "id": "<span:1>",
+│   │   │         "name": "read",
+│   │   │         "type": "toolCall"
+│   │   │       }
+│   │   │     ],
+│   │   │     "role": "assistant"
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.api": "anthropic-messages",
+│   │   │     "flue.model": "claude-sonnet-4-5-20250929",
+│   │   │     "flue.provider": "anthropic",
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.stop_reason": "toolUse",
+│   │   │     "flue.turn_purpose": "agent",
+│   │   │     "model": "claude-sonnet-4-5-20250929",
+│   │   │     "provider": "anthropic"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "completion_tokens": 68,
+│   │   │     "duration_ms": 0,
+│   │   │     "estimated_cost": 0.0019618500000000002,
+│   │   │     "prompt_cache_creation_tokens": 79,
+│   │   │     "prompt_cached_tokens": 2092,
+│   │   │     "prompt_tokens": 6,
+│   │   │     "tokens": 2245
+│   │   │   }
+│   │   ├── tool:read [tool]
+│   │   │   input: {
+│   │   │     "path": ".agents/skills/e2e-flue-skill/SKILL.md"
+│   │   │   }
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
+│   │   │         "type": "text"
+│   │   │       }
+│   │   │     ],
+│   │   │     "details": {
+│   │   │       "lines": 7,
+│   │   │       "path": ".agents/skills/e2e-flue-skill/SKILL.md"
+│   │   │     }
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.tool_name": "read",
+│   │   │     "provider": "flue"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "duration_ms": 0
+│   │   │   }
+│   │   └── flue.turn [llm]
+│   │       input: [
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "role": "user"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
+│   │               "type": "text"
+│   │             },
+│   │             {
+│   │               "arguments": {
+│   │                 "path": ".agents/e2e-flue-skill.md"
+│   │               },
+│   │               "id": "<span:1>",
+│   │               "name": "read",
+│   │               "type": "toolCall"
+│   │             }
+│   │           ],
+│   │           "role": "assistant"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "isError": true,
+│   │           "role": "toolResult",
+│   │           "toolCallId": "<span:1>",
+│   │           "toolName": "read"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "arguments": {
+│   │                 "path": ".agents"
+│   │               },
+│   │               "id": "<span:2>",
+│   │               "name": "read",
+│   │               "type": "toolCall"
+│   │             }
+│   │           ],
+│   │           "role": "assistant"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "skills",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "isError": false,
+│   │           "role": "toolResult",
+│   │           "toolCallId": "<span:2>",
+│   │           "toolName": "read"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "arguments": {
+│   │                 "path": ".agents/skills"
+│   │               },
+│   │               "id": "<span:3>",
+│   │               "name": "read",
+│   │               "type": "toolCall"
+│   │             }
+│   │           ],
+│   │           "role": "assistant"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "e2e-flue-skill",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "isError": false,
+│   │           "role": "toolResult",
+│   │           "toolCallId": "<span:3>",
+│   │           "toolName": "read"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "arguments": {
+│   │                 "path": ".agents/skills/e2e-flue-skill"
+│   │               },
+│   │               "id": "<span:4>",
+│   │               "name": "read",
+│   │               "type": "toolCall"
+│   │             }
+│   │           ],
+│   │           "role": "assistant"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "SKILL.md",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "isError": false,
+│   │           "role": "toolResult",
+│   │           "toolCallId": "<span:4>",
+│   │           "toolName": "read"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "arguments": {
+│   │                 "path": ".agents/skills/e2e-flue-skill/SKILL.md"
+│   │               },
+│   │               "id": "<span:5>",
+│   │               "name": "read",
+│   │               "type": "toolCall"
+│   │             }
+│   │           ],
+│   │           "role": "assistant"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "isError": false,
+│   │           "role": "toolResult",
+│   │           "toolCallId": "<span:5>",
+│   │           "toolName": "read"
+│   │         }
+│   │       ]
+│   │       output: {
+│   │         "content": [
+│   │           {
+│   │             "text": "SKILL_DONE",
+│   │             "type": "text"
+│   │           }
+│   │         ],
+│   │         "role": "assistant"
+│   │       }
+│   │       metadata: {
+│   │         "flue.api": "anthropic-messages",
+│   │         "flue.model": "claude-sonnet-4-5-20250929",
+│   │         "flue.provider": "anthropic",
+│   │         "flue.session": "skill",
+│   │         "flue.stop_reason": "stop",
+│   │         "flue.turn_purpose": "agent",
+│   │         "model": "claude-sonnet-4-5-20250929",
+│   │         "provider": "anthropic"
+│   │       }
+│   │       metrics: {
+│   │         "completion_tokens": 8,
+│   │         "duration_ms": 0,
+│   │         "estimated_cost": 0.00129555,
+│   │         "prompt_cache_creation_tokens": 135,
+│   │         "prompt_cached_tokens": 2171,
+│   │         "prompt_tokens": 6,
+│   │         "tokens": 2320
+│   │       }
+│   ├── flue.task [task]
+│   │   input: "Reply with exactly TASK_DONE and no other text."
+│   │   output: "TASK_DONE"
+│   │   metadata: {
+│   │     "flue.session": "task",
+│   │     "provider": "flue"
+│   │   }
+│   │   metrics: {
+│   │     "duration_ms": 0
+│   │   }
+│   │   └── flue.turn [llm]
+│   │       input: [
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "Reply with exactly TASK_DONE and no other text.",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "role": "user"
+│   │         }
+│   │       ]
+│   │       output: {
+│   │         "content": [
+│   │           {
+│   │             "text": "TASK_DONE",
+│   │             "textSignature": "{\"v\":1,\"id\":\"msg_09b32b2821e9a4d8016a184600019081929d34bb7d4c6a246f\"}",
+│   │             "type": "text"
+│   │           }
+│   │         ],
+│   │         "role": "assistant"
+│   │       }
+│   │       metadata: {
+│   │         "flue.api": "openai-responses",
+│   │         "flue.input_mode": "full",
+│   │         "flue.model": "gpt-4o-mini",
+│   │         "flue.provider": "openai",
+│   │         "flue.session": "task:task:<uuid:1>",
+│   │         "flue.stop_reason": "stop",
+│   │         "flue.turn_purpose": "agent",
+│   │         "model": "gpt-4o-mini",
+│   │         "provider": "openai"
+│   │       }
+│   │       metrics: {
+│   │         "completion_tokens": 4,
+│   │         "duration_ms": 0,
+│   │         "estimated_cost": 0.00012299999999999998,
+│   │         "prompt_cache_creation_tokens": 0,
+│   │         "prompt_cached_tokens": 0,
+│   │         "prompt_tokens": 804,
+│   │         "tokens": 808
+│   │       }
+│   └── flue.compact [task]
+│       input: {
+│         "estimatedTokens": 2950,
+│         "reason": "manual"
+│       }
+│       output: {
+│         "completed": true
+│       }
+│       metadata: {
+│         "flue.operation": "compact",
+│         "flue.session": "main",
+│         "flue.workflow_name": "instrumentation",
+│         "provider": "flue",
+│         "scenario": "flue-instrumentation"
+│       }
+│       metrics: {
+│         "duration_ms": 0
+│       }
+│       └── compaction:manual [task]
+│           input: {
+│             "estimatedTokens": 2950,
+│             "reason": "manual"
+│           }
+│           output: {
+│             "messagesAfter": 2,
+│             "messagesBefore": 8
+│           }
+│           metadata: {
+│             "flue.compaction_reason": "manual",
+│             "flue.session": "main",
+│             "provider": "flue"
+│           }
+│           metrics: {
+│             "duration_ms": 0,
+│             "messages_after": 2,
+│             "messages_before": 8
+│           }
+│           └── flue.turn [llm]
+│               input: [
+│                 {
+│                   "content": [
+│                     {
+│                       "text": "<conversation>\n[User]: Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.\n\n[Assistant thinking]: The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.\n\n[Assistant]: I'll complete this instrumented research flow step by step. Starting with Step 1:\n\n[Assistant tool calls]: lookup(query=\"flue instrumentation\")\n\n[Tool result]: {\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}\n\n[Assistant thinking]: Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".\n\n[Assistant]: Now proceeding to Step 2:\n\n[Assistant tool calls]: web_search(lookupId=\"flue-session-2026\", query=\"Braintrust Flue reasoning stream instrumentation\")\n\n[Tool result]: {\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}\n\n[Assistant thinking]: Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.\n\n[Assistant]: Now proceeding to Step 3:\n\n[Assistant tool calls]: summarize_source(url=\"https://example.test/flue/reasoning-streams\")\n\n[Tool result]: {\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}\n</conversation>\n\nThis is the PREFIX of a turn that was too large to keep. The SUFFIX (recent work) is retained.\n\nSummarize the prefix to provide context for the retained suffix:\n\n## Original Request\n[What did the user ask for in this turn?]\n\n## Early Progress\n- [Key decisions and work done in the prefix]\n\n## Context for Suffix\n- [Information needed to understand the retained recent work]\n\nBe concise. Focus on what's needed to understand the kept suffix.",
+│                       "type": "text"
+│                     }
+│                   ],
+│                   "role": "user"
+│                 }
+│               ]
+│               output: {
+│                 "content": [
+│                   {
+│                     "text": "## Original Request\nThe user requested to complete an instrumented research flow consisting of three specific steps, involving calling various tools in a sequential manner.\n\n## Early Progress",
+│                     "textSignature": "{\"v\":1,\"id\":\"msg_01ecf68325f9e202016a184601309081a0878ef4054e950d32\"}",
+│                     "type": "text"
+│                   }
+│                 ],
+│                 "role": "assistant"
+│               }
+│               metadata: {
+│                 "flue.api": "openai-responses",
+│                 "flue.model": "gpt-4o-mini",
+│                 "flue.provider": "openai",
+│                 "flue.session": "main",
+│                 "flue.stop_reason": "stop",
+│                 "flue.turn_purpose": "compaction_prefix",
+│                 "model": "gpt-4o-mini",
+│                 "provider": "openai"
+│               }
+│               metrics: {
+│                 "completion_tokens": 0,
+│                 "duration_ms": 0,
+│                 "estimated_cost": 0,
+│                 "prompt_cache_creation_tokens": 0,
+│                 "prompt_cached_tokens": 0,
+│                 "prompt_tokens": 0,
+│                 "tokens": 0
+│               }
+└── flue.prompt [task]
+    input: [
+      {
+        "content": [
+          {
+            "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+            "type": "text"
+          }
+        ],
+        "role": "user"
+      }
+    ]
+    output: "PROMPT_DONE"
     metadata: {
+      "flue.operation": "prompt",
+      "flue.session": "main",
       "flue.workflow_name": "instrumentation",
       "provider": "flue",
       "scenario": "flue-instrumentation"
@@ -19,7 +975,7 @@ span_tree:
     metrics: {
       "duration_ms": 0
     }
-    ├── flue.prompt [task]
+    ├── flue.turn [llm]
     │   input: [
     │     {
     │       "content": [
@@ -31,1421 +987,349 @@ span_tree:
     │       "role": "user"
     │     }
     │   ]
-    │   output: "PROMPT_DONE"
+    │   output: {
+    │     "content": [
+    │       {
+    │         "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
+    │         "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
+    │         "type": "thinking"
+    │       },
+    │       {
+    │         "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
+    │         "type": "text"
+    │       },
+    │       {
+    │         "arguments": {
+    │           "query": "flue instrumentation"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "lookup",
+    │         "type": "toolCall"
+    │       }
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.operation": "prompt",
+    │     "flue.api": "anthropic-messages",
+    │     "flue.input_mode": "full",
+    │     "flue.model": "claude-sonnet-4-5-20250929",
+    │     "flue.provider": "anthropic",
     │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "claude-sonnet-4-5-20250929",
+    │     "provider": "anthropic"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 196,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.0113025,
+    │     "prompt_cache_creation_tokens": 2222,
+    │     "prompt_cached_tokens": 0,
+    │     "prompt_tokens": 10,
+    │     "tokens": 2428
+    │   }
+    ├── tool:lookup [tool]
+    │   input: {
+    │     "query": "flue instrumentation"
+    │   }
+    │   output: {
+    │     "content": [
+    │       {
+    │         "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
+    │         "type": "text"
+    │       }
+    │     ],
+    │     "details": {
+    │       "customTool": "lookup"
+    │     }
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "lookup",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-    │   │         "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-    │   │         "type": "thinking"
-    │   │       },
-    │   │       {
-    │   │         "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-    │   │         "type": "text"
-    │   │       },
-    │   │       {
-    │   │         "arguments": {
-    │   │           "query": "flue instrumentation"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "lookup",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 196,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0113025,
-    │   │     "prompt_cache_creation_tokens": 2222,
-    │   │     "prompt_cached_tokens": 0,
-    │   │     "prompt_tokens": 10,
-    │   │     "tokens": 2428
-    │   │   }
-    │   ├── tool:lookup [tool]
-    │   │   input: {
-    │   │     "query": "flue instrumentation"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "customTool": "lookup"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "lookup",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-    │   │           "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-    │   │           "type": "thinking"
-    │   │         },
-    │   │         {
-    │   │           "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "query": "flue instrumentation"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "lookup",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "lookup"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-    │   │         "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
-    │   │         "type": "thinking"
-    │   │       },
-    │   │       {
-    │   │         "text": "Now proceeding to Step 2:",
-    │   │         "type": "text"
-    │   │       },
-    │   │       {
-    │   │         "arguments": {
-    │   │           "lookupId": "flue-session-2026",
-    │   │           "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "web_search",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 158,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0039606,
-    │   │     "prompt_cache_creation_tokens": 236,
-    │   │     "prompt_cached_tokens": 2222,
-    │   │     "prompt_tokens": 13,
-    │   │     "tokens": 2629
-    │   │   }
-    │   ├── tool:web_search [tool]
-    │   │   input: {
-    │   │     "lookupId": "flue-session-2026",
-    │   │     "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "customTool": "web_search"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "web_search",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-    │   │           "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-    │   │           "type": "thinking"
-    │   │         },
-    │   │         {
-    │   │           "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "query": "flue instrumentation"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "lookup",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "lookup"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-    │   │           "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
-    │   │           "type": "thinking"
-    │   │         },
-    │   │         {
-    │   │           "text": "Now proceeding to Step 2:",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "lookupId": "flue-session-2026",
-    │   │             "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │           },
-    │   │           "id": "<span:2>",
-    │   │           "name": "web_search",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:2>",
-    │   │       "toolName": "web_search"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
-    │   │         "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
-    │   │         "type": "thinking"
-    │   │       },
-    │   │       {
-    │   │         "text": "Now proceeding to Step 3:",
-    │   │         "type": "text"
-    │   │       },
-    │   │       {
-    │   │         "arguments": {
-    │   │           "url": "https://example.test/flue/reasoning-streams"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "summarize_source",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 138,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0037239000000000005,
-    │   │     "prompt_cache_creation_tokens": 234,
-    │   │     "prompt_cached_tokens": 2458,
-    │   │     "prompt_tokens": 13,
-    │   │     "tokens": 2843
-    │   │   }
-    │   ├── tool:summarize_source [tool]
-    │   │   input: {
-    │   │     "url": "https://example.test/flue/reasoning-streams"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "customTool": "summarize_source"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "summarize_source",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   └── flue.turn [llm]
-    │       input: [
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
-    │               "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
-    │               "type": "thinking"
-    │             },
-    │             {
-    │               "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
-    │               "type": "text"
-    │             },
-    │             {
-    │               "arguments": {
-    │                 "query": "flue instrumentation"
-    │               },
-    │               "id": "<span:1>",
-    │               "name": "lookup",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:1>",
-    │           "toolName": "lookup"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-    │               "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
-    │               "type": "thinking"
-    │             },
-    │             {
-    │               "text": "Now proceeding to Step 2:",
-    │               "type": "text"
-    │             },
-    │             {
-    │               "arguments": {
-    │                 "lookupId": "flue-session-2026",
-    │                 "query": "Braintrust Flue reasoning stream instrumentation"
-    │               },
-    │               "id": "<span:2>",
-    │               "name": "web_search",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:2>",
-    │           "toolName": "web_search"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
-    │               "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
-    │               "type": "thinking"
-    │             },
-    │             {
-    │               "text": "Now proceeding to Step 3:",
-    │               "type": "text"
-    │             },
-    │             {
-    │               "arguments": {
-    │                 "url": "https://example.test/flue/reasoning-streams"
-    │               },
-    │               "id": "<span:3>",
-    │               "name": "summarize_source",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:3>",
-    │           "toolName": "summarize_source"
-    │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "thinking": "Perfect! The summarize_source call has completed successfully. According to the instructions, I should now reply with exactly \"PROMPT_DONE\" and no other text.",
-    │             "thinkingSignature": "Eu8CCm4IDhgCKkAn2QOIIlYfvcs6ynsmhCslHDtBsrTA4CfmimK7zyz6+k6dZldV2JBtEBET41It0gFcGEKC0n0mAhaYVuLutpDDMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIM1xfLptxSF8rKzou8GgwRLuVmfiBYOT4CZIsiMAYz8TpvchMAWodP+T9uZ+dJ47MVdNv+p86nZXmT5d5EWlCroiAOFHHzJH2o0UjJQSquAX6wu+jIC8/DXwurGIIf2ToldPuJWF5HGj8kHMnwh777XS1NUFl1irM24rvP7kTAv3Dp8YEwb8t3g1EsicY7j+C5DzgwxVsPYCVOCgdMqQjtsqpL7AX5KQ9+hR1gK1DQjshv4Gze3hw/+C+9iptd3RlDIuwO0cm8NY+sVqeWVh3TtQujQlVt1rW/HfWjclrtT0LZSGwc6RypmfMMQi6lncIk/EPgy0XbS1plKW0tLBgB",
-    │             "type": "thinking"
-    │           },
-    │           {
-    │             "text": "PROMPT_DONE",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
-    │       }
-    │       metadata: {
-    │         "flue.api": "anthropic-messages",
-    │         "flue.model": "claude-sonnet-4-5-20250929",
-    │         "flue.provider": "anthropic",
-    │         "flue.session": "main",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "claude-sonnet-4-5-20250929",
-    │         "provider": "anthropic"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 51,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.0023391,
-    │         "prompt_cache_creation_tokens": 194,
-    │         "prompt_cached_tokens": 2692,
-    │         "prompt_tokens": 13,
-    │         "tokens": 2950
-    │       }
-    ├── flue.skill [task]
+    ├── flue.turn [llm]
     │   input: [
     │     {
     │       "content": [
     │         {
-    │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+    │           "thinking": "The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.",
+    │           "thinkingSignature": "EoQFCm4IDhgCKkD+AoKMhpXNPUJ5eANwM28uUCJPCE+AXh0ACw7aXniX+YN04zdJl3hlHMbtAuKhhczLiEeOJtu4KtVpea5u5NFdMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMIOTWCNEtsiI9vF4SGgwPXC861uZx8lpOziEiMLsCukGIluD0U44degzYnHFc+BwXNIEB+yatSHlZE+a5smr9crZcft3OLmsIdXuaFSrDAyQxWd9oqfJdnvza9eWIaOCeNkVCjrTc/wotBwh5Xp8m9k/WKt7P4zzUJBuLQ1f6ZnsdWkL8OiL/2E7Up55z2+UuVWsg1Y90/x27YRFdQjv3RnztYp4bZ5oIHAlTJoCzWiBYEh/Z8c2O+wy6MHo1cp0T57OroB/4HAqRZxrjTOXpKYLmYKXAY5tU8DTd3A0/FfEhg3oPSbOhX+112szFCpm3BRNJYooUUhwSu1hO4H/6r7d/Yp9XIM4tBfzuDx83CC/YetdOFgnYkdliw0xaUGaj4o37rWIRctWHAMdlUc4NDA0Ljc1uirHDXkN8EJwWSoIjPSBTA/p/wgLrvRV5Yy9Z0dMoWOpgYF6t1H/tNAyY8ml1CA7IWyd3jnfTZ1/G3Y0xFDwJDFlb4/QKc67w36SSCa+X9mMoTxD/DYN249lsII+XX3lQ7F1zJ07THOtCyRirCaRhmE/kGwl5tiB1QHrWa9bNHxQxf9i92435JGKN053Fe14AR70MtBSzIU2/zbgvhB1vF5lZt2i46hNxfo4lXR495gEwdwC6+8HJnlEJAJkdeHfZKj+RiwXoiYKPKsSbHi83X8Hh32IifuglNxdlxVQYAQ==",
+    │           "type": "thinking"
+    │         },
+    │         {
+    │           "text": "I'll complete this instrumented research flow step by step. Starting with Step 1:",
+    │           "type": "text"
+    │         },
+    │         {
+    │           "arguments": {
+    │             "query": "flue instrumentation"
+    │           },
+    │           "id": "<span:1>",
+    │           "name": "lookup",
+    │           "type": "toolCall"
+    │         }
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
     │           "type": "text"
     │         }
     │       ],
-    │       "role": "user"
+    │       "isError": false,
+    │       "role": "toolResult",
+    │       "toolCallId": "<span:1>",
+    │       "toolName": "lookup"
     │     }
     │   ]
-    │   output: "SKILL_DONE"
+    │   output: {
+    │     "content": [
+    │       {
+    │         "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
+    │         "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
+    │         "type": "thinking"
+    │       },
+    │       {
+    │         "text": "Now proceeding to Step 2:",
+    │         "type": "text"
+    │       },
+    │       {
+    │         "arguments": {
+    │           "lookupId": "flue-session-2026",
+    │           "query": "Braintrust Flue reasoning stream instrumentation"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "web_search",
+    │         "type": "toolCall"
+    │       }
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.operation": "skill",
-    │     "flue.session": "skill",
+    │     "flue.api": "anthropic-messages",
+    │     "flue.input_message_offset": 1,
+    │     "flue.input_mode": "delta",
+    │     "flue.model": "claude-sonnet-4-5-20250929",
+    │     "flue.provider": "anthropic",
+    │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "claude-sonnet-4-5-20250929",
+    │     "provider": "anthropic"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 158,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.0039606,
+    │     "prompt_cache_creation_tokens": 236,
+    │     "prompt_cached_tokens": 2222,
+    │     "prompt_tokens": 13,
+    │     "tokens": 2629
+    │   }
+    ├── tool:web_search [tool]
+    │   input: {
+    │     "lookupId": "flue-session-2026",
+    │     "query": "Braintrust Flue reasoning stream instrumentation"
+    │   }
+    │   output: {
+    │     "content": [
+    │       {
+    │         "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+    │         "type": "text"
+    │       }
+    │     ],
+    │     "details": {
+    │       "customTool": "web_search"
+    │     }
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "web_search",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
-    │   │         "type": "text"
-    │   │       },
-    │   │       {
-    │   │         "arguments": {
-    │   │           "path": ".agents/e2e-flue-skill.md"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "read",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "skill",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 89,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0041862,
-    │   │     "prompt_cache_creation_tokens": 670,
-    │   │     "prompt_cached_tokens": 1099,
-    │   │     "prompt_tokens": 3,
-    │   │     "tokens": 1861
-    │   │   }
-    │   ├── tool:read [tool]
-    │   │   input: {
-    │   │     "path": ".agents/e2e-flue-skill.md"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {}
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "skill",
-    │   │     "flue.tool_name": "read",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   │   error: "{\"content\":[{\"type\":\"text\",\"text\":\"ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'\"}],\"details\":{}}"
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents/e2e-flue-skill.md"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": true,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "read"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "path": ".agents"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "read",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "skill",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 52,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.00201795,
-    │   │     "prompt_cache_creation_tokens": 183,
-    │   │     "prompt_cached_tokens": 1769,
-    │   │     "prompt_tokens": 7,
-    │   │     "tokens": 2011
-    │   │   }
-    │   ├── tool:read [tool]
-    │   │   input: {
-    │   │     "path": ".agents"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "skills",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "entries": 1,
-    │   │       "isDirectory": true,
-    │   │       "path": ".agents"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "skill",
-    │   │     "flue.tool_name": "read",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents/e2e-flue-skill.md"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": true,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "read"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents"
-    │   │           },
-    │   │           "id": "<span:2>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "skills",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:2>",
-    │   │       "toolName": "read"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "path": ".agents/skills"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "read",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "skill",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 54,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0016611,
-    │   │     "prompt_cache_creation_tokens": 66,
-    │   │     "prompt_cached_tokens": 1952,
-    │   │     "prompt_tokens": 6,
-    │   │     "tokens": 2078
-    │   │   }
-    │   ├── tool:read [tool]
-    │   │   input: {
-    │   │     "path": ".agents/skills"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "e2e-flue-skill",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "entries": 1,
-    │   │       "isDirectory": true,
-    │   │       "path": ".agents/skills"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "skill",
-    │   │     "flue.tool_name": "read",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents/e2e-flue-skill.md"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": true,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "read"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents"
-    │   │           },
-    │   │           "id": "<span:2>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "skills",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:2>",
-    │   │       "toolName": "read"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents/skills"
-    │   │           },
-    │   │           "id": "<span:3>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "e2e-flue-skill",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:3>",
-    │   │       "toolName": "read"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "path": ".agents/skills/e2e-flue-skill"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "read",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "skill",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 63,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0018459,
-    │   │     "prompt_cache_creation_tokens": 74,
-    │   │     "prompt_cached_tokens": 2018,
-    │   │     "prompt_tokens": 6,
-    │   │     "tokens": 2161
-    │   │   }
-    │   ├── tool:read [tool]
-    │   │   input: {
-    │   │     "path": ".agents/skills/e2e-flue-skill"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "SKILL.md",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "entries": 1,
-    │   │       "isDirectory": true,
-    │   │       "path": ".agents/skills/e2e-flue-skill"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "skill",
-    │   │     "flue.tool_name": "read",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents/e2e-flue-skill.md"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": true,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "read"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents"
-    │   │           },
-    │   │           "id": "<span:2>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "skills",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:2>",
-    │   │       "toolName": "read"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents/skills"
-    │   │           },
-    │   │           "id": "<span:3>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "e2e-flue-skill",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:3>",
-    │   │       "toolName": "read"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "path": ".agents/skills/e2e-flue-skill"
-    │   │           },
-    │   │           "id": "<span:4>",
-    │   │           "name": "read",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "SKILL.md",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:4>",
-    │   │       "toolName": "read"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "path": ".agents/skills/e2e-flue-skill/SKILL.md"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "read",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "skill",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 68,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0019618500000000002,
-    │   │     "prompt_cache_creation_tokens": 79,
-    │   │     "prompt_cached_tokens": 2092,
-    │   │     "prompt_tokens": 6,
-    │   │     "tokens": 2245
-    │   │   }
-    │   ├── tool:read [tool]
-    │   │   input: {
-    │   │     "path": ".agents/skills/e2e-flue-skill/SKILL.md"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "lines": 7,
-    │   │       "path": ".agents/skills/e2e-flue-skill/SKILL.md"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "skill",
-    │   │     "flue.tool_name": "read",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   └── flue.turn [llm]
-    │       input: [
+    ├── flue.turn [llm]
+    │   input: [
+    │     {
+    │       "content": [
     │         {
-    │           "content": [
-    │             {
-    │               "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
+    │           "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
+    │           "thinkingSignature": "EpEDCm4IDhgCKkAMahve1kB1j4njp1ZSzO8eCK4bb5Ex7MB6tjdoOXfuUDRfkBqvIGdwVly8GiA8GGYC7Y/RVfREXF6A6OXHTwFyMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMLw+fsa4yo7a7ZSoIGgyaTdvH020n2dQj9bUiMB4OokY29w+uZb4rqDnKDbLXUqUj6U0f1QCGQF2ZBYDDfDJyM5Jv1xY3rQiUUjkhBirQAS4XivjvMnWI5zHBmpI/u/pq4aGdrdb3vUsJ/ne6R1d80JA/INGF8vLkQcZ5xxEK0jU4yRE+ldc2uzavmtoxIKAFD6bqKks1Qv6u+TIZtuW7tUB/7jFxDw93KmJNruMIa8c1J6pPUyBy3xE7QwgmU0kDfIfdnljxLoEBiMwtnxjCPj9lT7HHz4FkrhbnQTV4MvAQohCLjaSbOTd6LdLxwtJPm9mc26ID4eYN1gCCzyAxGXhqLHlzc23PafvQjsZliWnLhaiNMnG0YEo78XkuJQsYAQ==",
+    │           "type": "thinking"
     │         },
     │         {
-    │           "content": [
-    │             {
-    │               "text": "I'll run the e2e-flue-skill. Let me first read the skill file to understand its instructions.",
-    │               "type": "text"
-    │             },
-    │             {
-    │               "arguments": {
-    │                 "path": ".agents/e2e-flue-skill.md"
-    │               },
-    │               "id": "<span:1>",
-    │               "name": "read",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
+    │           "text": "Now proceeding to Step 2:",
+    │           "type": "text"
     │         },
     │         {
-    │           "content": [
-    │             {
-    │               "text": "ENOENT: no such file or directory, open '<repo>/e2e/scenarios/flue-instrumentation/.agents/e2e-flue-skill.md'",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": true,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:1>",
-    │           "toolName": "read"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "path": ".agents"
-    │               },
-    │               "id": "<span:2>",
-    │               "name": "read",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "skills",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:2>",
-    │           "toolName": "read"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "path": ".agents/skills"
-    │               },
-    │               "id": "<span:3>",
-    │               "name": "read",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "e2e-flue-skill",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:3>",
-    │           "toolName": "read"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "path": ".agents/skills/e2e-flue-skill"
-    │               },
-    │               "id": "<span:4>",
-    │               "name": "read",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "SKILL.md",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:4>",
-    │           "toolName": "read"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "path": ".agents/skills/e2e-flue-skill/SKILL.md"
-    │               },
-    │               "id": "<span:5>",
-    │               "name": "read",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:5>",
-    │           "toolName": "read"
+    │           "arguments": {
+    │             "lookupId": "flue-session-2026",
+    │             "query": "Braintrust Flue reasoning stream instrumentation"
+    │           },
+    │           "id": "<span:1>",
+    │           "name": "web_search",
+    │           "type": "toolCall"
     │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "text": "SKILL_DONE",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+    │           "type": "text"
+    │         }
+    │       ],
+    │       "isError": false,
+    │       "role": "toolResult",
+    │       "toolCallId": "<span:1>",
+    │       "toolName": "web_search"
+    │     }
+    │   ]
+    │   output: {
+    │     "content": [
+    │       {
+    │         "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
+    │         "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
+    │         "type": "thinking"
+    │       },
+    │       {
+    │         "text": "Now proceeding to Step 3:",
+    │         "type": "text"
+    │       },
+    │       {
+    │         "arguments": {
+    │           "url": "https://example.test/flue/reasoning-streams"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "summarize_source",
+    │         "type": "toolCall"
     │       }
-    │       metadata: {
-    │         "flue.api": "anthropic-messages",
-    │         "flue.model": "claude-sonnet-4-5-20250929",
-    │         "flue.provider": "anthropic",
-    │         "flue.session": "skill",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "claude-sonnet-4-5-20250929",
-    │         "provider": "anthropic"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 8,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.00129555,
-    │         "prompt_cache_creation_tokens": 135,
-    │         "prompt_cached_tokens": 2171,
-    │         "prompt_tokens": 6,
-    │         "tokens": 2320
-    │       }
-    ├── flue.task [task]
-    │   input: "Reply with exactly TASK_DONE and no other text."
-    │   output: "TASK_DONE"
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.session": "task",
+    │     "flue.api": "anthropic-messages",
+    │     "flue.input_message_offset": 3,
+    │     "flue.input_mode": "delta",
+    │     "flue.model": "claude-sonnet-4-5-20250929",
+    │     "flue.provider": "anthropic",
+    │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "claude-sonnet-4-5-20250929",
+    │     "provider": "anthropic"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 138,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.0037239000000000005,
+    │     "prompt_cache_creation_tokens": 234,
+    │     "prompt_cached_tokens": 2458,
+    │     "prompt_tokens": 13,
+    │     "tokens": 2843
+    │   }
+    ├── tool:summarize_source [tool]
+    │   input: {
+    │     "url": "https://example.test/flue/reasoning-streams"
+    │   }
+    │   output: {
+    │     "content": [
+    │       {
+    │         "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+    │         "type": "text"
+    │       }
+    │     ],
+    │     "details": {
+    │       "customTool": "summarize_source"
+    │     }
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "summarize_source",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   └── flue.turn [llm]
-    │       input: [
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "Reply with exactly TASK_DONE and no other text.",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
-    │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "text": "TASK_DONE",
-    │             "textSignature": "{\"v\":1,\"id\":\"msg_09b32b2821e9a4d8016a184600019081929d34bb7d4c6a246f\"}",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
-    │       }
-    │       metadata: {
-    │         "flue.api": "openai-responses",
-    │         "flue.model": "gpt-4o-mini",
-    │         "flue.provider": "openai",
-    │         "flue.session": "task:task:<uuid:1>",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "gpt-4o-mini",
-    │         "provider": "openai"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 4,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.00012299999999999998,
-    │         "prompt_cache_creation_tokens": 0,
-    │         "prompt_cached_tokens": 0,
-    │         "prompt_tokens": 804,
-    │         "tokens": 808
-    │       }
-    └── flue.compact [task]
-        input: {
-          "estimatedTokens": 2950,
-          "reason": "manual"
-        }
+    └── flue.turn [llm]
+        input: [
+          {
+            "content": [
+              {
+                "thinking": "Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.",
+                "thinkingSignature": "EqQDCm4IDhgCKkAXv7EDAhWMcrBz11bUd5qxlzyy03CAGQfRgLHDE0uKzLATh1o2sedd8GxLwwQqV0CmLRfNxsdK/ZDp3Lks9iysMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMXDMniOy5Dy0KI8x7GgzgHs7BYJMs6/N0ur8iMPe0SwnHhP39OjEu7P8ASwK9ffwa3VP67QOlPzOstRRdEZNd0mq+BVjpmBXB+QcAzCrjAeAh/UO/d7SfFmXjqwA3//thoL/TTlGa6W+fdOCFRikn65JWT4ZdVFetfqD+9/QCP/nXEwMsLnTBAxC4EGryrgs2YT+OWwmEJ7rHKFeDs5djhwSb2J2ZJO1kRvD9s2vCCDkImygYBSIVgx1Y0CZJHhzn2Vf39v0Fbth2wDZa+OqxivV9NmDZEjmgcM+tTRx1CCnaww8LZEJQ68v/dUJy7hhD4MrNcQ62evJYPfT3+4EKKWJ/7HI7KXz91//+YAkph63XstbJMFJ3AldAFiq3ecauXt5r42N5gmCmwZX+sI48ENLGGAE=",
+                "type": "thinking"
+              },
+              {
+                "text": "Now proceeding to Step 3:",
+                "type": "text"
+              },
+              {
+                "arguments": {
+                  "url": "https://example.test/flue/reasoning-streams"
+                },
+                "id": "<span:1>",
+                "name": "summarize_source",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          {
+            "content": [
+              {
+                "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+                "type": "text"
+              }
+            ],
+            "isError": false,
+            "role": "toolResult",
+            "toolCallId": "<span:1>",
+            "toolName": "summarize_source"
+          }
+        ]
         output: {
-          "completed": true
+          "content": [
+            {
+              "thinking": "Perfect! The summarize_source call has completed successfully. According to the instructions, I should now reply with exactly \"PROMPT_DONE\" and no other text.",
+              "thinkingSignature": "Eu8CCm4IDhgCKkAn2QOIIlYfvcs6ynsmhCslHDtBsrTA4CfmimK7zyz6+k6dZldV2JBtEBET41It0gFcGEKC0n0mAhaYVuLutpDDMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIM1xfLptxSF8rKzou8GgwRLuVmfiBYOT4CZIsiMAYz8TpvchMAWodP+T9uZ+dJ47MVdNv+p86nZXmT5d5EWlCroiAOFHHzJH2o0UjJQSquAX6wu+jIC8/DXwurGIIf2ToldPuJWF5HGj8kHMnwh777XS1NUFl1irM24rvP7kTAv3Dp8YEwb8t3g1EsicY7j+C5DzgwxVsPYCVOCgdMqQjtsqpL7AX5KQ9+hR1gK1DQjshv4Gze3hw/+C+9iptd3RlDIuwO0cm8NY+sVqeWVh3TtQujQlVt1rW/HfWjclrtT0LZSGwc6RypmfMMQi6lncIk/EPgy0XbS1plKW0tLBgB",
+              "type": "thinking"
+            },
+            {
+              "text": "PROMPT_DONE",
+              "type": "text"
+            }
+          ],
+          "role": "assistant"
         }
         metadata: {
-          "flue.operation": "compact",
+          "flue.api": "anthropic-messages",
+          "flue.input_message_offset": 5,
+          "flue.input_mode": "delta",
+          "flue.model": "claude-sonnet-4-5-20250929",
+          "flue.provider": "anthropic",
           "flue.session": "main",
-          "provider": "flue"
+          "flue.stop_reason": "stop",
+          "flue.turn_purpose": "agent",
+          "model": "claude-sonnet-4-5-20250929",
+          "provider": "anthropic"
         }
         metrics: {
-          "duration_ms": 0
+          "completion_tokens": 51,
+          "duration_ms": 0,
+          "estimated_cost": 0.0023391,
+          "prompt_cache_creation_tokens": 194,
+          "prompt_cached_tokens": 2692,
+          "prompt_tokens": 13,
+          "tokens": 2950
         }
-        └── compaction:manual [task]
-            input: {
-              "estimatedTokens": 2950,
-              "reason": "manual"
-            }
-            output: {
-              "messagesAfter": 2,
-              "messagesBefore": 8
-            }
-            metadata: {
-              "flue.compaction_reason": "manual",
-              "flue.session": "main",
-              "provider": "flue"
-            }
-            metrics: {
-              "duration_ms": 0,
-              "messages_after": 2,
-              "messages_before": 8
-            }
-            └── flue.turn [llm]
-                input: [
-                  {
-                    "content": [
-                      {
-                        "text": "<conversation>\n[User]: Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.\n\n[Assistant thinking]: The user wants me to complete a research flow with exactly three steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Call web_search with the lookupId from step 1 and query \"Braintrust Flue reasoning stream instrumentation\"\n3. Call summarize_source with the first URL from step 2\n4. Reply with exactly \"PROMPT_DONE\"\n\nThe user emphasizes I should call exactly one tool per turn and wait for each result. Let me start with step 1.\n\n[Assistant]: I'll complete this instrumented research flow step by step. Starting with Step 1:\n\n[Assistant tool calls]: lookup(query=\"flue instrumentation\")\n\n[Tool result]: {\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}\n\n[Assistant thinking]: Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2: call web_search with this lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".\n\n[Assistant]: Now proceeding to Step 2:\n\n[Assistant tool calls]: web_search(lookupId=\"flue-session-2026\", query=\"Braintrust Flue reasoning stream instrumentation\")\n\n[Tool result]: {\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}\n\n[Assistant thinking]: Perfect! I got the web_search results with one result. The first (and only) result has the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3: call summarize_source with this URL.\n\n[Assistant]: Now proceeding to Step 3:\n\n[Assistant tool calls]: summarize_source(url=\"https://example.test/flue/reasoning-streams\")\n\n[Tool result]: {\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}\n</conversation>\n\nThis is the PREFIX of a turn that was too large to keep. The SUFFIX (recent work) is retained.\n\nSummarize the prefix to provide context for the retained suffix:\n\n## Original Request\n[What did the user ask for in this turn?]\n\n## Early Progress\n- [Key decisions and work done in the prefix]\n\n## Context for Suffix\n- [Information needed to understand the retained recent work]\n\nBe concise. Focus on what's needed to understand the kept suffix.",
-                        "type": "text"
-                      }
-                    ],
-                    "role": "user"
-                  }
-                ]
-                output: {
-                  "content": [
-                    {
-                      "text": "## Original Request\nThe user requested to complete an instrumented research flow consisting of three specific steps, involving calling various tools in a sequential manner.\n\n## Early Progress",
-                      "textSignature": "{\"v\":1,\"id\":\"msg_01ecf68325f9e202016a184601309081a0878ef4054e950d32\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "assistant"
-                }
-                metadata: {
-                  "flue.api": "openai-responses",
-                  "flue.model": "gpt-4o-mini",
-                  "flue.provider": "openai",
-                  "flue.session": "main",
-                  "flue.stop_reason": "stop",
-                  "flue.turn_purpose": "compaction_prefix",
-                  "model": "gpt-4o-mini",
-                  "provider": "openai"
-                }
-                metrics: {
-                  "completion_tokens": 0,
-                  "duration_ms": 0,
-                  "estimated_cost": 0,
-                  "prompt_cache_creation_tokens": 0,
-                  "prompt_cached_tokens": 0,
-                  "prompt_tokens": 0,
-                  "tokens": 0
-                }

--- a/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-latest-auto-hook.span-tree.json
+++ b/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-latest-auto-hook.span-tree.json
@@ -5,456 +5,6 @@
       "type": "task",
       "children": [
         {
-          "name": "flue.prompt",
-          "type": "task",
-          "children": [
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "arguments": {
-                      "query": "flue instrumentation"
-                    },
-                    "id": "<span:1>",
-                    "name": "lookup",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "openai-responses",
-                "flue.model": "gpt-5.4-nano",
-                "flue.provider": "openai",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "gpt-5.4-nano",
-                "provider": "openai"
-              },
-              "metrics": {
-                "completion_tokens": 19,
-                "duration_ms": 0,
-                "estimated_cost": 0.00022475000000000001,
-                "prompt_cache_creation_tokens": 0,
-                "prompt_cached_tokens": 0,
-                "prompt_tokens": 1005,
-                "tokens": 1024
-              }
-            },
-            {
-              "name": "tool:lookup",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "query": "flue instrumentation"
-              },
-              "output": {
-                "content": [
-                  {
-                    "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                    "type": "text"
-                  }
-                ],
-                "details": {
-                  "customTool": "lookup"
-                }
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "lookup",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "arguments": {
-                      "lookupId": "flue-session-2026",
-                      "query": "Braintrust Flue reasoning stream instrumentation"
-                    },
-                    "id": "<span:1>",
-                    "name": "web_search",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "openai-responses",
-                "flue.model": "gpt-5.4-nano",
-                "flue.provider": "openai",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "gpt-5.4-nano",
-                "provider": "openai"
-              },
-              "metrics": {
-                "completion_tokens": 34,
-                "duration_ms": 0,
-                "estimated_cost": 0.00025350000000000004,
-                "prompt_cache_creation_tokens": 0,
-                "prompt_cached_tokens": 0,
-                "prompt_tokens": 1055,
-                "tokens": 1089
-              }
-            },
-            {
-              "name": "tool:web_search",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "lookupId": "flue-session-2026",
-                "query": "Braintrust Flue reasoning stream instrumentation"
-              },
-              "output": {
-                "content": [
-                  {
-                    "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-                    "type": "text"
-                  }
-                ],
-                "details": {
-                  "customTool": "web_search"
-                }
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "web_search",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                },
-                {
-                  "content": [
-                    {
-                      "arguments": {
-                        "lookupId": "flue-session-2026",
-                        "query": "Braintrust Flue reasoning stream instrumentation"
-                      },
-                      "id": "<span:2>",
-                      "name": "web_search",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:2>",
-                  "toolName": "web_search"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "arguments": {
-                      "url": "https://example.test/flue/reasoning-streams"
-                    },
-                    "id": "<span:1>",
-                    "name": "summarize_source",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "openai-responses",
-                "flue.model": "gpt-5.4-nano",
-                "flue.provider": "openai",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "gpt-5.4-nano",
-                "provider": "openai"
-              },
-              "metrics": {
-                "completion_tokens": 30,
-                "duration_ms": 0,
-                "estimated_cost": 0.00026690000000000004,
-                "prompt_cache_creation_tokens": 0,
-                "prompt_cached_tokens": 0,
-                "prompt_tokens": 1147,
-                "tokens": 1177
-              }
-            },
-            {
-              "name": "tool:summarize_source",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "url": "https://example.test/flue/reasoning-streams"
-              },
-              "output": {
-                "content": [
-                  {
-                    "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-                    "type": "text"
-                  }
-                ],
-                "details": {
-                  "customTool": "summarize_source"
-                }
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "summarize_source",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                },
-                {
-                  "content": [
-                    {
-                      "arguments": {
-                        "lookupId": "flue-session-2026",
-                        "query": "Braintrust Flue reasoning stream instrumentation"
-                      },
-                      "id": "<span:2>",
-                      "name": "web_search",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:2>",
-                  "toolName": "web_search"
-                },
-                {
-                  "content": [
-                    {
-                      "arguments": {
-                        "url": "https://example.test/flue/reasoning-streams"
-                      },
-                      "id": "<span:3>",
-                      "name": "summarize_source",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:3>",
-                  "toolName": "summarize_source"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "text": "PROMPT_DONE",
-                    "textSignature": "{\"v\":1,\"id\":\"msg_045458052dc10379016a705b62dbd8819189b8287061debf12\",\"phase\":\"final_answer\"}",
-                    "type": "text"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "openai-responses",
-                "flue.model": "gpt-5.4-nano",
-                "flue.provider": "openai",
-                "flue.session": "main",
-                "flue.stop_reason": "stop",
-                "flue.turn_purpose": "agent",
-                "model": "gpt-5.4-nano",
-                "provider": "openai"
-              },
-              "metrics": {
-                "completion_tokens": 7,
-                "duration_ms": 0,
-                "estimated_cost": 0.00025315000000000005,
-                "prompt_cache_creation_tokens": 0,
-                "prompt_cached_tokens": 0,
-                "prompt_tokens": 1222,
-                "tokens": 1229
-              }
-            }
-          ],
-          "input": [
-            {
-              "content": [
-                {
-                  "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                  "type": "text"
-                }
-              ],
-              "role": "user"
-            }
-          ],
-          "output": "PROMPT_DONE",
-          "metadata": {
-            "flue.operation": "prompt",
-            "flue.session": "main",
-            "provider": "flue"
-          },
-          "metrics": {
-            "duration_ms": 0
-          }
-        },
-        {
           "name": "flue.skill",
           "type": "task",
           "children": [
@@ -499,6 +49,7 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_mode": "full",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -554,15 +105,6 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "agent": "e2e-flue-skill",
                                 "cwd": ".",
@@ -605,6 +147,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 1,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -660,48 +204,11 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "command": "find . -maxdepth 4 -name AGENTS.md -print",
                                 "timeout": 100000
                               },
-                              "id": "<span:2>",
+                              "id": "<span:1>",
                               "name": "bash",
                               "type": "toolCall"
                             }
@@ -717,7 +224,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:2>",
+                          "toolCallId": "<span:1>",
                           "toolName": "bash"
                         }
                       ],
@@ -737,6 +244,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 3,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -792,74 +301,11 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -name AGENTS.md -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:2>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:2>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
                                 "timeout": 100000
                               },
-                              "id": "<span:3>",
+                              "id": "<span:1>",
                               "name": "bash",
                               "type": "toolCall"
                             }
@@ -875,7 +321,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:3>",
+                          "toolCallId": "<span:1>",
                           "toolName": "bash"
                         }
                       ],
@@ -895,6 +341,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 5,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -950,100 +398,11 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -name AGENTS.md -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:2>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:2>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-                                "timeout": 100000
-                              },
-                              "id": "<span:3>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:3>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
                                 "timeout": 100000
                               },
-                              "id": "<span:4>",
+                              "id": "<span:1>",
                               "name": "bash",
                               "type": "toolCall"
                             }
@@ -1059,7 +418,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:4>",
+                          "toolCallId": "<span:1>",
                           "toolName": "bash"
                         }
                       ],
@@ -1079,6 +438,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 7,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -1134,126 +495,11 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -name AGENTS.md -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:2>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:2>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-                                "timeout": 100000
-                              },
-                              "id": "<span:3>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:3>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:4>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:4>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
                                 "timeout": 100000
                               },
-                              "id": "<span:5>",
+                              "id": "<span:1>",
                               "name": "bash",
                               "type": "toolCall"
                             }
@@ -1269,7 +515,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:5>",
+                          "toolCallId": "<span:1>",
                           "toolName": "bash"
                         }
                       ],
@@ -1289,6 +535,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 9,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -1344,152 +592,11 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -name AGENTS.md -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:2>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:2>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-                                "timeout": 100000
-                              },
-                              "id": "<span:3>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:3>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:4>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:4>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-                                "timeout": 100000
-                              },
-                              "id": "<span:5>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:5>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
                                 "timeout": 100000
                               },
-                              "id": "<span:6>",
+                              "id": "<span:1>",
                               "name": "bash",
                               "type": "toolCall"
                             }
@@ -1505,7 +612,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:6>",
+                          "toolCallId": "<span:1>",
                           "toolName": "bash"
                         }
                       ],
@@ -1526,6 +633,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 11,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -1582,179 +691,12 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -name AGENTS.md -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:2>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:2>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-                                "timeout": 100000
-                              },
-                              "id": "<span:3>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:3>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:4>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:4>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-                                "timeout": 100000
-                              },
-                              "id": "<span:5>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:5>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:6>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:6>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "limit": 200,
                                 "offset": 1,
                                 "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
                               },
-                              "id": "<span:7>",
+                              "id": "<span:1>",
                               "name": "read",
                               "type": "toolCall"
                             }
@@ -1770,7 +712,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:7>",
+                          "toolCallId": "<span:1>",
                           "toolName": "read"
                         }
                       ],
@@ -1790,6 +732,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 13,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -1845,205 +789,11 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -name AGENTS.md -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:2>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:2>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-                                "timeout": 100000
-                              },
-                              "id": "<span:3>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:3>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:4>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:4>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-                                "timeout": 100000
-                              },
-                              "id": "<span:5>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:5>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:6>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:6>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "limit": 200,
-                                "offset": 1,
-                                "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-                              },
-                              "id": "<span:7>",
-                              "name": "read",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:7>",
-                          "toolName": "read"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "command": "cat ./package.json",
                                 "timeout": 100000
                               },
-                              "id": "<span:8>",
+                              "id": "<span:1>",
                               "name": "bash",
                               "type": "toolCall"
                             }
@@ -2059,7 +809,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:8>",
+                          "toolCallId": "<span:1>",
                           "toolName": "bash"
                         }
                       ],
@@ -2079,6 +829,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 15,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -2134,231 +886,11 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -name AGENTS.md -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:2>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:2>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-                                "timeout": 100000
-                              },
-                              "id": "<span:3>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:3>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:4>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:4>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-                                "timeout": 100000
-                              },
-                              "id": "<span:5>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:5>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:6>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:6>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "limit": 200,
-                                "offset": 1,
-                                "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-                              },
-                              "id": "<span:7>",
-                              "name": "read",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:7>",
-                          "toolName": "read"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "cat ./package.json",
-                                "timeout": 100000
-                              },
-                              "id": "<span:8>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "{\n  \"name\": \"flue-instrumentation-scenario\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"braintrustScenario\": {\n    \"bump\": {\n      \"dependencies\": {\n        \"flue-cli-v0-8-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-cli-v1-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v0-8-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-runtime-v1-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v2-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=2.0.0 <3.0.0\"\n        }\n      }\n    }\n  },\n  \"dependencies\": {\n    \"@flue/cli\": \"0.8.0\",\n    \"@flue/runtime\": \"0.8.0\",\n    \"flue-cli-v0-8-latest\": \"npm:@flue/cli@0.8.1\",\n    \"flue-cli-v1\": \"npm:@flue/cli@1.0.0-beta.3\",\n    \"flue-cli-v1-latest\": \"npm:@flue/cli@1.0.0-beta.9\",\n    \"flue-runtime-v0-8-latest\": \"npm:@flue/runtime@0.8.1\",\n    \"flue-runtime-v1\": \"npm:@flue/runtime@1.0.0-beta.3\",\n    \"flue-runtime-v1-latest\": \"npm:@flue/runtime@1.0.0-beta.9\",\n    \"flue-runtime-v2\": \"npm:@flue/runtime@2.0.0\",\n    \"flue-runtime-v2-latest\": \"npm:@flue/runtime@2.0.1\",\n    \"pi-ai-v2\": \"npm:@earendil-works/pi-ai@0.83.0\",\n    \"valibot\": \"1.4.2\"\n  },\n  \"pnpm\": {\n    \"overrides\": {\n      \"@flue/runtime@0.8.0>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.0>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@hono/node-server@>=2.0.0 <2.0.10\": \"^2.0.10\",\n      \"fast-uri@<3.1.5\": \"^3.1.5\",\n      \"hono@>=4.0.0 <4.12.27\": \"^4.12.27\",\n      \"brace-expansion@>=3.0.0 <5.0.9\": \"^5.0.9\",\n      \"postcss@<8.5.18\": \"^8.5.18\",\n      \"valibot@<1.4.2\": \"^1.4.2\",\n      \"ip-address@<10.2.2\": \"^10.2.2\",\n      \"undici@<7.29.0\": \"^7.29.0\"\n    }\n  }\n}",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:8>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "command": "printf SKILL_DONE",
                                 "timeout": 100000
                               },
-                              "id": "<span:9>",
+                              "id": "<span:1>",
                               "name": "bash",
                               "type": "toolCall"
                             }
@@ -2374,7 +906,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:9>",
+                          "toolCallId": "<span:1>",
                           "toolName": "bash"
                         }
                       ],
@@ -2390,6 +922,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 17,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -2586,7 +1120,9 @@
           "metadata": {
             "flue.operation": "skill",
             "flue.session": "skill",
-            "provider": "flue"
+            "flue.workflow_name": "instrumentation",
+            "provider": "flue",
+            "scenario": "flue-instrumentation"
           },
           "metrics": {
             "duration_ms": 0
@@ -2623,6 +1159,7 @@
               },
               "metadata": {
                 "flue.api": "openai-responses",
+                "flue.input_mode": "full",
                 "flue.model": "gpt-4o-mini",
                 "flue.provider": "openai",
                 "flue.session": "task:task:<uuid:1>",
@@ -2736,7 +1273,9 @@
           "metadata": {
             "flue.operation": "compact",
             "flue.session": "main",
-            "provider": "flue"
+            "flue.workflow_name": "instrumentation",
+            "provider": "flue",
+            "scenario": "flue-instrumentation"
           },
           "metrics": {
             "duration_ms": 0
@@ -2755,6 +1294,362 @@
         "status": "done"
       },
       "metadata": {
+        "flue.workflow_name": "instrumentation",
+        "provider": "flue",
+        "scenario": "flue-instrumentation"
+      },
+      "metrics": {
+        "duration_ms": 0
+      }
+    },
+    {
+      "name": "flue.prompt",
+      "type": "task",
+      "children": [
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+                  "type": "text"
+                }
+              ],
+              "role": "user"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "arguments": {
+                  "query": "flue instrumentation"
+                },
+                "id": "<span:1>",
+                "name": "lookup",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "openai-responses",
+            "flue.input_mode": "full",
+            "flue.model": "gpt-5.4-nano",
+            "flue.provider": "openai",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "gpt-5.4-nano",
+            "provider": "openai"
+          },
+          "metrics": {
+            "completion_tokens": 19,
+            "duration_ms": 0,
+            "estimated_cost": 0.00022475000000000001,
+            "prompt_cache_creation_tokens": 0,
+            "prompt_cached_tokens": 0,
+            "prompt_tokens": 1005,
+            "tokens": 1024
+          }
+        },
+        {
+          "name": "tool:lookup",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "query": "flue instrumentation"
+          },
+          "output": {
+            "content": [
+              {
+                "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
+                "type": "text"
+              }
+            ],
+            "details": {
+              "customTool": "lookup"
+            }
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "lookup",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "arguments": {
+                    "query": "flue instrumentation"
+                  },
+                  "id": "<span:1>",
+                  "name": "lookup",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "lookup"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "arguments": {
+                  "lookupId": "flue-session-2026",
+                  "query": "Braintrust Flue reasoning stream instrumentation"
+                },
+                "id": "<span:1>",
+                "name": "web_search",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "openai-responses",
+            "flue.input_message_offset": 1,
+            "flue.input_mode": "delta",
+            "flue.model": "gpt-5.4-nano",
+            "flue.provider": "openai",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "gpt-5.4-nano",
+            "provider": "openai"
+          },
+          "metrics": {
+            "completion_tokens": 34,
+            "duration_ms": 0,
+            "estimated_cost": 0.00025350000000000004,
+            "prompt_cache_creation_tokens": 0,
+            "prompt_cached_tokens": 0,
+            "prompt_tokens": 1055,
+            "tokens": 1089
+          }
+        },
+        {
+          "name": "tool:web_search",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "lookupId": "flue-session-2026",
+            "query": "Braintrust Flue reasoning stream instrumentation"
+          },
+          "output": {
+            "content": [
+              {
+                "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+                "type": "text"
+              }
+            ],
+            "details": {
+              "customTool": "web_search"
+            }
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "web_search",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "arguments": {
+                    "lookupId": "flue-session-2026",
+                    "query": "Braintrust Flue reasoning stream instrumentation"
+                  },
+                  "id": "<span:1>",
+                  "name": "web_search",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "web_search"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "arguments": {
+                  "url": "https://example.test/flue/reasoning-streams"
+                },
+                "id": "<span:1>",
+                "name": "summarize_source",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "openai-responses",
+            "flue.input_message_offset": 3,
+            "flue.input_mode": "delta",
+            "flue.model": "gpt-5.4-nano",
+            "flue.provider": "openai",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "gpt-5.4-nano",
+            "provider": "openai"
+          },
+          "metrics": {
+            "completion_tokens": 30,
+            "duration_ms": 0,
+            "estimated_cost": 0.00026690000000000004,
+            "prompt_cache_creation_tokens": 0,
+            "prompt_cached_tokens": 0,
+            "prompt_tokens": 1147,
+            "tokens": 1177
+          }
+        },
+        {
+          "name": "tool:summarize_source",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "url": "https://example.test/flue/reasoning-streams"
+          },
+          "output": {
+            "content": [
+              {
+                "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+                "type": "text"
+              }
+            ],
+            "details": {
+              "customTool": "summarize_source"
+            }
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "summarize_source",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "arguments": {
+                    "url": "https://example.test/flue/reasoning-streams"
+                  },
+                  "id": "<span:1>",
+                  "name": "summarize_source",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "summarize_source"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "text": "PROMPT_DONE",
+                "textSignature": "{\"v\":1,\"id\":\"msg_045458052dc10379016a705b62dbd8819189b8287061debf12\",\"phase\":\"final_answer\"}",
+                "type": "text"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "openai-responses",
+            "flue.input_message_offset": 5,
+            "flue.input_mode": "delta",
+            "flue.model": "gpt-5.4-nano",
+            "flue.provider": "openai",
+            "flue.session": "main",
+            "flue.stop_reason": "stop",
+            "flue.turn_purpose": "agent",
+            "model": "gpt-5.4-nano",
+            "provider": "openai"
+          },
+          "metrics": {
+            "completion_tokens": 7,
+            "duration_ms": 0,
+            "estimated_cost": 0.00025315000000000005,
+            "prompt_cache_creation_tokens": 0,
+            "prompt_cached_tokens": 0,
+            "prompt_tokens": 1222,
+            "tokens": 1229
+          }
+        }
+      ],
+      "input": [
+        {
+          "content": [
+            {
+              "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+              "type": "text"
+            }
+          ],
+          "role": "user"
+        }
+      ],
+      "output": "PROMPT_DONE",
+      "metadata": {
+        "flue.operation": "prompt",
+        "flue.session": "main",
         "flue.workflow_name": "instrumentation",
         "provider": "flue",
         "scenario": "flue-instrumentation"

--- a/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-latest-auto-hook.span-tree.txt
+++ b/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-latest-auto-hook.span-tree.txt
@@ -1,17 +1,1195 @@
 span_tree:
-└── workflow:instrumentation [task]
-    input: {
-      "metadata": {
-        "scenario": "flue-instrumentation",
-        "testRunId": "<run:1>"
-      },
-      "scenario": "flue-instrumentation"
-    }
-    output: {
-      "scenario": "flue-instrumentation",
-      "status": "done"
-    }
+├── workflow:instrumentation [task]
+│   input: {
+│     "metadata": {
+│       "scenario": "flue-instrumentation",
+│       "testRunId": "<run:1>"
+│     },
+│     "scenario": "flue-instrumentation"
+│   }
+│   output: {
+│     "scenario": "flue-instrumentation",
+│     "status": "done"
+│   }
+│   metadata: {
+│     "flue.workflow_name": "instrumentation",
+│     "provider": "flue",
+│     "scenario": "flue-instrumentation"
+│   }
+│   metrics: {
+│     "duration_ms": 0
+│   }
+│   ├── flue.skill [task]
+│   │   input: [
+│   │     {
+│   │       "content": [
+│   │         {
+│   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │           "type": "text"
+│   │         }
+│   │       ],
+│   │       "role": "user"
+│   │     }
+│   │   ]
+│   │   output: "SKILL_DONE"
+│   │   metadata: {
+│   │     "flue.operation": "skill",
+│   │     "flue.session": "skill",
+│   │     "flue.workflow_name": "instrumentation",
+│   │     "provider": "flue",
+│   │     "scenario": "flue-instrumentation"
+│   │   }
+│   │   metrics: {
+│   │     "duration_ms": 0
+│   │   }
+│   │   ├── flue.turn [llm]
+│   │   │   input: [
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "user"
+│   │   │     }
+│   │   │   ]
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "arguments": {
+│   │   │           "cwd": ".",
+│   │   │           "description": "Run the deterministic Flue instrumentation e2e test skill e2e-flue-skill.",
+│   │   │           "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
+│   │   │         },
+│   │   │         "id": "<span:1>",
+│   │   │         "name": "task",
+│   │   │         "type": "toolCall"
+│   │   │       }
+│   │   │     ],
+│   │   │     "role": "assistant"
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.api": "openai-responses",
+│   │   │     "flue.model": "gpt-5.4-nano",
+│   │   │     "flue.provider": "openai",
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.stop_reason": "toolUse",
+│   │   │     "flue.turn_purpose": "agent",
+│   │   │     "model": "gpt-5.4-nano",
+│   │   │     "provider": "openai"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "completion_tokens": 109,
+│   │   │     "duration_ms": 0,
+│   │   │     "estimated_cost": 0.00030565000000000003,
+│   │   │     "prompt_cache_creation_tokens": 0,
+│   │   │     "prompt_cached_tokens": 0,
+│   │   │     "prompt_tokens": 847,
+│   │   │     "tokens": 956
+│   │   │   }
+│   │   │   └── flue.task [task]
+│   │   │       input: "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
+│   │   │       output: "SKILL_DONE"
+│   │   │       metadata: {
+│   │   │         "flue.session": "skill",
+│   │   │         "provider": "flue"
+│   │   │       }
+│   │   │       metrics: {
+│   │   │         "duration_ms": 0
+│   │   │       }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "user"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "agent": "e2e-flue-skill",
+│   │   │       │           "cwd": ".",
+│   │   │       │           "description": "Run e2e-flue-skill with marker SKILL_DONE",
+│   │   │       │           "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "task",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_mode": "full",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 113,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.00031225000000000003,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 0,
+│   │   │       │     "prompt_tokens": 855,
+│   │   │       │     "tokens": 968
+│   │   │       │   }
+│   │   │       ├── tool:task [tool]
+│   │   │       │   input: {
+│   │   │       │     "agent": "e2e-flue-skill",
+│   │   │       │     "cwd": ".",
+│   │   │       │     "description": "Run e2e-flue-skill with marker SKILL_DONE",
+│   │   │       │     "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {}
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "task",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       │   error: "{\"content\":[{\"type\":\"text\",\"text\":\"[flue] Subagent \\\"e2e-flue-skill\\\" is not declared. Available: (none).\"}],\"details\":{}}"
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "agent": "e2e-flue-skill",
+│   │   │       │             "cwd": ".",
+│   │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
+│   │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "task",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": true,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "task"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "command": "find . -maxdepth 4 -name AGENTS.md -print",
+│   │   │       │           "timeout": 100000
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "bash",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 1,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 94,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.00031790000000000003,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 0,
+│   │   │       │     "prompt_tokens": 1002,
+│   │   │       │     "tokens": 1096
+│   │   │       │   }
+│   │   │       ├── tool:bash [tool]
+│   │   │       │   input: {
+│   │   │       │     "command": "find . -maxdepth 4 -name AGENTS.md -print",
+│   │   │       │     "timeout": 100000
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "(no output)",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "command": "find . -maxdepth 4 -name AGENTS.md -print",
+│   │   │       │       "exitCode": 0
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "bash",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
+│   │   │       │             "timeout": 100000
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "bash",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "(no output)",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": false,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "bash"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
+│   │   │       │           "timeout": 100000
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "bash",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 3,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 87,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.00034815000000000003,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 0,
+│   │   │       │     "prompt_tokens": 1197,
+│   │   │       │     "tokens": 1284
+│   │   │       │   }
+│   │   │       ├── tool:bash [tool]
+│   │   │       │   input: {
+│   │   │       │     "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
+│   │   │       │     "timeout": 100000
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "(no output)",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
+│   │   │       │       "exitCode": 0
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "bash",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
+│   │   │       │             "timeout": 100000
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "bash",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "(no output)",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": false,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "bash"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
+│   │   │       │           "timeout": 100000
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "bash",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 5,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 58,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.0003321,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 0,
+│   │   │       │     "prompt_tokens": 1298,
+│   │   │       │     "tokens": 1356
+│   │   │       │   }
+│   │   │       ├── tool:bash [tool]
+│   │   │       │   input: {
+│   │   │       │     "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
+│   │   │       │     "timeout": 100000
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "(no output)",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
+│   │   │       │       "exitCode": 0
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "bash",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
+│   │   │       │             "timeout": 100000
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "bash",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "(no output)",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": false,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "bash"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
+│   │   │       │           "timeout": 100000
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "bash",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 7,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 68,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.00035900000000000005,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 0,
+│   │   │       │     "prompt_tokens": 1370,
+│   │   │       │     "tokens": 1438
+│   │   │       │   }
+│   │   │       ├── tool:bash [tool]
+│   │   │       │   input: {
+│   │   │       │     "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
+│   │   │       │     "timeout": 100000
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
+│   │   │       │       "exitCode": 0
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "bash",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
+│   │   │       │             "timeout": 100000
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "bash",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": false,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "bash"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
+│   │   │       │           "timeout": 100000
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "bash",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 9,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 109,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.00043885000000000007,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 0,
+│   │   │       │     "prompt_tokens": 1513,
+│   │   │       │     "tokens": 1622
+│   │   │       │   }
+│   │   │       ├── tool:bash [tool]
+│   │   │       │   input: {
+│   │   │       │     "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
+│   │   │       │     "timeout": 100000
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
+│   │   │       │       "exitCode": 0
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "bash",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
+│   │   │       │             "timeout": 100000
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "bash",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": false,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "bash"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "limit": 200,
+│   │   │       │           "offset": 1,
+│   │   │       │           "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "read",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 11,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 64,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.00015592,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 1536,
+│   │   │       │     "prompt_tokens": 226,
+│   │   │       │     "tokens": 1826
+│   │   │       │   }
+│   │   │       ├── tool:read [tool]
+│   │   │       │   input: {
+│   │   │       │     "limit": 200,
+│   │   │       │     "offset": 1,
+│   │   │       │     "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "lines": 7,
+│   │   │       │       "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "read",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "limit": 200,
+│   │   │       │             "offset": 1,
+│   │   │       │             "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "read",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": false,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "read"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "command": "cat ./package.json",
+│   │   │       │           "timeout": 100000
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "bash",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 13,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 90,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.00021242000000000003,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 1536,
+│   │   │       │     "prompt_tokens": 346,
+│   │   │       │     "tokens": 1972
+│   │   │       │   }
+│   │   │       ├── tool:bash [tool]
+│   │   │       │   input: {
+│   │   │       │     "command": "cat ./package.json",
+│   │   │       │     "timeout": 100000
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "{\n  \"name\": \"flue-instrumentation-scenario\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"braintrustScenario\": {\n    \"bump\": {\n      \"dependencies\": {\n        \"flue-cli-v0-8-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-cli-v1-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v0-8-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-runtime-v1-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v2-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=2.0.0 <3.0.0\"\n        }\n      }\n    }\n  },\n  \"dependencies\": {\n    \"@flue/cli\": \"0.8.0\",\n    \"@flue/runtime\": \"0.8.0\",\n    \"flue-cli-v0-8-latest\": \"npm:@flue/cli@0.8.1\",\n    \"flue-cli-v1\": \"npm:@flue/cli@1.0.0-beta.3\",\n    \"flue-cli-v1-latest\": \"npm:@flue/cli@1.0.0-beta.9\",\n    \"flue-runtime-v0-8-latest\": \"npm:@flue/runtime@0.8.1\",\n    \"flue-runtime-v1\": \"npm:@flue/runtime@1.0.0-beta.3\",\n    \"flue-runtime-v1-latest\": \"npm:@flue/runtime@1.0.0-beta.9\",\n    \"flue-runtime-v2\": \"npm:@flue/runtime@2.0.0\",\n    \"flue-runtime-v2-latest\": \"npm:@flue/runtime@2.0.1\",\n    \"pi-ai-v2\": \"npm:@earendil-works/pi-ai@0.83.0\",\n    \"valibot\": \"1.4.2\"\n  },\n  \"pnpm\": {\n    \"overrides\": {\n      \"@flue/runtime@0.8.0>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.0>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@hono/node-server@>=2.0.0 <2.0.10\": \"^2.0.10\",\n      \"fast-uri@<3.1.5\": \"^3.1.5\",\n      \"hono@>=4.0.0 <4.12.27\": \"^4.12.27\",\n      \"brace-expansion@>=3.0.0 <5.0.9\": \"^5.0.9\",\n      \"postcss@<8.5.18\": \"^8.5.18\",\n      \"valibot@<1.4.2\": \"^1.4.2\",\n      \"ip-address@<10.2.2\": \"^10.2.2\",\n      \"undici@<7.29.0\": \"^7.29.0\"\n    }\n  }\n}",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "command": "cat ./package.json",
+│   │   │       │       "exitCode": 0
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "bash",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "command": "cat ./package.json",
+│   │   │       │             "timeout": 100000
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "bash",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "{\n  \"name\": \"flue-instrumentation-scenario\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"braintrustScenario\": {\n    \"bump\": {\n      \"dependencies\": {\n        \"flue-cli-v0-8-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-cli-v1-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v0-8-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-runtime-v1-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v2-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=2.0.0 <3.0.0\"\n        }\n      }\n    }\n  },\n  \"dependencies\": {\n    \"@flue/cli\": \"0.8.0\",\n    \"@flue/runtime\": \"0.8.0\",\n    \"flue-cli-v0-8-latest\": \"npm:@flue/cli@0.8.1\",\n    \"flue-cli-v1\": \"npm:@flue/cli@1.0.0-beta.3\",\n    \"flue-cli-v1-latest\": \"npm:@flue/cli@1.0.0-beta.9\",\n    \"flue-runtime-v0-8-latest\": \"npm:@flue/runtime@0.8.1\",\n    \"flue-runtime-v1\": \"npm:@flue/runtime@1.0.0-beta.3\",\n    \"flue-runtime-v1-latest\": \"npm:@flue/runtime@1.0.0-beta.9\",\n    \"flue-runtime-v2\": \"npm:@flue/runtime@2.0.0\",\n    \"flue-runtime-v2-latest\": \"npm:@flue/runtime@2.0.1\",\n    \"pi-ai-v2\": \"npm:@earendil-works/pi-ai@0.83.0\",\n    \"valibot\": \"1.4.2\"\n  },\n  \"pnpm\": {\n    \"overrides\": {\n      \"@flue/runtime@0.8.0>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.0>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@hono/node-server@>=2.0.0 <2.0.10\": \"^2.0.10\",\n      \"fast-uri@<3.1.5\": \"^3.1.5\",\n      \"hono@>=4.0.0 <4.12.27\": \"^4.12.27\",\n      \"brace-expansion@>=3.0.0 <5.0.9\": \"^5.0.9\",\n      \"postcss@<8.5.18\": \"^8.5.18\",\n      \"valibot@<1.4.2\": \"^1.4.2\",\n      \"ip-address@<10.2.2\": \"^10.2.2\",\n      \"undici@<7.29.0\": \"^7.29.0\"\n    }\n  }\n}",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": false,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "bash"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "command": "printf SKILL_DONE",
+│   │   │       │           "timeout": 100000
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "bash",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 15,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 59,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.0004814700000000001,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 1536,
+│   │   │       │     "prompt_tokens": 1885,
+│   │   │       │     "tokens": 3480
+│   │   │       │   }
+│   │   │       ├── tool:bash [tool]
+│   │   │       │   input: {
+│   │   │       │     "command": "printf SKILL_DONE",
+│   │   │       │     "timeout": 100000
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "SKILL_DONE",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "command": "printf SKILL_DONE",
+│   │   │       │       "exitCode": 0
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "bash",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       └── flue.turn [llm]
+│   │   │           input: [
+│   │   │             {
+│   │   │               "content": [
+│   │   │                 {
+│   │   │                   "arguments": {
+│   │   │                     "command": "printf SKILL_DONE",
+│   │   │                     "timeout": 100000
+│   │   │                   },
+│   │   │                   "id": "<span:1>",
+│   │   │                   "name": "bash",
+│   │   │                   "type": "toolCall"
+│   │   │                 }
+│   │   │               ],
+│   │   │               "role": "assistant"
+│   │   │             },
+│   │   │             {
+│   │   │               "content": [
+│   │   │                 {
+│   │   │                   "text": "SKILL_DONE",
+│   │   │                   "type": "text"
+│   │   │                 }
+│   │   │               ],
+│   │   │               "isError": false,
+│   │   │               "role": "toolResult",
+│   │   │               "toolCallId": "<span:1>",
+│   │   │               "toolName": "bash"
+│   │   │             }
+│   │   │           ]
+│   │   │           output: {
+│   │   │             "content": [
+│   │   │               {
+│   │   │                 "text": "SKILL_DONE",
+│   │   │                 "textSignature": "{\"v\":1,\"id\":\"msg_054a16a2f2ea3217016a705b70a41481a38ece40ecddf69512\",\"phase\":\"final_answer\"}",
+│   │   │                 "type": "text"
+│   │   │               }
+│   │   │             ],
+│   │   │             "role": "assistant"
+│   │   │           }
+│   │   │           metadata: {
+│   │   │             "flue.api": "openai-responses",
+│   │   │             "flue.input_message_offset": 17,
+│   │   │             "flue.input_mode": "delta",
+│   │   │             "flue.model": "gpt-5.4-nano",
+│   │   │             "flue.provider": "openai",
+│   │   │             "flue.session": "task:skill:<uuid:1>",
+│   │   │             "flue.stop_reason": "stop",
+│   │   │             "flue.turn_purpose": "agent",
+│   │   │             "model": "gpt-5.4-nano",
+│   │   │             "provider": "openai"
+│   │   │           }
+│   │   │           metrics: {
+│   │   │             "completion_tokens": 7,
+│   │   │             "duration_ms": 0,
+│   │   │             "estimated_cost": 0.00031035000000000004,
+│   │   │             "prompt_cache_creation_tokens": 0,
+│   │   │             "prompt_cached_tokens": 2560,
+│   │   │             "prompt_tokens": 1252,
+│   │   │             "tokens": 3819
+│   │   │           }
+│   │   ├── tool:task [tool]
+│   │   │   input: {
+│   │   │     "cwd": ".",
+│   │   │     "description": "Run the deterministic Flue instrumentation e2e test skill e2e-flue-skill.",
+│   │   │     "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
+│   │   │   }
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "text": "SKILL_DONE",
+│   │   │         "type": "text"
+│   │   │       }
+│   │   │     ],
+│   │   │     "details": {
+│   │   │       "cwd": ".",
+│   │   │       "messageId": "<messageId:2>",
+│   │   │       "session": "task:skill:<uuid:1>",
+│   │   │       "taskId": "<uuid:1>"
+│   │   │     }
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.tool_name": "task",
+│   │   │     "provider": "flue"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "duration_ms": 0
+│   │   │   }
+│   │   └── flue.turn [llm]
+│   │       input: [
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "role": "user"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "arguments": {
+│   │                 "cwd": ".",
+│   │                 "description": "Run the deterministic Flue instrumentation e2e test skill e2e-flue-skill.",
+│   │                 "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
+│   │               },
+│   │               "id": "<span:1>",
+│   │               "name": "task",
+│   │               "type": "toolCall"
+│   │             }
+│   │           ],
+│   │           "role": "assistant"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "SKILL_DONE",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "isError": false,
+│   │           "role": "toolResult",
+│   │           "toolCallId": "<span:1>",
+│   │           "toolName": "task"
+│   │         }
+│   │       ]
+│   │       output: {
+│   │         "content": [
+│   │           {
+│   │             "text": "SKILL_DONE",
+│   │             "textSignature": "{\"v\":1,\"id\":\"msg_0f099b3fce0721fd016a705b71558881a38c53a767e09d9e31\",\"phase\":\"final_answer\"}",
+│   │             "type": "text"
+│   │           }
+│   │         ],
+│   │         "role": "assistant"
+│   │       }
+│   │       metadata: {
+│   │         "flue.api": "openai-responses",
+│   │         "flue.model": "gpt-5.4-nano",
+│   │         "flue.provider": "openai",
+│   │         "flue.session": "skill",
+│   │         "flue.stop_reason": "stop",
+│   │         "flue.turn_purpose": "agent",
+│   │         "model": "gpt-5.4-nano",
+│   │         "provider": "openai"
+│   │       }
+│   │       metrics: {
+│   │         "completion_tokens": 7,
+│   │         "duration_ms": 0,
+│   │         "estimated_cost": 0.00020255000000000002,
+│   │         "prompt_cache_creation_tokens": 0,
+│   │         "prompt_cached_tokens": 0,
+│   │         "prompt_tokens": 969,
+│   │         "tokens": 976
+│   │       }
+│   ├── flue.task [task]
+│   │   input: "Reply with exactly TASK_DONE and no other text."
+│   │   output: "TASK_DONE"
+│   │   metadata: {
+│   │     "flue.session": "task",
+│   │     "provider": "flue"
+│   │   }
+│   │   metrics: {
+│   │     "duration_ms": 0
+│   │   }
+│   │   └── flue.turn [llm]
+│   │       input: [
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "Reply with exactly TASK_DONE and no other text.",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "role": "user"
+│   │         }
+│   │       ]
+│   │       output: {
+│   │         "content": [
+│   │           {
+│   │             "text": "TASK_DONE",
+│   │             "textSignature": "{\"v\":1,\"id\":\"msg_0f3adfdb1510c165016a705b72843c81a0b30d242da683a882\"}",
+│   │             "type": "text"
+│   │           }
+│   │         ],
+│   │         "role": "assistant"
+│   │       }
+│   │       metadata: {
+│   │         "flue.api": "openai-responses",
+│   │         "flue.input_mode": "full",
+│   │         "flue.model": "gpt-4o-mini",
+│   │         "flue.provider": "openai",
+│   │         "flue.session": "task:task:<uuid:1>",
+│   │         "flue.stop_reason": "stop",
+│   │         "flue.turn_purpose": "agent",
+│   │         "model": "gpt-4o-mini",
+│   │         "provider": "openai"
+│   │       }
+│   │       metrics: {
+│   │         "completion_tokens": 4,
+│   │         "duration_ms": 0,
+│   │         "estimated_cost": 0.0001263,
+│   │         "prompt_cache_creation_tokens": 0,
+│   │         "prompt_cached_tokens": 0,
+│   │         "prompt_tokens": 826,
+│   │         "tokens": 830
+│   │       }
+│   └── flue.compact [task]
+│       input: {
+│         "estimatedTokens": 1229,
+│         "reason": "manual"
+│       }
+│       output: {
+│         "completed": true
+│       }
+│       metadata: {
+│         "flue.operation": "compact",
+│         "flue.session": "main",
+│         "flue.workflow_name": "instrumentation",
+│         "provider": "flue",
+│         "scenario": "flue-instrumentation"
+│       }
+│       metrics: {
+│         "duration_ms": 0
+│       }
+│       └── compaction:manual [task]
+│           input: {
+│             "estimatedTokens": 1229,
+│             "reason": "manual"
+│           }
+│           output: {
+│             "messagesAfter": 2,
+│             "messagesBefore": 8
+│           }
+│           metadata: {
+│             "flue.compaction_reason": "manual",
+│             "flue.session": "main",
+│             "provider": "flue"
+│           }
+│           metrics: {
+│             "duration_ms": 0,
+│             "messages_after": 2,
+│             "messages_before": 8
+│           }
+│           └── flue.turn [llm]
+│               input: [
+│                 {
+│                   "content": [
+│                     {
+│                       "text": "<conversation>\n[User]: Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.\n\n[Assistant tool calls]: lookup(query=\"flue instrumentation\")\n\n[Tool result]: {\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}\n\n[Assistant tool calls]: web_search(lookupId=\"flue-session-2026\", query=\"Braintrust Flue reasoning stream instrumentation\")\n\n[Tool result]: {\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}\n\n[Assistant tool calls]: summarize_source(url=\"https://example.test/flue/reasoning-streams\")\n\n[Tool result]: {\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}\n</conversation>\n\nThis is the PREFIX of a turn that was too large to keep. The SUFFIX (recent work) is retained.\n\nSummarize the prefix to provide context for the retained suffix:\n\n## Original Request\n[What did the user ask for in this turn?]\n\n## Early Progress\n- [Key decisions and work done in the prefix]\n\n## Context for Suffix\n- [Information needed to understand the retained recent work]\n\nBe concise. Focus on what's needed to understand the kept suffix.",
+│                       "type": "text"
+│                     }
+│                   ],
+│                   "role": "user"
+│                 }
+│               ]
+│               output: {
+│                 "content": [
+│                   {
+│                     "text": "## Original Request\nThe user requested a step-by-step execution of an instrumented research flow involving tool calls to gather information on \"flue instrumentation\" and \"",
+│                     "textSignature": "{\"v\":1,\"id\":\"msg_04d28ba03840bb65016a705b7358a081a38e69464057840036\"}",
+│                     "type": "text"
+│                   }
+│                 ],
+│                 "role": "assistant"
+│               }
+│               metadata: {
+│                 "flue.api": "openai-responses",
+│                 "flue.model": "gpt-4o-mini",
+│                 "flue.provider": "openai",
+│                 "flue.session": "main",
+│                 "flue.stop_reason": "stop",
+│                 "flue.turn_purpose": "compaction_prefix",
+│                 "model": "gpt-4o-mini",
+│                 "provider": "openai"
+│               }
+│               metrics: {
+│                 "completion_tokens": 0,
+│                 "duration_ms": 0,
+│                 "estimated_cost": 0,
+│                 "prompt_cache_creation_tokens": 0,
+│                 "prompt_cached_tokens": 0,
+│                 "prompt_tokens": 0,
+│                 "tokens": 0
+│               }
+└── flue.prompt [task]
+    input: [
+      {
+        "content": [
+          {
+            "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+            "type": "text"
+          }
+        ],
+        "role": "user"
+      }
+    ]
+    output: "PROMPT_DONE"
     metadata: {
+      "flue.operation": "prompt",
+      "flue.session": "main",
       "flue.workflow_name": "instrumentation",
       "provider": "flue",
       "scenario": "flue-instrumentation"
@@ -19,7 +1197,7 @@ span_tree:
     metrics: {
       "duration_ms": 0
     }
-    ├── flue.prompt [task]
+    ├── flue.turn [llm]
     │   input: [
     │     {
     │       "content": [
@@ -31,2574 +1209,291 @@ span_tree:
     │       "role": "user"
     │     }
     │   ]
-    │   output: "PROMPT_DONE"
+    │   output: {
+    │     "content": [
+    │       {
+    │         "arguments": {
+    │           "query": "flue instrumentation"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "lookup",
+    │         "type": "toolCall"
+    │       }
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.operation": "prompt",
+    │     "flue.api": "openai-responses",
+    │     "flue.input_mode": "full",
+    │     "flue.model": "gpt-5.4-nano",
+    │     "flue.provider": "openai",
     │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "gpt-5.4-nano",
+    │     "provider": "openai"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 19,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.00022475000000000001,
+    │     "prompt_cache_creation_tokens": 0,
+    │     "prompt_cached_tokens": 0,
+    │     "prompt_tokens": 1005,
+    │     "tokens": 1024
+    │   }
+    ├── tool:lookup [tool]
+    │   input: {
+    │     "query": "flue instrumentation"
+    │   }
+    │   output: {
+    │     "content": [
+    │       {
+    │         "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
+    │         "type": "text"
+    │       }
+    │     ],
+    │     "details": {
+    │       "customTool": "lookup"
+    │     }
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "lookup",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "query": "flue instrumentation"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "lookup",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "openai-responses",
-    │   │     "flue.model": "gpt-5.4-nano",
-    │   │     "flue.provider": "openai",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "gpt-5.4-nano",
-    │   │     "provider": "openai"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 19,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.00022475000000000001,
-    │   │     "prompt_cache_creation_tokens": 0,
-    │   │     "prompt_cached_tokens": 0,
-    │   │     "prompt_tokens": 1005,
-    │   │     "tokens": 1024
-    │   │   }
-    │   ├── tool:lookup [tool]
-    │   │   input: {
-    │   │     "query": "flue instrumentation"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "customTool": "lookup"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "lookup",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "query": "flue instrumentation"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "lookup",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "lookup"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "lookupId": "flue-session-2026",
-    │   │           "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "web_search",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "openai-responses",
-    │   │     "flue.model": "gpt-5.4-nano",
-    │   │     "flue.provider": "openai",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "gpt-5.4-nano",
-    │   │     "provider": "openai"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 34,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.00025350000000000004,
-    │   │     "prompt_cache_creation_tokens": 0,
-    │   │     "prompt_cached_tokens": 0,
-    │   │     "prompt_tokens": 1055,
-    │   │     "tokens": 1089
-    │   │   }
-    │   ├── tool:web_search [tool]
-    │   │   input: {
-    │   │     "lookupId": "flue-session-2026",
-    │   │     "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "customTool": "web_search"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "web_search",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "query": "flue instrumentation"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "lookup",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "lookup"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "lookupId": "flue-session-2026",
-    │   │             "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │           },
-    │   │           "id": "<span:2>",
-    │   │           "name": "web_search",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:2>",
-    │   │       "toolName": "web_search"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "url": "https://example.test/flue/reasoning-streams"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "summarize_source",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "openai-responses",
-    │   │     "flue.model": "gpt-5.4-nano",
-    │   │     "flue.provider": "openai",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "gpt-5.4-nano",
-    │   │     "provider": "openai"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 30,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.00026690000000000004,
-    │   │     "prompt_cache_creation_tokens": 0,
-    │   │     "prompt_cached_tokens": 0,
-    │   │     "prompt_tokens": 1147,
-    │   │     "tokens": 1177
-    │   │   }
-    │   ├── tool:summarize_source [tool]
-    │   │   input: {
-    │   │     "url": "https://example.test/flue/reasoning-streams"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "customTool": "summarize_source"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "summarize_source",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   └── flue.turn [llm]
-    │       input: [
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "query": "flue instrumentation"
-    │               },
-    │               "id": "<span:1>",
-    │               "name": "lookup",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:1>",
-    │           "toolName": "lookup"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "lookupId": "flue-session-2026",
-    │                 "query": "Braintrust Flue reasoning stream instrumentation"
-    │               },
-    │               "id": "<span:2>",
-    │               "name": "web_search",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:2>",
-    │           "toolName": "web_search"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "url": "https://example.test/flue/reasoning-streams"
-    │               },
-    │               "id": "<span:3>",
-    │               "name": "summarize_source",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:3>",
-    │           "toolName": "summarize_source"
-    │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "text": "PROMPT_DONE",
-    │             "textSignature": "{\"v\":1,\"id\":\"msg_045458052dc10379016a705b62dbd8819189b8287061debf12\",\"phase\":\"final_answer\"}",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
-    │       }
-    │       metadata: {
-    │         "flue.api": "openai-responses",
-    │         "flue.model": "gpt-5.4-nano",
-    │         "flue.provider": "openai",
-    │         "flue.session": "main",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "gpt-5.4-nano",
-    │         "provider": "openai"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 7,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.00025315000000000005,
-    │         "prompt_cache_creation_tokens": 0,
-    │         "prompt_cached_tokens": 0,
-    │         "prompt_tokens": 1222,
-    │         "tokens": 1229
-    │       }
-    ├── flue.skill [task]
+    ├── flue.turn [llm]
     │   input: [
     │     {
     │       "content": [
     │         {
-    │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+    │           "arguments": {
+    │             "query": "flue instrumentation"
+    │           },
+    │           "id": "<span:1>",
+    │           "name": "lookup",
+    │           "type": "toolCall"
+    │         }
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
     │           "type": "text"
     │         }
     │       ],
-    │       "role": "user"
+    │       "isError": false,
+    │       "role": "toolResult",
+    │       "toolCallId": "<span:1>",
+    │       "toolName": "lookup"
     │     }
     │   ]
-    │   output: "SKILL_DONE"
+    │   output: {
+    │     "content": [
+    │       {
+    │         "arguments": {
+    │           "lookupId": "flue-session-2026",
+    │           "query": "Braintrust Flue reasoning stream instrumentation"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "web_search",
+    │         "type": "toolCall"
+    │       }
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.operation": "skill",
-    │     "flue.session": "skill",
+    │     "flue.api": "openai-responses",
+    │     "flue.input_message_offset": 1,
+    │     "flue.input_mode": "delta",
+    │     "flue.model": "gpt-5.4-nano",
+    │     "flue.provider": "openai",
+    │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "gpt-5.4-nano",
+    │     "provider": "openai"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 34,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.00025350000000000004,
+    │     "prompt_cache_creation_tokens": 0,
+    │     "prompt_cached_tokens": 0,
+    │     "prompt_tokens": 1055,
+    │     "tokens": 1089
+    │   }
+    ├── tool:web_search [tool]
+    │   input: {
+    │     "lookupId": "flue-session-2026",
+    │     "query": "Braintrust Flue reasoning stream instrumentation"
+    │   }
+    │   output: {
+    │     "content": [
+    │       {
+    │         "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+    │         "type": "text"
+    │       }
+    │     ],
+    │     "details": {
+    │       "customTool": "web_search"
+    │     }
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "web_search",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "cwd": ".",
-    │   │           "description": "Run the deterministic Flue instrumentation e2e test skill e2e-flue-skill.",
-    │   │           "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "task",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "openai-responses",
-    │   │     "flue.model": "gpt-5.4-nano",
-    │   │     "flue.provider": "openai",
-    │   │     "flue.session": "skill",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "gpt-5.4-nano",
-    │   │     "provider": "openai"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 109,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.00030565000000000003,
-    │   │     "prompt_cache_creation_tokens": 0,
-    │   │     "prompt_cached_tokens": 0,
-    │   │     "prompt_tokens": 847,
-    │   │     "tokens": 956
-    │   │   }
-    │   │   └── flue.task [task]
-    │   │       input: "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
-    │   │       output: "SKILL_DONE"
-    │   │       metadata: {
-    │   │         "flue.session": "skill",
-    │   │         "provider": "flue"
-    │   │       }
-    │   │       metrics: {
-    │   │         "duration_ms": 0
-    │   │       }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "agent": "e2e-flue-skill",
-    │   │       │           "cwd": ".",
-    │   │       │           "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │           "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "task",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 113,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.00031225000000000003,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 0,
-    │   │       │     "prompt_tokens": 855,
-    │   │       │     "tokens": 968
-    │   │       │   }
-    │   │       ├── tool:task [tool]
-    │   │       │   input: {
-    │   │       │     "agent": "e2e-flue-skill",
-    │   │       │     "cwd": ".",
-    │   │       │     "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │     "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {}
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "task",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       │   error: "{\"content\":[{\"type\":\"text\",\"text\":\"[flue] Subagent \\\"e2e-flue-skill\\\" is not declared. Available: (none).\"}],\"details\":{}}"
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │           "timeout": 100000
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "bash",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 94,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.00031790000000000003,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 0,
-    │   │       │     "prompt_tokens": 1002,
-    │   │       │     "tokens": 1096
-    │   │       │   }
-    │   │       ├── tool:bash [tool]
-    │   │       │   input: {
-    │   │       │     "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │     "timeout": 100000
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "(no output)",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │       "exitCode": 0
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "bash",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:2>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:2>",
-    │   │       │       "toolName": "bash"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │           "timeout": 100000
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "bash",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 87,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.00034815000000000003,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 0,
-    │   │       │     "prompt_tokens": 1197,
-    │   │       │     "tokens": 1284
-    │   │       │   }
-    │   │       ├── tool:bash [tool]
-    │   │       │   input: {
-    │   │       │     "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │     "timeout": 100000
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "(no output)",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │       "exitCode": 0
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "bash",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:2>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:2>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:3>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:3>",
-    │   │       │       "toolName": "bash"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │           "timeout": 100000
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "bash",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 58,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.0003321,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 0,
-    │   │       │     "prompt_tokens": 1298,
-    │   │       │     "tokens": 1356
-    │   │       │   }
-    │   │       ├── tool:bash [tool]
-    │   │       │   input: {
-    │   │       │     "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │     "timeout": 100000
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "(no output)",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │       "exitCode": 0
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "bash",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:2>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:2>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:3>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:3>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:4>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:4>",
-    │   │       │       "toolName": "bash"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │       │           "timeout": 100000
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "bash",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 68,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.00035900000000000005,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 0,
-    │   │       │     "prompt_tokens": 1370,
-    │   │       │     "tokens": 1438
-    │   │       │   }
-    │   │       ├── tool:bash [tool]
-    │   │       │   input: {
-    │   │       │     "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │       │     "timeout": 100000
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │       │       "exitCode": 0
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "bash",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:2>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:2>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:3>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:3>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:4>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:4>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:5>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:5>",
-    │   │       │       "toolName": "bash"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-    │   │       │           "timeout": 100000
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "bash",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 109,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.00043885000000000007,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 0,
-    │   │       │     "prompt_tokens": 1513,
-    │   │       │     "tokens": 1622
-    │   │       │   }
-    │   │       ├── tool:bash [tool]
-    │   │       │   input: {
-    │   │       │     "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-    │   │       │     "timeout": 100000
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-    │   │       │       "exitCode": 0
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "bash",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:2>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:2>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:3>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:3>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:4>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:4>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:5>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:5>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:6>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:6>",
-    │   │       │       "toolName": "bash"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "limit": 200,
-    │   │       │           "offset": 1,
-    │   │       │           "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "read",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 64,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.00015592,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 1536,
-    │   │       │     "prompt_tokens": 226,
-    │   │       │     "tokens": 1826
-    │   │       │   }
-    │   │       ├── tool:read [tool]
-    │   │       │   input: {
-    │   │       │     "limit": 200,
-    │   │       │     "offset": 1,
-    │   │       │     "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "lines": 7,
-    │   │       │       "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "read",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:2>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:2>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:3>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:3>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:4>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:4>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:5>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:5>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:6>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:6>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "limit": 200,
-    │   │       │             "offset": 1,
-    │   │       │             "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-    │   │       │           },
-    │   │       │           "id": "<span:7>",
-    │   │       │           "name": "read",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:7>",
-    │   │       │       "toolName": "read"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "command": "cat ./package.json",
-    │   │       │           "timeout": 100000
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "bash",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 90,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.00021242000000000003,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 1536,
-    │   │       │     "prompt_tokens": 346,
-    │   │       │     "tokens": 1972
-    │   │       │   }
-    │   │       ├── tool:bash [tool]
-    │   │       │   input: {
-    │   │       │     "command": "cat ./package.json",
-    │   │       │     "timeout": 100000
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "{\n  \"name\": \"flue-instrumentation-scenario\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"braintrustScenario\": {\n    \"bump\": {\n      \"dependencies\": {\n        \"flue-cli-v0-8-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-cli-v1-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v0-8-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-runtime-v1-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v2-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=2.0.0 <3.0.0\"\n        }\n      }\n    }\n  },\n  \"dependencies\": {\n    \"@flue/cli\": \"0.8.0\",\n    \"@flue/runtime\": \"0.8.0\",\n    \"flue-cli-v0-8-latest\": \"npm:@flue/cli@0.8.1\",\n    \"flue-cli-v1\": \"npm:@flue/cli@1.0.0-beta.3\",\n    \"flue-cli-v1-latest\": \"npm:@flue/cli@1.0.0-beta.9\",\n    \"flue-runtime-v0-8-latest\": \"npm:@flue/runtime@0.8.1\",\n    \"flue-runtime-v1\": \"npm:@flue/runtime@1.0.0-beta.3\",\n    \"flue-runtime-v1-latest\": \"npm:@flue/runtime@1.0.0-beta.9\",\n    \"flue-runtime-v2\": \"npm:@flue/runtime@2.0.0\",\n    \"flue-runtime-v2-latest\": \"npm:@flue/runtime@2.0.1\",\n    \"pi-ai-v2\": \"npm:@earendil-works/pi-ai@0.83.0\",\n    \"valibot\": \"1.4.2\"\n  },\n  \"pnpm\": {\n    \"overrides\": {\n      \"@flue/runtime@0.8.0>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.0>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@hono/node-server@>=2.0.0 <2.0.10\": \"^2.0.10\",\n      \"fast-uri@<3.1.5\": \"^3.1.5\",\n      \"hono@>=4.0.0 <4.12.27\": \"^4.12.27\",\n      \"brace-expansion@>=3.0.0 <5.0.9\": \"^5.0.9\",\n      \"postcss@<8.5.18\": \"^8.5.18\",\n      \"valibot@<1.4.2\": \"^1.4.2\",\n      \"ip-address@<10.2.2\": \"^10.2.2\",\n      \"undici@<7.29.0\": \"^7.29.0\"\n    }\n  }\n}",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "command": "cat ./package.json",
-    │   │       │       "exitCode": 0
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "bash",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:2>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:2>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:3>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:3>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:4>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:4>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:5>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:5>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:6>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:6>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "limit": 200,
-    │   │       │             "offset": 1,
-    │   │       │             "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-    │   │       │           },
-    │   │       │           "id": "<span:7>",
-    │   │       │           "name": "read",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:7>",
-    │   │       │       "toolName": "read"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "cat ./package.json",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:8>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "{\n  \"name\": \"flue-instrumentation-scenario\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"braintrustScenario\": {\n    \"bump\": {\n      \"dependencies\": {\n        \"flue-cli-v0-8-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-cli-v1-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v0-8-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-runtime-v1-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v2-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=2.0.0 <3.0.0\"\n        }\n      }\n    }\n  },\n  \"dependencies\": {\n    \"@flue/cli\": \"0.8.0\",\n    \"@flue/runtime\": \"0.8.0\",\n    \"flue-cli-v0-8-latest\": \"npm:@flue/cli@0.8.1\",\n    \"flue-cli-v1\": \"npm:@flue/cli@1.0.0-beta.3\",\n    \"flue-cli-v1-latest\": \"npm:@flue/cli@1.0.0-beta.9\",\n    \"flue-runtime-v0-8-latest\": \"npm:@flue/runtime@0.8.1\",\n    \"flue-runtime-v1\": \"npm:@flue/runtime@1.0.0-beta.3\",\n    \"flue-runtime-v1-latest\": \"npm:@flue/runtime@1.0.0-beta.9\",\n    \"flue-runtime-v2\": \"npm:@flue/runtime@2.0.0\",\n    \"flue-runtime-v2-latest\": \"npm:@flue/runtime@2.0.1\",\n    \"pi-ai-v2\": \"npm:@earendil-works/pi-ai@0.83.0\",\n    \"valibot\": \"1.4.2\"\n  },\n  \"pnpm\": {\n    \"overrides\": {\n      \"@flue/runtime@0.8.0>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.0>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@hono/node-server@>=2.0.0 <2.0.10\": \"^2.0.10\",\n      \"fast-uri@<3.1.5\": \"^3.1.5\",\n      \"hono@>=4.0.0 <4.12.27\": \"^4.12.27\",\n      \"brace-expansion@>=3.0.0 <5.0.9\": \"^5.0.9\",\n      \"postcss@<8.5.18\": \"^8.5.18\",\n      \"valibot@<1.4.2\": \"^1.4.2\",\n      \"ip-address@<10.2.2\": \"^10.2.2\",\n      \"undici@<7.29.0\": \"^7.29.0\"\n    }\n  }\n}",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:8>",
-    │   │       │       "toolName": "bash"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "command": "printf SKILL_DONE",
-    │   │       │           "timeout": 100000
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "bash",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 59,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.0004814700000000001,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 1536,
-    │   │       │     "prompt_tokens": 1885,
-    │   │       │     "tokens": 3480
-    │   │       │   }
-    │   │       ├── tool:bash [tool]
-    │   │       │   input: {
-    │   │       │     "command": "printf SKILL_DONE",
-    │   │       │     "timeout": 100000
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "SKILL_DONE",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "command": "printf SKILL_DONE",
-    │   │       │       "exitCode": 0
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "bash",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       └── flue.turn [llm]
-    │   │           input: [
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "user"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "agent": "e2e-flue-skill",
-    │   │                     "cwd": ".",
-    │   │                     "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │                     "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │                   },
-    │   │                   "id": "<span:1>",
-    │   │                   "name": "task",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": true,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:1>",
-    │   │               "toolName": "task"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │                     "timeout": 100000
-    │   │                   },
-    │   │                   "id": "<span:2>",
-    │   │                   "name": "bash",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "(no output)",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:2>",
-    │   │               "toolName": "bash"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │                     "timeout": 100000
-    │   │                   },
-    │   │                   "id": "<span:3>",
-    │   │                   "name": "bash",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "(no output)",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:3>",
-    │   │               "toolName": "bash"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │                     "timeout": 100000
-    │   │                   },
-    │   │                   "id": "<span:4>",
-    │   │                   "name": "bash",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "(no output)",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:4>",
-    │   │               "toolName": "bash"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │                     "timeout": 100000
-    │   │                   },
-    │   │                   "id": "<span:5>",
-    │   │                   "name": "bash",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:5>",
-    │   │               "toolName": "bash"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-    │   │                     "timeout": 100000
-    │   │                   },
-    │   │                   "id": "<span:6>",
-    │   │                   "name": "bash",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:6>",
-    │   │               "toolName": "bash"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "limit": 200,
-    │   │                     "offset": 1,
-    │   │                     "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-    │   │                   },
-    │   │                   "id": "<span:7>",
-    │   │                   "name": "read",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:7>",
-    │   │               "toolName": "read"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "command": "cat ./package.json",
-    │   │                     "timeout": 100000
-    │   │                   },
-    │   │                   "id": "<span:8>",
-    │   │                   "name": "bash",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "{\n  \"name\": \"flue-instrumentation-scenario\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"braintrustScenario\": {\n    \"bump\": {\n      \"dependencies\": {\n        \"flue-cli-v0-8-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-cli-v1-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v0-8-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-runtime-v1-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v2-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=2.0.0 <3.0.0\"\n        }\n      }\n    }\n  },\n  \"dependencies\": {\n    \"@flue/cli\": \"0.8.0\",\n    \"@flue/runtime\": \"0.8.0\",\n    \"flue-cli-v0-8-latest\": \"npm:@flue/cli@0.8.1\",\n    \"flue-cli-v1\": \"npm:@flue/cli@1.0.0-beta.3\",\n    \"flue-cli-v1-latest\": \"npm:@flue/cli@1.0.0-beta.9\",\n    \"flue-runtime-v0-8-latest\": \"npm:@flue/runtime@0.8.1\",\n    \"flue-runtime-v1\": \"npm:@flue/runtime@1.0.0-beta.3\",\n    \"flue-runtime-v1-latest\": \"npm:@flue/runtime@1.0.0-beta.9\",\n    \"flue-runtime-v2\": \"npm:@flue/runtime@2.0.0\",\n    \"flue-runtime-v2-latest\": \"npm:@flue/runtime@2.0.1\",\n    \"pi-ai-v2\": \"npm:@earendil-works/pi-ai@0.83.0\",\n    \"valibot\": \"1.4.2\"\n  },\n  \"pnpm\": {\n    \"overrides\": {\n      \"@flue/runtime@0.8.0>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.0>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@hono/node-server@>=2.0.0 <2.0.10\": \"^2.0.10\",\n      \"fast-uri@<3.1.5\": \"^3.1.5\",\n      \"hono@>=4.0.0 <4.12.27\": \"^4.12.27\",\n      \"brace-expansion@>=3.0.0 <5.0.9\": \"^5.0.9\",\n      \"postcss@<8.5.18\": \"^8.5.18\",\n      \"valibot@<1.4.2\": \"^1.4.2\",\n      \"ip-address@<10.2.2\": \"^10.2.2\",\n      \"undici@<7.29.0\": \"^7.29.0\"\n    }\n  }\n}",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:8>",
-    │   │               "toolName": "bash"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "command": "printf SKILL_DONE",
-    │   │                     "timeout": 100000
-    │   │                   },
-    │   │                   "id": "<span:9>",
-    │   │                   "name": "bash",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "SKILL_DONE",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:9>",
-    │   │               "toolName": "bash"
-    │   │             }
-    │   │           ]
-    │   │           output: {
-    │   │             "content": [
-    │   │               {
-    │   │                 "text": "SKILL_DONE",
-    │   │                 "textSignature": "{\"v\":1,\"id\":\"msg_054a16a2f2ea3217016a705b70a41481a38ece40ecddf69512\",\"phase\":\"final_answer\"}",
-    │   │                 "type": "text"
-    │   │               }
-    │   │             ],
-    │   │             "role": "assistant"
-    │   │           }
-    │   │           metadata: {
-    │   │             "flue.api": "openai-responses",
-    │   │             "flue.model": "gpt-5.4-nano",
-    │   │             "flue.provider": "openai",
-    │   │             "flue.session": "task:skill:<uuid:1>",
-    │   │             "flue.stop_reason": "stop",
-    │   │             "flue.turn_purpose": "agent",
-    │   │             "model": "gpt-5.4-nano",
-    │   │             "provider": "openai"
-    │   │           }
-    │   │           metrics: {
-    │   │             "completion_tokens": 7,
-    │   │             "duration_ms": 0,
-    │   │             "estimated_cost": 0.00031035000000000004,
-    │   │             "prompt_cache_creation_tokens": 0,
-    │   │             "prompt_cached_tokens": 2560,
-    │   │             "prompt_tokens": 1252,
-    │   │             "tokens": 3819
-    │   │           }
-    │   ├── tool:task [tool]
-    │   │   input: {
-    │   │     "cwd": ".",
-    │   │     "description": "Run the deterministic Flue instrumentation e2e test skill e2e-flue-skill.",
-    │   │     "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "SKILL_DONE",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "cwd": ".",
-    │   │       "messageId": "<messageId:2>",
-    │   │       "session": "task:skill:<uuid:1>",
-    │   │       "taskId": "<uuid:1>"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "skill",
-    │   │     "flue.tool_name": "task",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   └── flue.turn [llm]
-    │       input: [
+    ├── flue.turn [llm]
+    │   input: [
+    │     {
+    │       "content": [
     │         {
-    │           "content": [
-    │             {
-    │               "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "cwd": ".",
-    │                 "description": "Run the deterministic Flue instrumentation e2e test skill e2e-flue-skill.",
-    │                 "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
-    │               },
-    │               "id": "<span:1>",
-    │               "name": "task",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "SKILL_DONE",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:1>",
-    │           "toolName": "task"
+    │           "arguments": {
+    │             "lookupId": "flue-session-2026",
+    │             "query": "Braintrust Flue reasoning stream instrumentation"
+    │           },
+    │           "id": "<span:1>",
+    │           "name": "web_search",
+    │           "type": "toolCall"
     │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "text": "SKILL_DONE",
-    │             "textSignature": "{\"v\":1,\"id\":\"msg_0f099b3fce0721fd016a705b71558881a38c53a767e09d9e31\",\"phase\":\"final_answer\"}",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+    │           "type": "text"
+    │         }
+    │       ],
+    │       "isError": false,
+    │       "role": "toolResult",
+    │       "toolCallId": "<span:1>",
+    │       "toolName": "web_search"
+    │     }
+    │   ]
+    │   output: {
+    │     "content": [
+    │       {
+    │         "arguments": {
+    │           "url": "https://example.test/flue/reasoning-streams"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "summarize_source",
+    │         "type": "toolCall"
     │       }
-    │       metadata: {
-    │         "flue.api": "openai-responses",
-    │         "flue.model": "gpt-5.4-nano",
-    │         "flue.provider": "openai",
-    │         "flue.session": "skill",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "gpt-5.4-nano",
-    │         "provider": "openai"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 7,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.00020255000000000002,
-    │         "prompt_cache_creation_tokens": 0,
-    │         "prompt_cached_tokens": 0,
-    │         "prompt_tokens": 969,
-    │         "tokens": 976
-    │       }
-    ├── flue.task [task]
-    │   input: "Reply with exactly TASK_DONE and no other text."
-    │   output: "TASK_DONE"
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.session": "task",
+    │     "flue.api": "openai-responses",
+    │     "flue.input_message_offset": 3,
+    │     "flue.input_mode": "delta",
+    │     "flue.model": "gpt-5.4-nano",
+    │     "flue.provider": "openai",
+    │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "gpt-5.4-nano",
+    │     "provider": "openai"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 30,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.00026690000000000004,
+    │     "prompt_cache_creation_tokens": 0,
+    │     "prompt_cached_tokens": 0,
+    │     "prompt_tokens": 1147,
+    │     "tokens": 1177
+    │   }
+    ├── tool:summarize_source [tool]
+    │   input: {
+    │     "url": "https://example.test/flue/reasoning-streams"
+    │   }
+    │   output: {
+    │     "content": [
+    │       {
+    │         "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+    │         "type": "text"
+    │       }
+    │     ],
+    │     "details": {
+    │       "customTool": "summarize_source"
+    │     }
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "summarize_source",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   └── flue.turn [llm]
-    │       input: [
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "Reply with exactly TASK_DONE and no other text.",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
-    │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "text": "TASK_DONE",
-    │             "textSignature": "{\"v\":1,\"id\":\"msg_0f3adfdb1510c165016a705b72843c81a0b30d242da683a882\"}",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
-    │       }
-    │       metadata: {
-    │         "flue.api": "openai-responses",
-    │         "flue.model": "gpt-4o-mini",
-    │         "flue.provider": "openai",
-    │         "flue.session": "task:task:<uuid:1>",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "gpt-4o-mini",
-    │         "provider": "openai"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 4,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.0001263,
-    │         "prompt_cache_creation_tokens": 0,
-    │         "prompt_cached_tokens": 0,
-    │         "prompt_tokens": 826,
-    │         "tokens": 830
-    │       }
-    └── flue.compact [task]
-        input: {
-          "estimatedTokens": 1229,
-          "reason": "manual"
-        }
+    └── flue.turn [llm]
+        input: [
+          {
+            "content": [
+              {
+                "arguments": {
+                  "url": "https://example.test/flue/reasoning-streams"
+                },
+                "id": "<span:1>",
+                "name": "summarize_source",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          {
+            "content": [
+              {
+                "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+                "type": "text"
+              }
+            ],
+            "isError": false,
+            "role": "toolResult",
+            "toolCallId": "<span:1>",
+            "toolName": "summarize_source"
+          }
+        ]
         output: {
-          "completed": true
+          "content": [
+            {
+              "text": "PROMPT_DONE",
+              "textSignature": "{\"v\":1,\"id\":\"msg_045458052dc10379016a705b62dbd8819189b8287061debf12\",\"phase\":\"final_answer\"}",
+              "type": "text"
+            }
+          ],
+          "role": "assistant"
         }
         metadata: {
-          "flue.operation": "compact",
+          "flue.api": "openai-responses",
+          "flue.input_message_offset": 5,
+          "flue.input_mode": "delta",
+          "flue.model": "gpt-5.4-nano",
+          "flue.provider": "openai",
           "flue.session": "main",
-          "provider": "flue"
+          "flue.stop_reason": "stop",
+          "flue.turn_purpose": "agent",
+          "model": "gpt-5.4-nano",
+          "provider": "openai"
         }
         metrics: {
-          "duration_ms": 0
+          "completion_tokens": 7,
+          "duration_ms": 0,
+          "estimated_cost": 0.00025315000000000005,
+          "prompt_cache_creation_tokens": 0,
+          "prompt_cached_tokens": 0,
+          "prompt_tokens": 1222,
+          "tokens": 1229
         }
-        └── compaction:manual [task]
-            input: {
-              "estimatedTokens": 1229,
-              "reason": "manual"
-            }
-            output: {
-              "messagesAfter": 2,
-              "messagesBefore": 8
-            }
-            metadata: {
-              "flue.compaction_reason": "manual",
-              "flue.session": "main",
-              "provider": "flue"
-            }
-            metrics: {
-              "duration_ms": 0,
-              "messages_after": 2,
-              "messages_before": 8
-            }
-            └── flue.turn [llm]
-                input: [
-                  {
-                    "content": [
-                      {
-                        "text": "<conversation>\n[User]: Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.\n\n[Assistant tool calls]: lookup(query=\"flue instrumentation\")\n\n[Tool result]: {\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}\n\n[Assistant tool calls]: web_search(lookupId=\"flue-session-2026\", query=\"Braintrust Flue reasoning stream instrumentation\")\n\n[Tool result]: {\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}\n\n[Assistant tool calls]: summarize_source(url=\"https://example.test/flue/reasoning-streams\")\n\n[Tool result]: {\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}\n</conversation>\n\nThis is the PREFIX of a turn that was too large to keep. The SUFFIX (recent work) is retained.\n\nSummarize the prefix to provide context for the retained suffix:\n\n## Original Request\n[What did the user ask for in this turn?]\n\n## Early Progress\n- [Key decisions and work done in the prefix]\n\n## Context for Suffix\n- [Information needed to understand the retained recent work]\n\nBe concise. Focus on what's needed to understand the kept suffix.",
-                        "type": "text"
-                      }
-                    ],
-                    "role": "user"
-                  }
-                ]
-                output: {
-                  "content": [
-                    {
-                      "text": "## Original Request\nThe user requested a step-by-step execution of an instrumented research flow involving tool calls to gather information on \"flue instrumentation\" and \"",
-                      "textSignature": "{\"v\":1,\"id\":\"msg_04d28ba03840bb65016a705b7358a081a38e69464057840036\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "assistant"
-                }
-                metadata: {
-                  "flue.api": "openai-responses",
-                  "flue.model": "gpt-4o-mini",
-                  "flue.provider": "openai",
-                  "flue.session": "main",
-                  "flue.stop_reason": "stop",
-                  "flue.turn_purpose": "compaction_prefix",
-                  "model": "gpt-4o-mini",
-                  "provider": "openai"
-                }
-                metrics: {
-                  "completion_tokens": 0,
-                  "duration_ms": 0,
-                  "estimated_cost": 0,
-                  "prompt_cache_creation_tokens": 0,
-                  "prompt_cached_tokens": 0,
-                  "prompt_tokens": 0,
-                  "tokens": 0
-                }

--- a/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-latest-cli.span-tree.json
+++ b/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-latest-cli.span-tree.json
@@ -5,456 +5,6 @@
       "type": "task",
       "children": [
         {
-          "name": "flue.prompt",
-          "type": "task",
-          "children": [
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "arguments": {
-                      "query": "flue instrumentation"
-                    },
-                    "id": "<span:1>",
-                    "name": "lookup",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "openai-responses",
-                "flue.model": "gpt-5.4-nano",
-                "flue.provider": "openai",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "gpt-5.4-nano",
-                "provider": "openai"
-              },
-              "metrics": {
-                "completion_tokens": 19,
-                "duration_ms": 0,
-                "estimated_cost": 0.00022475000000000001,
-                "prompt_cache_creation_tokens": 0,
-                "prompt_cached_tokens": 0,
-                "prompt_tokens": 1005,
-                "tokens": 1024
-              }
-            },
-            {
-              "name": "tool:lookup",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "query": "flue instrumentation"
-              },
-              "output": {
-                "content": [
-                  {
-                    "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                    "type": "text"
-                  }
-                ],
-                "details": {
-                  "customTool": "lookup"
-                }
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "lookup",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "arguments": {
-                      "lookupId": "flue-session-2026",
-                      "query": "Braintrust Flue reasoning stream instrumentation"
-                    },
-                    "id": "<span:1>",
-                    "name": "web_search",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "openai-responses",
-                "flue.model": "gpt-5.4-nano",
-                "flue.provider": "openai",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "gpt-5.4-nano",
-                "provider": "openai"
-              },
-              "metrics": {
-                "completion_tokens": 34,
-                "duration_ms": 0,
-                "estimated_cost": 0.00025350000000000004,
-                "prompt_cache_creation_tokens": 0,
-                "prompt_cached_tokens": 0,
-                "prompt_tokens": 1055,
-                "tokens": 1089
-              }
-            },
-            {
-              "name": "tool:web_search",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "lookupId": "flue-session-2026",
-                "query": "Braintrust Flue reasoning stream instrumentation"
-              },
-              "output": {
-                "content": [
-                  {
-                    "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-                    "type": "text"
-                  }
-                ],
-                "details": {
-                  "customTool": "web_search"
-                }
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "web_search",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                },
-                {
-                  "content": [
-                    {
-                      "arguments": {
-                        "lookupId": "flue-session-2026",
-                        "query": "Braintrust Flue reasoning stream instrumentation"
-                      },
-                      "id": "<span:2>",
-                      "name": "web_search",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:2>",
-                  "toolName": "web_search"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "arguments": {
-                      "url": "https://example.test/flue/reasoning-streams"
-                    },
-                    "id": "<span:1>",
-                    "name": "summarize_source",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "openai-responses",
-                "flue.model": "gpt-5.4-nano",
-                "flue.provider": "openai",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "gpt-5.4-nano",
-                "provider": "openai"
-              },
-              "metrics": {
-                "completion_tokens": 30,
-                "duration_ms": 0,
-                "estimated_cost": 0.00026690000000000004,
-                "prompt_cache_creation_tokens": 0,
-                "prompt_cached_tokens": 0,
-                "prompt_tokens": 1147,
-                "tokens": 1177
-              }
-            },
-            {
-              "name": "tool:summarize_source",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "url": "https://example.test/flue/reasoning-streams"
-              },
-              "output": {
-                "content": [
-                  {
-                    "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-                    "type": "text"
-                  }
-                ],
-                "details": {
-                  "customTool": "summarize_source"
-                }
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "summarize_source",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                },
-                {
-                  "content": [
-                    {
-                      "arguments": {
-                        "lookupId": "flue-session-2026",
-                        "query": "Braintrust Flue reasoning stream instrumentation"
-                      },
-                      "id": "<span:2>",
-                      "name": "web_search",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:2>",
-                  "toolName": "web_search"
-                },
-                {
-                  "content": [
-                    {
-                      "arguments": {
-                        "url": "https://example.test/flue/reasoning-streams"
-                      },
-                      "id": "<span:3>",
-                      "name": "summarize_source",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:3>",
-                  "toolName": "summarize_source"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "text": "PROMPT_DONE",
-                    "textSignature": "{\"v\":1,\"id\":\"msg_045458052dc10379016a705b62dbd8819189b8287061debf12\",\"phase\":\"final_answer\"}",
-                    "type": "text"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "openai-responses",
-                "flue.model": "gpt-5.4-nano",
-                "flue.provider": "openai",
-                "flue.session": "main",
-                "flue.stop_reason": "stop",
-                "flue.turn_purpose": "agent",
-                "model": "gpt-5.4-nano",
-                "provider": "openai"
-              },
-              "metrics": {
-                "completion_tokens": 7,
-                "duration_ms": 0,
-                "estimated_cost": 0.00025315000000000005,
-                "prompt_cache_creation_tokens": 0,
-                "prompt_cached_tokens": 0,
-                "prompt_tokens": 1222,
-                "tokens": 1229
-              }
-            }
-          ],
-          "input": [
-            {
-              "content": [
-                {
-                  "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                  "type": "text"
-                }
-              ],
-              "role": "user"
-            }
-          ],
-          "output": "PROMPT_DONE",
-          "metadata": {
-            "flue.operation": "prompt",
-            "flue.session": "main",
-            "provider": "flue"
-          },
-          "metrics": {
-            "duration_ms": 0
-          }
-        },
-        {
           "name": "flue.skill",
           "type": "task",
           "children": [
@@ -499,6 +49,7 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_mode": "full",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -554,15 +105,6 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "agent": "e2e-flue-skill",
                                 "cwd": ".",
@@ -605,6 +147,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 1,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -660,48 +204,11 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "command": "find . -maxdepth 4 -name AGENTS.md -print",
                                 "timeout": 100000
                               },
-                              "id": "<span:2>",
+                              "id": "<span:1>",
                               "name": "bash",
                               "type": "toolCall"
                             }
@@ -717,7 +224,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:2>",
+                          "toolCallId": "<span:1>",
                           "toolName": "bash"
                         }
                       ],
@@ -737,6 +244,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 3,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -792,74 +301,11 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -name AGENTS.md -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:2>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:2>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
                                 "timeout": 100000
                               },
-                              "id": "<span:3>",
+                              "id": "<span:1>",
                               "name": "bash",
                               "type": "toolCall"
                             }
@@ -875,7 +321,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:3>",
+                          "toolCallId": "<span:1>",
                           "toolName": "bash"
                         }
                       ],
@@ -895,6 +341,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 5,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -950,100 +398,11 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -name AGENTS.md -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:2>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:2>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-                                "timeout": 100000
-                              },
-                              "id": "<span:3>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:3>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
                                 "timeout": 100000
                               },
-                              "id": "<span:4>",
+                              "id": "<span:1>",
                               "name": "bash",
                               "type": "toolCall"
                             }
@@ -1059,7 +418,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:4>",
+                          "toolCallId": "<span:1>",
                           "toolName": "bash"
                         }
                       ],
@@ -1079,6 +438,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 7,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -1134,126 +495,11 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -name AGENTS.md -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:2>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:2>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-                                "timeout": 100000
-                              },
-                              "id": "<span:3>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:3>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:4>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:4>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
                                 "timeout": 100000
                               },
-                              "id": "<span:5>",
+                              "id": "<span:1>",
                               "name": "bash",
                               "type": "toolCall"
                             }
@@ -1269,7 +515,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:5>",
+                          "toolCallId": "<span:1>",
                           "toolName": "bash"
                         }
                       ],
@@ -1289,6 +535,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 9,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -1344,152 +592,11 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -name AGENTS.md -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:2>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:2>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-                                "timeout": 100000
-                              },
-                              "id": "<span:3>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:3>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:4>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:4>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-                                "timeout": 100000
-                              },
-                              "id": "<span:5>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:5>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
                                 "timeout": 100000
                               },
-                              "id": "<span:6>",
+                              "id": "<span:1>",
                               "name": "bash",
                               "type": "toolCall"
                             }
@@ -1505,7 +612,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:6>",
+                          "toolCallId": "<span:1>",
                           "toolName": "bash"
                         }
                       ],
@@ -1526,6 +633,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 11,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -1582,179 +691,12 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -name AGENTS.md -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:2>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:2>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-                                "timeout": 100000
-                              },
-                              "id": "<span:3>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:3>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:4>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:4>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-                                "timeout": 100000
-                              },
-                              "id": "<span:5>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:5>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:6>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:6>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "limit": 200,
                                 "offset": 1,
                                 "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
                               },
-                              "id": "<span:7>",
+                              "id": "<span:1>",
                               "name": "read",
                               "type": "toolCall"
                             }
@@ -1770,7 +712,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:7>",
+                          "toolCallId": "<span:1>",
                           "toolName": "read"
                         }
                       ],
@@ -1790,6 +732,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 13,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -1845,205 +789,11 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -name AGENTS.md -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:2>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:2>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-                                "timeout": 100000
-                              },
-                              "id": "<span:3>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:3>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:4>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:4>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-                                "timeout": 100000
-                              },
-                              "id": "<span:5>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:5>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:6>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:6>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "limit": 200,
-                                "offset": 1,
-                                "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-                              },
-                              "id": "<span:7>",
-                              "name": "read",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:7>",
-                          "toolName": "read"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "command": "cat ./package.json",
                                 "timeout": 100000
                               },
-                              "id": "<span:8>",
+                              "id": "<span:1>",
                               "name": "bash",
                               "type": "toolCall"
                             }
@@ -2059,7 +809,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:8>",
+                          "toolCallId": "<span:1>",
                           "toolName": "bash"
                         }
                       ],
@@ -2079,6 +829,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 15,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -2134,231 +886,11 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -name AGENTS.md -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:2>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:2>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-                                "timeout": 100000
-                              },
-                              "id": "<span:3>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:3>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:4>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:4>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-                                "timeout": 100000
-                              },
-                              "id": "<span:5>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:5>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:6>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:6>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "limit": 200,
-                                "offset": 1,
-                                "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-                              },
-                              "id": "<span:7>",
-                              "name": "read",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:7>",
-                          "toolName": "read"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "cat ./package.json",
-                                "timeout": 100000
-                              },
-                              "id": "<span:8>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "{\n  \"name\": \"flue-instrumentation-scenario\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"braintrustScenario\": {\n    \"bump\": {\n      \"dependencies\": {\n        \"flue-cli-v0-8-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-cli-v1-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v0-8-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-runtime-v1-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v2-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=2.0.0 <3.0.0\"\n        }\n      }\n    }\n  },\n  \"dependencies\": {\n    \"@flue/cli\": \"0.8.0\",\n    \"@flue/runtime\": \"0.8.0\",\n    \"flue-cli-v0-8-latest\": \"npm:@flue/cli@0.8.1\",\n    \"flue-cli-v1\": \"npm:@flue/cli@1.0.0-beta.3\",\n    \"flue-cli-v1-latest\": \"npm:@flue/cli@1.0.0-beta.9\",\n    \"flue-runtime-v0-8-latest\": \"npm:@flue/runtime@0.8.1\",\n    \"flue-runtime-v1\": \"npm:@flue/runtime@1.0.0-beta.3\",\n    \"flue-runtime-v1-latest\": \"npm:@flue/runtime@1.0.0-beta.9\",\n    \"flue-runtime-v2\": \"npm:@flue/runtime@2.0.0\",\n    \"flue-runtime-v2-latest\": \"npm:@flue/runtime@2.0.1\",\n    \"pi-ai-v2\": \"npm:@earendil-works/pi-ai@0.83.0\",\n    \"valibot\": \"1.4.2\"\n  },\n  \"pnpm\": {\n    \"overrides\": {\n      \"@flue/runtime@0.8.0>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.0>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@hono/node-server@>=2.0.0 <2.0.10\": \"^2.0.10\",\n      \"fast-uri@<3.1.5\": \"^3.1.5\",\n      \"hono@>=4.0.0 <4.12.27\": \"^4.12.27\",\n      \"brace-expansion@>=3.0.0 <5.0.9\": \"^5.0.9\",\n      \"postcss@<8.5.18\": \"^8.5.18\",\n      \"valibot@<1.4.2\": \"^1.4.2\",\n      \"ip-address@<10.2.2\": \"^10.2.2\",\n      \"undici@<7.29.0\": \"^7.29.0\"\n    }\n  }\n}",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:8>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "command": "printf SKILL_DONE",
                                 "timeout": 100000
                               },
-                              "id": "<span:9>",
+                              "id": "<span:1>",
                               "name": "bash",
                               "type": "toolCall"
                             }
@@ -2374,7 +906,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:9>",
+                          "toolCallId": "<span:1>",
                           "toolName": "bash"
                         }
                       ],
@@ -2390,6 +922,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 17,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -2586,7 +1120,9 @@
           "metadata": {
             "flue.operation": "skill",
             "flue.session": "skill",
-            "provider": "flue"
+            "flue.workflow_name": "instrumentation",
+            "provider": "flue",
+            "scenario": "flue-instrumentation"
           },
           "metrics": {
             "duration_ms": 0
@@ -2623,6 +1159,7 @@
               },
               "metadata": {
                 "flue.api": "openai-responses",
+                "flue.input_mode": "full",
                 "flue.model": "gpt-4o-mini",
                 "flue.provider": "openai",
                 "flue.session": "task:task:<uuid:1>",
@@ -2736,7 +1273,9 @@
           "metadata": {
             "flue.operation": "compact",
             "flue.session": "main",
-            "provider": "flue"
+            "flue.workflow_name": "instrumentation",
+            "provider": "flue",
+            "scenario": "flue-instrumentation"
           },
           "metrics": {
             "duration_ms": 0
@@ -2755,6 +1294,362 @@
         "status": "done"
       },
       "metadata": {
+        "flue.workflow_name": "instrumentation",
+        "provider": "flue",
+        "scenario": "flue-instrumentation"
+      },
+      "metrics": {
+        "duration_ms": 0
+      }
+    },
+    {
+      "name": "flue.prompt",
+      "type": "task",
+      "children": [
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+                  "type": "text"
+                }
+              ],
+              "role": "user"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "arguments": {
+                  "query": "flue instrumentation"
+                },
+                "id": "<span:1>",
+                "name": "lookup",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "openai-responses",
+            "flue.input_mode": "full",
+            "flue.model": "gpt-5.4-nano",
+            "flue.provider": "openai",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "gpt-5.4-nano",
+            "provider": "openai"
+          },
+          "metrics": {
+            "completion_tokens": 19,
+            "duration_ms": 0,
+            "estimated_cost": 0.00022475000000000001,
+            "prompt_cache_creation_tokens": 0,
+            "prompt_cached_tokens": 0,
+            "prompt_tokens": 1005,
+            "tokens": 1024
+          }
+        },
+        {
+          "name": "tool:lookup",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "query": "flue instrumentation"
+          },
+          "output": {
+            "content": [
+              {
+                "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
+                "type": "text"
+              }
+            ],
+            "details": {
+              "customTool": "lookup"
+            }
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "lookup",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "arguments": {
+                    "query": "flue instrumentation"
+                  },
+                  "id": "<span:1>",
+                  "name": "lookup",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "lookup"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "arguments": {
+                  "lookupId": "flue-session-2026",
+                  "query": "Braintrust Flue reasoning stream instrumentation"
+                },
+                "id": "<span:1>",
+                "name": "web_search",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "openai-responses",
+            "flue.input_message_offset": 1,
+            "flue.input_mode": "delta",
+            "flue.model": "gpt-5.4-nano",
+            "flue.provider": "openai",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "gpt-5.4-nano",
+            "provider": "openai"
+          },
+          "metrics": {
+            "completion_tokens": 34,
+            "duration_ms": 0,
+            "estimated_cost": 0.00025350000000000004,
+            "prompt_cache_creation_tokens": 0,
+            "prompt_cached_tokens": 0,
+            "prompt_tokens": 1055,
+            "tokens": 1089
+          }
+        },
+        {
+          "name": "tool:web_search",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "lookupId": "flue-session-2026",
+            "query": "Braintrust Flue reasoning stream instrumentation"
+          },
+          "output": {
+            "content": [
+              {
+                "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+                "type": "text"
+              }
+            ],
+            "details": {
+              "customTool": "web_search"
+            }
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "web_search",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "arguments": {
+                    "lookupId": "flue-session-2026",
+                    "query": "Braintrust Flue reasoning stream instrumentation"
+                  },
+                  "id": "<span:1>",
+                  "name": "web_search",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "web_search"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "arguments": {
+                  "url": "https://example.test/flue/reasoning-streams"
+                },
+                "id": "<span:1>",
+                "name": "summarize_source",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "openai-responses",
+            "flue.input_message_offset": 3,
+            "flue.input_mode": "delta",
+            "flue.model": "gpt-5.4-nano",
+            "flue.provider": "openai",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "gpt-5.4-nano",
+            "provider": "openai"
+          },
+          "metrics": {
+            "completion_tokens": 30,
+            "duration_ms": 0,
+            "estimated_cost": 0.00026690000000000004,
+            "prompt_cache_creation_tokens": 0,
+            "prompt_cached_tokens": 0,
+            "prompt_tokens": 1147,
+            "tokens": 1177
+          }
+        },
+        {
+          "name": "tool:summarize_source",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "url": "https://example.test/flue/reasoning-streams"
+          },
+          "output": {
+            "content": [
+              {
+                "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+                "type": "text"
+              }
+            ],
+            "details": {
+              "customTool": "summarize_source"
+            }
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "summarize_source",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "arguments": {
+                    "url": "https://example.test/flue/reasoning-streams"
+                  },
+                  "id": "<span:1>",
+                  "name": "summarize_source",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "summarize_source"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "text": "PROMPT_DONE",
+                "textSignature": "{\"v\":1,\"id\":\"msg_045458052dc10379016a705b62dbd8819189b8287061debf12\",\"phase\":\"final_answer\"}",
+                "type": "text"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "openai-responses",
+            "flue.input_message_offset": 5,
+            "flue.input_mode": "delta",
+            "flue.model": "gpt-5.4-nano",
+            "flue.provider": "openai",
+            "flue.session": "main",
+            "flue.stop_reason": "stop",
+            "flue.turn_purpose": "agent",
+            "model": "gpt-5.4-nano",
+            "provider": "openai"
+          },
+          "metrics": {
+            "completion_tokens": 7,
+            "duration_ms": 0,
+            "estimated_cost": 0.00025315000000000005,
+            "prompt_cache_creation_tokens": 0,
+            "prompt_cached_tokens": 0,
+            "prompt_tokens": 1222,
+            "tokens": 1229
+          }
+        }
+      ],
+      "input": [
+        {
+          "content": [
+            {
+              "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+              "type": "text"
+            }
+          ],
+          "role": "user"
+        }
+      ],
+      "output": "PROMPT_DONE",
+      "metadata": {
+        "flue.operation": "prompt",
+        "flue.session": "main",
         "flue.workflow_name": "instrumentation",
         "provider": "flue",
         "scenario": "flue-instrumentation"

--- a/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-latest-cli.span-tree.txt
+++ b/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-latest-cli.span-tree.txt
@@ -1,17 +1,1195 @@
 span_tree:
-└── workflow:instrumentation [task]
-    input: {
-      "metadata": {
-        "scenario": "flue-instrumentation",
-        "testRunId": "<run:1>"
-      },
-      "scenario": "flue-instrumentation"
-    }
-    output: {
-      "scenario": "flue-instrumentation",
-      "status": "done"
-    }
+├── workflow:instrumentation [task]
+│   input: {
+│     "metadata": {
+│       "scenario": "flue-instrumentation",
+│       "testRunId": "<run:1>"
+│     },
+│     "scenario": "flue-instrumentation"
+│   }
+│   output: {
+│     "scenario": "flue-instrumentation",
+│     "status": "done"
+│   }
+│   metadata: {
+│     "flue.workflow_name": "instrumentation",
+│     "provider": "flue",
+│     "scenario": "flue-instrumentation"
+│   }
+│   metrics: {
+│     "duration_ms": 0
+│   }
+│   ├── flue.skill [task]
+│   │   input: [
+│   │     {
+│   │       "content": [
+│   │         {
+│   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │           "type": "text"
+│   │         }
+│   │       ],
+│   │       "role": "user"
+│   │     }
+│   │   ]
+│   │   output: "SKILL_DONE"
+│   │   metadata: {
+│   │     "flue.operation": "skill",
+│   │     "flue.session": "skill",
+│   │     "flue.workflow_name": "instrumentation",
+│   │     "provider": "flue",
+│   │     "scenario": "flue-instrumentation"
+│   │   }
+│   │   metrics: {
+│   │     "duration_ms": 0
+│   │   }
+│   │   ├── flue.turn [llm]
+│   │   │   input: [
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "user"
+│   │   │     }
+│   │   │   ]
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "arguments": {
+│   │   │           "cwd": ".",
+│   │   │           "description": "Run the deterministic Flue instrumentation e2e test skill e2e-flue-skill.",
+│   │   │           "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
+│   │   │         },
+│   │   │         "id": "<span:1>",
+│   │   │         "name": "task",
+│   │   │         "type": "toolCall"
+│   │   │       }
+│   │   │     ],
+│   │   │     "role": "assistant"
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.api": "openai-responses",
+│   │   │     "flue.model": "gpt-5.4-nano",
+│   │   │     "flue.provider": "openai",
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.stop_reason": "toolUse",
+│   │   │     "flue.turn_purpose": "agent",
+│   │   │     "model": "gpt-5.4-nano",
+│   │   │     "provider": "openai"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "completion_tokens": 109,
+│   │   │     "duration_ms": 0,
+│   │   │     "estimated_cost": 0.00030565000000000003,
+│   │   │     "prompt_cache_creation_tokens": 0,
+│   │   │     "prompt_cached_tokens": 0,
+│   │   │     "prompt_tokens": 847,
+│   │   │     "tokens": 956
+│   │   │   }
+│   │   │   └── flue.task [task]
+│   │   │       input: "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
+│   │   │       output: "SKILL_DONE"
+│   │   │       metadata: {
+│   │   │         "flue.session": "skill",
+│   │   │         "provider": "flue"
+│   │   │       }
+│   │   │       metrics: {
+│   │   │         "duration_ms": 0
+│   │   │       }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "user"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "agent": "e2e-flue-skill",
+│   │   │       │           "cwd": ".",
+│   │   │       │           "description": "Run e2e-flue-skill with marker SKILL_DONE",
+│   │   │       │           "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "task",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_mode": "full",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 113,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.00031225000000000003,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 0,
+│   │   │       │     "prompt_tokens": 855,
+│   │   │       │     "tokens": 968
+│   │   │       │   }
+│   │   │       ├── tool:task [tool]
+│   │   │       │   input: {
+│   │   │       │     "agent": "e2e-flue-skill",
+│   │   │       │     "cwd": ".",
+│   │   │       │     "description": "Run e2e-flue-skill with marker SKILL_DONE",
+│   │   │       │     "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {}
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "task",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       │   error: "{\"content\":[{\"type\":\"text\",\"text\":\"[flue] Subagent \\\"e2e-flue-skill\\\" is not declared. Available: (none).\"}],\"details\":{}}"
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "agent": "e2e-flue-skill",
+│   │   │       │             "cwd": ".",
+│   │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
+│   │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "task",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": true,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "task"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "command": "find . -maxdepth 4 -name AGENTS.md -print",
+│   │   │       │           "timeout": 100000
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "bash",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 1,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 94,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.00031790000000000003,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 0,
+│   │   │       │     "prompt_tokens": 1002,
+│   │   │       │     "tokens": 1096
+│   │   │       │   }
+│   │   │       ├── tool:bash [tool]
+│   │   │       │   input: {
+│   │   │       │     "command": "find . -maxdepth 4 -name AGENTS.md -print",
+│   │   │       │     "timeout": 100000
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "(no output)",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "command": "find . -maxdepth 4 -name AGENTS.md -print",
+│   │   │       │       "exitCode": 0
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "bash",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
+│   │   │       │             "timeout": 100000
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "bash",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "(no output)",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": false,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "bash"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
+│   │   │       │           "timeout": 100000
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "bash",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 3,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 87,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.00034815000000000003,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 0,
+│   │   │       │     "prompt_tokens": 1197,
+│   │   │       │     "tokens": 1284
+│   │   │       │   }
+│   │   │       ├── tool:bash [tool]
+│   │   │       │   input: {
+│   │   │       │     "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
+│   │   │       │     "timeout": 100000
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "(no output)",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
+│   │   │       │       "exitCode": 0
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "bash",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
+│   │   │       │             "timeout": 100000
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "bash",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "(no output)",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": false,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "bash"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
+│   │   │       │           "timeout": 100000
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "bash",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 5,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 58,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.0003321,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 0,
+│   │   │       │     "prompt_tokens": 1298,
+│   │   │       │     "tokens": 1356
+│   │   │       │   }
+│   │   │       ├── tool:bash [tool]
+│   │   │       │   input: {
+│   │   │       │     "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
+│   │   │       │     "timeout": 100000
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "(no output)",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
+│   │   │       │       "exitCode": 0
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "bash",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
+│   │   │       │             "timeout": 100000
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "bash",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "(no output)",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": false,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "bash"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
+│   │   │       │           "timeout": 100000
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "bash",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 7,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 68,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.00035900000000000005,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 0,
+│   │   │       │     "prompt_tokens": 1370,
+│   │   │       │     "tokens": 1438
+│   │   │       │   }
+│   │   │       ├── tool:bash [tool]
+│   │   │       │   input: {
+│   │   │       │     "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
+│   │   │       │     "timeout": 100000
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
+│   │   │       │       "exitCode": 0
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "bash",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
+│   │   │       │             "timeout": 100000
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "bash",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": false,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "bash"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
+│   │   │       │           "timeout": 100000
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "bash",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 9,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 109,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.00043885000000000007,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 0,
+│   │   │       │     "prompt_tokens": 1513,
+│   │   │       │     "tokens": 1622
+│   │   │       │   }
+│   │   │       ├── tool:bash [tool]
+│   │   │       │   input: {
+│   │   │       │     "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
+│   │   │       │     "timeout": 100000
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
+│   │   │       │       "exitCode": 0
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "bash",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
+│   │   │       │             "timeout": 100000
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "bash",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": false,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "bash"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "limit": 200,
+│   │   │       │           "offset": 1,
+│   │   │       │           "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "read",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 11,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 64,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.00015592,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 1536,
+│   │   │       │     "prompt_tokens": 226,
+│   │   │       │     "tokens": 1826
+│   │   │       │   }
+│   │   │       ├── tool:read [tool]
+│   │   │       │   input: {
+│   │   │       │     "limit": 200,
+│   │   │       │     "offset": 1,
+│   │   │       │     "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "lines": 7,
+│   │   │       │       "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "read",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "limit": 200,
+│   │   │       │             "offset": 1,
+│   │   │       │             "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "read",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": false,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "read"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "command": "cat ./package.json",
+│   │   │       │           "timeout": 100000
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "bash",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 13,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 90,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.00021242000000000003,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 1536,
+│   │   │       │     "prompt_tokens": 346,
+│   │   │       │     "tokens": 1972
+│   │   │       │   }
+│   │   │       ├── tool:bash [tool]
+│   │   │       │   input: {
+│   │   │       │     "command": "cat ./package.json",
+│   │   │       │     "timeout": 100000
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "{\n  \"name\": \"flue-instrumentation-scenario\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"braintrustScenario\": {\n    \"bump\": {\n      \"dependencies\": {\n        \"flue-cli-v0-8-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-cli-v1-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v0-8-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-runtime-v1-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v2-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=2.0.0 <3.0.0\"\n        }\n      }\n    }\n  },\n  \"dependencies\": {\n    \"@flue/cli\": \"0.8.0\",\n    \"@flue/runtime\": \"0.8.0\",\n    \"flue-cli-v0-8-latest\": \"npm:@flue/cli@0.8.1\",\n    \"flue-cli-v1\": \"npm:@flue/cli@1.0.0-beta.3\",\n    \"flue-cli-v1-latest\": \"npm:@flue/cli@1.0.0-beta.9\",\n    \"flue-runtime-v0-8-latest\": \"npm:@flue/runtime@0.8.1\",\n    \"flue-runtime-v1\": \"npm:@flue/runtime@1.0.0-beta.3\",\n    \"flue-runtime-v1-latest\": \"npm:@flue/runtime@1.0.0-beta.9\",\n    \"flue-runtime-v2\": \"npm:@flue/runtime@2.0.0\",\n    \"flue-runtime-v2-latest\": \"npm:@flue/runtime@2.0.1\",\n    \"pi-ai-v2\": \"npm:@earendil-works/pi-ai@0.83.0\",\n    \"valibot\": \"1.4.2\"\n  },\n  \"pnpm\": {\n    \"overrides\": {\n      \"@flue/runtime@0.8.0>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.0>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@hono/node-server@>=2.0.0 <2.0.10\": \"^2.0.10\",\n      \"fast-uri@<3.1.5\": \"^3.1.5\",\n      \"hono@>=4.0.0 <4.12.27\": \"^4.12.27\",\n      \"brace-expansion@>=3.0.0 <5.0.9\": \"^5.0.9\",\n      \"postcss@<8.5.18\": \"^8.5.18\",\n      \"valibot@<1.4.2\": \"^1.4.2\",\n      \"ip-address@<10.2.2\": \"^10.2.2\",\n      \"undici@<7.29.0\": \"^7.29.0\"\n    }\n  }\n}",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "command": "cat ./package.json",
+│   │   │       │       "exitCode": 0
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "bash",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "command": "cat ./package.json",
+│   │   │       │             "timeout": 100000
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "bash",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "{\n  \"name\": \"flue-instrumentation-scenario\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"braintrustScenario\": {\n    \"bump\": {\n      \"dependencies\": {\n        \"flue-cli-v0-8-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-cli-v1-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v0-8-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-runtime-v1-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v2-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=2.0.0 <3.0.0\"\n        }\n      }\n    }\n  },\n  \"dependencies\": {\n    \"@flue/cli\": \"0.8.0\",\n    \"@flue/runtime\": \"0.8.0\",\n    \"flue-cli-v0-8-latest\": \"npm:@flue/cli@0.8.1\",\n    \"flue-cli-v1\": \"npm:@flue/cli@1.0.0-beta.3\",\n    \"flue-cli-v1-latest\": \"npm:@flue/cli@1.0.0-beta.9\",\n    \"flue-runtime-v0-8-latest\": \"npm:@flue/runtime@0.8.1\",\n    \"flue-runtime-v1\": \"npm:@flue/runtime@1.0.0-beta.3\",\n    \"flue-runtime-v1-latest\": \"npm:@flue/runtime@1.0.0-beta.9\",\n    \"flue-runtime-v2\": \"npm:@flue/runtime@2.0.0\",\n    \"flue-runtime-v2-latest\": \"npm:@flue/runtime@2.0.1\",\n    \"pi-ai-v2\": \"npm:@earendil-works/pi-ai@0.83.0\",\n    \"valibot\": \"1.4.2\"\n  },\n  \"pnpm\": {\n    \"overrides\": {\n      \"@flue/runtime@0.8.0>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.0>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@hono/node-server@>=2.0.0 <2.0.10\": \"^2.0.10\",\n      \"fast-uri@<3.1.5\": \"^3.1.5\",\n      \"hono@>=4.0.0 <4.12.27\": \"^4.12.27\",\n      \"brace-expansion@>=3.0.0 <5.0.9\": \"^5.0.9\",\n      \"postcss@<8.5.18\": \"^8.5.18\",\n      \"valibot@<1.4.2\": \"^1.4.2\",\n      \"ip-address@<10.2.2\": \"^10.2.2\",\n      \"undici@<7.29.0\": \"^7.29.0\"\n    }\n  }\n}",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": false,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "bash"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "command": "printf SKILL_DONE",
+│   │   │       │           "timeout": 100000
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "bash",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 15,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 59,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.0004814700000000001,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 1536,
+│   │   │       │     "prompt_tokens": 1885,
+│   │   │       │     "tokens": 3480
+│   │   │       │   }
+│   │   │       ├── tool:bash [tool]
+│   │   │       │   input: {
+│   │   │       │     "command": "printf SKILL_DONE",
+│   │   │       │     "timeout": 100000
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "SKILL_DONE",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "command": "printf SKILL_DONE",
+│   │   │       │       "exitCode": 0
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "bash",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       └── flue.turn [llm]
+│   │   │           input: [
+│   │   │             {
+│   │   │               "content": [
+│   │   │                 {
+│   │   │                   "arguments": {
+│   │   │                     "command": "printf SKILL_DONE",
+│   │   │                     "timeout": 100000
+│   │   │                   },
+│   │   │                   "id": "<span:1>",
+│   │   │                   "name": "bash",
+│   │   │                   "type": "toolCall"
+│   │   │                 }
+│   │   │               ],
+│   │   │               "role": "assistant"
+│   │   │             },
+│   │   │             {
+│   │   │               "content": [
+│   │   │                 {
+│   │   │                   "text": "SKILL_DONE",
+│   │   │                   "type": "text"
+│   │   │                 }
+│   │   │               ],
+│   │   │               "isError": false,
+│   │   │               "role": "toolResult",
+│   │   │               "toolCallId": "<span:1>",
+│   │   │               "toolName": "bash"
+│   │   │             }
+│   │   │           ]
+│   │   │           output: {
+│   │   │             "content": [
+│   │   │               {
+│   │   │                 "text": "SKILL_DONE",
+│   │   │                 "textSignature": "{\"v\":1,\"id\":\"msg_054a16a2f2ea3217016a705b70a41481a38ece40ecddf69512\",\"phase\":\"final_answer\"}",
+│   │   │                 "type": "text"
+│   │   │               }
+│   │   │             ],
+│   │   │             "role": "assistant"
+│   │   │           }
+│   │   │           metadata: {
+│   │   │             "flue.api": "openai-responses",
+│   │   │             "flue.input_message_offset": 17,
+│   │   │             "flue.input_mode": "delta",
+│   │   │             "flue.model": "gpt-5.4-nano",
+│   │   │             "flue.provider": "openai",
+│   │   │             "flue.session": "task:skill:<uuid:1>",
+│   │   │             "flue.stop_reason": "stop",
+│   │   │             "flue.turn_purpose": "agent",
+│   │   │             "model": "gpt-5.4-nano",
+│   │   │             "provider": "openai"
+│   │   │           }
+│   │   │           metrics: {
+│   │   │             "completion_tokens": 7,
+│   │   │             "duration_ms": 0,
+│   │   │             "estimated_cost": 0.00031035000000000004,
+│   │   │             "prompt_cache_creation_tokens": 0,
+│   │   │             "prompt_cached_tokens": 2560,
+│   │   │             "prompt_tokens": 1252,
+│   │   │             "tokens": 3819
+│   │   │           }
+│   │   ├── tool:task [tool]
+│   │   │   input: {
+│   │   │     "cwd": ".",
+│   │   │     "description": "Run the deterministic Flue instrumentation e2e test skill e2e-flue-skill.",
+│   │   │     "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
+│   │   │   }
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "text": "SKILL_DONE",
+│   │   │         "type": "text"
+│   │   │       }
+│   │   │     ],
+│   │   │     "details": {
+│   │   │       "cwd": ".",
+│   │   │       "messageId": "<messageId:2>",
+│   │   │       "session": "task:skill:<uuid:1>",
+│   │   │       "taskId": "<uuid:1>"
+│   │   │     }
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.tool_name": "task",
+│   │   │     "provider": "flue"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "duration_ms": 0
+│   │   │   }
+│   │   └── flue.turn [llm]
+│   │       input: [
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "role": "user"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "arguments": {
+│   │                 "cwd": ".",
+│   │                 "description": "Run the deterministic Flue instrumentation e2e test skill e2e-flue-skill.",
+│   │                 "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
+│   │               },
+│   │               "id": "<span:1>",
+│   │               "name": "task",
+│   │               "type": "toolCall"
+│   │             }
+│   │           ],
+│   │           "role": "assistant"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "SKILL_DONE",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "isError": false,
+│   │           "role": "toolResult",
+│   │           "toolCallId": "<span:1>",
+│   │           "toolName": "task"
+│   │         }
+│   │       ]
+│   │       output: {
+│   │         "content": [
+│   │           {
+│   │             "text": "SKILL_DONE",
+│   │             "textSignature": "{\"v\":1,\"id\":\"msg_0f099b3fce0721fd016a705b71558881a38c53a767e09d9e31\",\"phase\":\"final_answer\"}",
+│   │             "type": "text"
+│   │           }
+│   │         ],
+│   │         "role": "assistant"
+│   │       }
+│   │       metadata: {
+│   │         "flue.api": "openai-responses",
+│   │         "flue.model": "gpt-5.4-nano",
+│   │         "flue.provider": "openai",
+│   │         "flue.session": "skill",
+│   │         "flue.stop_reason": "stop",
+│   │         "flue.turn_purpose": "agent",
+│   │         "model": "gpt-5.4-nano",
+│   │         "provider": "openai"
+│   │       }
+│   │       metrics: {
+│   │         "completion_tokens": 7,
+│   │         "duration_ms": 0,
+│   │         "estimated_cost": 0.00020255000000000002,
+│   │         "prompt_cache_creation_tokens": 0,
+│   │         "prompt_cached_tokens": 0,
+│   │         "prompt_tokens": 969,
+│   │         "tokens": 976
+│   │       }
+│   ├── flue.task [task]
+│   │   input: "Reply with exactly TASK_DONE and no other text."
+│   │   output: "TASK_DONE"
+│   │   metadata: {
+│   │     "flue.session": "task",
+│   │     "provider": "flue"
+│   │   }
+│   │   metrics: {
+│   │     "duration_ms": 0
+│   │   }
+│   │   └── flue.turn [llm]
+│   │       input: [
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "Reply with exactly TASK_DONE and no other text.",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "role": "user"
+│   │         }
+│   │       ]
+│   │       output: {
+│   │         "content": [
+│   │           {
+│   │             "text": "TASK_DONE",
+│   │             "textSignature": "{\"v\":1,\"id\":\"msg_0f3adfdb1510c165016a705b72843c81a0b30d242da683a882\"}",
+│   │             "type": "text"
+│   │           }
+│   │         ],
+│   │         "role": "assistant"
+│   │       }
+│   │       metadata: {
+│   │         "flue.api": "openai-responses",
+│   │         "flue.input_mode": "full",
+│   │         "flue.model": "gpt-4o-mini",
+│   │         "flue.provider": "openai",
+│   │         "flue.session": "task:task:<uuid:1>",
+│   │         "flue.stop_reason": "stop",
+│   │         "flue.turn_purpose": "agent",
+│   │         "model": "gpt-4o-mini",
+│   │         "provider": "openai"
+│   │       }
+│   │       metrics: {
+│   │         "completion_tokens": 4,
+│   │         "duration_ms": 0,
+│   │         "estimated_cost": 0.0001263,
+│   │         "prompt_cache_creation_tokens": 0,
+│   │         "prompt_cached_tokens": 0,
+│   │         "prompt_tokens": 826,
+│   │         "tokens": 830
+│   │       }
+│   └── flue.compact [task]
+│       input: {
+│         "estimatedTokens": 1229,
+│         "reason": "manual"
+│       }
+│       output: {
+│         "completed": true
+│       }
+│       metadata: {
+│         "flue.operation": "compact",
+│         "flue.session": "main",
+│         "flue.workflow_name": "instrumentation",
+│         "provider": "flue",
+│         "scenario": "flue-instrumentation"
+│       }
+│       metrics: {
+│         "duration_ms": 0
+│       }
+│       └── compaction:manual [task]
+│           input: {
+│             "estimatedTokens": 1229,
+│             "reason": "manual"
+│           }
+│           output: {
+│             "messagesAfter": 2,
+│             "messagesBefore": 8
+│           }
+│           metadata: {
+│             "flue.compaction_reason": "manual",
+│             "flue.session": "main",
+│             "provider": "flue"
+│           }
+│           metrics: {
+│             "duration_ms": 0,
+│             "messages_after": 2,
+│             "messages_before": 8
+│           }
+│           └── flue.turn [llm]
+│               input: [
+│                 {
+│                   "content": [
+│                     {
+│                       "text": "<conversation>\n[User]: Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.\n\n[Assistant tool calls]: lookup(query=\"flue instrumentation\")\n\n[Tool result]: {\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}\n\n[Assistant tool calls]: web_search(lookupId=\"flue-session-2026\", query=\"Braintrust Flue reasoning stream instrumentation\")\n\n[Tool result]: {\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}\n\n[Assistant tool calls]: summarize_source(url=\"https://example.test/flue/reasoning-streams\")\n\n[Tool result]: {\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}\n</conversation>\n\nThis is the PREFIX of a turn that was too large to keep. The SUFFIX (recent work) is retained.\n\nSummarize the prefix to provide context for the retained suffix:\n\n## Original Request\n[What did the user ask for in this turn?]\n\n## Early Progress\n- [Key decisions and work done in the prefix]\n\n## Context for Suffix\n- [Information needed to understand the retained recent work]\n\nBe concise. Focus on what's needed to understand the kept suffix.",
+│                       "type": "text"
+│                     }
+│                   ],
+│                   "role": "user"
+│                 }
+│               ]
+│               output: {
+│                 "content": [
+│                   {
+│                     "text": "## Original Request\nThe user requested a step-by-step execution of an instrumented research flow involving tool calls to gather information on \"flue instrumentation\" and \"",
+│                     "textSignature": "{\"v\":1,\"id\":\"msg_04d28ba03840bb65016a705b7358a081a38e69464057840036\"}",
+│                     "type": "text"
+│                   }
+│                 ],
+│                 "role": "assistant"
+│               }
+│               metadata: {
+│                 "flue.api": "openai-responses",
+│                 "flue.model": "gpt-4o-mini",
+│                 "flue.provider": "openai",
+│                 "flue.session": "main",
+│                 "flue.stop_reason": "stop",
+│                 "flue.turn_purpose": "compaction_prefix",
+│                 "model": "gpt-4o-mini",
+│                 "provider": "openai"
+│               }
+│               metrics: {
+│                 "completion_tokens": 0,
+│                 "duration_ms": 0,
+│                 "estimated_cost": 0,
+│                 "prompt_cache_creation_tokens": 0,
+│                 "prompt_cached_tokens": 0,
+│                 "prompt_tokens": 0,
+│                 "tokens": 0
+│               }
+└── flue.prompt [task]
+    input: [
+      {
+        "content": [
+          {
+            "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+            "type": "text"
+          }
+        ],
+        "role": "user"
+      }
+    ]
+    output: "PROMPT_DONE"
     metadata: {
+      "flue.operation": "prompt",
+      "flue.session": "main",
       "flue.workflow_name": "instrumentation",
       "provider": "flue",
       "scenario": "flue-instrumentation"
@@ -19,7 +1197,7 @@ span_tree:
     metrics: {
       "duration_ms": 0
     }
-    ├── flue.prompt [task]
+    ├── flue.turn [llm]
     │   input: [
     │     {
     │       "content": [
@@ -31,2574 +1209,291 @@ span_tree:
     │       "role": "user"
     │     }
     │   ]
-    │   output: "PROMPT_DONE"
+    │   output: {
+    │     "content": [
+    │       {
+    │         "arguments": {
+    │           "query": "flue instrumentation"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "lookup",
+    │         "type": "toolCall"
+    │       }
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.operation": "prompt",
+    │     "flue.api": "openai-responses",
+    │     "flue.input_mode": "full",
+    │     "flue.model": "gpt-5.4-nano",
+    │     "flue.provider": "openai",
     │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "gpt-5.4-nano",
+    │     "provider": "openai"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 19,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.00022475000000000001,
+    │     "prompt_cache_creation_tokens": 0,
+    │     "prompt_cached_tokens": 0,
+    │     "prompt_tokens": 1005,
+    │     "tokens": 1024
+    │   }
+    ├── tool:lookup [tool]
+    │   input: {
+    │     "query": "flue instrumentation"
+    │   }
+    │   output: {
+    │     "content": [
+    │       {
+    │         "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
+    │         "type": "text"
+    │       }
+    │     ],
+    │     "details": {
+    │       "customTool": "lookup"
+    │     }
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "lookup",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "query": "flue instrumentation"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "lookup",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "openai-responses",
-    │   │     "flue.model": "gpt-5.4-nano",
-    │   │     "flue.provider": "openai",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "gpt-5.4-nano",
-    │   │     "provider": "openai"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 19,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.00022475000000000001,
-    │   │     "prompt_cache_creation_tokens": 0,
-    │   │     "prompt_cached_tokens": 0,
-    │   │     "prompt_tokens": 1005,
-    │   │     "tokens": 1024
-    │   │   }
-    │   ├── tool:lookup [tool]
-    │   │   input: {
-    │   │     "query": "flue instrumentation"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "customTool": "lookup"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "lookup",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "query": "flue instrumentation"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "lookup",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "lookup"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "lookupId": "flue-session-2026",
-    │   │           "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "web_search",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "openai-responses",
-    │   │     "flue.model": "gpt-5.4-nano",
-    │   │     "flue.provider": "openai",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "gpt-5.4-nano",
-    │   │     "provider": "openai"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 34,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.00025350000000000004,
-    │   │     "prompt_cache_creation_tokens": 0,
-    │   │     "prompt_cached_tokens": 0,
-    │   │     "prompt_tokens": 1055,
-    │   │     "tokens": 1089
-    │   │   }
-    │   ├── tool:web_search [tool]
-    │   │   input: {
-    │   │     "lookupId": "flue-session-2026",
-    │   │     "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "customTool": "web_search"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "web_search",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "query": "flue instrumentation"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "lookup",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "lookup"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "lookupId": "flue-session-2026",
-    │   │             "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │           },
-    │   │           "id": "<span:2>",
-    │   │           "name": "web_search",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:2>",
-    │   │       "toolName": "web_search"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "url": "https://example.test/flue/reasoning-streams"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "summarize_source",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "openai-responses",
-    │   │     "flue.model": "gpt-5.4-nano",
-    │   │     "flue.provider": "openai",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "gpt-5.4-nano",
-    │   │     "provider": "openai"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 30,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.00026690000000000004,
-    │   │     "prompt_cache_creation_tokens": 0,
-    │   │     "prompt_cached_tokens": 0,
-    │   │     "prompt_tokens": 1147,
-    │   │     "tokens": 1177
-    │   │   }
-    │   ├── tool:summarize_source [tool]
-    │   │   input: {
-    │   │     "url": "https://example.test/flue/reasoning-streams"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "customTool": "summarize_source"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "summarize_source",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   └── flue.turn [llm]
-    │       input: [
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "query": "flue instrumentation"
-    │               },
-    │               "id": "<span:1>",
-    │               "name": "lookup",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:1>",
-    │           "toolName": "lookup"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "lookupId": "flue-session-2026",
-    │                 "query": "Braintrust Flue reasoning stream instrumentation"
-    │               },
-    │               "id": "<span:2>",
-    │               "name": "web_search",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:2>",
-    │           "toolName": "web_search"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "url": "https://example.test/flue/reasoning-streams"
-    │               },
-    │               "id": "<span:3>",
-    │               "name": "summarize_source",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:3>",
-    │           "toolName": "summarize_source"
-    │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "text": "PROMPT_DONE",
-    │             "textSignature": "{\"v\":1,\"id\":\"msg_045458052dc10379016a705b62dbd8819189b8287061debf12\",\"phase\":\"final_answer\"}",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
-    │       }
-    │       metadata: {
-    │         "flue.api": "openai-responses",
-    │         "flue.model": "gpt-5.4-nano",
-    │         "flue.provider": "openai",
-    │         "flue.session": "main",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "gpt-5.4-nano",
-    │         "provider": "openai"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 7,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.00025315000000000005,
-    │         "prompt_cache_creation_tokens": 0,
-    │         "prompt_cached_tokens": 0,
-    │         "prompt_tokens": 1222,
-    │         "tokens": 1229
-    │       }
-    ├── flue.skill [task]
+    ├── flue.turn [llm]
     │   input: [
     │     {
     │       "content": [
     │         {
-    │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+    │           "arguments": {
+    │             "query": "flue instrumentation"
+    │           },
+    │           "id": "<span:1>",
+    │           "name": "lookup",
+    │           "type": "toolCall"
+    │         }
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
     │           "type": "text"
     │         }
     │       ],
-    │       "role": "user"
+    │       "isError": false,
+    │       "role": "toolResult",
+    │       "toolCallId": "<span:1>",
+    │       "toolName": "lookup"
     │     }
     │   ]
-    │   output: "SKILL_DONE"
+    │   output: {
+    │     "content": [
+    │       {
+    │         "arguments": {
+    │           "lookupId": "flue-session-2026",
+    │           "query": "Braintrust Flue reasoning stream instrumentation"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "web_search",
+    │         "type": "toolCall"
+    │       }
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.operation": "skill",
-    │     "flue.session": "skill",
+    │     "flue.api": "openai-responses",
+    │     "flue.input_message_offset": 1,
+    │     "flue.input_mode": "delta",
+    │     "flue.model": "gpt-5.4-nano",
+    │     "flue.provider": "openai",
+    │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "gpt-5.4-nano",
+    │     "provider": "openai"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 34,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.00025350000000000004,
+    │     "prompt_cache_creation_tokens": 0,
+    │     "prompt_cached_tokens": 0,
+    │     "prompt_tokens": 1055,
+    │     "tokens": 1089
+    │   }
+    ├── tool:web_search [tool]
+    │   input: {
+    │     "lookupId": "flue-session-2026",
+    │     "query": "Braintrust Flue reasoning stream instrumentation"
+    │   }
+    │   output: {
+    │     "content": [
+    │       {
+    │         "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+    │         "type": "text"
+    │       }
+    │     ],
+    │     "details": {
+    │       "customTool": "web_search"
+    │     }
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "web_search",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "cwd": ".",
-    │   │           "description": "Run the deterministic Flue instrumentation e2e test skill e2e-flue-skill.",
-    │   │           "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "task",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "openai-responses",
-    │   │     "flue.model": "gpt-5.4-nano",
-    │   │     "flue.provider": "openai",
-    │   │     "flue.session": "skill",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "gpt-5.4-nano",
-    │   │     "provider": "openai"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 109,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.00030565000000000003,
-    │   │     "prompt_cache_creation_tokens": 0,
-    │   │     "prompt_cached_tokens": 0,
-    │   │     "prompt_tokens": 847,
-    │   │     "tokens": 956
-    │   │   }
-    │   │   └── flue.task [task]
-    │   │       input: "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
-    │   │       output: "SKILL_DONE"
-    │   │       metadata: {
-    │   │         "flue.session": "skill",
-    │   │         "provider": "flue"
-    │   │       }
-    │   │       metrics: {
-    │   │         "duration_ms": 0
-    │   │       }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "agent": "e2e-flue-skill",
-    │   │       │           "cwd": ".",
-    │   │       │           "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │           "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "task",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 113,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.00031225000000000003,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 0,
-    │   │       │     "prompt_tokens": 855,
-    │   │       │     "tokens": 968
-    │   │       │   }
-    │   │       ├── tool:task [tool]
-    │   │       │   input: {
-    │   │       │     "agent": "e2e-flue-skill",
-    │   │       │     "cwd": ".",
-    │   │       │     "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │     "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {}
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "task",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       │   error: "{\"content\":[{\"type\":\"text\",\"text\":\"[flue] Subagent \\\"e2e-flue-skill\\\" is not declared. Available: (none).\"}],\"details\":{}}"
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │           "timeout": 100000
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "bash",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 94,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.00031790000000000003,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 0,
-    │   │       │     "prompt_tokens": 1002,
-    │   │       │     "tokens": 1096
-    │   │       │   }
-    │   │       ├── tool:bash [tool]
-    │   │       │   input: {
-    │   │       │     "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │     "timeout": 100000
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "(no output)",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │       "exitCode": 0
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "bash",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:2>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:2>",
-    │   │       │       "toolName": "bash"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │           "timeout": 100000
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "bash",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 87,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.00034815000000000003,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 0,
-    │   │       │     "prompt_tokens": 1197,
-    │   │       │     "tokens": 1284
-    │   │       │   }
-    │   │       ├── tool:bash [tool]
-    │   │       │   input: {
-    │   │       │     "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │     "timeout": 100000
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "(no output)",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │       "exitCode": 0
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "bash",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:2>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:2>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:3>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:3>",
-    │   │       │       "toolName": "bash"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │           "timeout": 100000
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "bash",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 58,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.0003321,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 0,
-    │   │       │     "prompt_tokens": 1298,
-    │   │       │     "tokens": 1356
-    │   │       │   }
-    │   │       ├── tool:bash [tool]
-    │   │       │   input: {
-    │   │       │     "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │     "timeout": 100000
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "(no output)",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │       "exitCode": 0
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "bash",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:2>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:2>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:3>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:3>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:4>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:4>",
-    │   │       │       "toolName": "bash"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │       │           "timeout": 100000
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "bash",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 68,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.00035900000000000005,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 0,
-    │   │       │     "prompt_tokens": 1370,
-    │   │       │     "tokens": 1438
-    │   │       │   }
-    │   │       ├── tool:bash [tool]
-    │   │       │   input: {
-    │   │       │     "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │       │     "timeout": 100000
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │       │       "exitCode": 0
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "bash",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:2>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:2>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:3>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:3>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:4>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:4>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:5>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:5>",
-    │   │       │       "toolName": "bash"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-    │   │       │           "timeout": 100000
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "bash",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 109,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.00043885000000000007,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 0,
-    │   │       │     "prompt_tokens": 1513,
-    │   │       │     "tokens": 1622
-    │   │       │   }
-    │   │       ├── tool:bash [tool]
-    │   │       │   input: {
-    │   │       │     "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-    │   │       │     "timeout": 100000
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-    │   │       │       "exitCode": 0
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "bash",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:2>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:2>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:3>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:3>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:4>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:4>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:5>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:5>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:6>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:6>",
-    │   │       │       "toolName": "bash"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "limit": 200,
-    │   │       │           "offset": 1,
-    │   │       │           "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "read",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 64,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.00015592,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 1536,
-    │   │       │     "prompt_tokens": 226,
-    │   │       │     "tokens": 1826
-    │   │       │   }
-    │   │       ├── tool:read [tool]
-    │   │       │   input: {
-    │   │       │     "limit": 200,
-    │   │       │     "offset": 1,
-    │   │       │     "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "lines": 7,
-    │   │       │       "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "read",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:2>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:2>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:3>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:3>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:4>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:4>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:5>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:5>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:6>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:6>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "limit": 200,
-    │   │       │             "offset": 1,
-    │   │       │             "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-    │   │       │           },
-    │   │       │           "id": "<span:7>",
-    │   │       │           "name": "read",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:7>",
-    │   │       │       "toolName": "read"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "command": "cat ./package.json",
-    │   │       │           "timeout": 100000
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "bash",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 90,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.00021242000000000003,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 1536,
-    │   │       │     "prompt_tokens": 346,
-    │   │       │     "tokens": 1972
-    │   │       │   }
-    │   │       ├── tool:bash [tool]
-    │   │       │   input: {
-    │   │       │     "command": "cat ./package.json",
-    │   │       │     "timeout": 100000
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "{\n  \"name\": \"flue-instrumentation-scenario\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"braintrustScenario\": {\n    \"bump\": {\n      \"dependencies\": {\n        \"flue-cli-v0-8-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-cli-v1-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v0-8-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-runtime-v1-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v2-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=2.0.0 <3.0.0\"\n        }\n      }\n    }\n  },\n  \"dependencies\": {\n    \"@flue/cli\": \"0.8.0\",\n    \"@flue/runtime\": \"0.8.0\",\n    \"flue-cli-v0-8-latest\": \"npm:@flue/cli@0.8.1\",\n    \"flue-cli-v1\": \"npm:@flue/cli@1.0.0-beta.3\",\n    \"flue-cli-v1-latest\": \"npm:@flue/cli@1.0.0-beta.9\",\n    \"flue-runtime-v0-8-latest\": \"npm:@flue/runtime@0.8.1\",\n    \"flue-runtime-v1\": \"npm:@flue/runtime@1.0.0-beta.3\",\n    \"flue-runtime-v1-latest\": \"npm:@flue/runtime@1.0.0-beta.9\",\n    \"flue-runtime-v2\": \"npm:@flue/runtime@2.0.0\",\n    \"flue-runtime-v2-latest\": \"npm:@flue/runtime@2.0.1\",\n    \"pi-ai-v2\": \"npm:@earendil-works/pi-ai@0.83.0\",\n    \"valibot\": \"1.4.2\"\n  },\n  \"pnpm\": {\n    \"overrides\": {\n      \"@flue/runtime@0.8.0>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.0>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@hono/node-server@>=2.0.0 <2.0.10\": \"^2.0.10\",\n      \"fast-uri@<3.1.5\": \"^3.1.5\",\n      \"hono@>=4.0.0 <4.12.27\": \"^4.12.27\",\n      \"brace-expansion@>=3.0.0 <5.0.9\": \"^5.0.9\",\n      \"postcss@<8.5.18\": \"^8.5.18\",\n      \"valibot@<1.4.2\": \"^1.4.2\",\n      \"ip-address@<10.2.2\": \"^10.2.2\",\n      \"undici@<7.29.0\": \"^7.29.0\"\n    }\n  }\n}",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "command": "cat ./package.json",
-    │   │       │       "exitCode": 0
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "bash",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:2>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:2>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:3>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:3>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:4>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:4>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:5>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:5>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:6>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:6>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "limit": 200,
-    │   │       │             "offset": 1,
-    │   │       │             "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-    │   │       │           },
-    │   │       │           "id": "<span:7>",
-    │   │       │           "name": "read",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:7>",
-    │   │       │       "toolName": "read"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "cat ./package.json",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:8>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "{\n  \"name\": \"flue-instrumentation-scenario\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"braintrustScenario\": {\n    \"bump\": {\n      \"dependencies\": {\n        \"flue-cli-v0-8-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-cli-v1-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v0-8-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-runtime-v1-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v2-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=2.0.0 <3.0.0\"\n        }\n      }\n    }\n  },\n  \"dependencies\": {\n    \"@flue/cli\": \"0.8.0\",\n    \"@flue/runtime\": \"0.8.0\",\n    \"flue-cli-v0-8-latest\": \"npm:@flue/cli@0.8.1\",\n    \"flue-cli-v1\": \"npm:@flue/cli@1.0.0-beta.3\",\n    \"flue-cli-v1-latest\": \"npm:@flue/cli@1.0.0-beta.9\",\n    \"flue-runtime-v0-8-latest\": \"npm:@flue/runtime@0.8.1\",\n    \"flue-runtime-v1\": \"npm:@flue/runtime@1.0.0-beta.3\",\n    \"flue-runtime-v1-latest\": \"npm:@flue/runtime@1.0.0-beta.9\",\n    \"flue-runtime-v2\": \"npm:@flue/runtime@2.0.0\",\n    \"flue-runtime-v2-latest\": \"npm:@flue/runtime@2.0.1\",\n    \"pi-ai-v2\": \"npm:@earendil-works/pi-ai@0.83.0\",\n    \"valibot\": \"1.4.2\"\n  },\n  \"pnpm\": {\n    \"overrides\": {\n      \"@flue/runtime@0.8.0>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.0>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@hono/node-server@>=2.0.0 <2.0.10\": \"^2.0.10\",\n      \"fast-uri@<3.1.5\": \"^3.1.5\",\n      \"hono@>=4.0.0 <4.12.27\": \"^4.12.27\",\n      \"brace-expansion@>=3.0.0 <5.0.9\": \"^5.0.9\",\n      \"postcss@<8.5.18\": \"^8.5.18\",\n      \"valibot@<1.4.2\": \"^1.4.2\",\n      \"ip-address@<10.2.2\": \"^10.2.2\",\n      \"undici@<7.29.0\": \"^7.29.0\"\n    }\n  }\n}",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:8>",
-    │   │       │       "toolName": "bash"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "command": "printf SKILL_DONE",
-    │   │       │           "timeout": 100000
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "bash",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 59,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.0004814700000000001,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 1536,
-    │   │       │     "prompt_tokens": 1885,
-    │   │       │     "tokens": 3480
-    │   │       │   }
-    │   │       ├── tool:bash [tool]
-    │   │       │   input: {
-    │   │       │     "command": "printf SKILL_DONE",
-    │   │       │     "timeout": 100000
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "SKILL_DONE",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "command": "printf SKILL_DONE",
-    │   │       │       "exitCode": 0
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "bash",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       └── flue.turn [llm]
-    │   │           input: [
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "user"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "agent": "e2e-flue-skill",
-    │   │                     "cwd": ".",
-    │   │                     "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │                     "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │                   },
-    │   │                   "id": "<span:1>",
-    │   │                   "name": "task",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": true,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:1>",
-    │   │               "toolName": "task"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │                     "timeout": 100000
-    │   │                   },
-    │   │                   "id": "<span:2>",
-    │   │                   "name": "bash",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "(no output)",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:2>",
-    │   │               "toolName": "bash"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │                     "timeout": 100000
-    │   │                   },
-    │   │                   "id": "<span:3>",
-    │   │                   "name": "bash",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "(no output)",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:3>",
-    │   │               "toolName": "bash"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │                     "timeout": 100000
-    │   │                   },
-    │   │                   "id": "<span:4>",
-    │   │                   "name": "bash",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "(no output)",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:4>",
-    │   │               "toolName": "bash"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │                     "timeout": 100000
-    │   │                   },
-    │   │                   "id": "<span:5>",
-    │   │                   "name": "bash",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:5>",
-    │   │               "toolName": "bash"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-    │   │                     "timeout": 100000
-    │   │                   },
-    │   │                   "id": "<span:6>",
-    │   │                   "name": "bash",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:6>",
-    │   │               "toolName": "bash"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "limit": 200,
-    │   │                     "offset": 1,
-    │   │                     "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-    │   │                   },
-    │   │                   "id": "<span:7>",
-    │   │                   "name": "read",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:7>",
-    │   │               "toolName": "read"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "command": "cat ./package.json",
-    │   │                     "timeout": 100000
-    │   │                   },
-    │   │                   "id": "<span:8>",
-    │   │                   "name": "bash",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "{\n  \"name\": \"flue-instrumentation-scenario\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"braintrustScenario\": {\n    \"bump\": {\n      \"dependencies\": {\n        \"flue-cli-v0-8-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-cli-v1-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v0-8-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-runtime-v1-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v2-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=2.0.0 <3.0.0\"\n        }\n      }\n    }\n  },\n  \"dependencies\": {\n    \"@flue/cli\": \"0.8.0\",\n    \"@flue/runtime\": \"0.8.0\",\n    \"flue-cli-v0-8-latest\": \"npm:@flue/cli@0.8.1\",\n    \"flue-cli-v1\": \"npm:@flue/cli@1.0.0-beta.3\",\n    \"flue-cli-v1-latest\": \"npm:@flue/cli@1.0.0-beta.9\",\n    \"flue-runtime-v0-8-latest\": \"npm:@flue/runtime@0.8.1\",\n    \"flue-runtime-v1\": \"npm:@flue/runtime@1.0.0-beta.3\",\n    \"flue-runtime-v1-latest\": \"npm:@flue/runtime@1.0.0-beta.9\",\n    \"flue-runtime-v2\": \"npm:@flue/runtime@2.0.0\",\n    \"flue-runtime-v2-latest\": \"npm:@flue/runtime@2.0.1\",\n    \"pi-ai-v2\": \"npm:@earendil-works/pi-ai@0.83.0\",\n    \"valibot\": \"1.4.2\"\n  },\n  \"pnpm\": {\n    \"overrides\": {\n      \"@flue/runtime@0.8.0>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.0>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@hono/node-server@>=2.0.0 <2.0.10\": \"^2.0.10\",\n      \"fast-uri@<3.1.5\": \"^3.1.5\",\n      \"hono@>=4.0.0 <4.12.27\": \"^4.12.27\",\n      \"brace-expansion@>=3.0.0 <5.0.9\": \"^5.0.9\",\n      \"postcss@<8.5.18\": \"^8.5.18\",\n      \"valibot@<1.4.2\": \"^1.4.2\",\n      \"ip-address@<10.2.2\": \"^10.2.2\",\n      \"undici@<7.29.0\": \"^7.29.0\"\n    }\n  }\n}",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:8>",
-    │   │               "toolName": "bash"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "command": "printf SKILL_DONE",
-    │   │                     "timeout": 100000
-    │   │                   },
-    │   │                   "id": "<span:9>",
-    │   │                   "name": "bash",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "SKILL_DONE",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:9>",
-    │   │               "toolName": "bash"
-    │   │             }
-    │   │           ]
-    │   │           output: {
-    │   │             "content": [
-    │   │               {
-    │   │                 "text": "SKILL_DONE",
-    │   │                 "textSignature": "{\"v\":1,\"id\":\"msg_054a16a2f2ea3217016a705b70a41481a38ece40ecddf69512\",\"phase\":\"final_answer\"}",
-    │   │                 "type": "text"
-    │   │               }
-    │   │             ],
-    │   │             "role": "assistant"
-    │   │           }
-    │   │           metadata: {
-    │   │             "flue.api": "openai-responses",
-    │   │             "flue.model": "gpt-5.4-nano",
-    │   │             "flue.provider": "openai",
-    │   │             "flue.session": "task:skill:<uuid:1>",
-    │   │             "flue.stop_reason": "stop",
-    │   │             "flue.turn_purpose": "agent",
-    │   │             "model": "gpt-5.4-nano",
-    │   │             "provider": "openai"
-    │   │           }
-    │   │           metrics: {
-    │   │             "completion_tokens": 7,
-    │   │             "duration_ms": 0,
-    │   │             "estimated_cost": 0.00031035000000000004,
-    │   │             "prompt_cache_creation_tokens": 0,
-    │   │             "prompt_cached_tokens": 2560,
-    │   │             "prompt_tokens": 1252,
-    │   │             "tokens": 3819
-    │   │           }
-    │   ├── tool:task [tool]
-    │   │   input: {
-    │   │     "cwd": ".",
-    │   │     "description": "Run the deterministic Flue instrumentation e2e test skill e2e-flue-skill.",
-    │   │     "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "SKILL_DONE",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "cwd": ".",
-    │   │       "messageId": "<messageId:2>",
-    │   │       "session": "task:skill:<uuid:1>",
-    │   │       "taskId": "<uuid:1>"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "skill",
-    │   │     "flue.tool_name": "task",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   └── flue.turn [llm]
-    │       input: [
+    ├── flue.turn [llm]
+    │   input: [
+    │     {
+    │       "content": [
     │         {
-    │           "content": [
-    │             {
-    │               "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "cwd": ".",
-    │                 "description": "Run the deterministic Flue instrumentation e2e test skill e2e-flue-skill.",
-    │                 "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
-    │               },
-    │               "id": "<span:1>",
-    │               "name": "task",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "SKILL_DONE",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:1>",
-    │           "toolName": "task"
+    │           "arguments": {
+    │             "lookupId": "flue-session-2026",
+    │             "query": "Braintrust Flue reasoning stream instrumentation"
+    │           },
+    │           "id": "<span:1>",
+    │           "name": "web_search",
+    │           "type": "toolCall"
     │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "text": "SKILL_DONE",
-    │             "textSignature": "{\"v\":1,\"id\":\"msg_0f099b3fce0721fd016a705b71558881a38c53a767e09d9e31\",\"phase\":\"final_answer\"}",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+    │           "type": "text"
+    │         }
+    │       ],
+    │       "isError": false,
+    │       "role": "toolResult",
+    │       "toolCallId": "<span:1>",
+    │       "toolName": "web_search"
+    │     }
+    │   ]
+    │   output: {
+    │     "content": [
+    │       {
+    │         "arguments": {
+    │           "url": "https://example.test/flue/reasoning-streams"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "summarize_source",
+    │         "type": "toolCall"
     │       }
-    │       metadata: {
-    │         "flue.api": "openai-responses",
-    │         "flue.model": "gpt-5.4-nano",
-    │         "flue.provider": "openai",
-    │         "flue.session": "skill",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "gpt-5.4-nano",
-    │         "provider": "openai"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 7,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.00020255000000000002,
-    │         "prompt_cache_creation_tokens": 0,
-    │         "prompt_cached_tokens": 0,
-    │         "prompt_tokens": 969,
-    │         "tokens": 976
-    │       }
-    ├── flue.task [task]
-    │   input: "Reply with exactly TASK_DONE and no other text."
-    │   output: "TASK_DONE"
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.session": "task",
+    │     "flue.api": "openai-responses",
+    │     "flue.input_message_offset": 3,
+    │     "flue.input_mode": "delta",
+    │     "flue.model": "gpt-5.4-nano",
+    │     "flue.provider": "openai",
+    │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "gpt-5.4-nano",
+    │     "provider": "openai"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 30,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.00026690000000000004,
+    │     "prompt_cache_creation_tokens": 0,
+    │     "prompt_cached_tokens": 0,
+    │     "prompt_tokens": 1147,
+    │     "tokens": 1177
+    │   }
+    ├── tool:summarize_source [tool]
+    │   input: {
+    │     "url": "https://example.test/flue/reasoning-streams"
+    │   }
+    │   output: {
+    │     "content": [
+    │       {
+    │         "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+    │         "type": "text"
+    │       }
+    │     ],
+    │     "details": {
+    │       "customTool": "summarize_source"
+    │     }
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "summarize_source",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   └── flue.turn [llm]
-    │       input: [
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "Reply with exactly TASK_DONE and no other text.",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
-    │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "text": "TASK_DONE",
-    │             "textSignature": "{\"v\":1,\"id\":\"msg_0f3adfdb1510c165016a705b72843c81a0b30d242da683a882\"}",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
-    │       }
-    │       metadata: {
-    │         "flue.api": "openai-responses",
-    │         "flue.model": "gpt-4o-mini",
-    │         "flue.provider": "openai",
-    │         "flue.session": "task:task:<uuid:1>",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "gpt-4o-mini",
-    │         "provider": "openai"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 4,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.0001263,
-    │         "prompt_cache_creation_tokens": 0,
-    │         "prompt_cached_tokens": 0,
-    │         "prompt_tokens": 826,
-    │         "tokens": 830
-    │       }
-    └── flue.compact [task]
-        input: {
-          "estimatedTokens": 1229,
-          "reason": "manual"
-        }
+    └── flue.turn [llm]
+        input: [
+          {
+            "content": [
+              {
+                "arguments": {
+                  "url": "https://example.test/flue/reasoning-streams"
+                },
+                "id": "<span:1>",
+                "name": "summarize_source",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          {
+            "content": [
+              {
+                "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+                "type": "text"
+              }
+            ],
+            "isError": false,
+            "role": "toolResult",
+            "toolCallId": "<span:1>",
+            "toolName": "summarize_source"
+          }
+        ]
         output: {
-          "completed": true
+          "content": [
+            {
+              "text": "PROMPT_DONE",
+              "textSignature": "{\"v\":1,\"id\":\"msg_045458052dc10379016a705b62dbd8819189b8287061debf12\",\"phase\":\"final_answer\"}",
+              "type": "text"
+            }
+          ],
+          "role": "assistant"
         }
         metadata: {
-          "flue.operation": "compact",
+          "flue.api": "openai-responses",
+          "flue.input_message_offset": 5,
+          "flue.input_mode": "delta",
+          "flue.model": "gpt-5.4-nano",
+          "flue.provider": "openai",
           "flue.session": "main",
-          "provider": "flue"
+          "flue.stop_reason": "stop",
+          "flue.turn_purpose": "agent",
+          "model": "gpt-5.4-nano",
+          "provider": "openai"
         }
         metrics: {
-          "duration_ms": 0
+          "completion_tokens": 7,
+          "duration_ms": 0,
+          "estimated_cost": 0.00025315000000000005,
+          "prompt_cache_creation_tokens": 0,
+          "prompt_cached_tokens": 0,
+          "prompt_tokens": 1222,
+          "tokens": 1229
         }
-        └── compaction:manual [task]
-            input: {
-              "estimatedTokens": 1229,
-              "reason": "manual"
-            }
-            output: {
-              "messagesAfter": 2,
-              "messagesBefore": 8
-            }
-            metadata: {
-              "flue.compaction_reason": "manual",
-              "flue.session": "main",
-              "provider": "flue"
-            }
-            metrics: {
-              "duration_ms": 0,
-              "messages_after": 2,
-              "messages_before": 8
-            }
-            └── flue.turn [llm]
-                input: [
-                  {
-                    "content": [
-                      {
-                        "text": "<conversation>\n[User]: Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.\n\n[Assistant tool calls]: lookup(query=\"flue instrumentation\")\n\n[Tool result]: {\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}\n\n[Assistant tool calls]: web_search(lookupId=\"flue-session-2026\", query=\"Braintrust Flue reasoning stream instrumentation\")\n\n[Tool result]: {\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}\n\n[Assistant tool calls]: summarize_source(url=\"https://example.test/flue/reasoning-streams\")\n\n[Tool result]: {\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}\n</conversation>\n\nThis is the PREFIX of a turn that was too large to keep. The SUFFIX (recent work) is retained.\n\nSummarize the prefix to provide context for the retained suffix:\n\n## Original Request\n[What did the user ask for in this turn?]\n\n## Early Progress\n- [Key decisions and work done in the prefix]\n\n## Context for Suffix\n- [Information needed to understand the retained recent work]\n\nBe concise. Focus on what's needed to understand the kept suffix.",
-                        "type": "text"
-                      }
-                    ],
-                    "role": "user"
-                  }
-                ]
-                output: {
-                  "content": [
-                    {
-                      "text": "## Original Request\nThe user requested a step-by-step execution of an instrumented research flow involving tool calls to gather information on \"flue instrumentation\" and \"",
-                      "textSignature": "{\"v\":1,\"id\":\"msg_04d28ba03840bb65016a705b7358a081a38e69464057840036\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "assistant"
-                }
-                metadata: {
-                  "flue.api": "openai-responses",
-                  "flue.model": "gpt-4o-mini",
-                  "flue.provider": "openai",
-                  "flue.session": "main",
-                  "flue.stop_reason": "stop",
-                  "flue.turn_purpose": "compaction_prefix",
-                  "model": "gpt-4o-mini",
-                  "provider": "openai"
-                }
-                metrics: {
-                  "completion_tokens": 0,
-                  "duration_ms": 0,
-                  "estimated_cost": 0,
-                  "prompt_cache_creation_tokens": 0,
-                  "prompt_cached_tokens": 0,
-                  "prompt_tokens": 0,
-                  "tokens": 0
-                }

--- a/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-latest-explicit.span-tree.json
+++ b/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-latest-explicit.span-tree.json
@@ -5,456 +5,6 @@
       "type": "task",
       "children": [
         {
-          "name": "flue.prompt",
-          "type": "task",
-          "children": [
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "arguments": {
-                      "query": "flue instrumentation"
-                    },
-                    "id": "<span:1>",
-                    "name": "lookup",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "openai-responses",
-                "flue.model": "gpt-5.4-nano",
-                "flue.provider": "openai",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "gpt-5.4-nano",
-                "provider": "openai"
-              },
-              "metrics": {
-                "completion_tokens": 19,
-                "duration_ms": 0,
-                "estimated_cost": 0.00022475000000000001,
-                "prompt_cache_creation_tokens": 0,
-                "prompt_cached_tokens": 0,
-                "prompt_tokens": 1005,
-                "tokens": 1024
-              }
-            },
-            {
-              "name": "tool:lookup",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "query": "flue instrumentation"
-              },
-              "output": {
-                "content": [
-                  {
-                    "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                    "type": "text"
-                  }
-                ],
-                "details": {
-                  "customTool": "lookup"
-                }
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "lookup",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "arguments": {
-                      "lookupId": "flue-session-2026",
-                      "query": "Braintrust Flue reasoning stream instrumentation"
-                    },
-                    "id": "<span:1>",
-                    "name": "web_search",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "openai-responses",
-                "flue.model": "gpt-5.4-nano",
-                "flue.provider": "openai",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "gpt-5.4-nano",
-                "provider": "openai"
-              },
-              "metrics": {
-                "completion_tokens": 34,
-                "duration_ms": 0,
-                "estimated_cost": 0.00025350000000000004,
-                "prompt_cache_creation_tokens": 0,
-                "prompt_cached_tokens": 0,
-                "prompt_tokens": 1055,
-                "tokens": 1089
-              }
-            },
-            {
-              "name": "tool:web_search",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "lookupId": "flue-session-2026",
-                "query": "Braintrust Flue reasoning stream instrumentation"
-              },
-              "output": {
-                "content": [
-                  {
-                    "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-                    "type": "text"
-                  }
-                ],
-                "details": {
-                  "customTool": "web_search"
-                }
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "web_search",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                },
-                {
-                  "content": [
-                    {
-                      "arguments": {
-                        "lookupId": "flue-session-2026",
-                        "query": "Braintrust Flue reasoning stream instrumentation"
-                      },
-                      "id": "<span:2>",
-                      "name": "web_search",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:2>",
-                  "toolName": "web_search"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "arguments": {
-                      "url": "https://example.test/flue/reasoning-streams"
-                    },
-                    "id": "<span:1>",
-                    "name": "summarize_source",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "openai-responses",
-                "flue.model": "gpt-5.4-nano",
-                "flue.provider": "openai",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "gpt-5.4-nano",
-                "provider": "openai"
-              },
-              "metrics": {
-                "completion_tokens": 30,
-                "duration_ms": 0,
-                "estimated_cost": 0.00026690000000000004,
-                "prompt_cache_creation_tokens": 0,
-                "prompt_cached_tokens": 0,
-                "prompt_tokens": 1147,
-                "tokens": 1177
-              }
-            },
-            {
-              "name": "tool:summarize_source",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "url": "https://example.test/flue/reasoning-streams"
-              },
-              "output": {
-                "content": [
-                  {
-                    "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-                    "type": "text"
-                  }
-                ],
-                "details": {
-                  "customTool": "summarize_source"
-                }
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "summarize_source",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                },
-                {
-                  "content": [
-                    {
-                      "arguments": {
-                        "lookupId": "flue-session-2026",
-                        "query": "Braintrust Flue reasoning stream instrumentation"
-                      },
-                      "id": "<span:2>",
-                      "name": "web_search",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:2>",
-                  "toolName": "web_search"
-                },
-                {
-                  "content": [
-                    {
-                      "arguments": {
-                        "url": "https://example.test/flue/reasoning-streams"
-                      },
-                      "id": "<span:3>",
-                      "name": "summarize_source",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:3>",
-                  "toolName": "summarize_source"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "text": "PROMPT_DONE",
-                    "textSignature": "{\"v\":1,\"id\":\"msg_045458052dc10379016a705b62dbd8819189b8287061debf12\",\"phase\":\"final_answer\"}",
-                    "type": "text"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "openai-responses",
-                "flue.model": "gpt-5.4-nano",
-                "flue.provider": "openai",
-                "flue.session": "main",
-                "flue.stop_reason": "stop",
-                "flue.turn_purpose": "agent",
-                "model": "gpt-5.4-nano",
-                "provider": "openai"
-              },
-              "metrics": {
-                "completion_tokens": 7,
-                "duration_ms": 0,
-                "estimated_cost": 0.00025315000000000005,
-                "prompt_cache_creation_tokens": 0,
-                "prompt_cached_tokens": 0,
-                "prompt_tokens": 1222,
-                "tokens": 1229
-              }
-            }
-          ],
-          "input": [
-            {
-              "content": [
-                {
-                  "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                  "type": "text"
-                }
-              ],
-              "role": "user"
-            }
-          ],
-          "output": "PROMPT_DONE",
-          "metadata": {
-            "flue.operation": "prompt",
-            "flue.session": "main",
-            "provider": "flue"
-          },
-          "metrics": {
-            "duration_ms": 0
-          }
-        },
-        {
           "name": "flue.skill",
           "type": "task",
           "children": [
@@ -499,6 +49,7 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_mode": "full",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -554,15 +105,6 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "agent": "e2e-flue-skill",
                                 "cwd": ".",
@@ -605,6 +147,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 1,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -660,48 +204,11 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "command": "find . -maxdepth 4 -name AGENTS.md -print",
                                 "timeout": 100000
                               },
-                              "id": "<span:2>",
+                              "id": "<span:1>",
                               "name": "bash",
                               "type": "toolCall"
                             }
@@ -717,7 +224,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:2>",
+                          "toolCallId": "<span:1>",
                           "toolName": "bash"
                         }
                       ],
@@ -737,6 +244,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 3,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -792,74 +301,11 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -name AGENTS.md -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:2>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:2>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
                                 "timeout": 100000
                               },
-                              "id": "<span:3>",
+                              "id": "<span:1>",
                               "name": "bash",
                               "type": "toolCall"
                             }
@@ -875,7 +321,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:3>",
+                          "toolCallId": "<span:1>",
                           "toolName": "bash"
                         }
                       ],
@@ -895,6 +341,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 5,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -950,100 +398,11 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -name AGENTS.md -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:2>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:2>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-                                "timeout": 100000
-                              },
-                              "id": "<span:3>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:3>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
                                 "timeout": 100000
                               },
-                              "id": "<span:4>",
+                              "id": "<span:1>",
                               "name": "bash",
                               "type": "toolCall"
                             }
@@ -1059,7 +418,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:4>",
+                          "toolCallId": "<span:1>",
                           "toolName": "bash"
                         }
                       ],
@@ -1079,6 +438,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 7,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -1134,126 +495,11 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -name AGENTS.md -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:2>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:2>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-                                "timeout": 100000
-                              },
-                              "id": "<span:3>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:3>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:4>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:4>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
                                 "timeout": 100000
                               },
-                              "id": "<span:5>",
+                              "id": "<span:1>",
                               "name": "bash",
                               "type": "toolCall"
                             }
@@ -1269,7 +515,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:5>",
+                          "toolCallId": "<span:1>",
                           "toolName": "bash"
                         }
                       ],
@@ -1289,6 +535,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 9,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -1344,152 +592,11 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -name AGENTS.md -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:2>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:2>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-                                "timeout": 100000
-                              },
-                              "id": "<span:3>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:3>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:4>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:4>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-                                "timeout": 100000
-                              },
-                              "id": "<span:5>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:5>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
                                 "timeout": 100000
                               },
-                              "id": "<span:6>",
+                              "id": "<span:1>",
                               "name": "bash",
                               "type": "toolCall"
                             }
@@ -1505,7 +612,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:6>",
+                          "toolCallId": "<span:1>",
                           "toolName": "bash"
                         }
                       ],
@@ -1526,6 +633,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 11,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -1582,179 +691,12 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -name AGENTS.md -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:2>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:2>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-                                "timeout": 100000
-                              },
-                              "id": "<span:3>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:3>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:4>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:4>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-                                "timeout": 100000
-                              },
-                              "id": "<span:5>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:5>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:6>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:6>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "limit": 200,
                                 "offset": 1,
                                 "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
                               },
-                              "id": "<span:7>",
+                              "id": "<span:1>",
                               "name": "read",
                               "type": "toolCall"
                             }
@@ -1770,7 +712,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:7>",
+                          "toolCallId": "<span:1>",
                           "toolName": "read"
                         }
                       ],
@@ -1790,6 +732,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 13,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -1845,205 +789,11 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -name AGENTS.md -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:2>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:2>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-                                "timeout": 100000
-                              },
-                              "id": "<span:3>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:3>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:4>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:4>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-                                "timeout": 100000
-                              },
-                              "id": "<span:5>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:5>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:6>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:6>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "limit": 200,
-                                "offset": 1,
-                                "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-                              },
-                              "id": "<span:7>",
-                              "name": "read",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:7>",
-                          "toolName": "read"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "command": "cat ./package.json",
                                 "timeout": 100000
                               },
-                              "id": "<span:8>",
+                              "id": "<span:1>",
                               "name": "bash",
                               "type": "toolCall"
                             }
@@ -2059,7 +809,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:8>",
+                          "toolCallId": "<span:1>",
                           "toolName": "bash"
                         }
                       ],
@@ -2079,6 +829,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 15,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -2134,231 +886,11 @@
                         {
                           "content": [
                             {
-                              "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-                              "type": "text"
-                            }
-                          ],
-                          "role": "user"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "agent": "e2e-flue-skill",
-                                "cwd": ".",
-                                "description": "Run e2e-flue-skill with marker SKILL_DONE",
-                                "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-                              },
-                              "id": "<span:1>",
-                              "name": "task",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": true,
-                          "role": "toolResult",
-                          "toolCallId": "<span:1>",
-                          "toolName": "task"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -name AGENTS.md -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:2>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:2>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-                                "timeout": 100000
-                              },
-                              "id": "<span:3>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:3>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:4>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "(no output)",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:4>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-                                "timeout": 100000
-                              },
-                              "id": "<span:5>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:5>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-                                "timeout": 100000
-                              },
-                              "id": "<span:6>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:6>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "limit": 200,
-                                "offset": 1,
-                                "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-                              },
-                              "id": "<span:7>",
-                              "name": "read",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:7>",
-                          "toolName": "read"
-                        },
-                        {
-                          "content": [
-                            {
-                              "arguments": {
-                                "command": "cat ./package.json",
-                                "timeout": 100000
-                              },
-                              "id": "<span:8>",
-                              "name": "bash",
-                              "type": "toolCall"
-                            }
-                          ],
-                          "role": "assistant"
-                        },
-                        {
-                          "content": [
-                            {
-                              "text": "{\n  \"name\": \"flue-instrumentation-scenario\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"braintrustScenario\": {\n    \"bump\": {\n      \"dependencies\": {\n        \"flue-cli-v0-8-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-cli-v1-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v0-8-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-runtime-v1-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v2-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=2.0.0 <3.0.0\"\n        }\n      }\n    }\n  },\n  \"dependencies\": {\n    \"@flue/cli\": \"0.8.0\",\n    \"@flue/runtime\": \"0.8.0\",\n    \"flue-cli-v0-8-latest\": \"npm:@flue/cli@0.8.1\",\n    \"flue-cli-v1\": \"npm:@flue/cli@1.0.0-beta.3\",\n    \"flue-cli-v1-latest\": \"npm:@flue/cli@1.0.0-beta.9\",\n    \"flue-runtime-v0-8-latest\": \"npm:@flue/runtime@0.8.1\",\n    \"flue-runtime-v1\": \"npm:@flue/runtime@1.0.0-beta.3\",\n    \"flue-runtime-v1-latest\": \"npm:@flue/runtime@1.0.0-beta.9\",\n    \"flue-runtime-v2\": \"npm:@flue/runtime@2.0.0\",\n    \"flue-runtime-v2-latest\": \"npm:@flue/runtime@2.0.1\",\n    \"pi-ai-v2\": \"npm:@earendil-works/pi-ai@0.83.0\",\n    \"valibot\": \"1.4.2\"\n  },\n  \"pnpm\": {\n    \"overrides\": {\n      \"@flue/runtime@0.8.0>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.0>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@hono/node-server@>=2.0.0 <2.0.10\": \"^2.0.10\",\n      \"fast-uri@<3.1.5\": \"^3.1.5\",\n      \"hono@>=4.0.0 <4.12.27\": \"^4.12.27\",\n      \"brace-expansion@>=3.0.0 <5.0.9\": \"^5.0.9\",\n      \"postcss@<8.5.18\": \"^8.5.18\",\n      \"valibot@<1.4.2\": \"^1.4.2\",\n      \"ip-address@<10.2.2\": \"^10.2.2\",\n      \"undici@<7.29.0\": \"^7.29.0\"\n    }\n  }\n}",
-                              "type": "text"
-                            }
-                          ],
-                          "isError": false,
-                          "role": "toolResult",
-                          "toolCallId": "<span:8>",
-                          "toolName": "bash"
-                        },
-                        {
-                          "content": [
-                            {
                               "arguments": {
                                 "command": "printf SKILL_DONE",
                                 "timeout": 100000
                               },
-                              "id": "<span:9>",
+                              "id": "<span:1>",
                               "name": "bash",
                               "type": "toolCall"
                             }
@@ -2374,7 +906,7 @@
                           ],
                           "isError": false,
                           "role": "toolResult",
-                          "toolCallId": "<span:9>",
+                          "toolCallId": "<span:1>",
                           "toolName": "bash"
                         }
                       ],
@@ -2390,6 +922,8 @@
                       },
                       "metadata": {
                         "flue.api": "openai-responses",
+                        "flue.input_message_offset": 17,
+                        "flue.input_mode": "delta",
                         "flue.model": "gpt-5.4-nano",
                         "flue.provider": "openai",
                         "flue.session": "task:skill:<uuid:1>",
@@ -2586,7 +1120,9 @@
           "metadata": {
             "flue.operation": "skill",
             "flue.session": "skill",
-            "provider": "flue"
+            "flue.workflow_name": "instrumentation",
+            "provider": "flue",
+            "scenario": "flue-instrumentation"
           },
           "metrics": {
             "duration_ms": 0
@@ -2623,6 +1159,7 @@
               },
               "metadata": {
                 "flue.api": "openai-responses",
+                "flue.input_mode": "full",
                 "flue.model": "gpt-4o-mini",
                 "flue.provider": "openai",
                 "flue.session": "task:task:<uuid:1>",
@@ -2736,7 +1273,9 @@
           "metadata": {
             "flue.operation": "compact",
             "flue.session": "main",
-            "provider": "flue"
+            "flue.workflow_name": "instrumentation",
+            "provider": "flue",
+            "scenario": "flue-instrumentation"
           },
           "metrics": {
             "duration_ms": 0
@@ -2755,6 +1294,362 @@
         "status": "done"
       },
       "metadata": {
+        "flue.workflow_name": "instrumentation",
+        "provider": "flue",
+        "scenario": "flue-instrumentation"
+      },
+      "metrics": {
+        "duration_ms": 0
+      }
+    },
+    {
+      "name": "flue.prompt",
+      "type": "task",
+      "children": [
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+                  "type": "text"
+                }
+              ],
+              "role": "user"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "arguments": {
+                  "query": "flue instrumentation"
+                },
+                "id": "<span:1>",
+                "name": "lookup",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "openai-responses",
+            "flue.input_mode": "full",
+            "flue.model": "gpt-5.4-nano",
+            "flue.provider": "openai",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "gpt-5.4-nano",
+            "provider": "openai"
+          },
+          "metrics": {
+            "completion_tokens": 19,
+            "duration_ms": 0,
+            "estimated_cost": 0.00022475000000000001,
+            "prompt_cache_creation_tokens": 0,
+            "prompt_cached_tokens": 0,
+            "prompt_tokens": 1005,
+            "tokens": 1024
+          }
+        },
+        {
+          "name": "tool:lookup",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "query": "flue instrumentation"
+          },
+          "output": {
+            "content": [
+              {
+                "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
+                "type": "text"
+              }
+            ],
+            "details": {
+              "customTool": "lookup"
+            }
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "lookup",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "arguments": {
+                    "query": "flue instrumentation"
+                  },
+                  "id": "<span:1>",
+                  "name": "lookup",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "lookup"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "arguments": {
+                  "lookupId": "flue-session-2026",
+                  "query": "Braintrust Flue reasoning stream instrumentation"
+                },
+                "id": "<span:1>",
+                "name": "web_search",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "openai-responses",
+            "flue.input_message_offset": 1,
+            "flue.input_mode": "delta",
+            "flue.model": "gpt-5.4-nano",
+            "flue.provider": "openai",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "gpt-5.4-nano",
+            "provider": "openai"
+          },
+          "metrics": {
+            "completion_tokens": 34,
+            "duration_ms": 0,
+            "estimated_cost": 0.00025350000000000004,
+            "prompt_cache_creation_tokens": 0,
+            "prompt_cached_tokens": 0,
+            "prompt_tokens": 1055,
+            "tokens": 1089
+          }
+        },
+        {
+          "name": "tool:web_search",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "lookupId": "flue-session-2026",
+            "query": "Braintrust Flue reasoning stream instrumentation"
+          },
+          "output": {
+            "content": [
+              {
+                "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+                "type": "text"
+              }
+            ],
+            "details": {
+              "customTool": "web_search"
+            }
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "web_search",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "arguments": {
+                    "lookupId": "flue-session-2026",
+                    "query": "Braintrust Flue reasoning stream instrumentation"
+                  },
+                  "id": "<span:1>",
+                  "name": "web_search",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "web_search"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "arguments": {
+                  "url": "https://example.test/flue/reasoning-streams"
+                },
+                "id": "<span:1>",
+                "name": "summarize_source",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "openai-responses",
+            "flue.input_message_offset": 3,
+            "flue.input_mode": "delta",
+            "flue.model": "gpt-5.4-nano",
+            "flue.provider": "openai",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "gpt-5.4-nano",
+            "provider": "openai"
+          },
+          "metrics": {
+            "completion_tokens": 30,
+            "duration_ms": 0,
+            "estimated_cost": 0.00026690000000000004,
+            "prompt_cache_creation_tokens": 0,
+            "prompt_cached_tokens": 0,
+            "prompt_tokens": 1147,
+            "tokens": 1177
+          }
+        },
+        {
+          "name": "tool:summarize_source",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "url": "https://example.test/flue/reasoning-streams"
+          },
+          "output": {
+            "content": [
+              {
+                "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+                "type": "text"
+              }
+            ],
+            "details": {
+              "customTool": "summarize_source"
+            }
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "summarize_source",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "arguments": {
+                    "url": "https://example.test/flue/reasoning-streams"
+                  },
+                  "id": "<span:1>",
+                  "name": "summarize_source",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "summarize_source"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "text": "PROMPT_DONE",
+                "textSignature": "{\"v\":1,\"id\":\"msg_045458052dc10379016a705b62dbd8819189b8287061debf12\",\"phase\":\"final_answer\"}",
+                "type": "text"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "openai-responses",
+            "flue.input_message_offset": 5,
+            "flue.input_mode": "delta",
+            "flue.model": "gpt-5.4-nano",
+            "flue.provider": "openai",
+            "flue.session": "main",
+            "flue.stop_reason": "stop",
+            "flue.turn_purpose": "agent",
+            "model": "gpt-5.4-nano",
+            "provider": "openai"
+          },
+          "metrics": {
+            "completion_tokens": 7,
+            "duration_ms": 0,
+            "estimated_cost": 0.00025315000000000005,
+            "prompt_cache_creation_tokens": 0,
+            "prompt_cached_tokens": 0,
+            "prompt_tokens": 1222,
+            "tokens": 1229
+          }
+        }
+      ],
+      "input": [
+        {
+          "content": [
+            {
+              "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+              "type": "text"
+            }
+          ],
+          "role": "user"
+        }
+      ],
+      "output": "PROMPT_DONE",
+      "metadata": {
+        "flue.operation": "prompt",
+        "flue.session": "main",
         "flue.workflow_name": "instrumentation",
         "provider": "flue",
         "scenario": "flue-instrumentation"

--- a/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-latest-explicit.span-tree.txt
+++ b/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v0-8-latest-explicit.span-tree.txt
@@ -1,17 +1,1195 @@
 span_tree:
-└── workflow:instrumentation [task]
-    input: {
-      "metadata": {
-        "scenario": "flue-instrumentation",
-        "testRunId": "<run:1>"
-      },
-      "scenario": "flue-instrumentation"
-    }
-    output: {
-      "scenario": "flue-instrumentation",
-      "status": "done"
-    }
+├── workflow:instrumentation [task]
+│   input: {
+│     "metadata": {
+│       "scenario": "flue-instrumentation",
+│       "testRunId": "<run:1>"
+│     },
+│     "scenario": "flue-instrumentation"
+│   }
+│   output: {
+│     "scenario": "flue-instrumentation",
+│     "status": "done"
+│   }
+│   metadata: {
+│     "flue.workflow_name": "instrumentation",
+│     "provider": "flue",
+│     "scenario": "flue-instrumentation"
+│   }
+│   metrics: {
+│     "duration_ms": 0
+│   }
+│   ├── flue.skill [task]
+│   │   input: [
+│   │     {
+│   │       "content": [
+│   │         {
+│   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │           "type": "text"
+│   │         }
+│   │       ],
+│   │       "role": "user"
+│   │     }
+│   │   ]
+│   │   output: "SKILL_DONE"
+│   │   metadata: {
+│   │     "flue.operation": "skill",
+│   │     "flue.session": "skill",
+│   │     "flue.workflow_name": "instrumentation",
+│   │     "provider": "flue",
+│   │     "scenario": "flue-instrumentation"
+│   │   }
+│   │   metrics: {
+│   │     "duration_ms": 0
+│   │   }
+│   │   ├── flue.turn [llm]
+│   │   │   input: [
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "user"
+│   │   │     }
+│   │   │   ]
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "arguments": {
+│   │   │           "cwd": ".",
+│   │   │           "description": "Run the deterministic Flue instrumentation e2e test skill e2e-flue-skill.",
+│   │   │           "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
+│   │   │         },
+│   │   │         "id": "<span:1>",
+│   │   │         "name": "task",
+│   │   │         "type": "toolCall"
+│   │   │       }
+│   │   │     ],
+│   │   │     "role": "assistant"
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.api": "openai-responses",
+│   │   │     "flue.model": "gpt-5.4-nano",
+│   │   │     "flue.provider": "openai",
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.stop_reason": "toolUse",
+│   │   │     "flue.turn_purpose": "agent",
+│   │   │     "model": "gpt-5.4-nano",
+│   │   │     "provider": "openai"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "completion_tokens": 109,
+│   │   │     "duration_ms": 0,
+│   │   │     "estimated_cost": 0.00030565000000000003,
+│   │   │     "prompt_cache_creation_tokens": 0,
+│   │   │     "prompt_cached_tokens": 0,
+│   │   │     "prompt_tokens": 847,
+│   │   │     "tokens": 956
+│   │   │   }
+│   │   │   └── flue.task [task]
+│   │   │       input: "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
+│   │   │       output: "SKILL_DONE"
+│   │   │       metadata: {
+│   │   │         "flue.session": "skill",
+│   │   │         "provider": "flue"
+│   │   │       }
+│   │   │       metrics: {
+│   │   │         "duration_ms": 0
+│   │   │       }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "user"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "agent": "e2e-flue-skill",
+│   │   │       │           "cwd": ".",
+│   │   │       │           "description": "Run e2e-flue-skill with marker SKILL_DONE",
+│   │   │       │           "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "task",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_mode": "full",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 113,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.00031225000000000003,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 0,
+│   │   │       │     "prompt_tokens": 855,
+│   │   │       │     "tokens": 968
+│   │   │       │   }
+│   │   │       ├── tool:task [tool]
+│   │   │       │   input: {
+│   │   │       │     "agent": "e2e-flue-skill",
+│   │   │       │     "cwd": ".",
+│   │   │       │     "description": "Run e2e-flue-skill with marker SKILL_DONE",
+│   │   │       │     "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {}
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "task",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       │   error: "{\"content\":[{\"type\":\"text\",\"text\":\"[flue] Subagent \\\"e2e-flue-skill\\\" is not declared. Available: (none).\"}],\"details\":{}}"
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "agent": "e2e-flue-skill",
+│   │   │       │             "cwd": ".",
+│   │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
+│   │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "task",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": true,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "task"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "command": "find . -maxdepth 4 -name AGENTS.md -print",
+│   │   │       │           "timeout": 100000
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "bash",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 1,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 94,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.00031790000000000003,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 0,
+│   │   │       │     "prompt_tokens": 1002,
+│   │   │       │     "tokens": 1096
+│   │   │       │   }
+│   │   │       ├── tool:bash [tool]
+│   │   │       │   input: {
+│   │   │       │     "command": "find . -maxdepth 4 -name AGENTS.md -print",
+│   │   │       │     "timeout": 100000
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "(no output)",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "command": "find . -maxdepth 4 -name AGENTS.md -print",
+│   │   │       │       "exitCode": 0
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "bash",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
+│   │   │       │             "timeout": 100000
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "bash",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "(no output)",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": false,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "bash"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
+│   │   │       │           "timeout": 100000
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "bash",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 3,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 87,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.00034815000000000003,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 0,
+│   │   │       │     "prompt_tokens": 1197,
+│   │   │       │     "tokens": 1284
+│   │   │       │   }
+│   │   │       ├── tool:bash [tool]
+│   │   │       │   input: {
+│   │   │       │     "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
+│   │   │       │     "timeout": 100000
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "(no output)",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
+│   │   │       │       "exitCode": 0
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "bash",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
+│   │   │       │             "timeout": 100000
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "bash",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "(no output)",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": false,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "bash"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
+│   │   │       │           "timeout": 100000
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "bash",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 5,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 58,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.0003321,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 0,
+│   │   │       │     "prompt_tokens": 1298,
+│   │   │       │     "tokens": 1356
+│   │   │       │   }
+│   │   │       ├── tool:bash [tool]
+│   │   │       │   input: {
+│   │   │       │     "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
+│   │   │       │     "timeout": 100000
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "(no output)",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
+│   │   │       │       "exitCode": 0
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "bash",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
+│   │   │       │             "timeout": 100000
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "bash",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "(no output)",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": false,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "bash"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
+│   │   │       │           "timeout": 100000
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "bash",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 7,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 68,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.00035900000000000005,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 0,
+│   │   │       │     "prompt_tokens": 1370,
+│   │   │       │     "tokens": 1438
+│   │   │       │   }
+│   │   │       ├── tool:bash [tool]
+│   │   │       │   input: {
+│   │   │       │     "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
+│   │   │       │     "timeout": 100000
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
+│   │   │       │       "exitCode": 0
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "bash",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
+│   │   │       │             "timeout": 100000
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "bash",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": false,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "bash"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
+│   │   │       │           "timeout": 100000
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "bash",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 9,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 109,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.00043885000000000007,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 0,
+│   │   │       │     "prompt_tokens": 1513,
+│   │   │       │     "tokens": 1622
+│   │   │       │   }
+│   │   │       ├── tool:bash [tool]
+│   │   │       │   input: {
+│   │   │       │     "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
+│   │   │       │     "timeout": 100000
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
+│   │   │       │       "exitCode": 0
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "bash",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
+│   │   │       │             "timeout": 100000
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "bash",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": false,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "bash"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "limit": 200,
+│   │   │       │           "offset": 1,
+│   │   │       │           "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "read",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 11,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 64,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.00015592,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 1536,
+│   │   │       │     "prompt_tokens": 226,
+│   │   │       │     "tokens": 1826
+│   │   │       │   }
+│   │   │       ├── tool:read [tool]
+│   │   │       │   input: {
+│   │   │       │     "limit": 200,
+│   │   │       │     "offset": 1,
+│   │   │       │     "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "lines": 7,
+│   │   │       │       "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "read",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "limit": 200,
+│   │   │       │             "offset": 1,
+│   │   │       │             "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "read",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": false,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "read"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "command": "cat ./package.json",
+│   │   │       │           "timeout": 100000
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "bash",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 13,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 90,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.00021242000000000003,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 1536,
+│   │   │       │     "prompt_tokens": 346,
+│   │   │       │     "tokens": 1972
+│   │   │       │   }
+│   │   │       ├── tool:bash [tool]
+│   │   │       │   input: {
+│   │   │       │     "command": "cat ./package.json",
+│   │   │       │     "timeout": 100000
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "{\n  \"name\": \"flue-instrumentation-scenario\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"braintrustScenario\": {\n    \"bump\": {\n      \"dependencies\": {\n        \"flue-cli-v0-8-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-cli-v1-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v0-8-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-runtime-v1-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v2-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=2.0.0 <3.0.0\"\n        }\n      }\n    }\n  },\n  \"dependencies\": {\n    \"@flue/cli\": \"0.8.0\",\n    \"@flue/runtime\": \"0.8.0\",\n    \"flue-cli-v0-8-latest\": \"npm:@flue/cli@0.8.1\",\n    \"flue-cli-v1\": \"npm:@flue/cli@1.0.0-beta.3\",\n    \"flue-cli-v1-latest\": \"npm:@flue/cli@1.0.0-beta.9\",\n    \"flue-runtime-v0-8-latest\": \"npm:@flue/runtime@0.8.1\",\n    \"flue-runtime-v1\": \"npm:@flue/runtime@1.0.0-beta.3\",\n    \"flue-runtime-v1-latest\": \"npm:@flue/runtime@1.0.0-beta.9\",\n    \"flue-runtime-v2\": \"npm:@flue/runtime@2.0.0\",\n    \"flue-runtime-v2-latest\": \"npm:@flue/runtime@2.0.1\",\n    \"pi-ai-v2\": \"npm:@earendil-works/pi-ai@0.83.0\",\n    \"valibot\": \"1.4.2\"\n  },\n  \"pnpm\": {\n    \"overrides\": {\n      \"@flue/runtime@0.8.0>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.0>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@hono/node-server@>=2.0.0 <2.0.10\": \"^2.0.10\",\n      \"fast-uri@<3.1.5\": \"^3.1.5\",\n      \"hono@>=4.0.0 <4.12.27\": \"^4.12.27\",\n      \"brace-expansion@>=3.0.0 <5.0.9\": \"^5.0.9\",\n      \"postcss@<8.5.18\": \"^8.5.18\",\n      \"valibot@<1.4.2\": \"^1.4.2\",\n      \"ip-address@<10.2.2\": \"^10.2.2\",\n      \"undici@<7.29.0\": \"^7.29.0\"\n    }\n  }\n}",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "command": "cat ./package.json",
+│   │   │       │       "exitCode": 0
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "bash",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       ├── flue.turn [llm]
+│   │   │       │   input: [
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "arguments": {
+│   │   │       │             "command": "cat ./package.json",
+│   │   │       │             "timeout": 100000
+│   │   │       │           },
+│   │   │       │           "id": "<span:1>",
+│   │   │       │           "name": "bash",
+│   │   │       │           "type": "toolCall"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "role": "assistant"
+│   │   │       │     },
+│   │   │       │     {
+│   │   │       │       "content": [
+│   │   │       │         {
+│   │   │       │           "text": "{\n  \"name\": \"flue-instrumentation-scenario\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"braintrustScenario\": {\n    \"bump\": {\n      \"dependencies\": {\n        \"flue-cli-v0-8-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-cli-v1-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v0-8-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-runtime-v1-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v2-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=2.0.0 <3.0.0\"\n        }\n      }\n    }\n  },\n  \"dependencies\": {\n    \"@flue/cli\": \"0.8.0\",\n    \"@flue/runtime\": \"0.8.0\",\n    \"flue-cli-v0-8-latest\": \"npm:@flue/cli@0.8.1\",\n    \"flue-cli-v1\": \"npm:@flue/cli@1.0.0-beta.3\",\n    \"flue-cli-v1-latest\": \"npm:@flue/cli@1.0.0-beta.9\",\n    \"flue-runtime-v0-8-latest\": \"npm:@flue/runtime@0.8.1\",\n    \"flue-runtime-v1\": \"npm:@flue/runtime@1.0.0-beta.3\",\n    \"flue-runtime-v1-latest\": \"npm:@flue/runtime@1.0.0-beta.9\",\n    \"flue-runtime-v2\": \"npm:@flue/runtime@2.0.0\",\n    \"flue-runtime-v2-latest\": \"npm:@flue/runtime@2.0.1\",\n    \"pi-ai-v2\": \"npm:@earendil-works/pi-ai@0.83.0\",\n    \"valibot\": \"1.4.2\"\n  },\n  \"pnpm\": {\n    \"overrides\": {\n      \"@flue/runtime@0.8.0>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.0>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@hono/node-server@>=2.0.0 <2.0.10\": \"^2.0.10\",\n      \"fast-uri@<3.1.5\": \"^3.1.5\",\n      \"hono@>=4.0.0 <4.12.27\": \"^4.12.27\",\n      \"brace-expansion@>=3.0.0 <5.0.9\": \"^5.0.9\",\n      \"postcss@<8.5.18\": \"^8.5.18\",\n      \"valibot@<1.4.2\": \"^1.4.2\",\n      \"ip-address@<10.2.2\": \"^10.2.2\",\n      \"undici@<7.29.0\": \"^7.29.0\"\n    }\n  }\n}",
+│   │   │       │           "type": "text"
+│   │   │       │         }
+│   │   │       │       ],
+│   │   │       │       "isError": false,
+│   │   │       │       "role": "toolResult",
+│   │   │       │       "toolCallId": "<span:1>",
+│   │   │       │       "toolName": "bash"
+│   │   │       │     }
+│   │   │       │   ]
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "arguments": {
+│   │   │       │           "command": "printf SKILL_DONE",
+│   │   │       │           "timeout": 100000
+│   │   │       │         },
+│   │   │       │         "id": "<span:1>",
+│   │   │       │         "name": "bash",
+│   │   │       │         "type": "toolCall"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "role": "assistant"
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.api": "openai-responses",
+│   │   │       │     "flue.input_message_offset": 15,
+│   │   │       │     "flue.input_mode": "delta",
+│   │   │       │     "flue.model": "gpt-5.4-nano",
+│   │   │       │     "flue.provider": "openai",
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.stop_reason": "toolUse",
+│   │   │       │     "flue.turn_purpose": "agent",
+│   │   │       │     "model": "gpt-5.4-nano",
+│   │   │       │     "provider": "openai"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "completion_tokens": 59,
+│   │   │       │     "duration_ms": 0,
+│   │   │       │     "estimated_cost": 0.0004814700000000001,
+│   │   │       │     "prompt_cache_creation_tokens": 0,
+│   │   │       │     "prompt_cached_tokens": 1536,
+│   │   │       │     "prompt_tokens": 1885,
+│   │   │       │     "tokens": 3480
+│   │   │       │   }
+│   │   │       ├── tool:bash [tool]
+│   │   │       │   input: {
+│   │   │       │     "command": "printf SKILL_DONE",
+│   │   │       │     "timeout": 100000
+│   │   │       │   }
+│   │   │       │   output: {
+│   │   │       │     "content": [
+│   │   │       │       {
+│   │   │       │         "text": "SKILL_DONE",
+│   │   │       │         "type": "text"
+│   │   │       │       }
+│   │   │       │     ],
+│   │   │       │     "details": {
+│   │   │       │       "command": "printf SKILL_DONE",
+│   │   │       │       "exitCode": 0
+│   │   │       │     }
+│   │   │       │   }
+│   │   │       │   metadata: {
+│   │   │       │     "flue.session": "task:skill:<uuid:1>",
+│   │   │       │     "flue.tool_name": "bash",
+│   │   │       │     "provider": "flue"
+│   │   │       │   }
+│   │   │       │   metrics: {
+│   │   │       │     "duration_ms": 0
+│   │   │       │   }
+│   │   │       └── flue.turn [llm]
+│   │   │           input: [
+│   │   │             {
+│   │   │               "content": [
+│   │   │                 {
+│   │   │                   "arguments": {
+│   │   │                     "command": "printf SKILL_DONE",
+│   │   │                     "timeout": 100000
+│   │   │                   },
+│   │   │                   "id": "<span:1>",
+│   │   │                   "name": "bash",
+│   │   │                   "type": "toolCall"
+│   │   │                 }
+│   │   │               ],
+│   │   │               "role": "assistant"
+│   │   │             },
+│   │   │             {
+│   │   │               "content": [
+│   │   │                 {
+│   │   │                   "text": "SKILL_DONE",
+│   │   │                   "type": "text"
+│   │   │                 }
+│   │   │               ],
+│   │   │               "isError": false,
+│   │   │               "role": "toolResult",
+│   │   │               "toolCallId": "<span:1>",
+│   │   │               "toolName": "bash"
+│   │   │             }
+│   │   │           ]
+│   │   │           output: {
+│   │   │             "content": [
+│   │   │               {
+│   │   │                 "text": "SKILL_DONE",
+│   │   │                 "textSignature": "{\"v\":1,\"id\":\"msg_054a16a2f2ea3217016a705b70a41481a38ece40ecddf69512\",\"phase\":\"final_answer\"}",
+│   │   │                 "type": "text"
+│   │   │               }
+│   │   │             ],
+│   │   │             "role": "assistant"
+│   │   │           }
+│   │   │           metadata: {
+│   │   │             "flue.api": "openai-responses",
+│   │   │             "flue.input_message_offset": 17,
+│   │   │             "flue.input_mode": "delta",
+│   │   │             "flue.model": "gpt-5.4-nano",
+│   │   │             "flue.provider": "openai",
+│   │   │             "flue.session": "task:skill:<uuid:1>",
+│   │   │             "flue.stop_reason": "stop",
+│   │   │             "flue.turn_purpose": "agent",
+│   │   │             "model": "gpt-5.4-nano",
+│   │   │             "provider": "openai"
+│   │   │           }
+│   │   │           metrics: {
+│   │   │             "completion_tokens": 7,
+│   │   │             "duration_ms": 0,
+│   │   │             "estimated_cost": 0.00031035000000000004,
+│   │   │             "prompt_cache_creation_tokens": 0,
+│   │   │             "prompt_cached_tokens": 2560,
+│   │   │             "prompt_tokens": 1252,
+│   │   │             "tokens": 3819
+│   │   │           }
+│   │   ├── tool:task [tool]
+│   │   │   input: {
+│   │   │     "cwd": ".",
+│   │   │     "description": "Run the deterministic Flue instrumentation e2e test skill e2e-flue-skill.",
+│   │   │     "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
+│   │   │   }
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "text": "SKILL_DONE",
+│   │   │         "type": "text"
+│   │   │       }
+│   │   │     ],
+│   │   │     "details": {
+│   │   │       "cwd": ".",
+│   │   │       "messageId": "<messageId:2>",
+│   │   │       "session": "task:skill:<uuid:1>",
+│   │   │       "taskId": "<uuid:1>"
+│   │   │     }
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.tool_name": "task",
+│   │   │     "provider": "flue"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "duration_ms": 0
+│   │   │   }
+│   │   └── flue.turn [llm]
+│   │       input: [
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "role": "user"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "arguments": {
+│   │                 "cwd": ".",
+│   │                 "description": "Run the deterministic Flue instrumentation e2e test skill e2e-flue-skill.",
+│   │                 "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
+│   │               },
+│   │               "id": "<span:1>",
+│   │               "name": "task",
+│   │               "type": "toolCall"
+│   │             }
+│   │           ],
+│   │           "role": "assistant"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "SKILL_DONE",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "isError": false,
+│   │           "role": "toolResult",
+│   │           "toolCallId": "<span:1>",
+│   │           "toolName": "task"
+│   │         }
+│   │       ]
+│   │       output: {
+│   │         "content": [
+│   │           {
+│   │             "text": "SKILL_DONE",
+│   │             "textSignature": "{\"v\":1,\"id\":\"msg_0f099b3fce0721fd016a705b71558881a38c53a767e09d9e31\",\"phase\":\"final_answer\"}",
+│   │             "type": "text"
+│   │           }
+│   │         ],
+│   │         "role": "assistant"
+│   │       }
+│   │       metadata: {
+│   │         "flue.api": "openai-responses",
+│   │         "flue.model": "gpt-5.4-nano",
+│   │         "flue.provider": "openai",
+│   │         "flue.session": "skill",
+│   │         "flue.stop_reason": "stop",
+│   │         "flue.turn_purpose": "agent",
+│   │         "model": "gpt-5.4-nano",
+│   │         "provider": "openai"
+│   │       }
+│   │       metrics: {
+│   │         "completion_tokens": 7,
+│   │         "duration_ms": 0,
+│   │         "estimated_cost": 0.00020255000000000002,
+│   │         "prompt_cache_creation_tokens": 0,
+│   │         "prompt_cached_tokens": 0,
+│   │         "prompt_tokens": 969,
+│   │         "tokens": 976
+│   │       }
+│   ├── flue.task [task]
+│   │   input: "Reply with exactly TASK_DONE and no other text."
+│   │   output: "TASK_DONE"
+│   │   metadata: {
+│   │     "flue.session": "task",
+│   │     "provider": "flue"
+│   │   }
+│   │   metrics: {
+│   │     "duration_ms": 0
+│   │   }
+│   │   └── flue.turn [llm]
+│   │       input: [
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "Reply with exactly TASK_DONE and no other text.",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "role": "user"
+│   │         }
+│   │       ]
+│   │       output: {
+│   │         "content": [
+│   │           {
+│   │             "text": "TASK_DONE",
+│   │             "textSignature": "{\"v\":1,\"id\":\"msg_0f3adfdb1510c165016a705b72843c81a0b30d242da683a882\"}",
+│   │             "type": "text"
+│   │           }
+│   │         ],
+│   │         "role": "assistant"
+│   │       }
+│   │       metadata: {
+│   │         "flue.api": "openai-responses",
+│   │         "flue.input_mode": "full",
+│   │         "flue.model": "gpt-4o-mini",
+│   │         "flue.provider": "openai",
+│   │         "flue.session": "task:task:<uuid:1>",
+│   │         "flue.stop_reason": "stop",
+│   │         "flue.turn_purpose": "agent",
+│   │         "model": "gpt-4o-mini",
+│   │         "provider": "openai"
+│   │       }
+│   │       metrics: {
+│   │         "completion_tokens": 4,
+│   │         "duration_ms": 0,
+│   │         "estimated_cost": 0.0001263,
+│   │         "prompt_cache_creation_tokens": 0,
+│   │         "prompt_cached_tokens": 0,
+│   │         "prompt_tokens": 826,
+│   │         "tokens": 830
+│   │       }
+│   └── flue.compact [task]
+│       input: {
+│         "estimatedTokens": 1229,
+│         "reason": "manual"
+│       }
+│       output: {
+│         "completed": true
+│       }
+│       metadata: {
+│         "flue.operation": "compact",
+│         "flue.session": "main",
+│         "flue.workflow_name": "instrumentation",
+│         "provider": "flue",
+│         "scenario": "flue-instrumentation"
+│       }
+│       metrics: {
+│         "duration_ms": 0
+│       }
+│       └── compaction:manual [task]
+│           input: {
+│             "estimatedTokens": 1229,
+│             "reason": "manual"
+│           }
+│           output: {
+│             "messagesAfter": 2,
+│             "messagesBefore": 8
+│           }
+│           metadata: {
+│             "flue.compaction_reason": "manual",
+│             "flue.session": "main",
+│             "provider": "flue"
+│           }
+│           metrics: {
+│             "duration_ms": 0,
+│             "messages_after": 2,
+│             "messages_before": 8
+│           }
+│           └── flue.turn [llm]
+│               input: [
+│                 {
+│                   "content": [
+│                     {
+│                       "text": "<conversation>\n[User]: Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.\n\n[Assistant tool calls]: lookup(query=\"flue instrumentation\")\n\n[Tool result]: {\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}\n\n[Assistant tool calls]: web_search(lookupId=\"flue-session-2026\", query=\"Braintrust Flue reasoning stream instrumentation\")\n\n[Tool result]: {\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}\n\n[Assistant tool calls]: summarize_source(url=\"https://example.test/flue/reasoning-streams\")\n\n[Tool result]: {\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}\n</conversation>\n\nThis is the PREFIX of a turn that was too large to keep. The SUFFIX (recent work) is retained.\n\nSummarize the prefix to provide context for the retained suffix:\n\n## Original Request\n[What did the user ask for in this turn?]\n\n## Early Progress\n- [Key decisions and work done in the prefix]\n\n## Context for Suffix\n- [Information needed to understand the retained recent work]\n\nBe concise. Focus on what's needed to understand the kept suffix.",
+│                       "type": "text"
+│                     }
+│                   ],
+│                   "role": "user"
+│                 }
+│               ]
+│               output: {
+│                 "content": [
+│                   {
+│                     "text": "## Original Request\nThe user requested a step-by-step execution of an instrumented research flow involving tool calls to gather information on \"flue instrumentation\" and \"",
+│                     "textSignature": "{\"v\":1,\"id\":\"msg_04d28ba03840bb65016a705b7358a081a38e69464057840036\"}",
+│                     "type": "text"
+│                   }
+│                 ],
+│                 "role": "assistant"
+│               }
+│               metadata: {
+│                 "flue.api": "openai-responses",
+│                 "flue.model": "gpt-4o-mini",
+│                 "flue.provider": "openai",
+│                 "flue.session": "main",
+│                 "flue.stop_reason": "stop",
+│                 "flue.turn_purpose": "compaction_prefix",
+│                 "model": "gpt-4o-mini",
+│                 "provider": "openai"
+│               }
+│               metrics: {
+│                 "completion_tokens": 0,
+│                 "duration_ms": 0,
+│                 "estimated_cost": 0,
+│                 "prompt_cache_creation_tokens": 0,
+│                 "prompt_cached_tokens": 0,
+│                 "prompt_tokens": 0,
+│                 "tokens": 0
+│               }
+└── flue.prompt [task]
+    input: [
+      {
+        "content": [
+          {
+            "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+            "type": "text"
+          }
+        ],
+        "role": "user"
+      }
+    ]
+    output: "PROMPT_DONE"
     metadata: {
+      "flue.operation": "prompt",
+      "flue.session": "main",
       "flue.workflow_name": "instrumentation",
       "provider": "flue",
       "scenario": "flue-instrumentation"
@@ -19,7 +1197,7 @@ span_tree:
     metrics: {
       "duration_ms": 0
     }
-    ├── flue.prompt [task]
+    ├── flue.turn [llm]
     │   input: [
     │     {
     │       "content": [
@@ -31,2574 +1209,291 @@ span_tree:
     │       "role": "user"
     │     }
     │   ]
-    │   output: "PROMPT_DONE"
+    │   output: {
+    │     "content": [
+    │       {
+    │         "arguments": {
+    │           "query": "flue instrumentation"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "lookup",
+    │         "type": "toolCall"
+    │       }
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.operation": "prompt",
+    │     "flue.api": "openai-responses",
+    │     "flue.input_mode": "full",
+    │     "flue.model": "gpt-5.4-nano",
+    │     "flue.provider": "openai",
     │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "gpt-5.4-nano",
+    │     "provider": "openai"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 19,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.00022475000000000001,
+    │     "prompt_cache_creation_tokens": 0,
+    │     "prompt_cached_tokens": 0,
+    │     "prompt_tokens": 1005,
+    │     "tokens": 1024
+    │   }
+    ├── tool:lookup [tool]
+    │   input: {
+    │     "query": "flue instrumentation"
+    │   }
+    │   output: {
+    │     "content": [
+    │       {
+    │         "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
+    │         "type": "text"
+    │       }
+    │     ],
+    │     "details": {
+    │       "customTool": "lookup"
+    │     }
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "lookup",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "query": "flue instrumentation"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "lookup",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "openai-responses",
-    │   │     "flue.model": "gpt-5.4-nano",
-    │   │     "flue.provider": "openai",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "gpt-5.4-nano",
-    │   │     "provider": "openai"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 19,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.00022475000000000001,
-    │   │     "prompt_cache_creation_tokens": 0,
-    │   │     "prompt_cached_tokens": 0,
-    │   │     "prompt_tokens": 1005,
-    │   │     "tokens": 1024
-    │   │   }
-    │   ├── tool:lookup [tool]
-    │   │   input: {
-    │   │     "query": "flue instrumentation"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "customTool": "lookup"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "lookup",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "query": "flue instrumentation"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "lookup",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "lookup"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "lookupId": "flue-session-2026",
-    │   │           "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "web_search",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "openai-responses",
-    │   │     "flue.model": "gpt-5.4-nano",
-    │   │     "flue.provider": "openai",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "gpt-5.4-nano",
-    │   │     "provider": "openai"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 34,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.00025350000000000004,
-    │   │     "prompt_cache_creation_tokens": 0,
-    │   │     "prompt_cached_tokens": 0,
-    │   │     "prompt_tokens": 1055,
-    │   │     "tokens": 1089
-    │   │   }
-    │   ├── tool:web_search [tool]
-    │   │   input: {
-    │   │     "lookupId": "flue-session-2026",
-    │   │     "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "customTool": "web_search"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "web_search",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "query": "flue instrumentation"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "lookup",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "lookup"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "lookupId": "flue-session-2026",
-    │   │             "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │           },
-    │   │           "id": "<span:2>",
-    │   │           "name": "web_search",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:2>",
-    │   │       "toolName": "web_search"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "url": "https://example.test/flue/reasoning-streams"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "summarize_source",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "openai-responses",
-    │   │     "flue.model": "gpt-5.4-nano",
-    │   │     "flue.provider": "openai",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "gpt-5.4-nano",
-    │   │     "provider": "openai"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 30,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.00026690000000000004,
-    │   │     "prompt_cache_creation_tokens": 0,
-    │   │     "prompt_cached_tokens": 0,
-    │   │     "prompt_tokens": 1147,
-    │   │     "tokens": 1177
-    │   │   }
-    │   ├── tool:summarize_source [tool]
-    │   │   input: {
-    │   │     "url": "https://example.test/flue/reasoning-streams"
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "customTool": "summarize_source"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "summarize_source",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   └── flue.turn [llm]
-    │       input: [
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "query": "flue instrumentation"
-    │               },
-    │               "id": "<span:1>",
-    │               "name": "lookup",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:1>",
-    │           "toolName": "lookup"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "lookupId": "flue-session-2026",
-    │                 "query": "Braintrust Flue reasoning stream instrumentation"
-    │               },
-    │               "id": "<span:2>",
-    │               "name": "web_search",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:2>",
-    │           "toolName": "web_search"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "url": "https://example.test/flue/reasoning-streams"
-    │               },
-    │               "id": "<span:3>",
-    │               "name": "summarize_source",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:3>",
-    │           "toolName": "summarize_source"
-    │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "text": "PROMPT_DONE",
-    │             "textSignature": "{\"v\":1,\"id\":\"msg_045458052dc10379016a705b62dbd8819189b8287061debf12\",\"phase\":\"final_answer\"}",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
-    │       }
-    │       metadata: {
-    │         "flue.api": "openai-responses",
-    │         "flue.model": "gpt-5.4-nano",
-    │         "flue.provider": "openai",
-    │         "flue.session": "main",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "gpt-5.4-nano",
-    │         "provider": "openai"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 7,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.00025315000000000005,
-    │         "prompt_cache_creation_tokens": 0,
-    │         "prompt_cached_tokens": 0,
-    │         "prompt_tokens": 1222,
-    │         "tokens": 1229
-    │       }
-    ├── flue.skill [task]
+    ├── flue.turn [llm]
     │   input: [
     │     {
     │       "content": [
     │         {
-    │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+    │           "arguments": {
+    │             "query": "flue instrumentation"
+    │           },
+    │           "id": "<span:1>",
+    │           "name": "lookup",
+    │           "type": "toolCall"
+    │         }
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
     │           "type": "text"
     │         }
     │       ],
-    │       "role": "user"
+    │       "isError": false,
+    │       "role": "toolResult",
+    │       "toolCallId": "<span:1>",
+    │       "toolName": "lookup"
     │     }
     │   ]
-    │   output: "SKILL_DONE"
+    │   output: {
+    │     "content": [
+    │       {
+    │         "arguments": {
+    │           "lookupId": "flue-session-2026",
+    │           "query": "Braintrust Flue reasoning stream instrumentation"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "web_search",
+    │         "type": "toolCall"
+    │       }
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.operation": "skill",
-    │     "flue.session": "skill",
+    │     "flue.api": "openai-responses",
+    │     "flue.input_message_offset": 1,
+    │     "flue.input_mode": "delta",
+    │     "flue.model": "gpt-5.4-nano",
+    │     "flue.provider": "openai",
+    │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "gpt-5.4-nano",
+    │     "provider": "openai"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 34,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.00025350000000000004,
+    │     "prompt_cache_creation_tokens": 0,
+    │     "prompt_cached_tokens": 0,
+    │     "prompt_tokens": 1055,
+    │     "tokens": 1089
+    │   }
+    ├── tool:web_search [tool]
+    │   input: {
+    │     "lookupId": "flue-session-2026",
+    │     "query": "Braintrust Flue reasoning stream instrumentation"
+    │   }
+    │   output: {
+    │     "content": [
+    │       {
+    │         "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+    │         "type": "text"
+    │       }
+    │     ],
+    │     "details": {
+    │       "customTool": "web_search"
+    │     }
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "web_search",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "cwd": ".",
-    │   │           "description": "Run the deterministic Flue instrumentation e2e test skill e2e-flue-skill.",
-    │   │           "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "task",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "openai-responses",
-    │   │     "flue.model": "gpt-5.4-nano",
-    │   │     "flue.provider": "openai",
-    │   │     "flue.session": "skill",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "gpt-5.4-nano",
-    │   │     "provider": "openai"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 109,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.00030565000000000003,
-    │   │     "prompt_cache_creation_tokens": 0,
-    │   │     "prompt_cached_tokens": 0,
-    │   │     "prompt_tokens": 847,
-    │   │     "tokens": 956
-    │   │   }
-    │   │   └── flue.task [task]
-    │   │       input: "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
-    │   │       output: "SKILL_DONE"
-    │   │       metadata: {
-    │   │         "flue.session": "skill",
-    │   │         "provider": "flue"
-    │   │       }
-    │   │       metrics: {
-    │   │         "duration_ms": 0
-    │   │       }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "agent": "e2e-flue-skill",
-    │   │       │           "cwd": ".",
-    │   │       │           "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │           "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "task",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 113,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.00031225000000000003,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 0,
-    │   │       │     "prompt_tokens": 855,
-    │   │       │     "tokens": 968
-    │   │       │   }
-    │   │       ├── tool:task [tool]
-    │   │       │   input: {
-    │   │       │     "agent": "e2e-flue-skill",
-    │   │       │     "cwd": ".",
-    │   │       │     "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │     "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {}
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "task",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       │   error: "{\"content\":[{\"type\":\"text\",\"text\":\"[flue] Subagent \\\"e2e-flue-skill\\\" is not declared. Available: (none).\"}],\"details\":{}}"
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │           "timeout": 100000
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "bash",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 94,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.00031790000000000003,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 0,
-    │   │       │     "prompt_tokens": 1002,
-    │   │       │     "tokens": 1096
-    │   │       │   }
-    │   │       ├── tool:bash [tool]
-    │   │       │   input: {
-    │   │       │     "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │     "timeout": 100000
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "(no output)",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │       "exitCode": 0
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "bash",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:2>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:2>",
-    │   │       │       "toolName": "bash"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │           "timeout": 100000
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "bash",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 87,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.00034815000000000003,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 0,
-    │   │       │     "prompt_tokens": 1197,
-    │   │       │     "tokens": 1284
-    │   │       │   }
-    │   │       ├── tool:bash [tool]
-    │   │       │   input: {
-    │   │       │     "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │     "timeout": 100000
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "(no output)",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │       "exitCode": 0
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "bash",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:2>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:2>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:3>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:3>",
-    │   │       │       "toolName": "bash"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │           "timeout": 100000
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "bash",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 58,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.0003321,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 0,
-    │   │       │     "prompt_tokens": 1298,
-    │   │       │     "tokens": 1356
-    │   │       │   }
-    │   │       ├── tool:bash [tool]
-    │   │       │   input: {
-    │   │       │     "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │     "timeout": 100000
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "(no output)",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │       "exitCode": 0
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "bash",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:2>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:2>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:3>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:3>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:4>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:4>",
-    │   │       │       "toolName": "bash"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │       │           "timeout": 100000
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "bash",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 68,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.00035900000000000005,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 0,
-    │   │       │     "prompt_tokens": 1370,
-    │   │       │     "tokens": 1438
-    │   │       │   }
-    │   │       ├── tool:bash [tool]
-    │   │       │   input: {
-    │   │       │     "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │       │     "timeout": 100000
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │       │       "exitCode": 0
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "bash",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:2>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:2>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:3>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:3>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:4>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:4>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:5>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:5>",
-    │   │       │       "toolName": "bash"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-    │   │       │           "timeout": 100000
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "bash",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 109,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.00043885000000000007,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 0,
-    │   │       │     "prompt_tokens": 1513,
-    │   │       │     "tokens": 1622
-    │   │       │   }
-    │   │       ├── tool:bash [tool]
-    │   │       │   input: {
-    │   │       │     "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-    │   │       │     "timeout": 100000
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-    │   │       │       "exitCode": 0
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "bash",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:2>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:2>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:3>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:3>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:4>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:4>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:5>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:5>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:6>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:6>",
-    │   │       │       "toolName": "bash"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "limit": 200,
-    │   │       │           "offset": 1,
-    │   │       │           "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "read",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 64,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.00015592,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 1536,
-    │   │       │     "prompt_tokens": 226,
-    │   │       │     "tokens": 1826
-    │   │       │   }
-    │   │       ├── tool:read [tool]
-    │   │       │   input: {
-    │   │       │     "limit": 200,
-    │   │       │     "offset": 1,
-    │   │       │     "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "lines": 7,
-    │   │       │       "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "read",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:2>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:2>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:3>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:3>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:4>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:4>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:5>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:5>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:6>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:6>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "limit": 200,
-    │   │       │             "offset": 1,
-    │   │       │             "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-    │   │       │           },
-    │   │       │           "id": "<span:7>",
-    │   │       │           "name": "read",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:7>",
-    │   │       │       "toolName": "read"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "command": "cat ./package.json",
-    │   │       │           "timeout": 100000
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "bash",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 90,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.00021242000000000003,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 1536,
-    │   │       │     "prompt_tokens": 346,
-    │   │       │     "tokens": 1972
-    │   │       │   }
-    │   │       ├── tool:bash [tool]
-    │   │       │   input: {
-    │   │       │     "command": "cat ./package.json",
-    │   │       │     "timeout": 100000
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "{\n  \"name\": \"flue-instrumentation-scenario\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"braintrustScenario\": {\n    \"bump\": {\n      \"dependencies\": {\n        \"flue-cli-v0-8-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-cli-v1-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v0-8-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-runtime-v1-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v2-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=2.0.0 <3.0.0\"\n        }\n      }\n    }\n  },\n  \"dependencies\": {\n    \"@flue/cli\": \"0.8.0\",\n    \"@flue/runtime\": \"0.8.0\",\n    \"flue-cli-v0-8-latest\": \"npm:@flue/cli@0.8.1\",\n    \"flue-cli-v1\": \"npm:@flue/cli@1.0.0-beta.3\",\n    \"flue-cli-v1-latest\": \"npm:@flue/cli@1.0.0-beta.9\",\n    \"flue-runtime-v0-8-latest\": \"npm:@flue/runtime@0.8.1\",\n    \"flue-runtime-v1\": \"npm:@flue/runtime@1.0.0-beta.3\",\n    \"flue-runtime-v1-latest\": \"npm:@flue/runtime@1.0.0-beta.9\",\n    \"flue-runtime-v2\": \"npm:@flue/runtime@2.0.0\",\n    \"flue-runtime-v2-latest\": \"npm:@flue/runtime@2.0.1\",\n    \"pi-ai-v2\": \"npm:@earendil-works/pi-ai@0.83.0\",\n    \"valibot\": \"1.4.2\"\n  },\n  \"pnpm\": {\n    \"overrides\": {\n      \"@flue/runtime@0.8.0>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.0>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@hono/node-server@>=2.0.0 <2.0.10\": \"^2.0.10\",\n      \"fast-uri@<3.1.5\": \"^3.1.5\",\n      \"hono@>=4.0.0 <4.12.27\": \"^4.12.27\",\n      \"brace-expansion@>=3.0.0 <5.0.9\": \"^5.0.9\",\n      \"postcss@<8.5.18\": \"^8.5.18\",\n      \"valibot@<1.4.2\": \"^1.4.2\",\n      \"ip-address@<10.2.2\": \"^10.2.2\",\n      \"undici@<7.29.0\": \"^7.29.0\"\n    }\n  }\n}",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "command": "cat ./package.json",
-    │   │       │       "exitCode": 0
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "bash",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       ├── flue.turn [llm]
-    │   │       │   input: [
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "user"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "agent": "e2e-flue-skill",
-    │   │       │             "cwd": ".",
-    │   │       │             "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │       │             "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │       │           },
-    │   │       │           "id": "<span:1>",
-    │   │       │           "name": "task",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": true,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:1>",
-    │   │       │       "toolName": "task"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:2>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:2>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:3>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:3>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:4>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "(no output)",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:4>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:5>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:5>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:6>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:6>",
-    │   │       │       "toolName": "bash"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "limit": 200,
-    │   │       │             "offset": 1,
-    │   │       │             "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-    │   │       │           },
-    │   │       │           "id": "<span:7>",
-    │   │       │           "name": "read",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:7>",
-    │   │       │       "toolName": "read"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "arguments": {
-    │   │       │             "command": "cat ./package.json",
-    │   │       │             "timeout": 100000
-    │   │       │           },
-    │   │       │           "id": "<span:8>",
-    │   │       │           "name": "bash",
-    │   │       │           "type": "toolCall"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "role": "assistant"
-    │   │       │     },
-    │   │       │     {
-    │   │       │       "content": [
-    │   │       │         {
-    │   │       │           "text": "{\n  \"name\": \"flue-instrumentation-scenario\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"braintrustScenario\": {\n    \"bump\": {\n      \"dependencies\": {\n        \"flue-cli-v0-8-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-cli-v1-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v0-8-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-runtime-v1-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v2-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=2.0.0 <3.0.0\"\n        }\n      }\n    }\n  },\n  \"dependencies\": {\n    \"@flue/cli\": \"0.8.0\",\n    \"@flue/runtime\": \"0.8.0\",\n    \"flue-cli-v0-8-latest\": \"npm:@flue/cli@0.8.1\",\n    \"flue-cli-v1\": \"npm:@flue/cli@1.0.0-beta.3\",\n    \"flue-cli-v1-latest\": \"npm:@flue/cli@1.0.0-beta.9\",\n    \"flue-runtime-v0-8-latest\": \"npm:@flue/runtime@0.8.1\",\n    \"flue-runtime-v1\": \"npm:@flue/runtime@1.0.0-beta.3\",\n    \"flue-runtime-v1-latest\": \"npm:@flue/runtime@1.0.0-beta.9\",\n    \"flue-runtime-v2\": \"npm:@flue/runtime@2.0.0\",\n    \"flue-runtime-v2-latest\": \"npm:@flue/runtime@2.0.1\",\n    \"pi-ai-v2\": \"npm:@earendil-works/pi-ai@0.83.0\",\n    \"valibot\": \"1.4.2\"\n  },\n  \"pnpm\": {\n    \"overrides\": {\n      \"@flue/runtime@0.8.0>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.0>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@hono/node-server@>=2.0.0 <2.0.10\": \"^2.0.10\",\n      \"fast-uri@<3.1.5\": \"^3.1.5\",\n      \"hono@>=4.0.0 <4.12.27\": \"^4.12.27\",\n      \"brace-expansion@>=3.0.0 <5.0.9\": \"^5.0.9\",\n      \"postcss@<8.5.18\": \"^8.5.18\",\n      \"valibot@<1.4.2\": \"^1.4.2\",\n      \"ip-address@<10.2.2\": \"^10.2.2\",\n      \"undici@<7.29.0\": \"^7.29.0\"\n    }\n  }\n}",
-    │   │       │           "type": "text"
-    │   │       │         }
-    │   │       │       ],
-    │   │       │       "isError": false,
-    │   │       │       "role": "toolResult",
-    │   │       │       "toolCallId": "<span:8>",
-    │   │       │       "toolName": "bash"
-    │   │       │     }
-    │   │       │   ]
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "arguments": {
-    │   │       │           "command": "printf SKILL_DONE",
-    │   │       │           "timeout": 100000
-    │   │       │         },
-    │   │       │         "id": "<span:1>",
-    │   │       │         "name": "bash",
-    │   │       │         "type": "toolCall"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "role": "assistant"
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.api": "openai-responses",
-    │   │       │     "flue.model": "gpt-5.4-nano",
-    │   │       │     "flue.provider": "openai",
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.stop_reason": "toolUse",
-    │   │       │     "flue.turn_purpose": "agent",
-    │   │       │     "model": "gpt-5.4-nano",
-    │   │       │     "provider": "openai"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "completion_tokens": 59,
-    │   │       │     "duration_ms": 0,
-    │   │       │     "estimated_cost": 0.0004814700000000001,
-    │   │       │     "prompt_cache_creation_tokens": 0,
-    │   │       │     "prompt_cached_tokens": 1536,
-    │   │       │     "prompt_tokens": 1885,
-    │   │       │     "tokens": 3480
-    │   │       │   }
-    │   │       ├── tool:bash [tool]
-    │   │       │   input: {
-    │   │       │     "command": "printf SKILL_DONE",
-    │   │       │     "timeout": 100000
-    │   │       │   }
-    │   │       │   output: {
-    │   │       │     "content": [
-    │   │       │       {
-    │   │       │         "text": "SKILL_DONE",
-    │   │       │         "type": "text"
-    │   │       │       }
-    │   │       │     ],
-    │   │       │     "details": {
-    │   │       │       "command": "printf SKILL_DONE",
-    │   │       │       "exitCode": 0
-    │   │       │     }
-    │   │       │   }
-    │   │       │   metadata: {
-    │   │       │     "flue.session": "task:skill:<uuid:1>",
-    │   │       │     "flue.tool_name": "bash",
-    │   │       │     "provider": "flue"
-    │   │       │   }
-    │   │       │   metrics: {
-    │   │       │     "duration_ms": 0
-    │   │       │   }
-    │   │       └── flue.turn [llm]
-    │   │           input: [
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished.",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "user"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "agent": "e2e-flue-skill",
-    │   │                     "cwd": ".",
-    │   │                     "description": "Run e2e-flue-skill with marker SKILL_DONE",
-    │   │                     "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Ensure completion and report the final output marker only."
-    │   │                   },
-    │   │                   "id": "<span:1>",
-    │   │                   "name": "task",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "[flue] Subagent \"e2e-flue-skill\" is not declared. Available: (none).",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": true,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:1>",
-    │   │               "toolName": "task"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "command": "find . -maxdepth 4 -name AGENTS.md -print",
-    │   │                     "timeout": 100000
-    │   │                   },
-    │   │                   "id": "<span:2>",
-    │   │                   "name": "bash",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "(no output)",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:2>",
-    │   │               "toolName": "bash"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "command": "find . -maxdepth 4 -type f -name AGENTS.md -print -exec sed -n '1,200p' {} \\;",
-    │   │                     "timeout": 100000
-    │   │                   },
-    │   │                   "id": "<span:3>",
-    │   │                   "name": "bash",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "(no output)",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:3>",
-    │   │               "toolName": "bash"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "command": "find . -maxdepth 6 -type f -name 'AGENTS.md' -print",
-    │   │                     "timeout": 100000
-    │   │                   },
-    │   │                   "id": "<span:4>",
-    │   │                   "name": "bash",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "(no output)",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:4>",
-    │   │               "toolName": "bash"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "command": "find . -maxdepth 5 -type f -name '*flue*skill*' -o -name '*skill*' | head",
-    │   │                     "timeout": 100000
-    │   │                   },
-    │   │                   "id": "<span:5>",
-    │   │                   "name": "bash",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "./.agents/skills\n./.agents/skills/e2e-flue-skill",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:5>",
-    │   │               "toolName": "bash"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "command": "find ./.agents/skills/e2e-flue-skill -maxdepth 2 -type f -print",
-    │   │                     "timeout": 100000
-    │   │                   },
-    │   │                   "id": "<span:6>",
-    │   │                   "name": "bash",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "./.agents/skills/e2e-flue-skill/SKILL.md",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:6>",
-    │   │               "toolName": "bash"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "limit": 200,
-    │   │                     "offset": 1,
-    │   │                     "path": "./.agents/skills/e2e-flue-skill/SKILL.md"
-    │   │                   },
-    │   │                   "id": "<span:7>",
-    │   │                   "name": "read",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "---\nname: e2e-flue-skill\ndescription: Deterministic skill used by the Braintrust Flue instrumentation e2e test.\n---\n\nReturn the marker from the provided args exactly once. Output no other text.\n",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:7>",
-    │   │               "toolName": "read"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "command": "cat ./package.json",
-    │   │                     "timeout": 100000
-    │   │                   },
-    │   │                   "id": "<span:8>",
-    │   │                   "name": "bash",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "{\n  \"name\": \"flue-instrumentation-scenario\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"braintrustScenario\": {\n    \"bump\": {\n      \"dependencies\": {\n        \"flue-cli-v0-8-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-cli-v1-latest\": {\n          \"package\": \"@flue/cli\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v0-8-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=0.8.0 <0.9.0\"\n        },\n        \"flue-runtime-v1-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=1.0.0-beta.3 <2.0.0-0\",\n          \"allowPrerelease\": true\n        },\n        \"flue-runtime-v2-latest\": {\n          \"package\": \"@flue/runtime\",\n          \"range\": \">=2.0.0 <3.0.0\"\n        }\n      }\n    }\n  },\n  \"dependencies\": {\n    \"@flue/cli\": \"0.8.0\",\n    \"@flue/runtime\": \"0.8.0\",\n    \"flue-cli-v0-8-latest\": \"npm:@flue/cli@0.8.1\",\n    \"flue-cli-v1\": \"npm:@flue/cli@1.0.0-beta.3\",\n    \"flue-cli-v1-latest\": \"npm:@flue/cli@1.0.0-beta.9\",\n    \"flue-runtime-v0-8-latest\": \"npm:@flue/runtime@0.8.1\",\n    \"flue-runtime-v1\": \"npm:@flue/runtime@1.0.0-beta.3\",\n    \"flue-runtime-v1-latest\": \"npm:@flue/runtime@1.0.0-beta.9\",\n    \"flue-runtime-v2\": \"npm:@flue/runtime@2.0.0\",\n    \"flue-runtime-v2-latest\": \"npm:@flue/runtime@2.0.1\",\n    \"pi-ai-v2\": \"npm:@earendil-works/pi-ai@0.83.0\",\n    \"valibot\": \"1.4.2\"\n  },\n  \"pnpm\": {\n    \"overrides\": {\n      \"@flue/runtime@0.8.0>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.0>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-agent-core\": \"0.75.4\",\n      \"@flue/runtime@0.8.1>@earendil-works/pi-ai\": \"0.75.4\",\n      \"@hono/node-server@>=2.0.0 <2.0.10\": \"^2.0.10\",\n      \"fast-uri@<3.1.5\": \"^3.1.5\",\n      \"hono@>=4.0.0 <4.12.27\": \"^4.12.27\",\n      \"brace-expansion@>=3.0.0 <5.0.9\": \"^5.0.9\",\n      \"postcss@<8.5.18\": \"^8.5.18\",\n      \"valibot@<1.4.2\": \"^1.4.2\",\n      \"ip-address@<10.2.2\": \"^10.2.2\",\n      \"undici@<7.29.0\": \"^7.29.0\"\n    }\n  }\n}",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:8>",
-    │   │               "toolName": "bash"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "arguments": {
-    │   │                     "command": "printf SKILL_DONE",
-    │   │                     "timeout": 100000
-    │   │                   },
-    │   │                   "id": "<span:9>",
-    │   │                   "name": "bash",
-    │   │                   "type": "toolCall"
-    │   │                 }
-    │   │               ],
-    │   │               "role": "assistant"
-    │   │             },
-    │   │             {
-    │   │               "content": [
-    │   │                 {
-    │   │                   "text": "SKILL_DONE",
-    │   │                   "type": "text"
-    │   │                 }
-    │   │               ],
-    │   │               "isError": false,
-    │   │               "role": "toolResult",
-    │   │               "toolCallId": "<span:9>",
-    │   │               "toolName": "bash"
-    │   │             }
-    │   │           ]
-    │   │           output: {
-    │   │             "content": [
-    │   │               {
-    │   │                 "text": "SKILL_DONE",
-    │   │                 "textSignature": "{\"v\":1,\"id\":\"msg_054a16a2f2ea3217016a705b70a41481a38ece40ecddf69512\",\"phase\":\"final_answer\"}",
-    │   │                 "type": "text"
-    │   │               }
-    │   │             ],
-    │   │             "role": "assistant"
-    │   │           }
-    │   │           metadata: {
-    │   │             "flue.api": "openai-responses",
-    │   │             "flue.model": "gpt-5.4-nano",
-    │   │             "flue.provider": "openai",
-    │   │             "flue.session": "task:skill:<uuid:1>",
-    │   │             "flue.stop_reason": "stop",
-    │   │             "flue.turn_purpose": "agent",
-    │   │             "model": "gpt-5.4-nano",
-    │   │             "provider": "openai"
-    │   │           }
-    │   │           metrics: {
-    │   │             "completion_tokens": 7,
-    │   │             "duration_ms": 0,
-    │   │             "estimated_cost": 0.00031035000000000004,
-    │   │             "prompt_cache_creation_tokens": 0,
-    │   │             "prompt_cached_tokens": 2560,
-    │   │             "prompt_tokens": 1252,
-    │   │             "tokens": 3819
-    │   │           }
-    │   ├── tool:task [tool]
-    │   │   input: {
-    │   │     "cwd": ".",
-    │   │     "description": "Run the deterministic Flue instrumentation e2e test skill e2e-flue-skill.",
-    │   │     "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
-    │   │   }
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "SKILL_DONE",
-    │   │         "type": "text"
-    │   │       }
-    │   │     ],
-    │   │     "details": {
-    │   │       "cwd": ".",
-    │   │       "messageId": "<messageId:2>",
-    │   │       "session": "task:skill:<uuid:1>",
-    │   │       "taskId": "<uuid:1>"
-    │   │     }
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "skill",
-    │   │     "flue.tool_name": "task",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   └── flue.turn [llm]
-    │       input: [
+    ├── flue.turn [llm]
+    │   input: [
+    │     {
+    │       "content": [
     │         {
-    │           "content": [
-    │             {
-    │               "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "cwd": ".",
-    │                 "description": "Run the deterministic Flue instrumentation e2e test skill e2e-flue-skill.",
-    │                 "prompt": "Run the skill named \"e2e-flue-skill\" with arguments {\"marker\":\"SKILL_DONE\"}. Output only the marker and no extra text when finished."
-    │               },
-    │               "id": "<span:1>",
-    │               "name": "task",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "SKILL_DONE",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:1>",
-    │           "toolName": "task"
+    │           "arguments": {
+    │             "lookupId": "flue-session-2026",
+    │             "query": "Braintrust Flue reasoning stream instrumentation"
+    │           },
+    │           "id": "<span:1>",
+    │           "name": "web_search",
+    │           "type": "toolCall"
     │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "text": "SKILL_DONE",
-    │             "textSignature": "{\"v\":1,\"id\":\"msg_0f099b3fce0721fd016a705b71558881a38c53a767e09d9e31\",\"phase\":\"final_answer\"}",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+    │           "type": "text"
+    │         }
+    │       ],
+    │       "isError": false,
+    │       "role": "toolResult",
+    │       "toolCallId": "<span:1>",
+    │       "toolName": "web_search"
+    │     }
+    │   ]
+    │   output: {
+    │     "content": [
+    │       {
+    │         "arguments": {
+    │           "url": "https://example.test/flue/reasoning-streams"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "summarize_source",
+    │         "type": "toolCall"
     │       }
-    │       metadata: {
-    │         "flue.api": "openai-responses",
-    │         "flue.model": "gpt-5.4-nano",
-    │         "flue.provider": "openai",
-    │         "flue.session": "skill",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "gpt-5.4-nano",
-    │         "provider": "openai"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 7,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.00020255000000000002,
-    │         "prompt_cache_creation_tokens": 0,
-    │         "prompt_cached_tokens": 0,
-    │         "prompt_tokens": 969,
-    │         "tokens": 976
-    │       }
-    ├── flue.task [task]
-    │   input: "Reply with exactly TASK_DONE and no other text."
-    │   output: "TASK_DONE"
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.session": "task",
+    │     "flue.api": "openai-responses",
+    │     "flue.input_message_offset": 3,
+    │     "flue.input_mode": "delta",
+    │     "flue.model": "gpt-5.4-nano",
+    │     "flue.provider": "openai",
+    │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "gpt-5.4-nano",
+    │     "provider": "openai"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 30,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.00026690000000000004,
+    │     "prompt_cache_creation_tokens": 0,
+    │     "prompt_cached_tokens": 0,
+    │     "prompt_tokens": 1147,
+    │     "tokens": 1177
+    │   }
+    ├── tool:summarize_source [tool]
+    │   input: {
+    │     "url": "https://example.test/flue/reasoning-streams"
+    │   }
+    │   output: {
+    │     "content": [
+    │       {
+    │         "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+    │         "type": "text"
+    │       }
+    │     ],
+    │     "details": {
+    │       "customTool": "summarize_source"
+    │     }
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "summarize_source",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   └── flue.turn [llm]
-    │       input: [
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "Reply with exactly TASK_DONE and no other text.",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
-    │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "text": "TASK_DONE",
-    │             "textSignature": "{\"v\":1,\"id\":\"msg_0f3adfdb1510c165016a705b72843c81a0b30d242da683a882\"}",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
-    │       }
-    │       metadata: {
-    │         "flue.api": "openai-responses",
-    │         "flue.model": "gpt-4o-mini",
-    │         "flue.provider": "openai",
-    │         "flue.session": "task:task:<uuid:1>",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "gpt-4o-mini",
-    │         "provider": "openai"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 4,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.0001263,
-    │         "prompt_cache_creation_tokens": 0,
-    │         "prompt_cached_tokens": 0,
-    │         "prompt_tokens": 826,
-    │         "tokens": 830
-    │       }
-    └── flue.compact [task]
-        input: {
-          "estimatedTokens": 1229,
-          "reason": "manual"
-        }
+    └── flue.turn [llm]
+        input: [
+          {
+            "content": [
+              {
+                "arguments": {
+                  "url": "https://example.test/flue/reasoning-streams"
+                },
+                "id": "<span:1>",
+                "name": "summarize_source",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          {
+            "content": [
+              {
+                "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+                "type": "text"
+              }
+            ],
+            "isError": false,
+            "role": "toolResult",
+            "toolCallId": "<span:1>",
+            "toolName": "summarize_source"
+          }
+        ]
         output: {
-          "completed": true
+          "content": [
+            {
+              "text": "PROMPT_DONE",
+              "textSignature": "{\"v\":1,\"id\":\"msg_045458052dc10379016a705b62dbd8819189b8287061debf12\",\"phase\":\"final_answer\"}",
+              "type": "text"
+            }
+          ],
+          "role": "assistant"
         }
         metadata: {
-          "flue.operation": "compact",
+          "flue.api": "openai-responses",
+          "flue.input_message_offset": 5,
+          "flue.input_mode": "delta",
+          "flue.model": "gpt-5.4-nano",
+          "flue.provider": "openai",
           "flue.session": "main",
-          "provider": "flue"
+          "flue.stop_reason": "stop",
+          "flue.turn_purpose": "agent",
+          "model": "gpt-5.4-nano",
+          "provider": "openai"
         }
         metrics: {
-          "duration_ms": 0
+          "completion_tokens": 7,
+          "duration_ms": 0,
+          "estimated_cost": 0.00025315000000000005,
+          "prompt_cache_creation_tokens": 0,
+          "prompt_cached_tokens": 0,
+          "prompt_tokens": 1222,
+          "tokens": 1229
         }
-        └── compaction:manual [task]
-            input: {
-              "estimatedTokens": 1229,
-              "reason": "manual"
-            }
-            output: {
-              "messagesAfter": 2,
-              "messagesBefore": 8
-            }
-            metadata: {
-              "flue.compaction_reason": "manual",
-              "flue.session": "main",
-              "provider": "flue"
-            }
-            metrics: {
-              "duration_ms": 0,
-              "messages_after": 2,
-              "messages_before": 8
-            }
-            └── flue.turn [llm]
-                input: [
-                  {
-                    "content": [
-                      {
-                        "text": "<conversation>\n[User]: Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.\n\n[Assistant tool calls]: lookup(query=\"flue instrumentation\")\n\n[Tool result]: {\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}\n\n[Assistant tool calls]: web_search(lookupId=\"flue-session-2026\", query=\"Braintrust Flue reasoning stream instrumentation\")\n\n[Tool result]: {\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}\n\n[Assistant tool calls]: summarize_source(url=\"https://example.test/flue/reasoning-streams\")\n\n[Tool result]: {\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}\n</conversation>\n\nThis is the PREFIX of a turn that was too large to keep. The SUFFIX (recent work) is retained.\n\nSummarize the prefix to provide context for the retained suffix:\n\n## Original Request\n[What did the user ask for in this turn?]\n\n## Early Progress\n- [Key decisions and work done in the prefix]\n\n## Context for Suffix\n- [Information needed to understand the retained recent work]\n\nBe concise. Focus on what's needed to understand the kept suffix.",
-                        "type": "text"
-                      }
-                    ],
-                    "role": "user"
-                  }
-                ]
-                output: {
-                  "content": [
-                    {
-                      "text": "## Original Request\nThe user requested a step-by-step execution of an instrumented research flow involving tool calls to gather information on \"flue instrumentation\" and \"",
-                      "textSignature": "{\"v\":1,\"id\":\"msg_04d28ba03840bb65016a705b7358a081a38e69464057840036\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "assistant"
-                }
-                metadata: {
-                  "flue.api": "openai-responses",
-                  "flue.model": "gpt-4o-mini",
-                  "flue.provider": "openai",
-                  "flue.session": "main",
-                  "flue.stop_reason": "stop",
-                  "flue.turn_purpose": "compaction_prefix",
-                  "model": "gpt-4o-mini",
-                  "provider": "openai"
-                }
-                metrics: {
-                  "completion_tokens": 0,
-                  "duration_ms": 0,
-                  "estimated_cost": 0,
-                  "prompt_cache_creation_tokens": 0,
-                  "prompt_cached_tokens": 0,
-                  "prompt_tokens": 0,
-                  "tokens": 0
-                }

--- a/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v1-0-0-beta-3-explicit.span-tree.json
+++ b/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v1-0-0-beta-3-explicit.span-tree.json
@@ -13,536 +13,6 @@
           }
         },
         {
-          "name": "flue.prompt",
-          "type": "task",
-          "children": [
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "thinking": "The user wants me to complete an instrumented research flow with specific steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Use the lookup result id to call web_search with query \"Braintrust Flue reasoning stream instrumentation\"\n3. Use the first web_search result url to call summarize_source\n4. After that, reply with exactly \"PROMPT_DONE\" and no other text\n\nI need to call exactly one tool per turn and wait for each result. Let me start with step 1.",
-                    "thinkingSignature": "Ep8FCm4IDxgCKkBTlyrpwCmWoZZgVZ3PxPYStfE+BaFIFNhEYQQF0YKeCGz4ToT2CKBXeOZuZsWp1zrLOc2HuMZaxA/ygHO2NxjLMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMS/AtCZE4JKnKRLhOGgylnUjvllOsbR310yUiMCmXRxcL8tzWV1KSgF8qWn4uIMCVHyZR0DrcTgNx2FS/ZpExhUb822GAl+QfF4lRQSreA2dUf3MAbUbpJkwPR4YPmyh6y4DJh8rS2igclMIwkLJ7wtiBHrlZyFv2+T66HRPMDN3T6T5uE/JIVxjWdWwstsbCEEQaxaukCvQGJaxyIjwAj47A1KT4bY1v09zl74Di9gd77DoJfhFRKRt87PAj24kqB1KiZ0KO+YqBRVE9QmZVBhFXVCU0xszDyXWiAwj94qfHES/grCn4fk0A7uTiUqPO7jeCUMhEgQgy+EsIq6BWh6xWsoYsz9aPWzOq3d+LwbvHGvFm8OFZnTYbjRPj9BsT47UqL0pb75T1ZkmiXpIS9STPQzZJ/5fNShxGM+gsZnDvBpfsJ2YuHoCIrZJmTvR07gYQU16OukgZMcHz6qfrjzcMGThz42KkAua5O3u4VDE+AtVhJrY7OVGxrM88H9xaVUALHo+0ORZxh403ERIbt7Zpj6b14GETjLvFWg/JDK8+ErTRTKxgL9UuafZA/bSMiFDUI+RMmxJQxl7KWGkUD+qzAYwbZPQqiFGdydPfXzScqXuSHfsgaJh2TVtnR18i/DR6I2hcKA963xlGTIQHRi75/KksGqpdqtO1ANczzzeOagT1j49EAZcjS0lOplC0uWJ60ZZtLXWmpfR228Hi1hjPwTQZ6m/TcDZNR18YAQ==",
-                    "type": "thinking"
-                  },
-                  {
-                    "text": "I'll complete this instrumented research flow step by step. Starting with step 1:",
-                    "type": "text"
-                  },
-                  {
-                    "arguments": {
-                      "query": "flue instrumentation"
-                    },
-                    "id": "<span:1>",
-                    "name": "lookup",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "anthropic-messages",
-                "flue.model": "claude-sonnet-4-5-20250929",
-                "flue.provider": "anthropic",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "claude-sonnet-4-5-20250929",
-                "provider": "anthropic"
-              },
-              "metrics": {
-                "completion_tokens": 198,
-                "duration_ms": 0,
-                "estimated_cost": 0.0037323,
-                "prompt_cache_creation_tokens": 0,
-                "prompt_cached_tokens": 2441,
-                "prompt_tokens": 10,
-                "tokens": 2649
-              }
-            },
-            {
-              "name": "tool:lookup",
-              "type": "tool",
-              "children": [
-                {
-                  "name": "flue.toolCurrentProbe",
-                  "children": [],
-                  "output": "lookup-active",
-                  "metadata": {
-                    "scenario": "flue-instrumentation"
-                  }
-                }
-              ],
-              "input": {
-                "query": "flue instrumentation"
-              },
-              "output": {
-                "id": "<span:1>",
-                "query": "flue instrumentation",
-                "topic": "session instrumentation"
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "lookup",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "The user wants me to complete an instrumented research flow with specific steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Use the lookup result id to call web_search with query \"Braintrust Flue reasoning stream instrumentation\"\n3. Use the first web_search result url to call summarize_source\n4. After that, reply with exactly \"PROMPT_DONE\" and no other text\n\nI need to call exactly one tool per turn and wait for each result. Let me start with step 1.",
-                      "thinkingSignature": "Ep8FCm4IDxgCKkBTlyrpwCmWoZZgVZ3PxPYStfE+BaFIFNhEYQQF0YKeCGz4ToT2CKBXeOZuZsWp1zrLOc2HuMZaxA/ygHO2NxjLMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMS/AtCZE4JKnKRLhOGgylnUjvllOsbR310yUiMCmXRxcL8tzWV1KSgF8qWn4uIMCVHyZR0DrcTgNx2FS/ZpExhUb822GAl+QfF4lRQSreA2dUf3MAbUbpJkwPR4YPmyh6y4DJh8rS2igclMIwkLJ7wtiBHrlZyFv2+T66HRPMDN3T6T5uE/JIVxjWdWwstsbCEEQaxaukCvQGJaxyIjwAj47A1KT4bY1v09zl74Di9gd77DoJfhFRKRt87PAj24kqB1KiZ0KO+YqBRVE9QmZVBhFXVCU0xszDyXWiAwj94qfHES/grCn4fk0A7uTiUqPO7jeCUMhEgQgy+EsIq6BWh6xWsoYsz9aPWzOq3d+LwbvHGvFm8OFZnTYbjRPj9BsT47UqL0pb75T1ZkmiXpIS9STPQzZJ/5fNShxGM+gsZnDvBpfsJ2YuHoCIrZJmTvR07gYQU16OukgZMcHz6qfrjzcMGThz42KkAua5O3u4VDE+AtVhJrY7OVGxrM88H9xaVUALHo+0ORZxh403ERIbt7Zpj6b14GETjLvFWg/JDK8+ErTRTKxgL9UuafZA/bSMiFDUI+RMmxJQxl7KWGkUD+qzAYwbZPQqiFGdydPfXzScqXuSHfsgaJh2TVtnR18i/DR6I2hcKA963xlGTIQHRi75/KksGqpdqtO1ANczzzeOagT1j49EAZcjS0lOplC0uWJ60ZZtLXWmpfR228Hi1hjPwTQZ6m/TcDZNR18YAQ==",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "I'll complete this instrumented research flow step by step. Starting with step 1:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2 and call web_search using this id as lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-                    "thinkingSignature": "EpsDCm4IDxgCKkBVz7apPV9h9LusboVdpJwrzttKqOXyvHDFlQzj7JPqzb9GSFpO6kJB09+A0XmLJoNgcUGZ7wI16GPW17YhajUPMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMPHlrpXc4G+SeRPLYGgyoi7j0pviEn7fw6E0iMDgTZUDB0XR4vHWrqwj5XLlL9d/LRzBUM3xGbe8SrxPulobJu9x3puhvaPLHzgl7DCraAUe7rv9oz8fLc63ZESgtcVluQFbANLoeGho2afvBhavct+HaD34JOVbHB6kWA1rUFmuxPm/52c5GVPlmVbYHBP85wo1/qIQjZyeyaLM9eVONZQ+OnMFSkBqgD7QWBp1mkzdAM4jQ5FR0hxySPInj21taMPGKr2C4CKA8lsQIiBYQreqPaIvuzEcN30JkD6snWj4nwvjs7vRl4I5s9t4JZEgBC2UU71woXFYkj3F/JhH7Gndbo4yEubDapMXD9U5cvyT1cJIQmh2w/FKpToBjjup0a1G+2S5IWRvDGAE=",
-                    "type": "thinking"
-                  },
-                  {
-                    "text": "Now proceeding to step 2:",
-                    "type": "text"
-                  },
-                  {
-                    "arguments": {
-                      "lookupId": "flue-session-2026",
-                      "query": "Braintrust Flue reasoning stream instrumentation"
-                    },
-                    "id": "<span:1>",
-                    "name": "web_search",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "anthropic-messages",
-                "flue.model": "claude-sonnet-4-5-20250929",
-                "flue.provider": "anthropic",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "claude-sonnet-4-5-20250929",
-                "provider": "anthropic"
-              },
-              "metrics": {
-                "completion_tokens": 161,
-                "duration_ms": 0,
-                "estimated_cost": 0.0041125499999999995,
-                "prompt_cache_creation_tokens": 247,
-                "prompt_cached_tokens": 2441,
-                "prompt_tokens": 13,
-                "tokens": 2862
-              }
-            },
-            {
-              "name": "tool:web_search",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "lookupId": "flue-session-2026",
-                "query": "Braintrust Flue reasoning stream instrumentation"
-              },
-              "output": {
-                "lookupId": "flue-session-2026",
-                "query": "Braintrust Flue reasoning stream instrumentation",
-                "results": [
-                  {
-                    "title": "Flue reasoning stream instrumentation",
-                    "url": "https://example.test/flue/reasoning-streams"
-                  }
-                ]
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "web_search",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "The user wants me to complete an instrumented research flow with specific steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Use the lookup result id to call web_search with query \"Braintrust Flue reasoning stream instrumentation\"\n3. Use the first web_search result url to call summarize_source\n4. After that, reply with exactly \"PROMPT_DONE\" and no other text\n\nI need to call exactly one tool per turn and wait for each result. Let me start with step 1.",
-                      "thinkingSignature": "Ep8FCm4IDxgCKkBTlyrpwCmWoZZgVZ3PxPYStfE+BaFIFNhEYQQF0YKeCGz4ToT2CKBXeOZuZsWp1zrLOc2HuMZaxA/ygHO2NxjLMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMS/AtCZE4JKnKRLhOGgylnUjvllOsbR310yUiMCmXRxcL8tzWV1KSgF8qWn4uIMCVHyZR0DrcTgNx2FS/ZpExhUb822GAl+QfF4lRQSreA2dUf3MAbUbpJkwPR4YPmyh6y4DJh8rS2igclMIwkLJ7wtiBHrlZyFv2+T66HRPMDN3T6T5uE/JIVxjWdWwstsbCEEQaxaukCvQGJaxyIjwAj47A1KT4bY1v09zl74Di9gd77DoJfhFRKRt87PAj24kqB1KiZ0KO+YqBRVE9QmZVBhFXVCU0xszDyXWiAwj94qfHES/grCn4fk0A7uTiUqPO7jeCUMhEgQgy+EsIq6BWh6xWsoYsz9aPWzOq3d+LwbvHGvFm8OFZnTYbjRPj9BsT47UqL0pb75T1ZkmiXpIS9STPQzZJ/5fNShxGM+gsZnDvBpfsJ2YuHoCIrZJmTvR07gYQU16OukgZMcHz6qfrjzcMGThz42KkAua5O3u4VDE+AtVhJrY7OVGxrM88H9xaVUALHo+0ORZxh403ERIbt7Zpj6b14GETjLvFWg/JDK8+ErTRTKxgL9UuafZA/bSMiFDUI+RMmxJQxl7KWGkUD+qzAYwbZPQqiFGdydPfXzScqXuSHfsgaJh2TVtnR18i/DR6I2hcKA963xlGTIQHRi75/KksGqpdqtO1ANczzzeOagT1j49EAZcjS0lOplC0uWJ60ZZtLXWmpfR228Hi1hjPwTQZ6m/TcDZNR18YAQ==",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "I'll complete this instrumented research flow step by step. Starting with step 1:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2 and call web_search using this id as lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-                      "thinkingSignature": "EpsDCm4IDxgCKkBVz7apPV9h9LusboVdpJwrzttKqOXyvHDFlQzj7JPqzb9GSFpO6kJB09+A0XmLJoNgcUGZ7wI16GPW17YhajUPMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMPHlrpXc4G+SeRPLYGgyoi7j0pviEn7fw6E0iMDgTZUDB0XR4vHWrqwj5XLlL9d/LRzBUM3xGbe8SrxPulobJu9x3puhvaPLHzgl7DCraAUe7rv9oz8fLc63ZESgtcVluQFbANLoeGho2afvBhavct+HaD34JOVbHB6kWA1rUFmuxPm/52c5GVPlmVbYHBP85wo1/qIQjZyeyaLM9eVONZQ+OnMFSkBqgD7QWBp1mkzdAM4jQ5FR0hxySPInj21taMPGKr2C4CKA8lsQIiBYQreqPaIvuzEcN30JkD6snWj4nwvjs7vRl4I5s9t4JZEgBC2UU71woXFYkj3F/JhH7Gndbo4yEubDapMXD9U5cvyT1cJIQmh2w/FKpToBjjup0a1G+2S5IWRvDGAE=",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "Now proceeding to step 2:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "lookupId": "flue-session-2026",
-                        "query": "Braintrust Flue reasoning stream instrumentation"
-                      },
-                      "id": "<span:2>",
-                      "name": "web_search",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:2>",
-                  "toolName": "web_search"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "thinking": "Perfect! I got the web_search results. There is one result with the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3 and call summarize_source with this URL.",
-                    "thinkingSignature": "EpADCm4IDxgCKkCVRlKYbSv3A153B69UVt+HekGvKdqxbNq/4DCezEKdDM5cWN/r0z2jgOPsdbTmY0u/RPmEuFMkHc8McWGID3skMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMBm6HSOAplPJUgTunGgye6T2opxxCeCJtBqAiMNSQFh6SX7ifPvn3evsix9NgngOKUh0nK0kIn9+eyzpyl8WJF6hxPtI+08bsSOJ2nSrPAV1gIeY3BH8YZzKQDZwYnOHeezjZq3KKJ0mgPprk3kPGX+vWbdrwiiWmlAbRMZvg447XLOdEIJXzfuof5x8eE2cMlQiReYCBCHEfZEQxO1Zzep6kjfTL4z8ROB4+sDY0SAiQdBjHq9ASGilsZxnpfBw7FkCAzPNzpohKaP5Ix/BPijdxjtgTjafiz1jUOygRbXYXr63ZG3L1t0DaPQhCtTSGBkCFCxQerJ1C+IkizWgHIZgZc3ySwqW3HF8C+ok9appKtp6QfYzoJ8LelJrxVxgB",
-                    "type": "thinking"
-                  },
-                  {
-                    "text": "Now proceeding to step 3:",
-                    "type": "text"
-                  },
-                  {
-                    "arguments": {
-                      "url": "https://example.test/flue/reasoning-streams"
-                    },
-                    "id": "<span:1>",
-                    "name": "summarize_source",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "anthropic-messages",
-                "flue.model": "claude-sonnet-4-5-20250929",
-                "flue.provider": "anthropic",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "claude-sonnet-4-5-20250929",
-                "provider": "anthropic"
-              },
-              "metrics": {
-                "completion_tokens": 133,
-                "duration_ms": 0,
-                "estimated_cost": 0.00378165,
-                "prompt_cache_creation_tokens": 251,
-                "prompt_cached_tokens": 2688,
-                "prompt_tokens": 13,
-                "tokens": 3085
-              }
-            },
-            {
-              "name": "tool:summarize_source",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "url": "https://example.test/flue/reasoning-streams"
-              },
-              "output": {
-                "summary": "Flue emits reasoning, tool execution, and LLM turn events separately.",
-                "url": "https://example.test/flue/reasoning-streams"
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "summarize_source",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "The user wants me to complete an instrumented research flow with specific steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Use the lookup result id to call web_search with query \"Braintrust Flue reasoning stream instrumentation\"\n3. Use the first web_search result url to call summarize_source\n4. After that, reply with exactly \"PROMPT_DONE\" and no other text\n\nI need to call exactly one tool per turn and wait for each result. Let me start with step 1.",
-                      "thinkingSignature": "Ep8FCm4IDxgCKkBTlyrpwCmWoZZgVZ3PxPYStfE+BaFIFNhEYQQF0YKeCGz4ToT2CKBXeOZuZsWp1zrLOc2HuMZaxA/ygHO2NxjLMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMS/AtCZE4JKnKRLhOGgylnUjvllOsbR310yUiMCmXRxcL8tzWV1KSgF8qWn4uIMCVHyZR0DrcTgNx2FS/ZpExhUb822GAl+QfF4lRQSreA2dUf3MAbUbpJkwPR4YPmyh6y4DJh8rS2igclMIwkLJ7wtiBHrlZyFv2+T66HRPMDN3T6T5uE/JIVxjWdWwstsbCEEQaxaukCvQGJaxyIjwAj47A1KT4bY1v09zl74Di9gd77DoJfhFRKRt87PAj24kqB1KiZ0KO+YqBRVE9QmZVBhFXVCU0xszDyXWiAwj94qfHES/grCn4fk0A7uTiUqPO7jeCUMhEgQgy+EsIq6BWh6xWsoYsz9aPWzOq3d+LwbvHGvFm8OFZnTYbjRPj9BsT47UqL0pb75T1ZkmiXpIS9STPQzZJ/5fNShxGM+gsZnDvBpfsJ2YuHoCIrZJmTvR07gYQU16OukgZMcHz6qfrjzcMGThz42KkAua5O3u4VDE+AtVhJrY7OVGxrM88H9xaVUALHo+0ORZxh403ERIbt7Zpj6b14GETjLvFWg/JDK8+ErTRTKxgL9UuafZA/bSMiFDUI+RMmxJQxl7KWGkUD+qzAYwbZPQqiFGdydPfXzScqXuSHfsgaJh2TVtnR18i/DR6I2hcKA963xlGTIQHRi75/KksGqpdqtO1ANczzzeOagT1j49EAZcjS0lOplC0uWJ60ZZtLXWmpfR228Hi1hjPwTQZ6m/TcDZNR18YAQ==",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "I'll complete this instrumented research flow step by step. Starting with step 1:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2 and call web_search using this id as lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-                      "thinkingSignature": "EpsDCm4IDxgCKkBVz7apPV9h9LusboVdpJwrzttKqOXyvHDFlQzj7JPqzb9GSFpO6kJB09+A0XmLJoNgcUGZ7wI16GPW17YhajUPMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMPHlrpXc4G+SeRPLYGgyoi7j0pviEn7fw6E0iMDgTZUDB0XR4vHWrqwj5XLlL9d/LRzBUM3xGbe8SrxPulobJu9x3puhvaPLHzgl7DCraAUe7rv9oz8fLc63ZESgtcVluQFbANLoeGho2afvBhavct+HaD34JOVbHB6kWA1rUFmuxPm/52c5GVPlmVbYHBP85wo1/qIQjZyeyaLM9eVONZQ+OnMFSkBqgD7QWBp1mkzdAM4jQ5FR0hxySPInj21taMPGKr2C4CKA8lsQIiBYQreqPaIvuzEcN30JkD6snWj4nwvjs7vRl4I5s9t4JZEgBC2UU71woXFYkj3F/JhH7Gndbo4yEubDapMXD9U5cvyT1cJIQmh2w/FKpToBjjup0a1G+2S5IWRvDGAE=",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "Now proceeding to step 2:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "lookupId": "flue-session-2026",
-                        "query": "Braintrust Flue reasoning stream instrumentation"
-                      },
-                      "id": "<span:2>",
-                      "name": "web_search",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:2>",
-                  "toolName": "web_search"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "Perfect! I got the web_search results. There is one result with the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3 and call summarize_source with this URL.",
-                      "thinkingSignature": "EpADCm4IDxgCKkCVRlKYbSv3A153B69UVt+HekGvKdqxbNq/4DCezEKdDM5cWN/r0z2jgOPsdbTmY0u/RPmEuFMkHc8McWGID3skMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMBm6HSOAplPJUgTunGgye6T2opxxCeCJtBqAiMNSQFh6SX7ifPvn3evsix9NgngOKUh0nK0kIn9+eyzpyl8WJF6hxPtI+08bsSOJ2nSrPAV1gIeY3BH8YZzKQDZwYnOHeezjZq3KKJ0mgPprk3kPGX+vWbdrwiiWmlAbRMZvg447XLOdEIJXzfuof5x8eE2cMlQiReYCBCHEfZEQxO1Zzep6kjfTL4z8ROB4+sDY0SAiQdBjHq9ASGilsZxnpfBw7FkCAzPNzpohKaP5Ix/BPijdxjtgTjafiz1jUOygRbXYXr63ZG3L1t0DaPQhCtTSGBkCFCxQerJ1C+IkizWgHIZgZc3ySwqW3HF8C+ok9appKtp6QfYzoJ8LelJrxVxgB",
-                      "type": "thinking"
-                    },
-                    {
-                      "text": "Now proceeding to step 3:",
-                      "type": "text"
-                    },
-                    {
-                      "arguments": {
-                        "url": "https://example.test/flue/reasoning-streams"
-                      },
-                      "id": "<span:3>",
-                      "name": "summarize_source",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:3>",
-                  "toolName": "summarize_source"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "thinking": "Great! The summarize_source call has completed successfully. According to the instructions, I should now reply with exactly \"PROMPT_DONE\" and no other text.",
-                    "thinkingSignature": "Eu0CCm4IDxgCKkCBUYqhsARXFm5YQdB8B4fq/pryhtdDMyve+qLrKjJqHD3e6i8qwtMvaYLPzEs5dagCGN78HUOXUIGRyxayFLsaMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMAILMWTVVQ2iHMSjSGgxdI40CHmPXi48PMtsiMPZXJ6qruyQJiwzXWtcYT90WFodE/m3BJVrxRR5klhCMY+seUwvHBeLiFkkDO+p+tCqsAerKSHWqBpynxXrokMvGb0MlXV0rdHjUU73PONapUCT2MCvAldDS2yi1fh5HX/uiEgdVVTGIoxv3TxMbcVi+vfzf7SAwZdNL5fClFTveqEC6M2pv/3/IFeOWTqxD+t8sT5OjUumRCVPeqm9zBUe0EGvYU6dd3cO1nsvirAVaRANkjQ37a4tYiMC0wUtHuXHbXIJphun3TnJyLvUEMF5s6aDDh2/lOVAW28KRxdcYAQ==",
-                    "type": "thinking"
-                  },
-                  {
-                    "text": "PROMPT_DONE",
-                    "type": "text"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "anthropic-messages",
-                "flue.model": "claude-sonnet-4-5-20250929",
-                "flue.provider": "anthropic",
-                "flue.session": "main",
-                "flue.stop_reason": "stop",
-                "flue.turn_purpose": "agent",
-                "model": "claude-sonnet-4-5-20250929",
-                "provider": "anthropic"
-              },
-              "metrics": {
-                "completion_tokens": 51,
-                "duration_ms": 0,
-                "estimated_cost": 0.0024132,
-                "prompt_cache_creation_tokens": 194,
-                "prompt_cached_tokens": 2939,
-                "prompt_tokens": 13,
-                "tokens": 3197
-              }
-            }
-          ],
-          "input": [
-            {
-              "content": [
-                {
-                  "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                  "type": "text"
-                }
-              ],
-              "role": "user"
-            }
-          ],
-          "output": "PROMPT_DONE",
-          "metadata": {
-            "flue.operation": "prompt",
-            "flue.session": "main",
-            "provider": "flue"
-          },
-          "metrics": {
-            "duration_ms": 0
-          }
-        },
-        {
           "name": "flue.skill",
           "type": "task",
           "children": [
@@ -704,7 +174,9 @@
           "metadata": {
             "flue.operation": "skill",
             "flue.session": "skill",
-            "provider": "flue"
+            "flue.workflow_name": "instrumentation",
+            "provider": "flue",
+            "scenario": "flue-instrumentation"
           },
           "metrics": {
             "duration_ms": 0
@@ -741,6 +213,7 @@
               },
               "metadata": {
                 "flue.api": "openai-responses",
+                "flue.input_mode": "full",
                 "flue.model": "gpt-4o-mini",
                 "flue.provider": "openai",
                 "flue.session": "task:task:<uuid:1>",
@@ -854,7 +327,9 @@
           "metadata": {
             "flue.operation": "compact",
             "flue.session": "main",
-            "provider": "flue"
+            "flue.workflow_name": "instrumentation",
+            "provider": "flue",
+            "scenario": "flue-instrumentation"
           },
           "metrics": {
             "duration_ms": 0
@@ -873,6 +348,415 @@
         "status": "done"
       },
       "metadata": {
+        "flue.workflow_name": "instrumentation",
+        "provider": "flue",
+        "scenario": "flue-instrumentation"
+      },
+      "metrics": {
+        "duration_ms": 0
+      }
+    },
+    {
+      "name": "flue.prompt",
+      "type": "task",
+      "children": [
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+                  "type": "text"
+                }
+              ],
+              "role": "user"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "thinking": "The user wants me to complete an instrumented research flow with specific steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Use the lookup result id to call web_search with query \"Braintrust Flue reasoning stream instrumentation\"\n3. Use the first web_search result url to call summarize_source\n4. After that, reply with exactly \"PROMPT_DONE\" and no other text\n\nI need to call exactly one tool per turn and wait for each result. Let me start with step 1.",
+                "thinkingSignature": "Ep8FCm4IDxgCKkBTlyrpwCmWoZZgVZ3PxPYStfE+BaFIFNhEYQQF0YKeCGz4ToT2CKBXeOZuZsWp1zrLOc2HuMZaxA/ygHO2NxjLMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMS/AtCZE4JKnKRLhOGgylnUjvllOsbR310yUiMCmXRxcL8tzWV1KSgF8qWn4uIMCVHyZR0DrcTgNx2FS/ZpExhUb822GAl+QfF4lRQSreA2dUf3MAbUbpJkwPR4YPmyh6y4DJh8rS2igclMIwkLJ7wtiBHrlZyFv2+T66HRPMDN3T6T5uE/JIVxjWdWwstsbCEEQaxaukCvQGJaxyIjwAj47A1KT4bY1v09zl74Di9gd77DoJfhFRKRt87PAj24kqB1KiZ0KO+YqBRVE9QmZVBhFXVCU0xszDyXWiAwj94qfHES/grCn4fk0A7uTiUqPO7jeCUMhEgQgy+EsIq6BWh6xWsoYsz9aPWzOq3d+LwbvHGvFm8OFZnTYbjRPj9BsT47UqL0pb75T1ZkmiXpIS9STPQzZJ/5fNShxGM+gsZnDvBpfsJ2YuHoCIrZJmTvR07gYQU16OukgZMcHz6qfrjzcMGThz42KkAua5O3u4VDE+AtVhJrY7OVGxrM88H9xaVUALHo+0ORZxh403ERIbt7Zpj6b14GETjLvFWg/JDK8+ErTRTKxgL9UuafZA/bSMiFDUI+RMmxJQxl7KWGkUD+qzAYwbZPQqiFGdydPfXzScqXuSHfsgaJh2TVtnR18i/DR6I2hcKA963xlGTIQHRi75/KksGqpdqtO1ANczzzeOagT1j49EAZcjS0lOplC0uWJ60ZZtLXWmpfR228Hi1hjPwTQZ6m/TcDZNR18YAQ==",
+                "type": "thinking"
+              },
+              {
+                "text": "I'll complete this instrumented research flow step by step. Starting with step 1:",
+                "type": "text"
+              },
+              {
+                "arguments": {
+                  "query": "flue instrumentation"
+                },
+                "id": "<span:1>",
+                "name": "lookup",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "anthropic-messages",
+            "flue.input_mode": "full",
+            "flue.model": "claude-sonnet-4-5-20250929",
+            "flue.provider": "anthropic",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "claude-sonnet-4-5-20250929",
+            "provider": "anthropic"
+          },
+          "metrics": {
+            "completion_tokens": 198,
+            "duration_ms": 0,
+            "estimated_cost": 0.0037323,
+            "prompt_cache_creation_tokens": 0,
+            "prompt_cached_tokens": 2441,
+            "prompt_tokens": 10,
+            "tokens": 2649
+          }
+        },
+        {
+          "name": "tool:lookup",
+          "type": "tool",
+          "children": [
+            {
+              "name": "flue.toolCurrentProbe",
+              "children": [],
+              "output": "lookup-active",
+              "metadata": {
+                "scenario": "flue-instrumentation"
+              }
+            }
+          ],
+          "input": {
+            "query": "flue instrumentation"
+          },
+          "output": {
+            "id": "<span:1>",
+            "query": "flue instrumentation",
+            "topic": "session instrumentation"
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "lookup",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "thinking": "The user wants me to complete an instrumented research flow with specific steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Use the lookup result id to call web_search with query \"Braintrust Flue reasoning stream instrumentation\"\n3. Use the first web_search result url to call summarize_source\n4. After that, reply with exactly \"PROMPT_DONE\" and no other text\n\nI need to call exactly one tool per turn and wait for each result. Let me start with step 1.",
+                  "thinkingSignature": "Ep8FCm4IDxgCKkBTlyrpwCmWoZZgVZ3PxPYStfE+BaFIFNhEYQQF0YKeCGz4ToT2CKBXeOZuZsWp1zrLOc2HuMZaxA/ygHO2NxjLMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMS/AtCZE4JKnKRLhOGgylnUjvllOsbR310yUiMCmXRxcL8tzWV1KSgF8qWn4uIMCVHyZR0DrcTgNx2FS/ZpExhUb822GAl+QfF4lRQSreA2dUf3MAbUbpJkwPR4YPmyh6y4DJh8rS2igclMIwkLJ7wtiBHrlZyFv2+T66HRPMDN3T6T5uE/JIVxjWdWwstsbCEEQaxaukCvQGJaxyIjwAj47A1KT4bY1v09zl74Di9gd77DoJfhFRKRt87PAj24kqB1KiZ0KO+YqBRVE9QmZVBhFXVCU0xszDyXWiAwj94qfHES/grCn4fk0A7uTiUqPO7jeCUMhEgQgy+EsIq6BWh6xWsoYsz9aPWzOq3d+LwbvHGvFm8OFZnTYbjRPj9BsT47UqL0pb75T1ZkmiXpIS9STPQzZJ/5fNShxGM+gsZnDvBpfsJ2YuHoCIrZJmTvR07gYQU16OukgZMcHz6qfrjzcMGThz42KkAua5O3u4VDE+AtVhJrY7OVGxrM88H9xaVUALHo+0ORZxh403ERIbt7Zpj6b14GETjLvFWg/JDK8+ErTRTKxgL9UuafZA/bSMiFDUI+RMmxJQxl7KWGkUD+qzAYwbZPQqiFGdydPfXzScqXuSHfsgaJh2TVtnR18i/DR6I2hcKA963xlGTIQHRi75/KksGqpdqtO1ANczzzeOagT1j49EAZcjS0lOplC0uWJ60ZZtLXWmpfR228Hi1hjPwTQZ6m/TcDZNR18YAQ==",
+                  "type": "thinking"
+                },
+                {
+                  "text": "I'll complete this instrumented research flow step by step. Starting with step 1:",
+                  "type": "text"
+                },
+                {
+                  "arguments": {
+                    "query": "flue instrumentation"
+                  },
+                  "id": "<span:1>",
+                  "name": "lookup",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "lookup"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2 and call web_search using this id as lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
+                "thinkingSignature": "EpsDCm4IDxgCKkBVz7apPV9h9LusboVdpJwrzttKqOXyvHDFlQzj7JPqzb9GSFpO6kJB09+A0XmLJoNgcUGZ7wI16GPW17YhajUPMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMPHlrpXc4G+SeRPLYGgyoi7j0pviEn7fw6E0iMDgTZUDB0XR4vHWrqwj5XLlL9d/LRzBUM3xGbe8SrxPulobJu9x3puhvaPLHzgl7DCraAUe7rv9oz8fLc63ZESgtcVluQFbANLoeGho2afvBhavct+HaD34JOVbHB6kWA1rUFmuxPm/52c5GVPlmVbYHBP85wo1/qIQjZyeyaLM9eVONZQ+OnMFSkBqgD7QWBp1mkzdAM4jQ5FR0hxySPInj21taMPGKr2C4CKA8lsQIiBYQreqPaIvuzEcN30JkD6snWj4nwvjs7vRl4I5s9t4JZEgBC2UU71woXFYkj3F/JhH7Gndbo4yEubDapMXD9U5cvyT1cJIQmh2w/FKpToBjjup0a1G+2S5IWRvDGAE=",
+                "type": "thinking"
+              },
+              {
+                "text": "Now proceeding to step 2:",
+                "type": "text"
+              },
+              {
+                "arguments": {
+                  "lookupId": "flue-session-2026",
+                  "query": "Braintrust Flue reasoning stream instrumentation"
+                },
+                "id": "<span:1>",
+                "name": "web_search",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "anthropic-messages",
+            "flue.input_message_offset": 1,
+            "flue.input_mode": "delta",
+            "flue.model": "claude-sonnet-4-5-20250929",
+            "flue.provider": "anthropic",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "claude-sonnet-4-5-20250929",
+            "provider": "anthropic"
+          },
+          "metrics": {
+            "completion_tokens": 161,
+            "duration_ms": 0,
+            "estimated_cost": 0.0041125499999999995,
+            "prompt_cache_creation_tokens": 247,
+            "prompt_cached_tokens": 2441,
+            "prompt_tokens": 13,
+            "tokens": 2862
+          }
+        },
+        {
+          "name": "tool:web_search",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "lookupId": "flue-session-2026",
+            "query": "Braintrust Flue reasoning stream instrumentation"
+          },
+          "output": {
+            "lookupId": "flue-session-2026",
+            "query": "Braintrust Flue reasoning stream instrumentation",
+            "results": [
+              {
+                "title": "Flue reasoning stream instrumentation",
+                "url": "https://example.test/flue/reasoning-streams"
+              }
+            ]
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "web_search",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2 and call web_search using this id as lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
+                  "thinkingSignature": "EpsDCm4IDxgCKkBVz7apPV9h9LusboVdpJwrzttKqOXyvHDFlQzj7JPqzb9GSFpO6kJB09+A0XmLJoNgcUGZ7wI16GPW17YhajUPMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMPHlrpXc4G+SeRPLYGgyoi7j0pviEn7fw6E0iMDgTZUDB0XR4vHWrqwj5XLlL9d/LRzBUM3xGbe8SrxPulobJu9x3puhvaPLHzgl7DCraAUe7rv9oz8fLc63ZESgtcVluQFbANLoeGho2afvBhavct+HaD34JOVbHB6kWA1rUFmuxPm/52c5GVPlmVbYHBP85wo1/qIQjZyeyaLM9eVONZQ+OnMFSkBqgD7QWBp1mkzdAM4jQ5FR0hxySPInj21taMPGKr2C4CKA8lsQIiBYQreqPaIvuzEcN30JkD6snWj4nwvjs7vRl4I5s9t4JZEgBC2UU71woXFYkj3F/JhH7Gndbo4yEubDapMXD9U5cvyT1cJIQmh2w/FKpToBjjup0a1G+2S5IWRvDGAE=",
+                  "type": "thinking"
+                },
+                {
+                  "text": "Now proceeding to step 2:",
+                  "type": "text"
+                },
+                {
+                  "arguments": {
+                    "lookupId": "flue-session-2026",
+                    "query": "Braintrust Flue reasoning stream instrumentation"
+                  },
+                  "id": "<span:1>",
+                  "name": "web_search",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "web_search"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "thinking": "Perfect! I got the web_search results. There is one result with the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3 and call summarize_source with this URL.",
+                "thinkingSignature": "EpADCm4IDxgCKkCVRlKYbSv3A153B69UVt+HekGvKdqxbNq/4DCezEKdDM5cWN/r0z2jgOPsdbTmY0u/RPmEuFMkHc8McWGID3skMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMBm6HSOAplPJUgTunGgye6T2opxxCeCJtBqAiMNSQFh6SX7ifPvn3evsix9NgngOKUh0nK0kIn9+eyzpyl8WJF6hxPtI+08bsSOJ2nSrPAV1gIeY3BH8YZzKQDZwYnOHeezjZq3KKJ0mgPprk3kPGX+vWbdrwiiWmlAbRMZvg447XLOdEIJXzfuof5x8eE2cMlQiReYCBCHEfZEQxO1Zzep6kjfTL4z8ROB4+sDY0SAiQdBjHq9ASGilsZxnpfBw7FkCAzPNzpohKaP5Ix/BPijdxjtgTjafiz1jUOygRbXYXr63ZG3L1t0DaPQhCtTSGBkCFCxQerJ1C+IkizWgHIZgZc3ySwqW3HF8C+ok9appKtp6QfYzoJ8LelJrxVxgB",
+                "type": "thinking"
+              },
+              {
+                "text": "Now proceeding to step 3:",
+                "type": "text"
+              },
+              {
+                "arguments": {
+                  "url": "https://example.test/flue/reasoning-streams"
+                },
+                "id": "<span:1>",
+                "name": "summarize_source",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "anthropic-messages",
+            "flue.input_message_offset": 3,
+            "flue.input_mode": "delta",
+            "flue.model": "claude-sonnet-4-5-20250929",
+            "flue.provider": "anthropic",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "claude-sonnet-4-5-20250929",
+            "provider": "anthropic"
+          },
+          "metrics": {
+            "completion_tokens": 133,
+            "duration_ms": 0,
+            "estimated_cost": 0.00378165,
+            "prompt_cache_creation_tokens": 251,
+            "prompt_cached_tokens": 2688,
+            "prompt_tokens": 13,
+            "tokens": 3085
+          }
+        },
+        {
+          "name": "tool:summarize_source",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "url": "https://example.test/flue/reasoning-streams"
+          },
+          "output": {
+            "summary": "Flue emits reasoning, tool execution, and LLM turn events separately.",
+            "url": "https://example.test/flue/reasoning-streams"
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "summarize_source",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "thinking": "Perfect! I got the web_search results. There is one result with the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3 and call summarize_source with this URL.",
+                  "thinkingSignature": "EpADCm4IDxgCKkCVRlKYbSv3A153B69UVt+HekGvKdqxbNq/4DCezEKdDM5cWN/r0z2jgOPsdbTmY0u/RPmEuFMkHc8McWGID3skMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMBm6HSOAplPJUgTunGgye6T2opxxCeCJtBqAiMNSQFh6SX7ifPvn3evsix9NgngOKUh0nK0kIn9+eyzpyl8WJF6hxPtI+08bsSOJ2nSrPAV1gIeY3BH8YZzKQDZwYnOHeezjZq3KKJ0mgPprk3kPGX+vWbdrwiiWmlAbRMZvg447XLOdEIJXzfuof5x8eE2cMlQiReYCBCHEfZEQxO1Zzep6kjfTL4z8ROB4+sDY0SAiQdBjHq9ASGilsZxnpfBw7FkCAzPNzpohKaP5Ix/BPijdxjtgTjafiz1jUOygRbXYXr63ZG3L1t0DaPQhCtTSGBkCFCxQerJ1C+IkizWgHIZgZc3ySwqW3HF8C+ok9appKtp6QfYzoJ8LelJrxVxgB",
+                  "type": "thinking"
+                },
+                {
+                  "text": "Now proceeding to step 3:",
+                  "type": "text"
+                },
+                {
+                  "arguments": {
+                    "url": "https://example.test/flue/reasoning-streams"
+                  },
+                  "id": "<span:1>",
+                  "name": "summarize_source",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "summarize_source"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "thinking": "Great! The summarize_source call has completed successfully. According to the instructions, I should now reply with exactly \"PROMPT_DONE\" and no other text.",
+                "thinkingSignature": "Eu0CCm4IDxgCKkCBUYqhsARXFm5YQdB8B4fq/pryhtdDMyve+qLrKjJqHD3e6i8qwtMvaYLPzEs5dagCGN78HUOXUIGRyxayFLsaMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMAILMWTVVQ2iHMSjSGgxdI40CHmPXi48PMtsiMPZXJ6qruyQJiwzXWtcYT90WFodE/m3BJVrxRR5klhCMY+seUwvHBeLiFkkDO+p+tCqsAerKSHWqBpynxXrokMvGb0MlXV0rdHjUU73PONapUCT2MCvAldDS2yi1fh5HX/uiEgdVVTGIoxv3TxMbcVi+vfzf7SAwZdNL5fClFTveqEC6M2pv/3/IFeOWTqxD+t8sT5OjUumRCVPeqm9zBUe0EGvYU6dd3cO1nsvirAVaRANkjQ37a4tYiMC0wUtHuXHbXIJphun3TnJyLvUEMF5s6aDDh2/lOVAW28KRxdcYAQ==",
+                "type": "thinking"
+              },
+              {
+                "text": "PROMPT_DONE",
+                "type": "text"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "anthropic-messages",
+            "flue.input_message_offset": 5,
+            "flue.input_mode": "delta",
+            "flue.model": "claude-sonnet-4-5-20250929",
+            "flue.provider": "anthropic",
+            "flue.session": "main",
+            "flue.stop_reason": "stop",
+            "flue.turn_purpose": "agent",
+            "model": "claude-sonnet-4-5-20250929",
+            "provider": "anthropic"
+          },
+          "metrics": {
+            "completion_tokens": 51,
+            "duration_ms": 0,
+            "estimated_cost": 0.0024132,
+            "prompt_cache_creation_tokens": 194,
+            "prompt_cached_tokens": 2939,
+            "prompt_tokens": 13,
+            "tokens": 3197
+          }
+        }
+      ],
+      "input": [
+        {
+          "content": [
+            {
+              "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+              "type": "text"
+            }
+          ],
+          "role": "user"
+        }
+      ],
+      "output": "PROMPT_DONE",
+      "metadata": {
+        "flue.operation": "prompt",
+        "flue.session": "main",
         "flue.workflow_name": "instrumentation",
         "provider": "flue",
         "scenario": "flue-instrumentation"

--- a/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v1-0-0-beta-3-explicit.span-tree.txt
+++ b/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v1-0-0-beta-3-explicit.span-tree.txt
@@ -1,17 +1,328 @@
 span_tree:
-└── workflow:instrumentation [task]
-    input: {
-      "metadata": {
-        "scenario": "flue-instrumentation",
-        "testRunId": "<run:1>"
-      },
-      "scenario": "flue-instrumentation"
-    }
-    output: {
-      "scenario": "flue-instrumentation",
-      "status": "done"
-    }
+├── workflow:instrumentation [task]
+│   input: {
+│     "metadata": {
+│       "scenario": "flue-instrumentation",
+│       "testRunId": "<run:1>"
+│     },
+│     "scenario": "flue-instrumentation"
+│   }
+│   output: {
+│     "scenario": "flue-instrumentation",
+│     "status": "done"
+│   }
+│   metadata: {
+│     "flue.workflow_name": "instrumentation",
+│     "provider": "flue",
+│     "scenario": "flue-instrumentation"
+│   }
+│   metrics: {
+│     "duration_ms": 0
+│   }
+│   ├── flue.workflowCurrentProbe
+│   │   output: "active"
+│   │   metadata: {
+│   │     "scenario": "flue-instrumentation"
+│   │   }
+│   ├── flue.skill [task]
+│   │   input: [
+│   │     {
+│   │       "content": [
+│   │         {
+│   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │           "type": "text"
+│   │         }
+│   │       ],
+│   │       "role": "user"
+│   │     }
+│   │   ]
+│   │   output: "SKILL_DONE"
+│   │   metadata: {
+│   │     "flue.operation": "skill",
+│   │     "flue.session": "skill",
+│   │     "flue.workflow_name": "instrumentation",
+│   │     "provider": "flue",
+│   │     "scenario": "flue-instrumentation"
+│   │   }
+│   │   metrics: {
+│   │     "duration_ms": 0
+│   │   }
+│   │   ├── flue.turn [llm]
+│   │   │   input: [
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "user"
+│   │   │     }
+│   │   │   ]
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "text": "I'll activate and run the e2e-flue-skill with the provided marker.",
+│   │   │         "type": "text"
+│   │   │       },
+│   │   │       {
+│   │   │         "arguments": {
+│   │   │           "name": "e2e-flue-skill"
+│   │   │         },
+│   │   │         "id": "<span:1>",
+│   │   │         "name": "activate_skill",
+│   │   │         "type": "toolCall"
+│   │   │       }
+│   │   │     ],
+│   │   │     "role": "assistant"
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.api": "anthropic-messages",
+│   │   │     "flue.model": "claude-sonnet-4-5-20250929",
+│   │   │     "flue.provider": "anthropic",
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.stop_reason": "toolUse",
+│   │   │     "flue.turn_purpose": "agent",
+│   │   │     "model": "claude-sonnet-4-5-20250929",
+│   │   │     "provider": "anthropic"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "completion_tokens": 80,
+│   │   │     "duration_ms": 0,
+│   │   │     "estimated_cost": 0.0018054,
+│   │   │     "prompt_cache_creation_tokens": 0,
+│   │   │     "prompt_cached_tokens": 1988,
+│   │   │     "prompt_tokens": 3,
+│   │   │     "tokens": 2071
+│   │   │   }
+│   │   ├── tool:activate_skill [tool]
+│   │   │   input: {
+│   │   │     "name": "e2e-flue-skill"
+│   │   │   }
+│   │   │   output: "Run the skill named \"e2e-flue-skill\".\n\n<skill_instructions>\nReturn the marker from the provided args exactly once. Output no other text.\n</skill_instructions>\n\nSupporting skill resources are available relative to this workspace skill directory but are not loaded into context unless needed:\n<skill_resources>\n- Base directory: <repo>/e2e/scenarios/flue-v1/.agents/skills/e2e-flue-skill\n- Resolve relative resource paths from this directory and read only the files you need.\n</skill_resources>"
+│   │   │   metadata: {
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.tool_name": "activate_skill",
+│   │   │     "provider": "flue"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "duration_ms": 0
+│   │   │   }
+│   │   └── flue.turn [llm]
+│   │       input: [
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "role": "user"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "I'll activate and run the e2e-flue-skill with the provided marker.",
+│   │               "type": "text"
+│   │             },
+│   │             {
+│   │               "arguments": {
+│   │                 "name": "e2e-flue-skill"
+│   │               },
+│   │               "id": "<span:1>",
+│   │               "name": "activate_skill",
+│   │               "type": "toolCall"
+│   │             }
+│   │           ],
+│   │           "role": "assistant"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "Run the skill named \"e2e-flue-skill\".\n\n<skill_instructions>\nReturn the marker from the provided args exactly once. Output no other text.\n</skill_instructions>\n\nSupporting skill resources are available relative to this workspace skill directory but are not loaded into context unless needed:\n<skill_resources>\n- Base directory: <repo>/e2e/scenarios/flue-v1/.agents/skills/e2e-flue-skill\n- Resolve relative resource paths from this directory and read only the files you need.\n</skill_resources>",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "isError": false,
+│   │           "role": "toolResult",
+│   │           "toolCallId": "<span:1>",
+│   │           "toolName": "activate_skill"
+│   │         }
+│   │       ]
+│   │       output: {
+│   │         "content": [
+│   │           {
+│   │             "text": "SKILL_DONE",
+│   │             "type": "text"
+│   │           }
+│   │         ],
+│   │         "role": "assistant"
+│   │       }
+│   │       metadata: {
+│   │         "flue.api": "anthropic-messages",
+│   │         "flue.model": "claude-sonnet-4-5-20250929",
+│   │         "flue.provider": "anthropic",
+│   │         "flue.session": "skill",
+│   │         "flue.stop_reason": "stop",
+│   │         "flue.turn_purpose": "agent",
+│   │         "model": "claude-sonnet-4-5-20250929",
+│   │         "provider": "anthropic"
+│   │       }
+│   │       metrics: {
+│   │         "completion_tokens": 8,
+│   │         "duration_ms": 0,
+│   │         "estimated_cost": 0.0008094,
+│   │         "prompt_cache_creation_tokens": 0,
+│   │         "prompt_cached_tokens": 2248,
+│   │         "prompt_tokens": 5,
+│   │         "tokens": 2261
+│   │       }
+│   ├── flue.task [task]
+│   │   input: "Reply with exactly TASK_DONE and no other text."
+│   │   output: "TASK_DONE"
+│   │   metadata: {
+│   │     "flue.session": "task:task:<uuid:1>",
+│   │     "provider": "flue"
+│   │   }
+│   │   metrics: {
+│   │     "duration_ms": 0
+│   │   }
+│   │   └── flue.turn [llm]
+│   │       input: [
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "Reply with exactly TASK_DONE and no other text.",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "role": "user"
+│   │         }
+│   │       ]
+│   │       output: {
+│   │         "content": [
+│   │           {
+│   │             "text": "TASK_DONE",
+│   │             "textSignature": "{\"v\":1,\"id\":\"msg_0ac30bf9efc812ab016a3a4a2b2e0081949b1dcbda2ddd0feb\"}",
+│   │             "type": "text"
+│   │           }
+│   │         ],
+│   │         "role": "assistant"
+│   │       }
+│   │       metadata: {
+│   │         "flue.api": "openai-responses",
+│   │         "flue.input_mode": "full",
+│   │         "flue.model": "gpt-4o-mini",
+│   │         "flue.provider": "openai",
+│   │         "flue.session": "task:task:<uuid:1>",
+│   │         "flue.stop_reason": "stop",
+│   │         "flue.turn_purpose": "agent",
+│   │         "model": "gpt-4o-mini",
+│   │         "provider": "openai"
+│   │       }
+│   │       metrics: {
+│   │         "completion_tokens": 4,
+│   │         "duration_ms": 0,
+│   │         "estimated_cost": 0.0001416,
+│   │         "prompt_cache_creation_tokens": 0,
+│   │         "prompt_cached_tokens": 0,
+│   │         "prompt_tokens": 928,
+│   │         "tokens": 932
+│   │       }
+│   └── flue.compact [task]
+│       input: {
+│         "estimatedTokens": 3197,
+│         "reason": "manual"
+│       }
+│       output: {
+│         "completed": true
+│       }
+│       metadata: {
+│         "flue.operation": "compact",
+│         "flue.session": "main",
+│         "flue.workflow_name": "instrumentation",
+│         "provider": "flue",
+│         "scenario": "flue-instrumentation"
+│       }
+│       metrics: {
+│         "duration_ms": 0
+│       }
+│       └── compaction:manual [task]
+│           input: {
+│             "estimatedTokens": 3197,
+│             "reason": "manual"
+│           }
+│           output: {
+│             "messagesAfter": 2,
+│             "messagesBefore": 8
+│           }
+│           metadata: {
+│             "flue.compaction_reason": "manual",
+│             "flue.session": "main",
+│             "provider": "flue"
+│           }
+│           metrics: {
+│             "duration_ms": 0,
+│             "messages_after": 2,
+│             "messages_before": 8
+│           }
+│           └── flue.turn [llm]
+│               input: [
+│                 {
+│                   "content": [
+│                     {
+│                       "text": "<conversation>\n[User]: Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.\n\n[Assistant thinking]: The user wants me to complete an instrumented research flow with specific steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Use the lookup result id to call web_search with query \"Braintrust Flue reasoning stream instrumentation\"\n3. Use the first web_search result url to call summarize_source\n4. After that, reply with exactly \"PROMPT_DONE\" and no other text\n\nI need to call exactly one tool per turn and wait for each result. Let me start with step 1.\n\n[Assistant]: I'll complete this instrumented research flow step by step. Starting with step 1:\n\n[Assistant tool calls]: lookup(query=\"flue instrumentation\")\n\n[Tool result]: {\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}\n\n[Assistant thinking]: Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2 and call web_search using this id as lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".\n\n[Assistant]: Now proceeding to step 2:\n\n[Assistant tool calls]: web_search(lookupId=\"flue-session-2026\", query=\"Braintrust Flue reasoning stream instrumentation\")\n\n[Tool result]: {\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}\n\n[Assistant thinking]: Perfect! I got the web_search results. There is one result with the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3 and call summarize_source with this URL.\n\n[Assistant]: Now proceeding to step 3:\n\n[Assistant tool calls]: summarize_source(url=\"https://example.test/flue/reasoning-streams\")\n\n[Tool result]: {\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}\n</conversation>\n\nThis is the PREFIX of a turn that was too large to keep. The SUFFIX (recent work) is retained.\n\nSummarize the prefix to provide context for the retained suffix:\n\n## Original Request\n[What did the user ask for in this turn?]\n\n## Early Progress\n- [Key decisions and work done in the prefix]\n\n## Context for Suffix\n- [Information needed to understand the retained recent work]\n\nBe concise. Focus on what's needed to understand the kept suffix.",
+│                       "type": "text"
+│                     }
+│                   ],
+│                   "role": "user"
+│                 }
+│               ]
+│               output: {
+│                 "content": [
+│                   {
+│                     "text": "## Original Request\nThe user asked to complete a step-by-step instrumented research flow involving calls to lookup, web_search, and summarize_source tools, concluding with",
+│                     "textSignature": "{\"v\":1,\"id\":\"msg_052d8873d6fcd89e016a3a4a2c06588194ad13515f66cac040\"}",
+│                     "type": "text"
+│                   }
+│                 ],
+│                 "role": "assistant"
+│               }
+│               metadata: {
+│                 "flue.api": "openai-responses",
+│                 "flue.model": "gpt-4o-mini",
+│                 "flue.provider": "openai",
+│                 "flue.session": "main",
+│                 "flue.stop_reason": "stop",
+│                 "flue.turn_purpose": "compaction_prefix",
+│                 "model": "gpt-4o-mini",
+│                 "provider": "openai"
+│               }
+│               metrics: {
+│                 "completion_tokens": 0,
+│                 "duration_ms": 0,
+│                 "estimated_cost": 0,
+│                 "prompt_cache_creation_tokens": 0,
+│                 "prompt_cached_tokens": 0,
+│                 "prompt_tokens": 0,
+│                 "tokens": 0
+│               }
+└── flue.prompt [task]
+    input: [
+      {
+        "content": [
+          {
+            "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+            "type": "text"
+          }
+        ],
+        "role": "user"
+      }
+    ]
+    output: "PROMPT_DONE"
     metadata: {
+      "flue.operation": "prompt",
+      "flue.session": "main",
       "flue.workflow_name": "instrumentation",
       "provider": "flue",
       "scenario": "flue-instrumentation"
@@ -19,12 +330,7 @@ span_tree:
     metrics: {
       "duration_ms": 0
     }
-    ├── flue.workflowCurrentProbe
-    │   output: "active"
-    │   metadata: {
-    │     "scenario": "flue-instrumentation"
-    │   }
-    ├── flue.prompt [task]
+    ├── flue.turn [llm]
     │   input: [
     │     {
     │       "content": [
@@ -36,762 +342,340 @@ span_tree:
     │       "role": "user"
     │     }
     │   ]
-    │   output: "PROMPT_DONE"
+    │   output: {
+    │     "content": [
+    │       {
+    │         "thinking": "The user wants me to complete an instrumented research flow with specific steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Use the lookup result id to call web_search with query \"Braintrust Flue reasoning stream instrumentation\"\n3. Use the first web_search result url to call summarize_source\n4. After that, reply with exactly \"PROMPT_DONE\" and no other text\n\nI need to call exactly one tool per turn and wait for each result. Let me start with step 1.",
+    │         "thinkingSignature": "Ep8FCm4IDxgCKkBTlyrpwCmWoZZgVZ3PxPYStfE+BaFIFNhEYQQF0YKeCGz4ToT2CKBXeOZuZsWp1zrLOc2HuMZaxA/ygHO2NxjLMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMS/AtCZE4JKnKRLhOGgylnUjvllOsbR310yUiMCmXRxcL8tzWV1KSgF8qWn4uIMCVHyZR0DrcTgNx2FS/ZpExhUb822GAl+QfF4lRQSreA2dUf3MAbUbpJkwPR4YPmyh6y4DJh8rS2igclMIwkLJ7wtiBHrlZyFv2+T66HRPMDN3T6T5uE/JIVxjWdWwstsbCEEQaxaukCvQGJaxyIjwAj47A1KT4bY1v09zl74Di9gd77DoJfhFRKRt87PAj24kqB1KiZ0KO+YqBRVE9QmZVBhFXVCU0xszDyXWiAwj94qfHES/grCn4fk0A7uTiUqPO7jeCUMhEgQgy+EsIq6BWh6xWsoYsz9aPWzOq3d+LwbvHGvFm8OFZnTYbjRPj9BsT47UqL0pb75T1ZkmiXpIS9STPQzZJ/5fNShxGM+gsZnDvBpfsJ2YuHoCIrZJmTvR07gYQU16OukgZMcHz6qfrjzcMGThz42KkAua5O3u4VDE+AtVhJrY7OVGxrM88H9xaVUALHo+0ORZxh403ERIbt7Zpj6b14GETjLvFWg/JDK8+ErTRTKxgL9UuafZA/bSMiFDUI+RMmxJQxl7KWGkUD+qzAYwbZPQqiFGdydPfXzScqXuSHfsgaJh2TVtnR18i/DR6I2hcKA963xlGTIQHRi75/KksGqpdqtO1ANczzzeOagT1j49EAZcjS0lOplC0uWJ60ZZtLXWmpfR228Hi1hjPwTQZ6m/TcDZNR18YAQ==",
+    │         "type": "thinking"
+    │       },
+    │       {
+    │         "text": "I'll complete this instrumented research flow step by step. Starting with step 1:",
+    │         "type": "text"
+    │       },
+    │       {
+    │         "arguments": {
+    │           "query": "flue instrumentation"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "lookup",
+    │         "type": "toolCall"
+    │       }
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.operation": "prompt",
+    │     "flue.api": "anthropic-messages",
+    │     "flue.input_mode": "full",
+    │     "flue.model": "claude-sonnet-4-5-20250929",
+    │     "flue.provider": "anthropic",
     │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "claude-sonnet-4-5-20250929",
+    │     "provider": "anthropic"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 198,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.0037323,
+    │     "prompt_cache_creation_tokens": 0,
+    │     "prompt_cached_tokens": 2441,
+    │     "prompt_tokens": 10,
+    │     "tokens": 2649
+    │   }
+    ├── tool:lookup [tool]
+    │   input: {
+    │     "query": "flue instrumentation"
+    │   }
+    │   output: {
+    │     "id": "<span:1>",
+    │     "query": "flue instrumentation",
+    │     "topic": "session instrumentation"
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "lookup",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "thinking": "The user wants me to complete an instrumented research flow with specific steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Use the lookup result id to call web_search with query \"Braintrust Flue reasoning stream instrumentation\"\n3. Use the first web_search result url to call summarize_source\n4. After that, reply with exactly \"PROMPT_DONE\" and no other text\n\nI need to call exactly one tool per turn and wait for each result. Let me start with step 1.",
-    │   │         "thinkingSignature": "Ep8FCm4IDxgCKkBTlyrpwCmWoZZgVZ3PxPYStfE+BaFIFNhEYQQF0YKeCGz4ToT2CKBXeOZuZsWp1zrLOc2HuMZaxA/ygHO2NxjLMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMS/AtCZE4JKnKRLhOGgylnUjvllOsbR310yUiMCmXRxcL8tzWV1KSgF8qWn4uIMCVHyZR0DrcTgNx2FS/ZpExhUb822GAl+QfF4lRQSreA2dUf3MAbUbpJkwPR4YPmyh6y4DJh8rS2igclMIwkLJ7wtiBHrlZyFv2+T66HRPMDN3T6T5uE/JIVxjWdWwstsbCEEQaxaukCvQGJaxyIjwAj47A1KT4bY1v09zl74Di9gd77DoJfhFRKRt87PAj24kqB1KiZ0KO+YqBRVE9QmZVBhFXVCU0xszDyXWiAwj94qfHES/grCn4fk0A7uTiUqPO7jeCUMhEgQgy+EsIq6BWh6xWsoYsz9aPWzOq3d+LwbvHGvFm8OFZnTYbjRPj9BsT47UqL0pb75T1ZkmiXpIS9STPQzZJ/5fNShxGM+gsZnDvBpfsJ2YuHoCIrZJmTvR07gYQU16OukgZMcHz6qfrjzcMGThz42KkAua5O3u4VDE+AtVhJrY7OVGxrM88H9xaVUALHo+0ORZxh403ERIbt7Zpj6b14GETjLvFWg/JDK8+ErTRTKxgL9UuafZA/bSMiFDUI+RMmxJQxl7KWGkUD+qzAYwbZPQqiFGdydPfXzScqXuSHfsgaJh2TVtnR18i/DR6I2hcKA963xlGTIQHRi75/KksGqpdqtO1ANczzzeOagT1j49EAZcjS0lOplC0uWJ60ZZtLXWmpfR228Hi1hjPwTQZ6m/TcDZNR18YAQ==",
-    │   │         "type": "thinking"
-    │   │       },
-    │   │       {
-    │   │         "text": "I'll complete this instrumented research flow step by step. Starting with step 1:",
-    │   │         "type": "text"
-    │   │       },
-    │   │       {
-    │   │         "arguments": {
-    │   │           "query": "flue instrumentation"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "lookup",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 198,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0037323,
-    │   │     "prompt_cache_creation_tokens": 0,
-    │   │     "prompt_cached_tokens": 2441,
-    │   │     "prompt_tokens": 10,
-    │   │     "tokens": 2649
-    │   │   }
-    │   ├── tool:lookup [tool]
-    │   │   input: {
-    │   │     "query": "flue instrumentation"
-    │   │   }
-    │   │   output: {
-    │   │     "id": "<span:1>",
-    │   │     "query": "flue instrumentation",
-    │   │     "topic": "session instrumentation"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "lookup",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   │   └── flue.toolCurrentProbe
-    │   │       output: "lookup-active"
-    │   │       metadata: {
-    │   │         "scenario": "flue-instrumentation"
-    │   │       }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "thinking": "The user wants me to complete an instrumented research flow with specific steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Use the lookup result id to call web_search with query \"Braintrust Flue reasoning stream instrumentation\"\n3. Use the first web_search result url to call summarize_source\n4. After that, reply with exactly \"PROMPT_DONE\" and no other text\n\nI need to call exactly one tool per turn and wait for each result. Let me start with step 1.",
-    │   │           "thinkingSignature": "Ep8FCm4IDxgCKkBTlyrpwCmWoZZgVZ3PxPYStfE+BaFIFNhEYQQF0YKeCGz4ToT2CKBXeOZuZsWp1zrLOc2HuMZaxA/ygHO2NxjLMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMS/AtCZE4JKnKRLhOGgylnUjvllOsbR310yUiMCmXRxcL8tzWV1KSgF8qWn4uIMCVHyZR0DrcTgNx2FS/ZpExhUb822GAl+QfF4lRQSreA2dUf3MAbUbpJkwPR4YPmyh6y4DJh8rS2igclMIwkLJ7wtiBHrlZyFv2+T66HRPMDN3T6T5uE/JIVxjWdWwstsbCEEQaxaukCvQGJaxyIjwAj47A1KT4bY1v09zl74Di9gd77DoJfhFRKRt87PAj24kqB1KiZ0KO+YqBRVE9QmZVBhFXVCU0xszDyXWiAwj94qfHES/grCn4fk0A7uTiUqPO7jeCUMhEgQgy+EsIq6BWh6xWsoYsz9aPWzOq3d+LwbvHGvFm8OFZnTYbjRPj9BsT47UqL0pb75T1ZkmiXpIS9STPQzZJ/5fNShxGM+gsZnDvBpfsJ2YuHoCIrZJmTvR07gYQU16OukgZMcHz6qfrjzcMGThz42KkAua5O3u4VDE+AtVhJrY7OVGxrM88H9xaVUALHo+0ORZxh403ERIbt7Zpj6b14GETjLvFWg/JDK8+ErTRTKxgL9UuafZA/bSMiFDUI+RMmxJQxl7KWGkUD+qzAYwbZPQqiFGdydPfXzScqXuSHfsgaJh2TVtnR18i/DR6I2hcKA963xlGTIQHRi75/KksGqpdqtO1ANczzzeOagT1j49EAZcjS0lOplC0uWJ60ZZtLXWmpfR228Hi1hjPwTQZ6m/TcDZNR18YAQ==",
-    │   │           "type": "thinking"
-    │   │         },
-    │   │         {
-    │   │           "text": "I'll complete this instrumented research flow step by step. Starting with step 1:",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "query": "flue instrumentation"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "lookup",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "lookup"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2 and call web_search using this id as lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-    │   │         "thinkingSignature": "EpsDCm4IDxgCKkBVz7apPV9h9LusboVdpJwrzttKqOXyvHDFlQzj7JPqzb9GSFpO6kJB09+A0XmLJoNgcUGZ7wI16GPW17YhajUPMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMPHlrpXc4G+SeRPLYGgyoi7j0pviEn7fw6E0iMDgTZUDB0XR4vHWrqwj5XLlL9d/LRzBUM3xGbe8SrxPulobJu9x3puhvaPLHzgl7DCraAUe7rv9oz8fLc63ZESgtcVluQFbANLoeGho2afvBhavct+HaD34JOVbHB6kWA1rUFmuxPm/52c5GVPlmVbYHBP85wo1/qIQjZyeyaLM9eVONZQ+OnMFSkBqgD7QWBp1mkzdAM4jQ5FR0hxySPInj21taMPGKr2C4CKA8lsQIiBYQreqPaIvuzEcN30JkD6snWj4nwvjs7vRl4I5s9t4JZEgBC2UU71woXFYkj3F/JhH7Gndbo4yEubDapMXD9U5cvyT1cJIQmh2w/FKpToBjjup0a1G+2S5IWRvDGAE=",
-    │   │         "type": "thinking"
-    │   │       },
-    │   │       {
-    │   │         "text": "Now proceeding to step 2:",
-    │   │         "type": "text"
-    │   │       },
-    │   │       {
-    │   │         "arguments": {
-    │   │           "lookupId": "flue-session-2026",
-    │   │           "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "web_search",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 161,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0041125499999999995,
-    │   │     "prompt_cache_creation_tokens": 247,
-    │   │     "prompt_cached_tokens": 2441,
-    │   │     "prompt_tokens": 13,
-    │   │     "tokens": 2862
-    │   │   }
-    │   ├── tool:web_search [tool]
-    │   │   input: {
-    │   │     "lookupId": "flue-session-2026",
-    │   │     "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │   }
-    │   │   output: {
-    │   │     "lookupId": "flue-session-2026",
-    │   │     "query": "Braintrust Flue reasoning stream instrumentation",
-    │   │     "results": [
-    │   │       {
-    │   │         "title": "Flue reasoning stream instrumentation",
-    │   │         "url": "https://example.test/flue/reasoning-streams"
-    │   │       }
-    │   │     ]
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "web_search",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "thinking": "The user wants me to complete an instrumented research flow with specific steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Use the lookup result id to call web_search with query \"Braintrust Flue reasoning stream instrumentation\"\n3. Use the first web_search result url to call summarize_source\n4. After that, reply with exactly \"PROMPT_DONE\" and no other text\n\nI need to call exactly one tool per turn and wait for each result. Let me start with step 1.",
-    │   │           "thinkingSignature": "Ep8FCm4IDxgCKkBTlyrpwCmWoZZgVZ3PxPYStfE+BaFIFNhEYQQF0YKeCGz4ToT2CKBXeOZuZsWp1zrLOc2HuMZaxA/ygHO2NxjLMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMS/AtCZE4JKnKRLhOGgylnUjvllOsbR310yUiMCmXRxcL8tzWV1KSgF8qWn4uIMCVHyZR0DrcTgNx2FS/ZpExhUb822GAl+QfF4lRQSreA2dUf3MAbUbpJkwPR4YPmyh6y4DJh8rS2igclMIwkLJ7wtiBHrlZyFv2+T66HRPMDN3T6T5uE/JIVxjWdWwstsbCEEQaxaukCvQGJaxyIjwAj47A1KT4bY1v09zl74Di9gd77DoJfhFRKRt87PAj24kqB1KiZ0KO+YqBRVE9QmZVBhFXVCU0xszDyXWiAwj94qfHES/grCn4fk0A7uTiUqPO7jeCUMhEgQgy+EsIq6BWh6xWsoYsz9aPWzOq3d+LwbvHGvFm8OFZnTYbjRPj9BsT47UqL0pb75T1ZkmiXpIS9STPQzZJ/5fNShxGM+gsZnDvBpfsJ2YuHoCIrZJmTvR07gYQU16OukgZMcHz6qfrjzcMGThz42KkAua5O3u4VDE+AtVhJrY7OVGxrM88H9xaVUALHo+0ORZxh403ERIbt7Zpj6b14GETjLvFWg/JDK8+ErTRTKxgL9UuafZA/bSMiFDUI+RMmxJQxl7KWGkUD+qzAYwbZPQqiFGdydPfXzScqXuSHfsgaJh2TVtnR18i/DR6I2hcKA963xlGTIQHRi75/KksGqpdqtO1ANczzzeOagT1j49EAZcjS0lOplC0uWJ60ZZtLXWmpfR228Hi1hjPwTQZ6m/TcDZNR18YAQ==",
-    │   │           "type": "thinking"
-    │   │         },
-    │   │         {
-    │   │           "text": "I'll complete this instrumented research flow step by step. Starting with step 1:",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "query": "flue instrumentation"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "lookup",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "lookup"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2 and call web_search using this id as lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-    │   │           "thinkingSignature": "EpsDCm4IDxgCKkBVz7apPV9h9LusboVdpJwrzttKqOXyvHDFlQzj7JPqzb9GSFpO6kJB09+A0XmLJoNgcUGZ7wI16GPW17YhajUPMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMPHlrpXc4G+SeRPLYGgyoi7j0pviEn7fw6E0iMDgTZUDB0XR4vHWrqwj5XLlL9d/LRzBUM3xGbe8SrxPulobJu9x3puhvaPLHzgl7DCraAUe7rv9oz8fLc63ZESgtcVluQFbANLoeGho2afvBhavct+HaD34JOVbHB6kWA1rUFmuxPm/52c5GVPlmVbYHBP85wo1/qIQjZyeyaLM9eVONZQ+OnMFSkBqgD7QWBp1mkzdAM4jQ5FR0hxySPInj21taMPGKr2C4CKA8lsQIiBYQreqPaIvuzEcN30JkD6snWj4nwvjs7vRl4I5s9t4JZEgBC2UU71woXFYkj3F/JhH7Gndbo4yEubDapMXD9U5cvyT1cJIQmh2w/FKpToBjjup0a1G+2S5IWRvDGAE=",
-    │   │           "type": "thinking"
-    │   │         },
-    │   │         {
-    │   │           "text": "Now proceeding to step 2:",
-    │   │           "type": "text"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "lookupId": "flue-session-2026",
-    │   │             "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │           },
-    │   │           "id": "<span:2>",
-    │   │           "name": "web_search",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:2>",
-    │   │       "toolName": "web_search"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "thinking": "Perfect! I got the web_search results. There is one result with the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3 and call summarize_source with this URL.",
-    │   │         "thinkingSignature": "EpADCm4IDxgCKkCVRlKYbSv3A153B69UVt+HekGvKdqxbNq/4DCezEKdDM5cWN/r0z2jgOPsdbTmY0u/RPmEuFMkHc8McWGID3skMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMBm6HSOAplPJUgTunGgye6T2opxxCeCJtBqAiMNSQFh6SX7ifPvn3evsix9NgngOKUh0nK0kIn9+eyzpyl8WJF6hxPtI+08bsSOJ2nSrPAV1gIeY3BH8YZzKQDZwYnOHeezjZq3KKJ0mgPprk3kPGX+vWbdrwiiWmlAbRMZvg447XLOdEIJXzfuof5x8eE2cMlQiReYCBCHEfZEQxO1Zzep6kjfTL4z8ROB4+sDY0SAiQdBjHq9ASGilsZxnpfBw7FkCAzPNzpohKaP5Ix/BPijdxjtgTjafiz1jUOygRbXYXr63ZG3L1t0DaPQhCtTSGBkCFCxQerJ1C+IkizWgHIZgZc3ySwqW3HF8C+ok9appKtp6QfYzoJ8LelJrxVxgB",
-    │   │         "type": "thinking"
-    │   │       },
-    │   │       {
-    │   │         "text": "Now proceeding to step 3:",
-    │   │         "type": "text"
-    │   │       },
-    │   │       {
-    │   │         "arguments": {
-    │   │           "url": "https://example.test/flue/reasoning-streams"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "summarize_source",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 133,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.00378165,
-    │   │     "prompt_cache_creation_tokens": 251,
-    │   │     "prompt_cached_tokens": 2688,
-    │   │     "prompt_tokens": 13,
-    │   │     "tokens": 3085
-    │   │   }
-    │   ├── tool:summarize_source [tool]
-    │   │   input: {
-    │   │     "url": "https://example.test/flue/reasoning-streams"
-    │   │   }
-    │   │   output: {
-    │   │     "summary": "Flue emits reasoning, tool execution, and LLM turn events separately.",
-    │   │     "url": "https://example.test/flue/reasoning-streams"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "summarize_source",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   └── flue.turn [llm]
-    │       input: [
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "thinking": "The user wants me to complete an instrumented research flow with specific steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Use the lookup result id to call web_search with query \"Braintrust Flue reasoning stream instrumentation\"\n3. Use the first web_search result url to call summarize_source\n4. After that, reply with exactly \"PROMPT_DONE\" and no other text\n\nI need to call exactly one tool per turn and wait for each result. Let me start with step 1.",
-    │               "thinkingSignature": "Ep8FCm4IDxgCKkBTlyrpwCmWoZZgVZ3PxPYStfE+BaFIFNhEYQQF0YKeCGz4ToT2CKBXeOZuZsWp1zrLOc2HuMZaxA/ygHO2NxjLMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMS/AtCZE4JKnKRLhOGgylnUjvllOsbR310yUiMCmXRxcL8tzWV1KSgF8qWn4uIMCVHyZR0DrcTgNx2FS/ZpExhUb822GAl+QfF4lRQSreA2dUf3MAbUbpJkwPR4YPmyh6y4DJh8rS2igclMIwkLJ7wtiBHrlZyFv2+T66HRPMDN3T6T5uE/JIVxjWdWwstsbCEEQaxaukCvQGJaxyIjwAj47A1KT4bY1v09zl74Di9gd77DoJfhFRKRt87PAj24kqB1KiZ0KO+YqBRVE9QmZVBhFXVCU0xszDyXWiAwj94qfHES/grCn4fk0A7uTiUqPO7jeCUMhEgQgy+EsIq6BWh6xWsoYsz9aPWzOq3d+LwbvHGvFm8OFZnTYbjRPj9BsT47UqL0pb75T1ZkmiXpIS9STPQzZJ/5fNShxGM+gsZnDvBpfsJ2YuHoCIrZJmTvR07gYQU16OukgZMcHz6qfrjzcMGThz42KkAua5O3u4VDE+AtVhJrY7OVGxrM88H9xaVUALHo+0ORZxh403ERIbt7Zpj6b14GETjLvFWg/JDK8+ErTRTKxgL9UuafZA/bSMiFDUI+RMmxJQxl7KWGkUD+qzAYwbZPQqiFGdydPfXzScqXuSHfsgaJh2TVtnR18i/DR6I2hcKA963xlGTIQHRi75/KksGqpdqtO1ANczzzeOagT1j49EAZcjS0lOplC0uWJ60ZZtLXWmpfR228Hi1hjPwTQZ6m/TcDZNR18YAQ==",
-    │               "type": "thinking"
-    │             },
-    │             {
-    │               "text": "I'll complete this instrumented research flow step by step. Starting with step 1:",
-    │               "type": "text"
-    │             },
-    │             {
-    │               "arguments": {
-    │                 "query": "flue instrumentation"
-    │               },
-    │               "id": "<span:1>",
-    │               "name": "lookup",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:1>",
-    │           "toolName": "lookup"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2 and call web_search using this id as lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
-    │               "thinkingSignature": "EpsDCm4IDxgCKkBVz7apPV9h9LusboVdpJwrzttKqOXyvHDFlQzj7JPqzb9GSFpO6kJB09+A0XmLJoNgcUGZ7wI16GPW17YhajUPMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMPHlrpXc4G+SeRPLYGgyoi7j0pviEn7fw6E0iMDgTZUDB0XR4vHWrqwj5XLlL9d/LRzBUM3xGbe8SrxPulobJu9x3puhvaPLHzgl7DCraAUe7rv9oz8fLc63ZESgtcVluQFbANLoeGho2afvBhavct+HaD34JOVbHB6kWA1rUFmuxPm/52c5GVPlmVbYHBP85wo1/qIQjZyeyaLM9eVONZQ+OnMFSkBqgD7QWBp1mkzdAM4jQ5FR0hxySPInj21taMPGKr2C4CKA8lsQIiBYQreqPaIvuzEcN30JkD6snWj4nwvjs7vRl4I5s9t4JZEgBC2UU71woXFYkj3F/JhH7Gndbo4yEubDapMXD9U5cvyT1cJIQmh2w/FKpToBjjup0a1G+2S5IWRvDGAE=",
-    │               "type": "thinking"
-    │             },
-    │             {
-    │               "text": "Now proceeding to step 2:",
-    │               "type": "text"
-    │             },
-    │             {
-    │               "arguments": {
-    │                 "lookupId": "flue-session-2026",
-    │                 "query": "Braintrust Flue reasoning stream instrumentation"
-    │               },
-    │               "id": "<span:2>",
-    │               "name": "web_search",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:2>",
-    │           "toolName": "web_search"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "thinking": "Perfect! I got the web_search results. There is one result with the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3 and call summarize_source with this URL.",
-    │               "thinkingSignature": "EpADCm4IDxgCKkCVRlKYbSv3A153B69UVt+HekGvKdqxbNq/4DCezEKdDM5cWN/r0z2jgOPsdbTmY0u/RPmEuFMkHc8McWGID3skMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMBm6HSOAplPJUgTunGgye6T2opxxCeCJtBqAiMNSQFh6SX7ifPvn3evsix9NgngOKUh0nK0kIn9+eyzpyl8WJF6hxPtI+08bsSOJ2nSrPAV1gIeY3BH8YZzKQDZwYnOHeezjZq3KKJ0mgPprk3kPGX+vWbdrwiiWmlAbRMZvg447XLOdEIJXzfuof5x8eE2cMlQiReYCBCHEfZEQxO1Zzep6kjfTL4z8ROB4+sDY0SAiQdBjHq9ASGilsZxnpfBw7FkCAzPNzpohKaP5Ix/BPijdxjtgTjafiz1jUOygRbXYXr63ZG3L1t0DaPQhCtTSGBkCFCxQerJ1C+IkizWgHIZgZc3ySwqW3HF8C+ok9appKtp6QfYzoJ8LelJrxVxgB",
-    │               "type": "thinking"
-    │             },
-    │             {
-    │               "text": "Now proceeding to step 3:",
-    │               "type": "text"
-    │             },
-    │             {
-    │               "arguments": {
-    │                 "url": "https://example.test/flue/reasoning-streams"
-    │               },
-    │               "id": "<span:3>",
-    │               "name": "summarize_source",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:3>",
-    │           "toolName": "summarize_source"
-    │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "thinking": "Great! The summarize_source call has completed successfully. According to the instructions, I should now reply with exactly \"PROMPT_DONE\" and no other text.",
-    │             "thinkingSignature": "Eu0CCm4IDxgCKkCBUYqhsARXFm5YQdB8B4fq/pryhtdDMyve+qLrKjJqHD3e6i8qwtMvaYLPzEs5dagCGN78HUOXUIGRyxayFLsaMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMAILMWTVVQ2iHMSjSGgxdI40CHmPXi48PMtsiMPZXJ6qruyQJiwzXWtcYT90WFodE/m3BJVrxRR5klhCMY+seUwvHBeLiFkkDO+p+tCqsAerKSHWqBpynxXrokMvGb0MlXV0rdHjUU73PONapUCT2MCvAldDS2yi1fh5HX/uiEgdVVTGIoxv3TxMbcVi+vfzf7SAwZdNL5fClFTveqEC6M2pv/3/IFeOWTqxD+t8sT5OjUumRCVPeqm9zBUe0EGvYU6dd3cO1nsvirAVaRANkjQ37a4tYiMC0wUtHuXHbXIJphun3TnJyLvUEMF5s6aDDh2/lOVAW28KRxdcYAQ==",
-    │             "type": "thinking"
-    │           },
-    │           {
-    │             "text": "PROMPT_DONE",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
-    │       }
+    │   └── flue.toolCurrentProbe
+    │       output: "lookup-active"
     │       metadata: {
-    │         "flue.api": "anthropic-messages",
-    │         "flue.model": "claude-sonnet-4-5-20250929",
-    │         "flue.provider": "anthropic",
-    │         "flue.session": "main",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "claude-sonnet-4-5-20250929",
-    │         "provider": "anthropic"
+    │         "scenario": "flue-instrumentation"
     │       }
-    │       metrics: {
-    │         "completion_tokens": 51,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.0024132,
-    │         "prompt_cache_creation_tokens": 194,
-    │         "prompt_cached_tokens": 2939,
-    │         "prompt_tokens": 13,
-    │         "tokens": 3197
-    │       }
-    ├── flue.skill [task]
+    ├── flue.turn [llm]
     │   input: [
     │     {
     │       "content": [
     │         {
-    │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+    │           "thinking": "The user wants me to complete an instrumented research flow with specific steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Use the lookup result id to call web_search with query \"Braintrust Flue reasoning stream instrumentation\"\n3. Use the first web_search result url to call summarize_source\n4. After that, reply with exactly \"PROMPT_DONE\" and no other text\n\nI need to call exactly one tool per turn and wait for each result. Let me start with step 1.",
+    │           "thinkingSignature": "Ep8FCm4IDxgCKkBTlyrpwCmWoZZgVZ3PxPYStfE+BaFIFNhEYQQF0YKeCGz4ToT2CKBXeOZuZsWp1zrLOc2HuMZaxA/ygHO2NxjLMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMS/AtCZE4JKnKRLhOGgylnUjvllOsbR310yUiMCmXRxcL8tzWV1KSgF8qWn4uIMCVHyZR0DrcTgNx2FS/ZpExhUb822GAl+QfF4lRQSreA2dUf3MAbUbpJkwPR4YPmyh6y4DJh8rS2igclMIwkLJ7wtiBHrlZyFv2+T66HRPMDN3T6T5uE/JIVxjWdWwstsbCEEQaxaukCvQGJaxyIjwAj47A1KT4bY1v09zl74Di9gd77DoJfhFRKRt87PAj24kqB1KiZ0KO+YqBRVE9QmZVBhFXVCU0xszDyXWiAwj94qfHES/grCn4fk0A7uTiUqPO7jeCUMhEgQgy+EsIq6BWh6xWsoYsz9aPWzOq3d+LwbvHGvFm8OFZnTYbjRPj9BsT47UqL0pb75T1ZkmiXpIS9STPQzZJ/5fNShxGM+gsZnDvBpfsJ2YuHoCIrZJmTvR07gYQU16OukgZMcHz6qfrjzcMGThz42KkAua5O3u4VDE+AtVhJrY7OVGxrM88H9xaVUALHo+0ORZxh403ERIbt7Zpj6b14GETjLvFWg/JDK8+ErTRTKxgL9UuafZA/bSMiFDUI+RMmxJQxl7KWGkUD+qzAYwbZPQqiFGdydPfXzScqXuSHfsgaJh2TVtnR18i/DR6I2hcKA963xlGTIQHRi75/KksGqpdqtO1ANczzzeOagT1j49EAZcjS0lOplC0uWJ60ZZtLXWmpfR228Hi1hjPwTQZ6m/TcDZNR18YAQ==",
+    │           "type": "thinking"
+    │         },
+    │         {
+    │           "text": "I'll complete this instrumented research flow step by step. Starting with step 1:",
+    │           "type": "text"
+    │         },
+    │         {
+    │           "arguments": {
+    │             "query": "flue instrumentation"
+    │           },
+    │           "id": "<span:1>",
+    │           "name": "lookup",
+    │           "type": "toolCall"
+    │         }
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
     │           "type": "text"
     │         }
     │       ],
-    │       "role": "user"
+    │       "isError": false,
+    │       "role": "toolResult",
+    │       "toolCallId": "<span:1>",
+    │       "toolName": "lookup"
     │     }
     │   ]
-    │   output: "SKILL_DONE"
+    │   output: {
+    │     "content": [
+    │       {
+    │         "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2 and call web_search using this id as lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
+    │         "thinkingSignature": "EpsDCm4IDxgCKkBVz7apPV9h9LusboVdpJwrzttKqOXyvHDFlQzj7JPqzb9GSFpO6kJB09+A0XmLJoNgcUGZ7wI16GPW17YhajUPMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMPHlrpXc4G+SeRPLYGgyoi7j0pviEn7fw6E0iMDgTZUDB0XR4vHWrqwj5XLlL9d/LRzBUM3xGbe8SrxPulobJu9x3puhvaPLHzgl7DCraAUe7rv9oz8fLc63ZESgtcVluQFbANLoeGho2afvBhavct+HaD34JOVbHB6kWA1rUFmuxPm/52c5GVPlmVbYHBP85wo1/qIQjZyeyaLM9eVONZQ+OnMFSkBqgD7QWBp1mkzdAM4jQ5FR0hxySPInj21taMPGKr2C4CKA8lsQIiBYQreqPaIvuzEcN30JkD6snWj4nwvjs7vRl4I5s9t4JZEgBC2UU71woXFYkj3F/JhH7Gndbo4yEubDapMXD9U5cvyT1cJIQmh2w/FKpToBjjup0a1G+2S5IWRvDGAE=",
+    │         "type": "thinking"
+    │       },
+    │       {
+    │         "text": "Now proceeding to step 2:",
+    │         "type": "text"
+    │       },
+    │       {
+    │         "arguments": {
+    │           "lookupId": "flue-session-2026",
+    │           "query": "Braintrust Flue reasoning stream instrumentation"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "web_search",
+    │         "type": "toolCall"
+    │       }
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.operation": "skill",
-    │     "flue.session": "skill",
+    │     "flue.api": "anthropic-messages",
+    │     "flue.input_message_offset": 1,
+    │     "flue.input_mode": "delta",
+    │     "flue.model": "claude-sonnet-4-5-20250929",
+    │     "flue.provider": "anthropic",
+    │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "claude-sonnet-4-5-20250929",
+    │     "provider": "anthropic"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 161,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.0041125499999999995,
+    │     "prompt_cache_creation_tokens": 247,
+    │     "prompt_cached_tokens": 2441,
+    │     "prompt_tokens": 13,
+    │     "tokens": 2862
+    │   }
+    ├── tool:web_search [tool]
+    │   input: {
+    │     "lookupId": "flue-session-2026",
+    │     "query": "Braintrust Flue reasoning stream instrumentation"
+    │   }
+    │   output: {
+    │     "lookupId": "flue-session-2026",
+    │     "query": "Braintrust Flue reasoning stream instrumentation",
+    │     "results": [
+    │       {
+    │         "title": "Flue reasoning stream instrumentation",
+    │         "url": "https://example.test/flue/reasoning-streams"
+    │       }
+    │     ]
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "web_search",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "text": "I'll activate and run the e2e-flue-skill with the provided marker.",
-    │   │         "type": "text"
-    │   │       },
-    │   │       {
-    │   │         "arguments": {
-    │   │           "name": "e2e-flue-skill"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "activate_skill",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "anthropic-messages",
-    │   │     "flue.model": "claude-sonnet-4-5-20250929",
-    │   │     "flue.provider": "anthropic",
-    │   │     "flue.session": "skill",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "claude-sonnet-4-5-20250929",
-    │   │     "provider": "anthropic"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 80,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0018054,
-    │   │     "prompt_cache_creation_tokens": 0,
-    │   │     "prompt_cached_tokens": 1988,
-    │   │     "prompt_tokens": 3,
-    │   │     "tokens": 2071
-    │   │   }
-    │   ├── tool:activate_skill [tool]
-    │   │   input: {
-    │   │     "name": "e2e-flue-skill"
-    │   │   }
-    │   │   output: "Run the skill named \"e2e-flue-skill\".\n\n<skill_instructions>\nReturn the marker from the provided args exactly once. Output no other text.\n</skill_instructions>\n\nSupporting skill resources are available relative to this workspace skill directory but are not loaded into context unless needed:\n<skill_resources>\n- Base directory: <repo>/e2e/scenarios/flue-v1/.agents/skills/e2e-flue-skill\n- Resolve relative resource paths from this directory and read only the files you need.\n</skill_resources>"
-    │   │   metadata: {
-    │   │     "flue.session": "skill",
-    │   │     "flue.tool_name": "activate_skill",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   └── flue.turn [llm]
-    │       input: [
+    ├── flue.turn [llm]
+    │   input: [
+    │     {
+    │       "content": [
     │         {
-    │           "content": [
-    │             {
-    │               "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
+    │           "thinking": "Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2 and call web_search using this id as lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".",
+    │           "thinkingSignature": "EpsDCm4IDxgCKkBVz7apPV9h9LusboVdpJwrzttKqOXyvHDFlQzj7JPqzb9GSFpO6kJB09+A0XmLJoNgcUGZ7wI16GPW17YhajUPMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMPHlrpXc4G+SeRPLYGgyoi7j0pviEn7fw6E0iMDgTZUDB0XR4vHWrqwj5XLlL9d/LRzBUM3xGbe8SrxPulobJu9x3puhvaPLHzgl7DCraAUe7rv9oz8fLc63ZESgtcVluQFbANLoeGho2afvBhavct+HaD34JOVbHB6kWA1rUFmuxPm/52c5GVPlmVbYHBP85wo1/qIQjZyeyaLM9eVONZQ+OnMFSkBqgD7QWBp1mkzdAM4jQ5FR0hxySPInj21taMPGKr2C4CKA8lsQIiBYQreqPaIvuzEcN30JkD6snWj4nwvjs7vRl4I5s9t4JZEgBC2UU71woXFYkj3F/JhH7Gndbo4yEubDapMXD9U5cvyT1cJIQmh2w/FKpToBjjup0a1G+2S5IWRvDGAE=",
+    │           "type": "thinking"
     │         },
     │         {
-    │           "content": [
-    │             {
-    │               "text": "I'll activate and run the e2e-flue-skill with the provided marker.",
-    │               "type": "text"
-    │             },
-    │             {
-    │               "arguments": {
-    │                 "name": "e2e-flue-skill"
-    │               },
-    │               "id": "<span:1>",
-    │               "name": "activate_skill",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
+    │           "text": "Now proceeding to step 2:",
+    │           "type": "text"
     │         },
     │         {
-    │           "content": [
-    │             {
-    │               "text": "Run the skill named \"e2e-flue-skill\".\n\n<skill_instructions>\nReturn the marker from the provided args exactly once. Output no other text.\n</skill_instructions>\n\nSupporting skill resources are available relative to this workspace skill directory but are not loaded into context unless needed:\n<skill_resources>\n- Base directory: <repo>/e2e/scenarios/flue-v1/.agents/skills/e2e-flue-skill\n- Resolve relative resource paths from this directory and read only the files you need.\n</skill_resources>",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:1>",
-    │           "toolName": "activate_skill"
+    │           "arguments": {
+    │             "lookupId": "flue-session-2026",
+    │             "query": "Braintrust Flue reasoning stream instrumentation"
+    │           },
+    │           "id": "<span:1>",
+    │           "name": "web_search",
+    │           "type": "toolCall"
     │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "text": "SKILL_DONE",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+    │           "type": "text"
+    │         }
+    │       ],
+    │       "isError": false,
+    │       "role": "toolResult",
+    │       "toolCallId": "<span:1>",
+    │       "toolName": "web_search"
+    │     }
+    │   ]
+    │   output: {
+    │     "content": [
+    │       {
+    │         "thinking": "Perfect! I got the web_search results. There is one result with the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3 and call summarize_source with this URL.",
+    │         "thinkingSignature": "EpADCm4IDxgCKkCVRlKYbSv3A153B69UVt+HekGvKdqxbNq/4DCezEKdDM5cWN/r0z2jgOPsdbTmY0u/RPmEuFMkHc8McWGID3skMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMBm6HSOAplPJUgTunGgye6T2opxxCeCJtBqAiMNSQFh6SX7ifPvn3evsix9NgngOKUh0nK0kIn9+eyzpyl8WJF6hxPtI+08bsSOJ2nSrPAV1gIeY3BH8YZzKQDZwYnOHeezjZq3KKJ0mgPprk3kPGX+vWbdrwiiWmlAbRMZvg447XLOdEIJXzfuof5x8eE2cMlQiReYCBCHEfZEQxO1Zzep6kjfTL4z8ROB4+sDY0SAiQdBjHq9ASGilsZxnpfBw7FkCAzPNzpohKaP5Ix/BPijdxjtgTjafiz1jUOygRbXYXr63ZG3L1t0DaPQhCtTSGBkCFCxQerJ1C+IkizWgHIZgZc3ySwqW3HF8C+ok9appKtp6QfYzoJ8LelJrxVxgB",
+    │         "type": "thinking"
+    │       },
+    │       {
+    │         "text": "Now proceeding to step 3:",
+    │         "type": "text"
+    │       },
+    │       {
+    │         "arguments": {
+    │           "url": "https://example.test/flue/reasoning-streams"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "summarize_source",
+    │         "type": "toolCall"
     │       }
-    │       metadata: {
-    │         "flue.api": "anthropic-messages",
-    │         "flue.model": "claude-sonnet-4-5-20250929",
-    │         "flue.provider": "anthropic",
-    │         "flue.session": "skill",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "claude-sonnet-4-5-20250929",
-    │         "provider": "anthropic"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 8,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.0008094,
-    │         "prompt_cache_creation_tokens": 0,
-    │         "prompt_cached_tokens": 2248,
-    │         "prompt_tokens": 5,
-    │         "tokens": 2261
-    │       }
-    ├── flue.task [task]
-    │   input: "Reply with exactly TASK_DONE and no other text."
-    │   output: "TASK_DONE"
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.session": "task:task:<uuid:1>",
+    │     "flue.api": "anthropic-messages",
+    │     "flue.input_message_offset": 3,
+    │     "flue.input_mode": "delta",
+    │     "flue.model": "claude-sonnet-4-5-20250929",
+    │     "flue.provider": "anthropic",
+    │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "claude-sonnet-4-5-20250929",
+    │     "provider": "anthropic"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 133,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.00378165,
+    │     "prompt_cache_creation_tokens": 251,
+    │     "prompt_cached_tokens": 2688,
+    │     "prompt_tokens": 13,
+    │     "tokens": 3085
+    │   }
+    ├── tool:summarize_source [tool]
+    │   input: {
+    │     "url": "https://example.test/flue/reasoning-streams"
+    │   }
+    │   output: {
+    │     "summary": "Flue emits reasoning, tool execution, and LLM turn events separately.",
+    │     "url": "https://example.test/flue/reasoning-streams"
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "summarize_source",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   └── flue.turn [llm]
-    │       input: [
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "Reply with exactly TASK_DONE and no other text.",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
-    │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "text": "TASK_DONE",
-    │             "textSignature": "{\"v\":1,\"id\":\"msg_0ac30bf9efc812ab016a3a4a2b2e0081949b1dcbda2ddd0feb\"}",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
-    │       }
-    │       metadata: {
-    │         "flue.api": "openai-responses",
-    │         "flue.model": "gpt-4o-mini",
-    │         "flue.provider": "openai",
-    │         "flue.session": "task:task:<uuid:1>",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "gpt-4o-mini",
-    │         "provider": "openai"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 4,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.0001416,
-    │         "prompt_cache_creation_tokens": 0,
-    │         "prompt_cached_tokens": 0,
-    │         "prompt_tokens": 928,
-    │         "tokens": 932
-    │       }
-    └── flue.compact [task]
-        input: {
-          "estimatedTokens": 3197,
-          "reason": "manual"
-        }
+    └── flue.turn [llm]
+        input: [
+          {
+            "content": [
+              {
+                "thinking": "Perfect! I got the web_search results. There is one result with the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3 and call summarize_source with this URL.",
+                "thinkingSignature": "EpADCm4IDxgCKkCVRlKYbSv3A153B69UVt+HekGvKdqxbNq/4DCezEKdDM5cWN/r0z2jgOPsdbTmY0u/RPmEuFMkHc8McWGID3skMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMBm6HSOAplPJUgTunGgye6T2opxxCeCJtBqAiMNSQFh6SX7ifPvn3evsix9NgngOKUh0nK0kIn9+eyzpyl8WJF6hxPtI+08bsSOJ2nSrPAV1gIeY3BH8YZzKQDZwYnOHeezjZq3KKJ0mgPprk3kPGX+vWbdrwiiWmlAbRMZvg447XLOdEIJXzfuof5x8eE2cMlQiReYCBCHEfZEQxO1Zzep6kjfTL4z8ROB4+sDY0SAiQdBjHq9ASGilsZxnpfBw7FkCAzPNzpohKaP5Ix/BPijdxjtgTjafiz1jUOygRbXYXr63ZG3L1t0DaPQhCtTSGBkCFCxQerJ1C+IkizWgHIZgZc3ySwqW3HF8C+ok9appKtp6QfYzoJ8LelJrxVxgB",
+                "type": "thinking"
+              },
+              {
+                "text": "Now proceeding to step 3:",
+                "type": "text"
+              },
+              {
+                "arguments": {
+                  "url": "https://example.test/flue/reasoning-streams"
+                },
+                "id": "<span:1>",
+                "name": "summarize_source",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          {
+            "content": [
+              {
+                "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+                "type": "text"
+              }
+            ],
+            "isError": false,
+            "role": "toolResult",
+            "toolCallId": "<span:1>",
+            "toolName": "summarize_source"
+          }
+        ]
         output: {
-          "completed": true
+          "content": [
+            {
+              "thinking": "Great! The summarize_source call has completed successfully. According to the instructions, I should now reply with exactly \"PROMPT_DONE\" and no other text.",
+              "thinkingSignature": "Eu0CCm4IDxgCKkCBUYqhsARXFm5YQdB8B4fq/pryhtdDMyve+qLrKjJqHD3e6i8qwtMvaYLPzEs5dagCGN78HUOXUIGRyxayFLsaMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMAILMWTVVQ2iHMSjSGgxdI40CHmPXi48PMtsiMPZXJ6qruyQJiwzXWtcYT90WFodE/m3BJVrxRR5klhCMY+seUwvHBeLiFkkDO+p+tCqsAerKSHWqBpynxXrokMvGb0MlXV0rdHjUU73PONapUCT2MCvAldDS2yi1fh5HX/uiEgdVVTGIoxv3TxMbcVi+vfzf7SAwZdNL5fClFTveqEC6M2pv/3/IFeOWTqxD+t8sT5OjUumRCVPeqm9zBUe0EGvYU6dd3cO1nsvirAVaRANkjQ37a4tYiMC0wUtHuXHbXIJphun3TnJyLvUEMF5s6aDDh2/lOVAW28KRxdcYAQ==",
+              "type": "thinking"
+            },
+            {
+              "text": "PROMPT_DONE",
+              "type": "text"
+            }
+          ],
+          "role": "assistant"
         }
         metadata: {
-          "flue.operation": "compact",
+          "flue.api": "anthropic-messages",
+          "flue.input_message_offset": 5,
+          "flue.input_mode": "delta",
+          "flue.model": "claude-sonnet-4-5-20250929",
+          "flue.provider": "anthropic",
           "flue.session": "main",
-          "provider": "flue"
+          "flue.stop_reason": "stop",
+          "flue.turn_purpose": "agent",
+          "model": "claude-sonnet-4-5-20250929",
+          "provider": "anthropic"
         }
         metrics: {
-          "duration_ms": 0
+          "completion_tokens": 51,
+          "duration_ms": 0,
+          "estimated_cost": 0.0024132,
+          "prompt_cache_creation_tokens": 194,
+          "prompt_cached_tokens": 2939,
+          "prompt_tokens": 13,
+          "tokens": 3197
         }
-        └── compaction:manual [task]
-            input: {
-              "estimatedTokens": 3197,
-              "reason": "manual"
-            }
-            output: {
-              "messagesAfter": 2,
-              "messagesBefore": 8
-            }
-            metadata: {
-              "flue.compaction_reason": "manual",
-              "flue.session": "main",
-              "provider": "flue"
-            }
-            metrics: {
-              "duration_ms": 0,
-              "messages_after": 2,
-              "messages_before": 8
-            }
-            └── flue.turn [llm]
-                input: [
-                  {
-                    "content": [
-                      {
-                        "text": "<conversation>\n[User]: Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.\n\n[Assistant thinking]: The user wants me to complete an instrumented research flow with specific steps:\n1. Call lookup with query \"flue instrumentation\"\n2. Use the lookup result id to call web_search with query \"Braintrust Flue reasoning stream instrumentation\"\n3. Use the first web_search result url to call summarize_source\n4. After that, reply with exactly \"PROMPT_DONE\" and no other text\n\nI need to call exactly one tool per turn and wait for each result. Let me start with step 1.\n\n[Assistant]: I'll complete this instrumented research flow step by step. Starting with step 1:\n\n[Assistant tool calls]: lookup(query=\"flue instrumentation\")\n\n[Tool result]: {\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}\n\n[Assistant thinking]: Good, I got the lookup result with id \"flue-session-2026\". Now I need to proceed to step 2 and call web_search using this id as lookupId and the query \"Braintrust Flue reasoning stream instrumentation\".\n\n[Assistant]: Now proceeding to step 2:\n\n[Assistant tool calls]: web_search(lookupId=\"flue-session-2026\", query=\"Braintrust Flue reasoning stream instrumentation\")\n\n[Tool result]: {\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}\n\n[Assistant thinking]: Perfect! I got the web_search results. There is one result with the URL \"https://example.test/flue/reasoning-streams\". Now I need to proceed to step 3 and call summarize_source with this URL.\n\n[Assistant]: Now proceeding to step 3:\n\n[Assistant tool calls]: summarize_source(url=\"https://example.test/flue/reasoning-streams\")\n\n[Tool result]: {\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}\n</conversation>\n\nThis is the PREFIX of a turn that was too large to keep. The SUFFIX (recent work) is retained.\n\nSummarize the prefix to provide context for the retained suffix:\n\n## Original Request\n[What did the user ask for in this turn?]\n\n## Early Progress\n- [Key decisions and work done in the prefix]\n\n## Context for Suffix\n- [Information needed to understand the retained recent work]\n\nBe concise. Focus on what's needed to understand the kept suffix.",
-                        "type": "text"
-                      }
-                    ],
-                    "role": "user"
-                  }
-                ]
-                output: {
-                  "content": [
-                    {
-                      "text": "## Original Request\nThe user asked to complete a step-by-step instrumented research flow involving calls to lookup, web_search, and summarize_source tools, concluding with",
-                      "textSignature": "{\"v\":1,\"id\":\"msg_052d8873d6fcd89e016a3a4a2c06588194ad13515f66cac040\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "assistant"
-                }
-                metadata: {
-                  "flue.api": "openai-responses",
-                  "flue.model": "gpt-4o-mini",
-                  "flue.provider": "openai",
-                  "flue.session": "main",
-                  "flue.stop_reason": "stop",
-                  "flue.turn_purpose": "compaction_prefix",
-                  "model": "gpt-4o-mini",
-                  "provider": "openai"
-                }
-                metrics: {
-                  "completion_tokens": 0,
-                  "duration_ms": 0,
-                  "estimated_cost": 0,
-                  "prompt_cache_creation_tokens": 0,
-                  "prompt_cached_tokens": 0,
-                  "prompt_tokens": 0,
-                  "tokens": 0
-                }

--- a/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v1-latest-explicit.span-tree.json
+++ b/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v1-latest-explicit.span-tree.json
@@ -13,471 +13,6 @@
           }
         },
         {
-          "name": "flue.prompt",
-          "type": "task",
-          "children": [
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "thinking": "",
-                    "thinkingSignature": "{\"id\":\"rs_0f853fd4725c6abf016a705b77390081a288d115472f015631\",\"type\":\"reasoning\",\"content\":[],\"encrypted_content\":\"gAAAAABqcFt3puS3Bq2NJT6919lM43Dt2mcGVnW8d9pkTbZRTb0BpEdGQq-D__0GELauHW3Nv0KIYSHYvz7MJ5rd7sDesAFdfBjIzg6WheoB_qvcv9YJCQlG5rbRnQUOo8EeNn3xpVU2TnKQX2bFX-hqDIEr8gzeHzbzlyRkJ_As84geW8IgU7NEIDA0z_Up0Ud5WVPHgtnzkZ5PQiPdf0MBUX-PQ4r53y30Jg9dJulRqQR9nOZvp_okxIyD9I9mCwFeImbvLFpx2bs8ozMh346RUg-e-hub9xXbe7OeXvZ1XUWW5Q7RjCPTdbJ15dRBPogZ4iuqhN7sYeBei0AqYSKeA3vVchAaKM1Wpprub60TM_VPirl9SI2m1atxgGyy2BzPnswV4xGDhkx9XS_eN1eufO4pNRsBmNxg2ULSY001V7KU8FxjxN8ATRNOAbI7SqwDK5UUz55lCvowH4CX5gn8dRHuU9tVJHWdVe2NHiurWmnWWTtfGb_baV7qJJfWE71g-LaJjgTGqUR8DaF7Sz3jr82FCo4A14mvLuZTaeRQ5mj4fUwdMjwruaoOmpoUMnZ-HhduddsiMUF5TVl9VFFAs8yLun5oRBRpUvbgqix8J-erBApMtcsi_DzQkq24k7k7HXGIp1h9CC0RTrJ-R1ji_OuEbEL64xdqfndSGwh5tr5zmsvgNLOqvghow3NU7ZQl5_AUzi-0BrHrq0SowgNmZxoVoNfRHpnUZ5nUkW-Yp1Juz-0nI5WXZiPlSFalsQOb46NPLlXUtY98YmHP6telw_BJL6_EYBhB12GaiERBSrmzArZO0Tbf6oyl6W_ug8w45bQ_vduXuMPOLqfBHiIizO2Xv_7YTTeyosQUV9u25ooudI4v03pHJHLLVmmf_ld8R91-SkIP5iPHQXjIGpEczgWPxafev4PgsDTb-L5zEnuQoALfwK0CJAzUHORGJIttRIK63JoDvt6jaUNZJ0uSwYWu2JrR5u4RrIOW7fH4tpsOQ4MflVUNrWtSacG_QKqNIC9tz7nbCwC0VIdmSloCt8XUo5uOpA==\",\"summary\":[]}",
-                    "type": "thinking"
-                  },
-                  {
-                    "arguments": {
-                      "query": "flue instrumentation"
-                    },
-                    "id": "<span:1>",
-                    "name": "lookup",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "openai-responses",
-                "flue.model": "gpt-5.4-nano",
-                "flue.provider": "openai",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "gpt-5.4-nano",
-                "provider": "openai"
-              },
-              "metrics": {
-                "completion_tokens": 41,
-                "duration_ms": 0,
-                "estimated_cost": 0.00026885000000000006,
-                "prompt_cache_creation_tokens": 0,
-                "prompt_cached_tokens": 0,
-                "prompt_tokens": 1088,
-                "tokens": 1129
-              }
-            },
-            {
-              "name": "tool:lookup",
-              "type": "tool",
-              "children": [
-                {
-                  "name": "flue.toolCurrentProbe",
-                  "children": [],
-                  "output": "lookup-active",
-                  "metadata": {
-                    "scenario": "flue-instrumentation"
-                  }
-                }
-              ],
-              "input": {
-                "query": "flue instrumentation"
-              },
-              "output": {
-                "id": "<span:1>",
-                "query": "flue instrumentation",
-                "topic": "session instrumentation"
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "lookup",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "",
-                      "thinkingSignature": "{\"id\":\"rs_0f853fd4725c6abf016a705b77390081a288d115472f015631\",\"type\":\"reasoning\",\"content\":[],\"encrypted_content\":\"gAAAAABqcFt3puS3Bq2NJT6919lM43Dt2mcGVnW8d9pkTbZRTb0BpEdGQq-D__0GELauHW3Nv0KIYSHYvz7MJ5rd7sDesAFdfBjIzg6WheoB_qvcv9YJCQlG5rbRnQUOo8EeNn3xpVU2TnKQX2bFX-hqDIEr8gzeHzbzlyRkJ_As84geW8IgU7NEIDA0z_Up0Ud5WVPHgtnzkZ5PQiPdf0MBUX-PQ4r53y30Jg9dJulRqQR9nOZvp_okxIyD9I9mCwFeImbvLFpx2bs8ozMh346RUg-e-hub9xXbe7OeXvZ1XUWW5Q7RjCPTdbJ15dRBPogZ4iuqhN7sYeBei0AqYSKeA3vVchAaKM1Wpprub60TM_VPirl9SI2m1atxgGyy2BzPnswV4xGDhkx9XS_eN1eufO4pNRsBmNxg2ULSY001V7KU8FxjxN8ATRNOAbI7SqwDK5UUz55lCvowH4CX5gn8dRHuU9tVJHWdVe2NHiurWmnWWTtfGb_baV7qJJfWE71g-LaJjgTGqUR8DaF7Sz3jr82FCo4A14mvLuZTaeRQ5mj4fUwdMjwruaoOmpoUMnZ-HhduddsiMUF5TVl9VFFAs8yLun5oRBRpUvbgqix8J-erBApMtcsi_DzQkq24k7k7HXGIp1h9CC0RTrJ-R1ji_OuEbEL64xdqfndSGwh5tr5zmsvgNLOqvghow3NU7ZQl5_AUzi-0BrHrq0SowgNmZxoVoNfRHpnUZ5nUkW-Yp1Juz-0nI5WXZiPlSFalsQOb46NPLlXUtY98YmHP6telw_BJL6_EYBhB12GaiERBSrmzArZO0Tbf6oyl6W_ug8w45bQ_vduXuMPOLqfBHiIizO2Xv_7YTTeyosQUV9u25ooudI4v03pHJHLLVmmf_ld8R91-SkIP5iPHQXjIGpEczgWPxafev4PgsDTb-L5zEnuQoALfwK0CJAzUHORGJIttRIK63JoDvt6jaUNZJ0uSwYWu2JrR5u4RrIOW7fH4tpsOQ4MflVUNrWtSacG_QKqNIC9tz7nbCwC0VIdmSloCt8XUo5uOpA==\",\"summary\":[]}",
-                      "type": "thinking"
-                    },
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "arguments": {
-                      "lookupId": "flue-session-2026",
-                      "query": "Braintrust Flue reasoning stream instrumentation"
-                    },
-                    "id": "<span:1>",
-                    "name": "web_search",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "openai-responses",
-                "flue.model": "gpt-5.4-nano",
-                "flue.provider": "openai",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "gpt-5.4-nano",
-                "provider": "openai"
-              },
-              "metrics": {
-                "completion_tokens": 34,
-                "duration_ms": 0,
-                "estimated_cost": 0.0002749,
-                "prompt_cache_creation_tokens": 0,
-                "prompt_cached_tokens": 0,
-                "prompt_tokens": 1162,
-                "tokens": 1196
-              }
-            },
-            {
-              "name": "tool:web_search",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "lookupId": "flue-session-2026",
-                "query": "Braintrust Flue reasoning stream instrumentation"
-              },
-              "output": {
-                "lookupId": "flue-session-2026",
-                "query": "Braintrust Flue reasoning stream instrumentation",
-                "results": [
-                  {
-                    "title": "Flue reasoning stream instrumentation",
-                    "url": "https://example.test/flue/reasoning-streams"
-                  }
-                ]
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "web_search",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "",
-                      "thinkingSignature": "{\"id\":\"rs_0f853fd4725c6abf016a705b77390081a288d115472f015631\",\"type\":\"reasoning\",\"content\":[],\"encrypted_content\":\"gAAAAABqcFt3puS3Bq2NJT6919lM43Dt2mcGVnW8d9pkTbZRTb0BpEdGQq-D__0GELauHW3Nv0KIYSHYvz7MJ5rd7sDesAFdfBjIzg6WheoB_qvcv9YJCQlG5rbRnQUOo8EeNn3xpVU2TnKQX2bFX-hqDIEr8gzeHzbzlyRkJ_As84geW8IgU7NEIDA0z_Up0Ud5WVPHgtnzkZ5PQiPdf0MBUX-PQ4r53y30Jg9dJulRqQR9nOZvp_okxIyD9I9mCwFeImbvLFpx2bs8ozMh346RUg-e-hub9xXbe7OeXvZ1XUWW5Q7RjCPTdbJ15dRBPogZ4iuqhN7sYeBei0AqYSKeA3vVchAaKM1Wpprub60TM_VPirl9SI2m1atxgGyy2BzPnswV4xGDhkx9XS_eN1eufO4pNRsBmNxg2ULSY001V7KU8FxjxN8ATRNOAbI7SqwDK5UUz55lCvowH4CX5gn8dRHuU9tVJHWdVe2NHiurWmnWWTtfGb_baV7qJJfWE71g-LaJjgTGqUR8DaF7Sz3jr82FCo4A14mvLuZTaeRQ5mj4fUwdMjwruaoOmpoUMnZ-HhduddsiMUF5TVl9VFFAs8yLun5oRBRpUvbgqix8J-erBApMtcsi_DzQkq24k7k7HXGIp1h9CC0RTrJ-R1ji_OuEbEL64xdqfndSGwh5tr5zmsvgNLOqvghow3NU7ZQl5_AUzi-0BrHrq0SowgNmZxoVoNfRHpnUZ5nUkW-Yp1Juz-0nI5WXZiPlSFalsQOb46NPLlXUtY98YmHP6telw_BJL6_EYBhB12GaiERBSrmzArZO0Tbf6oyl6W_ug8w45bQ_vduXuMPOLqfBHiIizO2Xv_7YTTeyosQUV9u25ooudI4v03pHJHLLVmmf_ld8R91-SkIP5iPHQXjIGpEczgWPxafev4PgsDTb-L5zEnuQoALfwK0CJAzUHORGJIttRIK63JoDvt6jaUNZJ0uSwYWu2JrR5u4RrIOW7fH4tpsOQ4MflVUNrWtSacG_QKqNIC9tz7nbCwC0VIdmSloCt8XUo5uOpA==\",\"summary\":[]}",
-                      "type": "thinking"
-                    },
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                },
-                {
-                  "content": [
-                    {
-                      "arguments": {
-                        "lookupId": "flue-session-2026",
-                        "query": "Braintrust Flue reasoning stream instrumentation"
-                      },
-                      "id": "<span:2>",
-                      "name": "web_search",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:2>",
-                  "toolName": "web_search"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "arguments": {
-                      "url": "https://example.test/flue/reasoning-streams"
-                    },
-                    "id": "<span:1>",
-                    "name": "summarize_source",
-                    "type": "toolCall"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "openai-responses",
-                "flue.model": "gpt-5.4-nano",
-                "flue.provider": "openai",
-                "flue.session": "main",
-                "flue.stop_reason": "toolUse",
-                "flue.turn_purpose": "agent",
-                "model": "gpt-5.4-nano",
-                "provider": "openai"
-              },
-              "metrics": {
-                "completion_tokens": 30,
-                "duration_ms": 0,
-                "estimated_cost": 0.00028890000000000003,
-                "prompt_cache_creation_tokens": 0,
-                "prompt_cached_tokens": 0,
-                "prompt_tokens": 1257,
-                "tokens": 1287
-              }
-            },
-            {
-              "name": "tool:summarize_source",
-              "type": "tool",
-              "children": [],
-              "input": {
-                "url": "https://example.test/flue/reasoning-streams"
-              },
-              "output": {
-                "summary": "Flue emits reasoning, tool execution, and LLM turn events separately.",
-                "url": "https://example.test/flue/reasoning-streams"
-              },
-              "metadata": {
-                "flue.session": "main",
-                "flue.tool_name": "summarize_source",
-                "provider": "flue"
-              },
-              "metrics": {
-                "duration_ms": 0
-              }
-            },
-            {
-              "name": "flue.turn",
-              "type": "llm",
-              "children": [],
-              "input": [
-                {
-                  "content": [
-                    {
-                      "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "user"
-                },
-                {
-                  "content": [
-                    {
-                      "thinking": "",
-                      "thinkingSignature": "{\"id\":\"rs_0f853fd4725c6abf016a705b77390081a288d115472f015631\",\"type\":\"reasoning\",\"content\":[],\"encrypted_content\":\"gAAAAABqcFt3puS3Bq2NJT6919lM43Dt2mcGVnW8d9pkTbZRTb0BpEdGQq-D__0GELauHW3Nv0KIYSHYvz7MJ5rd7sDesAFdfBjIzg6WheoB_qvcv9YJCQlG5rbRnQUOo8EeNn3xpVU2TnKQX2bFX-hqDIEr8gzeHzbzlyRkJ_As84geW8IgU7NEIDA0z_Up0Ud5WVPHgtnzkZ5PQiPdf0MBUX-PQ4r53y30Jg9dJulRqQR9nOZvp_okxIyD9I9mCwFeImbvLFpx2bs8ozMh346RUg-e-hub9xXbe7OeXvZ1XUWW5Q7RjCPTdbJ15dRBPogZ4iuqhN7sYeBei0AqYSKeA3vVchAaKM1Wpprub60TM_VPirl9SI2m1atxgGyy2BzPnswV4xGDhkx9XS_eN1eufO4pNRsBmNxg2ULSY001V7KU8FxjxN8ATRNOAbI7SqwDK5UUz55lCvowH4CX5gn8dRHuU9tVJHWdVe2NHiurWmnWWTtfGb_baV7qJJfWE71g-LaJjgTGqUR8DaF7Sz3jr82FCo4A14mvLuZTaeRQ5mj4fUwdMjwruaoOmpoUMnZ-HhduddsiMUF5TVl9VFFAs8yLun5oRBRpUvbgqix8J-erBApMtcsi_DzQkq24k7k7HXGIp1h9CC0RTrJ-R1ji_OuEbEL64xdqfndSGwh5tr5zmsvgNLOqvghow3NU7ZQl5_AUzi-0BrHrq0SowgNmZxoVoNfRHpnUZ5nUkW-Yp1Juz-0nI5WXZiPlSFalsQOb46NPLlXUtY98YmHP6telw_BJL6_EYBhB12GaiERBSrmzArZO0Tbf6oyl6W_ug8w45bQ_vduXuMPOLqfBHiIizO2Xv_7YTTeyosQUV9u25ooudI4v03pHJHLLVmmf_ld8R91-SkIP5iPHQXjIGpEczgWPxafev4PgsDTb-L5zEnuQoALfwK0CJAzUHORGJIttRIK63JoDvt6jaUNZJ0uSwYWu2JrR5u4RrIOW7fH4tpsOQ4MflVUNrWtSacG_QKqNIC9tz7nbCwC0VIdmSloCt8XUo5uOpA==\",\"summary\":[]}",
-                      "type": "thinking"
-                    },
-                    {
-                      "arguments": {
-                        "query": "flue instrumentation"
-                      },
-                      "id": "<span:1>",
-                      "name": "lookup",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:1>",
-                  "toolName": "lookup"
-                },
-                {
-                  "content": [
-                    {
-                      "arguments": {
-                        "lookupId": "flue-session-2026",
-                        "query": "Braintrust Flue reasoning stream instrumentation"
-                      },
-                      "id": "<span:2>",
-                      "name": "web_search",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:2>",
-                  "toolName": "web_search"
-                },
-                {
-                  "content": [
-                    {
-                      "arguments": {
-                        "url": "https://example.test/flue/reasoning-streams"
-                      },
-                      "id": "<span:3>",
-                      "name": "summarize_source",
-                      "type": "toolCall"
-                    }
-                  ],
-                  "role": "assistant"
-                },
-                {
-                  "content": [
-                    {
-                      "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "isError": false,
-                  "role": "toolResult",
-                  "toolCallId": "<span:3>",
-                  "toolName": "summarize_source"
-                }
-              ],
-              "output": {
-                "content": [
-                  {
-                    "text": "PROMPT_DONE",
-                    "textSignature": "{\"v\":1,\"id\":\"msg_0f853fd4725c6abf016a705b79c4b881a286d3e4b2799b2c66\",\"phase\":\"final_answer\"}",
-                    "type": "text"
-                  }
-                ],
-                "role": "assistant"
-              },
-              "metadata": {
-                "flue.api": "openai-responses",
-                "flue.model": "gpt-5.4-nano",
-                "flue.provider": "openai",
-                "flue.session": "main",
-                "flue.stop_reason": "stop",
-                "flue.turn_purpose": "agent",
-                "model": "gpt-5.4-nano",
-                "provider": "openai"
-              },
-              "metrics": {
-                "completion_tokens": 7,
-                "duration_ms": 0,
-                "estimated_cost": 0.00027595000000000007,
-                "prompt_cache_creation_tokens": 0,
-                "prompt_cached_tokens": 0,
-                "prompt_tokens": 1336,
-                "tokens": 1343
-              }
-            }
-          ],
-          "input": [
-            {
-              "content": [
-                {
-                  "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-                  "type": "text"
-                }
-              ],
-              "role": "user"
-            }
-          ],
-          "output": "PROMPT_DONE",
-          "metadata": {
-            "flue.operation": "prompt",
-            "flue.session": "main",
-            "provider": "flue"
-          },
-          "metrics": {
-            "duration_ms": 0
-          }
-        },
-        {
           "name": "flue.skill",
           "type": "task",
           "children": [
@@ -632,7 +167,9 @@
           "metadata": {
             "flue.operation": "skill",
             "flue.session": "skill",
-            "provider": "flue"
+            "flue.workflow_name": "instrumentation",
+            "provider": "flue",
+            "scenario": "flue-instrumentation"
           },
           "metrics": {
             "duration_ms": 0
@@ -669,6 +206,7 @@
               },
               "metadata": {
                 "flue.api": "openai-responses",
+                "flue.input_mode": "full",
                 "flue.model": "gpt-4o-mini",
                 "flue.provider": "openai",
                 "flue.session": "task:task:<uuid:1>",
@@ -782,7 +320,9 @@
           "metadata": {
             "flue.operation": "compact",
             "flue.session": "main",
-            "provider": "flue"
+            "flue.workflow_name": "instrumentation",
+            "provider": "flue",
+            "scenario": "flue-instrumentation"
           },
           "metrics": {
             "duration_ms": 0
@@ -801,6 +341,367 @@
         "status": "done"
       },
       "metadata": {
+        "flue.workflow_name": "instrumentation",
+        "provider": "flue",
+        "scenario": "flue-instrumentation"
+      },
+      "metrics": {
+        "duration_ms": 0
+      }
+    },
+    {
+      "name": "flue.prompt",
+      "type": "task",
+      "children": [
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+                  "type": "text"
+                }
+              ],
+              "role": "user"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "thinking": "",
+                "thinkingSignature": "{\"id\":\"rs_0f853fd4725c6abf016a705b77390081a288d115472f015631\",\"type\":\"reasoning\",\"content\":[],\"encrypted_content\":\"gAAAAABqcFt3puS3Bq2NJT6919lM43Dt2mcGVnW8d9pkTbZRTb0BpEdGQq-D__0GELauHW3Nv0KIYSHYvz7MJ5rd7sDesAFdfBjIzg6WheoB_qvcv9YJCQlG5rbRnQUOo8EeNn3xpVU2TnKQX2bFX-hqDIEr8gzeHzbzlyRkJ_As84geW8IgU7NEIDA0z_Up0Ud5WVPHgtnzkZ5PQiPdf0MBUX-PQ4r53y30Jg9dJulRqQR9nOZvp_okxIyD9I9mCwFeImbvLFpx2bs8ozMh346RUg-e-hub9xXbe7OeXvZ1XUWW5Q7RjCPTdbJ15dRBPogZ4iuqhN7sYeBei0AqYSKeA3vVchAaKM1Wpprub60TM_VPirl9SI2m1atxgGyy2BzPnswV4xGDhkx9XS_eN1eufO4pNRsBmNxg2ULSY001V7KU8FxjxN8ATRNOAbI7SqwDK5UUz55lCvowH4CX5gn8dRHuU9tVJHWdVe2NHiurWmnWWTtfGb_baV7qJJfWE71g-LaJjgTGqUR8DaF7Sz3jr82FCo4A14mvLuZTaeRQ5mj4fUwdMjwruaoOmpoUMnZ-HhduddsiMUF5TVl9VFFAs8yLun5oRBRpUvbgqix8J-erBApMtcsi_DzQkq24k7k7HXGIp1h9CC0RTrJ-R1ji_OuEbEL64xdqfndSGwh5tr5zmsvgNLOqvghow3NU7ZQl5_AUzi-0BrHrq0SowgNmZxoVoNfRHpnUZ5nUkW-Yp1Juz-0nI5WXZiPlSFalsQOb46NPLlXUtY98YmHP6telw_BJL6_EYBhB12GaiERBSrmzArZO0Tbf6oyl6W_ug8w45bQ_vduXuMPOLqfBHiIizO2Xv_7YTTeyosQUV9u25ooudI4v03pHJHLLVmmf_ld8R91-SkIP5iPHQXjIGpEczgWPxafev4PgsDTb-L5zEnuQoALfwK0CJAzUHORGJIttRIK63JoDvt6jaUNZJ0uSwYWu2JrR5u4RrIOW7fH4tpsOQ4MflVUNrWtSacG_QKqNIC9tz7nbCwC0VIdmSloCt8XUo5uOpA==\",\"summary\":[]}",
+                "type": "thinking"
+              },
+              {
+                "arguments": {
+                  "query": "flue instrumentation"
+                },
+                "id": "<span:1>",
+                "name": "lookup",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "openai-responses",
+            "flue.input_mode": "full",
+            "flue.model": "gpt-5.4-nano",
+            "flue.provider": "openai",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "gpt-5.4-nano",
+            "provider": "openai"
+          },
+          "metrics": {
+            "completion_tokens": 41,
+            "duration_ms": 0,
+            "estimated_cost": 0.00026885000000000006,
+            "prompt_cache_creation_tokens": 0,
+            "prompt_cached_tokens": 0,
+            "prompt_tokens": 1088,
+            "tokens": 1129
+          }
+        },
+        {
+          "name": "tool:lookup",
+          "type": "tool",
+          "children": [
+            {
+              "name": "flue.toolCurrentProbe",
+              "children": [],
+              "output": "lookup-active",
+              "metadata": {
+                "scenario": "flue-instrumentation"
+              }
+            }
+          ],
+          "input": {
+            "query": "flue instrumentation"
+          },
+          "output": {
+            "id": "<span:1>",
+            "query": "flue instrumentation",
+            "topic": "session instrumentation"
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "lookup",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "thinking": "",
+                  "thinkingSignature": "{\"id\":\"rs_0f853fd4725c6abf016a705b77390081a288d115472f015631\",\"type\":\"reasoning\",\"content\":[],\"encrypted_content\":\"gAAAAABqcFt3puS3Bq2NJT6919lM43Dt2mcGVnW8d9pkTbZRTb0BpEdGQq-D__0GELauHW3Nv0KIYSHYvz7MJ5rd7sDesAFdfBjIzg6WheoB_qvcv9YJCQlG5rbRnQUOo8EeNn3xpVU2TnKQX2bFX-hqDIEr8gzeHzbzlyRkJ_As84geW8IgU7NEIDA0z_Up0Ud5WVPHgtnzkZ5PQiPdf0MBUX-PQ4r53y30Jg9dJulRqQR9nOZvp_okxIyD9I9mCwFeImbvLFpx2bs8ozMh346RUg-e-hub9xXbe7OeXvZ1XUWW5Q7RjCPTdbJ15dRBPogZ4iuqhN7sYeBei0AqYSKeA3vVchAaKM1Wpprub60TM_VPirl9SI2m1atxgGyy2BzPnswV4xGDhkx9XS_eN1eufO4pNRsBmNxg2ULSY001V7KU8FxjxN8ATRNOAbI7SqwDK5UUz55lCvowH4CX5gn8dRHuU9tVJHWdVe2NHiurWmnWWTtfGb_baV7qJJfWE71g-LaJjgTGqUR8DaF7Sz3jr82FCo4A14mvLuZTaeRQ5mj4fUwdMjwruaoOmpoUMnZ-HhduddsiMUF5TVl9VFFAs8yLun5oRBRpUvbgqix8J-erBApMtcsi_DzQkq24k7k7HXGIp1h9CC0RTrJ-R1ji_OuEbEL64xdqfndSGwh5tr5zmsvgNLOqvghow3NU7ZQl5_AUzi-0BrHrq0SowgNmZxoVoNfRHpnUZ5nUkW-Yp1Juz-0nI5WXZiPlSFalsQOb46NPLlXUtY98YmHP6telw_BJL6_EYBhB12GaiERBSrmzArZO0Tbf6oyl6W_ug8w45bQ_vduXuMPOLqfBHiIizO2Xv_7YTTeyosQUV9u25ooudI4v03pHJHLLVmmf_ld8R91-SkIP5iPHQXjIGpEczgWPxafev4PgsDTb-L5zEnuQoALfwK0CJAzUHORGJIttRIK63JoDvt6jaUNZJ0uSwYWu2JrR5u4RrIOW7fH4tpsOQ4MflVUNrWtSacG_QKqNIC9tz7nbCwC0VIdmSloCt8XUo5uOpA==\",\"summary\":[]}",
+                  "type": "thinking"
+                },
+                {
+                  "arguments": {
+                    "query": "flue instrumentation"
+                  },
+                  "id": "<span:1>",
+                  "name": "lookup",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "lookup"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "arguments": {
+                  "lookupId": "flue-session-2026",
+                  "query": "Braintrust Flue reasoning stream instrumentation"
+                },
+                "id": "<span:1>",
+                "name": "web_search",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "openai-responses",
+            "flue.input_message_offset": 1,
+            "flue.input_mode": "delta",
+            "flue.model": "gpt-5.4-nano",
+            "flue.provider": "openai",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "gpt-5.4-nano",
+            "provider": "openai"
+          },
+          "metrics": {
+            "completion_tokens": 34,
+            "duration_ms": 0,
+            "estimated_cost": 0.0002749,
+            "prompt_cache_creation_tokens": 0,
+            "prompt_cached_tokens": 0,
+            "prompt_tokens": 1162,
+            "tokens": 1196
+          }
+        },
+        {
+          "name": "tool:web_search",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "lookupId": "flue-session-2026",
+            "query": "Braintrust Flue reasoning stream instrumentation"
+          },
+          "output": {
+            "lookupId": "flue-session-2026",
+            "query": "Braintrust Flue reasoning stream instrumentation",
+            "results": [
+              {
+                "title": "Flue reasoning stream instrumentation",
+                "url": "https://example.test/flue/reasoning-streams"
+              }
+            ]
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "web_search",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "arguments": {
+                    "lookupId": "flue-session-2026",
+                    "query": "Braintrust Flue reasoning stream instrumentation"
+                  },
+                  "id": "<span:1>",
+                  "name": "web_search",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "web_search"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "arguments": {
+                  "url": "https://example.test/flue/reasoning-streams"
+                },
+                "id": "<span:1>",
+                "name": "summarize_source",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "openai-responses",
+            "flue.input_message_offset": 3,
+            "flue.input_mode": "delta",
+            "flue.model": "gpt-5.4-nano",
+            "flue.provider": "openai",
+            "flue.session": "main",
+            "flue.stop_reason": "toolUse",
+            "flue.turn_purpose": "agent",
+            "model": "gpt-5.4-nano",
+            "provider": "openai"
+          },
+          "metrics": {
+            "completion_tokens": 30,
+            "duration_ms": 0,
+            "estimated_cost": 0.00028890000000000003,
+            "prompt_cache_creation_tokens": 0,
+            "prompt_cached_tokens": 0,
+            "prompt_tokens": 1257,
+            "tokens": 1287
+          }
+        },
+        {
+          "name": "tool:summarize_source",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "url": "https://example.test/flue/reasoning-streams"
+          },
+          "output": {
+            "summary": "Flue emits reasoning, tool execution, and LLM turn events separately.",
+            "url": "https://example.test/flue/reasoning-streams"
+          },
+          "metadata": {
+            "flue.session": "main",
+            "flue.tool_name": "summarize_source",
+            "provider": "flue"
+          },
+          "metrics": {
+            "duration_ms": 0
+          }
+        },
+        {
+          "name": "flue.turn",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": [
+                {
+                  "arguments": {
+                    "url": "https://example.test/flue/reasoning-streams"
+                  },
+                  "id": "<span:1>",
+                  "name": "summarize_source",
+                  "type": "toolCall"
+                }
+              ],
+              "role": "assistant"
+            },
+            {
+              "content": [
+                {
+                  "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+                  "type": "text"
+                }
+              ],
+              "isError": false,
+              "role": "toolResult",
+              "toolCallId": "<span:1>",
+              "toolName": "summarize_source"
+            }
+          ],
+          "output": {
+            "content": [
+              {
+                "text": "PROMPT_DONE",
+                "textSignature": "{\"v\":1,\"id\":\"msg_0f853fd4725c6abf016a705b79c4b881a286d3e4b2799b2c66\",\"phase\":\"final_answer\"}",
+                "type": "text"
+              }
+            ],
+            "role": "assistant"
+          },
+          "metadata": {
+            "flue.api": "openai-responses",
+            "flue.input_message_offset": 5,
+            "flue.input_mode": "delta",
+            "flue.model": "gpt-5.4-nano",
+            "flue.provider": "openai",
+            "flue.session": "main",
+            "flue.stop_reason": "stop",
+            "flue.turn_purpose": "agent",
+            "model": "gpt-5.4-nano",
+            "provider": "openai"
+          },
+          "metrics": {
+            "completion_tokens": 7,
+            "duration_ms": 0,
+            "estimated_cost": 0.00027595000000000007,
+            "prompt_cache_creation_tokens": 0,
+            "prompt_cached_tokens": 0,
+            "prompt_tokens": 1336,
+            "tokens": 1343
+          }
+        }
+      ],
+      "input": [
+        {
+          "content": [
+            {
+              "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+              "type": "text"
+            }
+          ],
+          "role": "user"
+        }
+      ],
+      "output": "PROMPT_DONE",
+      "metadata": {
+        "flue.operation": "prompt",
+        "flue.session": "main",
         "flue.workflow_name": "instrumentation",
         "provider": "flue",
         "scenario": "flue-instrumentation"

--- a/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v1-latest-explicit.span-tree.txt
+++ b/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v1-latest-explicit.span-tree.txt
@@ -1,17 +1,321 @@
 span_tree:
-└── workflow:instrumentation [task]
-    input: {
-      "metadata": {
-        "scenario": "flue-instrumentation",
-        "testRunId": "<run:1>"
-      },
-      "scenario": "flue-instrumentation"
-    }
-    output: {
-      "scenario": "flue-instrumentation",
-      "status": "done"
-    }
+├── workflow:instrumentation [task]
+│   input: {
+│     "metadata": {
+│       "scenario": "flue-instrumentation",
+│       "testRunId": "<run:1>"
+│     },
+│     "scenario": "flue-instrumentation"
+│   }
+│   output: {
+│     "scenario": "flue-instrumentation",
+│     "status": "done"
+│   }
+│   metadata: {
+│     "flue.workflow_name": "instrumentation",
+│     "provider": "flue",
+│     "scenario": "flue-instrumentation"
+│   }
+│   metrics: {
+│     "duration_ms": 0
+│   }
+│   ├── flue.workflowCurrentProbe
+│   │   output: "active"
+│   │   metadata: {
+│   │     "scenario": "flue-instrumentation"
+│   │   }
+│   ├── flue.skill [task]
+│   │   input: [
+│   │     {
+│   │       "content": [
+│   │         {
+│   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │           "type": "text"
+│   │         }
+│   │       ],
+│   │       "role": "user"
+│   │     }
+│   │   ]
+│   │   output: "SKILL_DONE"
+│   │   metadata: {
+│   │     "flue.operation": "skill",
+│   │     "flue.session": "skill",
+│   │     "flue.workflow_name": "instrumentation",
+│   │     "provider": "flue",
+│   │     "scenario": "flue-instrumentation"
+│   │   }
+│   │   metrics: {
+│   │     "duration_ms": 0
+│   │   }
+│   │   ├── flue.turn [llm]
+│   │   │   input: [
+│   │   │     {
+│   │   │       "content": [
+│   │   │         {
+│   │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │   │           "type": "text"
+│   │   │         }
+│   │   │       ],
+│   │   │       "role": "user"
+│   │   │     }
+│   │   │   ]
+│   │   │   output: {
+│   │   │     "content": [
+│   │   │       {
+│   │   │         "arguments": {
+│   │   │           "name": "e2e-flue-skill"
+│   │   │         },
+│   │   │         "id": "<span:1>",
+│   │   │         "name": "activate_skill",
+│   │   │         "type": "toolCall"
+│   │   │       }
+│   │   │     ],
+│   │   │     "role": "assistant"
+│   │   │   }
+│   │   │   metadata: {
+│   │   │     "flue.api": "openai-responses",
+│   │   │     "flue.model": "gpt-5.4-nano",
+│   │   │     "flue.provider": "openai",
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.stop_reason": "toolUse",
+│   │   │     "flue.turn_purpose": "agent",
+│   │   │     "model": "gpt-5.4-nano",
+│   │   │     "provider": "openai"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "completion_tokens": 24,
+│   │   │     "duration_ms": 0,
+│   │   │     "estimated_cost": 0.00021600000000000002,
+│   │   │     "prompt_cache_creation_tokens": 0,
+│   │   │     "prompt_cached_tokens": 0,
+│   │   │     "prompt_tokens": 930,
+│   │   │     "tokens": 954
+│   │   │   }
+│   │   ├── tool:activate_skill [tool]
+│   │   │   input: {
+│   │   │     "name": "e2e-flue-skill"
+│   │   │   }
+│   │   │   output: "Run the skill named \"e2e-flue-skill\".\n\n<skill_instructions>\nReturn the marker from the provided args exactly once. Output no other text.\n</skill_instructions>\n\nSupporting skill resources are available relative to this workspace skill directory but are not loaded into context unless needed:\n<skill_resources>\n- Base directory: <repo>/e2e/scenarios/flue-v1/.agents/skills/e2e-flue-skill\n- Resolve relative resource paths from this directory and read only the files you need.\n</skill_resources>"
+│   │   │   metadata: {
+│   │   │     "flue.session": "skill",
+│   │   │     "flue.tool_name": "activate_skill",
+│   │   │     "provider": "flue"
+│   │   │   }
+│   │   │   metrics: {
+│   │   │     "duration_ms": 0
+│   │   │   }
+│   │   └── flue.turn [llm]
+│   │       input: [
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "role": "user"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "arguments": {
+│   │                 "name": "e2e-flue-skill"
+│   │               },
+│   │               "id": "<span:1>",
+│   │               "name": "activate_skill",
+│   │               "type": "toolCall"
+│   │             }
+│   │           ],
+│   │           "role": "assistant"
+│   │         },
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "Run the skill named \"e2e-flue-skill\".\n\n<skill_instructions>\nReturn the marker from the provided args exactly once. Output no other text.\n</skill_instructions>\n\nSupporting skill resources are available relative to this workspace skill directory but are not loaded into context unless needed:\n<skill_resources>\n- Base directory: <repo>/e2e/scenarios/flue-v1/.agents/skills/e2e-flue-skill\n- Resolve relative resource paths from this directory and read only the files you need.\n</skill_resources>",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "isError": false,
+│   │           "role": "toolResult",
+│   │           "toolCallId": "<span:1>",
+│   │           "toolName": "activate_skill"
+│   │         }
+│   │       ]
+│   │       output: {
+│   │         "content": [
+│   │           {
+│   │             "text": "SKILL_DONE",
+│   │             "textSignature": "{\"v\":1,\"id\":\"msg_013bd770d7f29cf5016a705b7b5a0481a18c76e74aa488fb85\",\"phase\":\"final_answer\"}",
+│   │             "type": "text"
+│   │           }
+│   │         ],
+│   │         "role": "assistant"
+│   │       }
+│   │       metadata: {
+│   │         "flue.api": "openai-responses",
+│   │         "flue.model": "gpt-5.4-nano",
+│   │         "flue.provider": "openai",
+│   │         "flue.session": "skill",
+│   │         "flue.stop_reason": "stop",
+│   │         "flue.turn_purpose": "agent",
+│   │         "model": "gpt-5.4-nano",
+│   │         "provider": "openai"
+│   │       }
+│   │       metrics: {
+│   │         "completion_tokens": 7,
+│   │         "duration_ms": 0,
+│   │         "estimated_cost": 0.00022815000000000002,
+│   │         "prompt_cache_creation_tokens": 0,
+│   │         "prompt_cached_tokens": 0,
+│   │         "prompt_tokens": 1097,
+│   │         "tokens": 1104
+│   │       }
+│   ├── flue.task [task]
+│   │   input: "Reply with exactly TASK_DONE and no other text."
+│   │   output: "TASK_DONE"
+│   │   metadata: {
+│   │     "flue.session": "task:task:<uuid:1>",
+│   │     "provider": "flue"
+│   │   }
+│   │   metrics: {
+│   │     "duration_ms": 0
+│   │   }
+│   │   └── flue.turn [llm]
+│   │       input: [
+│   │         {
+│   │           "content": [
+│   │             {
+│   │               "text": "Reply with exactly TASK_DONE and no other text.",
+│   │               "type": "text"
+│   │             }
+│   │           ],
+│   │           "role": "user"
+│   │         }
+│   │       ]
+│   │       output: {
+│   │         "content": [
+│   │           {
+│   │             "text": "TASK_DONE",
+│   │             "textSignature": "{\"v\":1,\"id\":\"msg_0f475aa27d287a19016a705b7e1ae881918fac78387e440a57\"}",
+│   │             "type": "text"
+│   │           }
+│   │         ],
+│   │         "role": "assistant"
+│   │       }
+│   │       metadata: {
+│   │         "flue.api": "openai-responses",
+│   │         "flue.input_mode": "full",
+│   │         "flue.model": "gpt-4o-mini",
+│   │         "flue.provider": "openai",
+│   │         "flue.session": "task:task:<uuid:1>",
+│   │         "flue.stop_reason": "stop",
+│   │         "flue.turn_purpose": "agent",
+│   │         "model": "gpt-4o-mini",
+│   │         "provider": "openai"
+│   │       }
+│   │       metrics: {
+│   │         "completion_tokens": 4,
+│   │         "duration_ms": 0,
+│   │         "estimated_cost": 0.00013874999999999998,
+│   │         "prompt_cache_creation_tokens": 0,
+│   │         "prompt_cached_tokens": 0,
+│   │         "prompt_tokens": 909,
+│   │         "tokens": 913
+│   │       }
+│   └── flue.compact [task]
+│       input: {
+│         "estimatedTokens": 1343,
+│         "reason": "manual"
+│       }
+│       output: {
+│         "completed": true
+│       }
+│       metadata: {
+│         "flue.operation": "compact",
+│         "flue.session": "main",
+│         "flue.workflow_name": "instrumentation",
+│         "provider": "flue",
+│         "scenario": "flue-instrumentation"
+│       }
+│       metrics: {
+│         "duration_ms": 0
+│       }
+│       └── compaction:manual [task]
+│           input: {
+│             "estimatedTokens": 1343,
+│             "reason": "manual"
+│           }
+│           output: {
+│             "messagesAfter": 2,
+│             "messagesBefore": 8
+│           }
+│           metadata: {
+│             "flue.compaction_reason": "manual",
+│             "flue.session": "main",
+│             "provider": "flue"
+│           }
+│           metrics: {
+│             "duration_ms": 0,
+│             "messages_after": 2,
+│             "messages_before": 8
+│           }
+│           └── flue.turn [llm]
+│               input: [
+│                 {
+│                   "content": [
+│                     {
+│                       "text": "<conversation>\n[User]: Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.\n\n[Assistant thinking]: \n\n[Assistant tool calls]: lookup(query=\"flue instrumentation\")\n\n[Tool result]: {\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}\n\n[Assistant tool calls]: web_search(lookupId=\"flue-session-2026\", query=\"Braintrust Flue reasoning stream instrumentation\")\n\n[Tool result]: {\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}\n\n[Assistant tool calls]: summarize_source(url=\"https://example.test/flue/reasoning-streams\")\n\n[Tool result]: {\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}\n</conversation>\n\nThis is the PREFIX of a turn that was too large to keep. The SUFFIX (recent work) is retained.\n\nSummarize the prefix to provide context for the retained suffix:\n\n## Original Request\n[What did the user ask for in this turn?]\n\n## Early Progress\n- [Key decisions and work done in the prefix]\n\n## Context for Suffix\n- [Information needed to understand the retained recent work]\n\nBe concise. Focus on what's needed to understand the kept suffix.",
+│                       "type": "text"
+│                     }
+│                   ],
+│                   "role": "user"
+│                 }
+│               ]
+│               output: {
+│                 "content": [
+│                   {
+│                     "text": "## Original Request\nThe user requested to complete an instrumented research flow by sequentially calling tools to gather information on \"flue instrumentation\" and \"Braintrust",
+│                     "textSignature": "{\"v\":1,\"id\":\"msg_05d8394c58cbd55e016a705b7e9ec4819cb3c6467697d006d6\"}",
+│                     "type": "text"
+│                   }
+│                 ],
+│                 "role": "assistant"
+│               }
+│               metadata: {
+│                 "flue.api": "openai-responses",
+│                 "flue.model": "gpt-4o-mini",
+│                 "flue.provider": "openai",
+│                 "flue.session": "main",
+│                 "flue.stop_reason": "length",
+│                 "flue.turn_purpose": "compaction_prefix",
+│                 "model": "gpt-4o-mini",
+│                 "provider": "openai"
+│               }
+│               metrics: {
+│                 "completion_tokens": 32,
+│                 "duration_ms": 0,
+│                 "estimated_cost": 0.00008774999999999999,
+│                 "prompt_cache_creation_tokens": 0,
+│                 "prompt_cached_tokens": 0,
+│                 "prompt_tokens": 457,
+│                 "tokens": 489
+│               }
+└── flue.prompt [task]
+    input: [
+      {
+        "content": [
+          {
+            "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
+            "type": "text"
+          }
+        ],
+        "role": "user"
+      }
+    ]
+    output: "PROMPT_DONE"
     metadata: {
+      "flue.operation": "prompt",
+      "flue.session": "main",
       "flue.workflow_name": "instrumentation",
       "provider": "flue",
       "scenario": "flue-instrumentation"
@@ -19,12 +323,7 @@ span_tree:
     metrics: {
       "duration_ms": 0
     }
-    ├── flue.workflowCurrentProbe
-    │   output: "active"
-    │   metadata: {
-    │     "scenario": "flue-instrumentation"
-    │   }
-    ├── flue.prompt [task]
+    ├── flue.turn [llm]
     │   input: [
     │     {
     │       "content": [
@@ -36,690 +335,292 @@ span_tree:
     │       "role": "user"
     │     }
     │   ]
-    │   output: "PROMPT_DONE"
+    │   output: {
+    │     "content": [
+    │       {
+    │         "thinking": "",
+    │         "thinkingSignature": "{\"id\":\"rs_0f853fd4725c6abf016a705b77390081a288d115472f015631\",\"type\":\"reasoning\",\"content\":[],\"encrypted_content\":\"gAAAAABqcFt3puS3Bq2NJT6919lM43Dt2mcGVnW8d9pkTbZRTb0BpEdGQq-D__0GELauHW3Nv0KIYSHYvz7MJ5rd7sDesAFdfBjIzg6WheoB_qvcv9YJCQlG5rbRnQUOo8EeNn3xpVU2TnKQX2bFX-hqDIEr8gzeHzbzlyRkJ_As84geW8IgU7NEIDA0z_Up0Ud5WVPHgtnzkZ5PQiPdf0MBUX-PQ4r53y30Jg9dJulRqQR9nOZvp_okxIyD9I9mCwFeImbvLFpx2bs8ozMh346RUg-e-hub9xXbe7OeXvZ1XUWW5Q7RjCPTdbJ15dRBPogZ4iuqhN7sYeBei0AqYSKeA3vVchAaKM1Wpprub60TM_VPirl9SI2m1atxgGyy2BzPnswV4xGDhkx9XS_eN1eufO4pNRsBmNxg2ULSY001V7KU8FxjxN8ATRNOAbI7SqwDK5UUz55lCvowH4CX5gn8dRHuU9tVJHWdVe2NHiurWmnWWTtfGb_baV7qJJfWE71g-LaJjgTGqUR8DaF7Sz3jr82FCo4A14mvLuZTaeRQ5mj4fUwdMjwruaoOmpoUMnZ-HhduddsiMUF5TVl9VFFAs8yLun5oRBRpUvbgqix8J-erBApMtcsi_DzQkq24k7k7HXGIp1h9CC0RTrJ-R1ji_OuEbEL64xdqfndSGwh5tr5zmsvgNLOqvghow3NU7ZQl5_AUzi-0BrHrq0SowgNmZxoVoNfRHpnUZ5nUkW-Yp1Juz-0nI5WXZiPlSFalsQOb46NPLlXUtY98YmHP6telw_BJL6_EYBhB12GaiERBSrmzArZO0Tbf6oyl6W_ug8w45bQ_vduXuMPOLqfBHiIizO2Xv_7YTTeyosQUV9u25ooudI4v03pHJHLLVmmf_ld8R91-SkIP5iPHQXjIGpEczgWPxafev4PgsDTb-L5zEnuQoALfwK0CJAzUHORGJIttRIK63JoDvt6jaUNZJ0uSwYWu2JrR5u4RrIOW7fH4tpsOQ4MflVUNrWtSacG_QKqNIC9tz7nbCwC0VIdmSloCt8XUo5uOpA==\",\"summary\":[]}",
+    │         "type": "thinking"
+    │       },
+    │       {
+    │         "arguments": {
+    │           "query": "flue instrumentation"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "lookup",
+    │         "type": "toolCall"
+    │       }
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.operation": "prompt",
+    │     "flue.api": "openai-responses",
+    │     "flue.input_mode": "full",
+    │     "flue.model": "gpt-5.4-nano",
+    │     "flue.provider": "openai",
     │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "gpt-5.4-nano",
+    │     "provider": "openai"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 41,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.00026885000000000006,
+    │     "prompt_cache_creation_tokens": 0,
+    │     "prompt_cached_tokens": 0,
+    │     "prompt_tokens": 1088,
+    │     "tokens": 1129
+    │   }
+    ├── tool:lookup [tool]
+    │   input: {
+    │     "query": "flue instrumentation"
+    │   }
+    │   output: {
+    │     "id": "<span:1>",
+    │     "query": "flue instrumentation",
+    │     "topic": "session instrumentation"
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "lookup",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "thinking": "",
-    │   │         "thinkingSignature": "{\"id\":\"rs_0f853fd4725c6abf016a705b77390081a288d115472f015631\",\"type\":\"reasoning\",\"content\":[],\"encrypted_content\":\"gAAAAABqcFt3puS3Bq2NJT6919lM43Dt2mcGVnW8d9pkTbZRTb0BpEdGQq-D__0GELauHW3Nv0KIYSHYvz7MJ5rd7sDesAFdfBjIzg6WheoB_qvcv9YJCQlG5rbRnQUOo8EeNn3xpVU2TnKQX2bFX-hqDIEr8gzeHzbzlyRkJ_As84geW8IgU7NEIDA0z_Up0Ud5WVPHgtnzkZ5PQiPdf0MBUX-PQ4r53y30Jg9dJulRqQR9nOZvp_okxIyD9I9mCwFeImbvLFpx2bs8ozMh346RUg-e-hub9xXbe7OeXvZ1XUWW5Q7RjCPTdbJ15dRBPogZ4iuqhN7sYeBei0AqYSKeA3vVchAaKM1Wpprub60TM_VPirl9SI2m1atxgGyy2BzPnswV4xGDhkx9XS_eN1eufO4pNRsBmNxg2ULSY001V7KU8FxjxN8ATRNOAbI7SqwDK5UUz55lCvowH4CX5gn8dRHuU9tVJHWdVe2NHiurWmnWWTtfGb_baV7qJJfWE71g-LaJjgTGqUR8DaF7Sz3jr82FCo4A14mvLuZTaeRQ5mj4fUwdMjwruaoOmpoUMnZ-HhduddsiMUF5TVl9VFFAs8yLun5oRBRpUvbgqix8J-erBApMtcsi_DzQkq24k7k7HXGIp1h9CC0RTrJ-R1ji_OuEbEL64xdqfndSGwh5tr5zmsvgNLOqvghow3NU7ZQl5_AUzi-0BrHrq0SowgNmZxoVoNfRHpnUZ5nUkW-Yp1Juz-0nI5WXZiPlSFalsQOb46NPLlXUtY98YmHP6telw_BJL6_EYBhB12GaiERBSrmzArZO0Tbf6oyl6W_ug8w45bQ_vduXuMPOLqfBHiIizO2Xv_7YTTeyosQUV9u25ooudI4v03pHJHLLVmmf_ld8R91-SkIP5iPHQXjIGpEczgWPxafev4PgsDTb-L5zEnuQoALfwK0CJAzUHORGJIttRIK63JoDvt6jaUNZJ0uSwYWu2JrR5u4RrIOW7fH4tpsOQ4MflVUNrWtSacG_QKqNIC9tz7nbCwC0VIdmSloCt8XUo5uOpA==\",\"summary\":[]}",
-    │   │         "type": "thinking"
-    │   │       },
-    │   │       {
-    │   │         "arguments": {
-    │   │           "query": "flue instrumentation"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "lookup",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "openai-responses",
-    │   │     "flue.model": "gpt-5.4-nano",
-    │   │     "flue.provider": "openai",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "gpt-5.4-nano",
-    │   │     "provider": "openai"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 41,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.00026885000000000006,
-    │   │     "prompt_cache_creation_tokens": 0,
-    │   │     "prompt_cached_tokens": 0,
-    │   │     "prompt_tokens": 1088,
-    │   │     "tokens": 1129
-    │   │   }
-    │   ├── tool:lookup [tool]
-    │   │   input: {
-    │   │     "query": "flue instrumentation"
-    │   │   }
-    │   │   output: {
-    │   │     "id": "<span:1>",
-    │   │     "query": "flue instrumentation",
-    │   │     "topic": "session instrumentation"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "lookup",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   │   └── flue.toolCurrentProbe
-    │   │       output: "lookup-active"
-    │   │       metadata: {
-    │   │         "scenario": "flue-instrumentation"
-    │   │       }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "thinking": "",
-    │   │           "thinkingSignature": "{\"id\":\"rs_0f853fd4725c6abf016a705b77390081a288d115472f015631\",\"type\":\"reasoning\",\"content\":[],\"encrypted_content\":\"gAAAAABqcFt3puS3Bq2NJT6919lM43Dt2mcGVnW8d9pkTbZRTb0BpEdGQq-D__0GELauHW3Nv0KIYSHYvz7MJ5rd7sDesAFdfBjIzg6WheoB_qvcv9YJCQlG5rbRnQUOo8EeNn3xpVU2TnKQX2bFX-hqDIEr8gzeHzbzlyRkJ_As84geW8IgU7NEIDA0z_Up0Ud5WVPHgtnzkZ5PQiPdf0MBUX-PQ4r53y30Jg9dJulRqQR9nOZvp_okxIyD9I9mCwFeImbvLFpx2bs8ozMh346RUg-e-hub9xXbe7OeXvZ1XUWW5Q7RjCPTdbJ15dRBPogZ4iuqhN7sYeBei0AqYSKeA3vVchAaKM1Wpprub60TM_VPirl9SI2m1atxgGyy2BzPnswV4xGDhkx9XS_eN1eufO4pNRsBmNxg2ULSY001V7KU8FxjxN8ATRNOAbI7SqwDK5UUz55lCvowH4CX5gn8dRHuU9tVJHWdVe2NHiurWmnWWTtfGb_baV7qJJfWE71g-LaJjgTGqUR8DaF7Sz3jr82FCo4A14mvLuZTaeRQ5mj4fUwdMjwruaoOmpoUMnZ-HhduddsiMUF5TVl9VFFAs8yLun5oRBRpUvbgqix8J-erBApMtcsi_DzQkq24k7k7HXGIp1h9CC0RTrJ-R1ji_OuEbEL64xdqfndSGwh5tr5zmsvgNLOqvghow3NU7ZQl5_AUzi-0BrHrq0SowgNmZxoVoNfRHpnUZ5nUkW-Yp1Juz-0nI5WXZiPlSFalsQOb46NPLlXUtY98YmHP6telw_BJL6_EYBhB12GaiERBSrmzArZO0Tbf6oyl6W_ug8w45bQ_vduXuMPOLqfBHiIizO2Xv_7YTTeyosQUV9u25ooudI4v03pHJHLLVmmf_ld8R91-SkIP5iPHQXjIGpEczgWPxafev4PgsDTb-L5zEnuQoALfwK0CJAzUHORGJIttRIK63JoDvt6jaUNZJ0uSwYWu2JrR5u4RrIOW7fH4tpsOQ4MflVUNrWtSacG_QKqNIC9tz7nbCwC0VIdmSloCt8XUo5uOpA==\",\"summary\":[]}",
-    │   │           "type": "thinking"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "query": "flue instrumentation"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "lookup",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "lookup"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "lookupId": "flue-session-2026",
-    │   │           "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "web_search",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "openai-responses",
-    │   │     "flue.model": "gpt-5.4-nano",
-    │   │     "flue.provider": "openai",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "gpt-5.4-nano",
-    │   │     "provider": "openai"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 34,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.0002749,
-    │   │     "prompt_cache_creation_tokens": 0,
-    │   │     "prompt_cached_tokens": 0,
-    │   │     "prompt_tokens": 1162,
-    │   │     "tokens": 1196
-    │   │   }
-    │   ├── tool:web_search [tool]
-    │   │   input: {
-    │   │     "lookupId": "flue-session-2026",
-    │   │     "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │   }
-    │   │   output: {
-    │   │     "lookupId": "flue-session-2026",
-    │   │     "query": "Braintrust Flue reasoning stream instrumentation",
-    │   │     "results": [
-    │   │       {
-    │   │         "title": "Flue reasoning stream instrumentation",
-    │   │         "url": "https://example.test/flue/reasoning-streams"
-    │   │       }
-    │   │     ]
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "web_search",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "thinking": "",
-    │   │           "thinkingSignature": "{\"id\":\"rs_0f853fd4725c6abf016a705b77390081a288d115472f015631\",\"type\":\"reasoning\",\"content\":[],\"encrypted_content\":\"gAAAAABqcFt3puS3Bq2NJT6919lM43Dt2mcGVnW8d9pkTbZRTb0BpEdGQq-D__0GELauHW3Nv0KIYSHYvz7MJ5rd7sDesAFdfBjIzg6WheoB_qvcv9YJCQlG5rbRnQUOo8EeNn3xpVU2TnKQX2bFX-hqDIEr8gzeHzbzlyRkJ_As84geW8IgU7NEIDA0z_Up0Ud5WVPHgtnzkZ5PQiPdf0MBUX-PQ4r53y30Jg9dJulRqQR9nOZvp_okxIyD9I9mCwFeImbvLFpx2bs8ozMh346RUg-e-hub9xXbe7OeXvZ1XUWW5Q7RjCPTdbJ15dRBPogZ4iuqhN7sYeBei0AqYSKeA3vVchAaKM1Wpprub60TM_VPirl9SI2m1atxgGyy2BzPnswV4xGDhkx9XS_eN1eufO4pNRsBmNxg2ULSY001V7KU8FxjxN8ATRNOAbI7SqwDK5UUz55lCvowH4CX5gn8dRHuU9tVJHWdVe2NHiurWmnWWTtfGb_baV7qJJfWE71g-LaJjgTGqUR8DaF7Sz3jr82FCo4A14mvLuZTaeRQ5mj4fUwdMjwruaoOmpoUMnZ-HhduddsiMUF5TVl9VFFAs8yLun5oRBRpUvbgqix8J-erBApMtcsi_DzQkq24k7k7HXGIp1h9CC0RTrJ-R1ji_OuEbEL64xdqfndSGwh5tr5zmsvgNLOqvghow3NU7ZQl5_AUzi-0BrHrq0SowgNmZxoVoNfRHpnUZ5nUkW-Yp1Juz-0nI5WXZiPlSFalsQOb46NPLlXUtY98YmHP6telw_BJL6_EYBhB12GaiERBSrmzArZO0Tbf6oyl6W_ug8w45bQ_vduXuMPOLqfBHiIizO2Xv_7YTTeyosQUV9u25ooudI4v03pHJHLLVmmf_ld8R91-SkIP5iPHQXjIGpEczgWPxafev4PgsDTb-L5zEnuQoALfwK0CJAzUHORGJIttRIK63JoDvt6jaUNZJ0uSwYWu2JrR5u4RrIOW7fH4tpsOQ4MflVUNrWtSacG_QKqNIC9tz7nbCwC0VIdmSloCt8XUo5uOpA==\",\"summary\":[]}",
-    │   │           "type": "thinking"
-    │   │         },
-    │   │         {
-    │   │           "arguments": {
-    │   │             "query": "flue instrumentation"
-    │   │           },
-    │   │           "id": "<span:1>",
-    │   │           "name": "lookup",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:1>",
-    │   │       "toolName": "lookup"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "arguments": {
-    │   │             "lookupId": "flue-session-2026",
-    │   │             "query": "Braintrust Flue reasoning stream instrumentation"
-    │   │           },
-    │   │           "id": "<span:2>",
-    │   │           "name": "web_search",
-    │   │           "type": "toolCall"
-    │   │         }
-    │   │       ],
-    │   │       "role": "assistant"
-    │   │     },
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "isError": false,
-    │   │       "role": "toolResult",
-    │   │       "toolCallId": "<span:2>",
-    │   │       "toolName": "web_search"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "url": "https://example.test/flue/reasoning-streams"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "summarize_source",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "openai-responses",
-    │   │     "flue.model": "gpt-5.4-nano",
-    │   │     "flue.provider": "openai",
-    │   │     "flue.session": "main",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "gpt-5.4-nano",
-    │   │     "provider": "openai"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 30,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.00028890000000000003,
-    │   │     "prompt_cache_creation_tokens": 0,
-    │   │     "prompt_cached_tokens": 0,
-    │   │     "prompt_tokens": 1257,
-    │   │     "tokens": 1287
-    │   │   }
-    │   ├── tool:summarize_source [tool]
-    │   │   input: {
-    │   │     "url": "https://example.test/flue/reasoning-streams"
-    │   │   }
-    │   │   output: {
-    │   │     "summary": "Flue emits reasoning, tool execution, and LLM turn events separately.",
-    │   │     "url": "https://example.test/flue/reasoning-streams"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.session": "main",
-    │   │     "flue.tool_name": "summarize_source",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   └── flue.turn [llm]
-    │       input: [
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "thinking": "",
-    │               "thinkingSignature": "{\"id\":\"rs_0f853fd4725c6abf016a705b77390081a288d115472f015631\",\"type\":\"reasoning\",\"content\":[],\"encrypted_content\":\"gAAAAABqcFt3puS3Bq2NJT6919lM43Dt2mcGVnW8d9pkTbZRTb0BpEdGQq-D__0GELauHW3Nv0KIYSHYvz7MJ5rd7sDesAFdfBjIzg6WheoB_qvcv9YJCQlG5rbRnQUOo8EeNn3xpVU2TnKQX2bFX-hqDIEr8gzeHzbzlyRkJ_As84geW8IgU7NEIDA0z_Up0Ud5WVPHgtnzkZ5PQiPdf0MBUX-PQ4r53y30Jg9dJulRqQR9nOZvp_okxIyD9I9mCwFeImbvLFpx2bs8ozMh346RUg-e-hub9xXbe7OeXvZ1XUWW5Q7RjCPTdbJ15dRBPogZ4iuqhN7sYeBei0AqYSKeA3vVchAaKM1Wpprub60TM_VPirl9SI2m1atxgGyy2BzPnswV4xGDhkx9XS_eN1eufO4pNRsBmNxg2ULSY001V7KU8FxjxN8ATRNOAbI7SqwDK5UUz55lCvowH4CX5gn8dRHuU9tVJHWdVe2NHiurWmnWWTtfGb_baV7qJJfWE71g-LaJjgTGqUR8DaF7Sz3jr82FCo4A14mvLuZTaeRQ5mj4fUwdMjwruaoOmpoUMnZ-HhduddsiMUF5TVl9VFFAs8yLun5oRBRpUvbgqix8J-erBApMtcsi_DzQkq24k7k7HXGIp1h9CC0RTrJ-R1ji_OuEbEL64xdqfndSGwh5tr5zmsvgNLOqvghow3NU7ZQl5_AUzi-0BrHrq0SowgNmZxoVoNfRHpnUZ5nUkW-Yp1Juz-0nI5WXZiPlSFalsQOb46NPLlXUtY98YmHP6telw_BJL6_EYBhB12GaiERBSrmzArZO0Tbf6oyl6W_ug8w45bQ_vduXuMPOLqfBHiIizO2Xv_7YTTeyosQUV9u25ooudI4v03pHJHLLVmmf_ld8R91-SkIP5iPHQXjIGpEczgWPxafev4PgsDTb-L5zEnuQoALfwK0CJAzUHORGJIttRIK63JoDvt6jaUNZJ0uSwYWu2JrR5u4RrIOW7fH4tpsOQ4MflVUNrWtSacG_QKqNIC9tz7nbCwC0VIdmSloCt8XUo5uOpA==\",\"summary\":[]}",
-    │               "type": "thinking"
-    │             },
-    │             {
-    │               "arguments": {
-    │                 "query": "flue instrumentation"
-    │               },
-    │               "id": "<span:1>",
-    │               "name": "lookup",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:1>",
-    │           "toolName": "lookup"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "lookupId": "flue-session-2026",
-    │                 "query": "Braintrust Flue reasoning stream instrumentation"
-    │               },
-    │               "id": "<span:2>",
-    │               "name": "web_search",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:2>",
-    │           "toolName": "web_search"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "url": "https://example.test/flue/reasoning-streams"
-    │               },
-    │               "id": "<span:3>",
-    │               "name": "summarize_source",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:3>",
-    │           "toolName": "summarize_source"
-    │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "text": "PROMPT_DONE",
-    │             "textSignature": "{\"v\":1,\"id\":\"msg_0f853fd4725c6abf016a705b79c4b881a286d3e4b2799b2c66\",\"phase\":\"final_answer\"}",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
-    │       }
+    │   └── flue.toolCurrentProbe
+    │       output: "lookup-active"
     │       metadata: {
-    │         "flue.api": "openai-responses",
-    │         "flue.model": "gpt-5.4-nano",
-    │         "flue.provider": "openai",
-    │         "flue.session": "main",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "gpt-5.4-nano",
-    │         "provider": "openai"
+    │         "scenario": "flue-instrumentation"
     │       }
-    │       metrics: {
-    │         "completion_tokens": 7,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.00027595000000000007,
-    │         "prompt_cache_creation_tokens": 0,
-    │         "prompt_cached_tokens": 0,
-    │         "prompt_tokens": 1336,
-    │         "tokens": 1343
-    │       }
-    ├── flue.skill [task]
+    ├── flue.turn [llm]
     │   input: [
     │     {
     │       "content": [
     │         {
-    │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
+    │           "thinking": "",
+    │           "thinkingSignature": "{\"id\":\"rs_0f853fd4725c6abf016a705b77390081a288d115472f015631\",\"type\":\"reasoning\",\"content\":[],\"encrypted_content\":\"gAAAAABqcFt3puS3Bq2NJT6919lM43Dt2mcGVnW8d9pkTbZRTb0BpEdGQq-D__0GELauHW3Nv0KIYSHYvz7MJ5rd7sDesAFdfBjIzg6WheoB_qvcv9YJCQlG5rbRnQUOo8EeNn3xpVU2TnKQX2bFX-hqDIEr8gzeHzbzlyRkJ_As84geW8IgU7NEIDA0z_Up0Ud5WVPHgtnzkZ5PQiPdf0MBUX-PQ4r53y30Jg9dJulRqQR9nOZvp_okxIyD9I9mCwFeImbvLFpx2bs8ozMh346RUg-e-hub9xXbe7OeXvZ1XUWW5Q7RjCPTdbJ15dRBPogZ4iuqhN7sYeBei0AqYSKeA3vVchAaKM1Wpprub60TM_VPirl9SI2m1atxgGyy2BzPnswV4xGDhkx9XS_eN1eufO4pNRsBmNxg2ULSY001V7KU8FxjxN8ATRNOAbI7SqwDK5UUz55lCvowH4CX5gn8dRHuU9tVJHWdVe2NHiurWmnWWTtfGb_baV7qJJfWE71g-LaJjgTGqUR8DaF7Sz3jr82FCo4A14mvLuZTaeRQ5mj4fUwdMjwruaoOmpoUMnZ-HhduddsiMUF5TVl9VFFAs8yLun5oRBRpUvbgqix8J-erBApMtcsi_DzQkq24k7k7HXGIp1h9CC0RTrJ-R1ji_OuEbEL64xdqfndSGwh5tr5zmsvgNLOqvghow3NU7ZQl5_AUzi-0BrHrq0SowgNmZxoVoNfRHpnUZ5nUkW-Yp1Juz-0nI5WXZiPlSFalsQOb46NPLlXUtY98YmHP6telw_BJL6_EYBhB12GaiERBSrmzArZO0Tbf6oyl6W_ug8w45bQ_vduXuMPOLqfBHiIizO2Xv_7YTTeyosQUV9u25ooudI4v03pHJHLLVmmf_ld8R91-SkIP5iPHQXjIGpEczgWPxafev4PgsDTb-L5zEnuQoALfwK0CJAzUHORGJIttRIK63JoDvt6jaUNZJ0uSwYWu2JrR5u4RrIOW7fH4tpsOQ4MflVUNrWtSacG_QKqNIC9tz7nbCwC0VIdmSloCt8XUo5uOpA==\",\"summary\":[]}",
+    │           "type": "thinking"
+    │         },
+    │         {
+    │           "arguments": {
+    │             "query": "flue instrumentation"
+    │           },
+    │           "id": "<span:1>",
+    │           "name": "lookup",
+    │           "type": "toolCall"
+    │         }
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "text": "{\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}",
     │           "type": "text"
     │         }
     │       ],
-    │       "role": "user"
+    │       "isError": false,
+    │       "role": "toolResult",
+    │       "toolCallId": "<span:1>",
+    │       "toolName": "lookup"
     │     }
     │   ]
-    │   output: "SKILL_DONE"
+    │   output: {
+    │     "content": [
+    │       {
+    │         "arguments": {
+    │           "lookupId": "flue-session-2026",
+    │           "query": "Braintrust Flue reasoning stream instrumentation"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "web_search",
+    │         "type": "toolCall"
+    │       }
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.operation": "skill",
-    │     "flue.session": "skill",
+    │     "flue.api": "openai-responses",
+    │     "flue.input_message_offset": 1,
+    │     "flue.input_mode": "delta",
+    │     "flue.model": "gpt-5.4-nano",
+    │     "flue.provider": "openai",
+    │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "gpt-5.4-nano",
+    │     "provider": "openai"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 34,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.0002749,
+    │     "prompt_cache_creation_tokens": 0,
+    │     "prompt_cached_tokens": 0,
+    │     "prompt_tokens": 1162,
+    │     "tokens": 1196
+    │   }
+    ├── tool:web_search [tool]
+    │   input: {
+    │     "lookupId": "flue-session-2026",
+    │     "query": "Braintrust Flue reasoning stream instrumentation"
+    │   }
+    │   output: {
+    │     "lookupId": "flue-session-2026",
+    │     "query": "Braintrust Flue reasoning stream instrumentation",
+    │     "results": [
+    │       {
+    │         "title": "Flue reasoning stream instrumentation",
+    │         "url": "https://example.test/flue/reasoning-streams"
+    │       }
+    │     ]
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "web_search",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   ├── flue.turn [llm]
-    │   │   input: [
-    │   │     {
-    │   │       "content": [
-    │   │         {
-    │   │           "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │   │           "type": "text"
-    │   │         }
-    │   │       ],
-    │   │       "role": "user"
-    │   │     }
-    │   │   ]
-    │   │   output: {
-    │   │     "content": [
-    │   │       {
-    │   │         "arguments": {
-    │   │           "name": "e2e-flue-skill"
-    │   │         },
-    │   │         "id": "<span:1>",
-    │   │         "name": "activate_skill",
-    │   │         "type": "toolCall"
-    │   │       }
-    │   │     ],
-    │   │     "role": "assistant"
-    │   │   }
-    │   │   metadata: {
-    │   │     "flue.api": "openai-responses",
-    │   │     "flue.model": "gpt-5.4-nano",
-    │   │     "flue.provider": "openai",
-    │   │     "flue.session": "skill",
-    │   │     "flue.stop_reason": "toolUse",
-    │   │     "flue.turn_purpose": "agent",
-    │   │     "model": "gpt-5.4-nano",
-    │   │     "provider": "openai"
-    │   │   }
-    │   │   metrics: {
-    │   │     "completion_tokens": 24,
-    │   │     "duration_ms": 0,
-    │   │     "estimated_cost": 0.00021600000000000002,
-    │   │     "prompt_cache_creation_tokens": 0,
-    │   │     "prompt_cached_tokens": 0,
-    │   │     "prompt_tokens": 930,
-    │   │     "tokens": 954
-    │   │   }
-    │   ├── tool:activate_skill [tool]
-    │   │   input: {
-    │   │     "name": "e2e-flue-skill"
-    │   │   }
-    │   │   output: "Run the skill named \"e2e-flue-skill\".\n\n<skill_instructions>\nReturn the marker from the provided args exactly once. Output no other text.\n</skill_instructions>\n\nSupporting skill resources are available relative to this workspace skill directory but are not loaded into context unless needed:\n<skill_resources>\n- Base directory: <repo>/e2e/scenarios/flue-v1/.agents/skills/e2e-flue-skill\n- Resolve relative resource paths from this directory and read only the files you need.\n</skill_resources>"
-    │   │   metadata: {
-    │   │     "flue.session": "skill",
-    │   │     "flue.tool_name": "activate_skill",
-    │   │     "provider": "flue"
-    │   │   }
-    │   │   metrics: {
-    │   │     "duration_ms": 0
-    │   │   }
-    │   └── flue.turn [llm]
-    │       input: [
+    ├── flue.turn [llm]
+    │   input: [
+    │     {
+    │       "content": [
     │         {
-    │           "content": [
-    │             {
-    │               "text": "Run the skill named \"e2e-flue-skill\".\n\nArguments:\n{\n  \"marker\": \"SKILL_DONE\"\n}",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "arguments": {
-    │                 "name": "e2e-flue-skill"
-    │               },
-    │               "id": "<span:1>",
-    │               "name": "activate_skill",
-    │               "type": "toolCall"
-    │             }
-    │           ],
-    │           "role": "assistant"
-    │         },
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "Run the skill named \"e2e-flue-skill\".\n\n<skill_instructions>\nReturn the marker from the provided args exactly once. Output no other text.\n</skill_instructions>\n\nSupporting skill resources are available relative to this workspace skill directory but are not loaded into context unless needed:\n<skill_resources>\n- Base directory: <repo>/e2e/scenarios/flue-v1/.agents/skills/e2e-flue-skill\n- Resolve relative resource paths from this directory and read only the files you need.\n</skill_resources>",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "isError": false,
-    │           "role": "toolResult",
-    │           "toolCallId": "<span:1>",
-    │           "toolName": "activate_skill"
+    │           "arguments": {
+    │             "lookupId": "flue-session-2026",
+    │             "query": "Braintrust Flue reasoning stream instrumentation"
+    │           },
+    │           "id": "<span:1>",
+    │           "name": "web_search",
+    │           "type": "toolCall"
     │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "text": "SKILL_DONE",
-    │             "textSignature": "{\"v\":1,\"id\":\"msg_013bd770d7f29cf5016a705b7b5a0481a18c76e74aa488fb85\",\"phase\":\"final_answer\"}",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
+    │       ],
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": [
+    │         {
+    │           "text": "{\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}",
+    │           "type": "text"
+    │         }
+    │       ],
+    │       "isError": false,
+    │       "role": "toolResult",
+    │       "toolCallId": "<span:1>",
+    │       "toolName": "web_search"
+    │     }
+    │   ]
+    │   output: {
+    │     "content": [
+    │       {
+    │         "arguments": {
+    │           "url": "https://example.test/flue/reasoning-streams"
+    │         },
+    │         "id": "<span:1>",
+    │         "name": "summarize_source",
+    │         "type": "toolCall"
     │       }
-    │       metadata: {
-    │         "flue.api": "openai-responses",
-    │         "flue.model": "gpt-5.4-nano",
-    │         "flue.provider": "openai",
-    │         "flue.session": "skill",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "gpt-5.4-nano",
-    │         "provider": "openai"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 7,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.00022815000000000002,
-    │         "prompt_cache_creation_tokens": 0,
-    │         "prompt_cached_tokens": 0,
-    │         "prompt_tokens": 1097,
-    │         "tokens": 1104
-    │       }
-    ├── flue.task [task]
-    │   input: "Reply with exactly TASK_DONE and no other text."
-    │   output: "TASK_DONE"
+    │     ],
+    │     "role": "assistant"
+    │   }
     │   metadata: {
-    │     "flue.session": "task:task:<uuid:1>",
+    │     "flue.api": "openai-responses",
+    │     "flue.input_message_offset": 3,
+    │     "flue.input_mode": "delta",
+    │     "flue.model": "gpt-5.4-nano",
+    │     "flue.provider": "openai",
+    │     "flue.session": "main",
+    │     "flue.stop_reason": "toolUse",
+    │     "flue.turn_purpose": "agent",
+    │     "model": "gpt-5.4-nano",
+    │     "provider": "openai"
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 30,
+    │     "duration_ms": 0,
+    │     "estimated_cost": 0.00028890000000000003,
+    │     "prompt_cache_creation_tokens": 0,
+    │     "prompt_cached_tokens": 0,
+    │     "prompt_tokens": 1257,
+    │     "tokens": 1287
+    │   }
+    ├── tool:summarize_source [tool]
+    │   input: {
+    │     "url": "https://example.test/flue/reasoning-streams"
+    │   }
+    │   output: {
+    │     "summary": "Flue emits reasoning, tool execution, and LLM turn events separately.",
+    │     "url": "https://example.test/flue/reasoning-streams"
+    │   }
+    │   metadata: {
+    │     "flue.session": "main",
+    │     "flue.tool_name": "summarize_source",
     │     "provider": "flue"
     │   }
     │   metrics: {
     │     "duration_ms": 0
     │   }
-    │   └── flue.turn [llm]
-    │       input: [
-    │         {
-    │           "content": [
-    │             {
-    │               "text": "Reply with exactly TASK_DONE and no other text.",
-    │               "type": "text"
-    │             }
-    │           ],
-    │           "role": "user"
-    │         }
-    │       ]
-    │       output: {
-    │         "content": [
-    │           {
-    │             "text": "TASK_DONE",
-    │             "textSignature": "{\"v\":1,\"id\":\"msg_0f475aa27d287a19016a705b7e1ae881918fac78387e440a57\"}",
-    │             "type": "text"
-    │           }
-    │         ],
-    │         "role": "assistant"
-    │       }
-    │       metadata: {
-    │         "flue.api": "openai-responses",
-    │         "flue.model": "gpt-4o-mini",
-    │         "flue.provider": "openai",
-    │         "flue.session": "task:task:<uuid:1>",
-    │         "flue.stop_reason": "stop",
-    │         "flue.turn_purpose": "agent",
-    │         "model": "gpt-4o-mini",
-    │         "provider": "openai"
-    │       }
-    │       metrics: {
-    │         "completion_tokens": 4,
-    │         "duration_ms": 0,
-    │         "estimated_cost": 0.00013874999999999998,
-    │         "prompt_cache_creation_tokens": 0,
-    │         "prompt_cached_tokens": 0,
-    │         "prompt_tokens": 909,
-    │         "tokens": 913
-    │       }
-    └── flue.compact [task]
-        input: {
-          "estimatedTokens": 1343,
-          "reason": "manual"
-        }
+    └── flue.turn [llm]
+        input: [
+          {
+            "content": [
+              {
+                "arguments": {
+                  "url": "https://example.test/flue/reasoning-streams"
+                },
+                "id": "<span:1>",
+                "name": "summarize_source",
+                "type": "toolCall"
+              }
+            ],
+            "role": "assistant"
+          },
+          {
+            "content": [
+              {
+                "text": "{\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}",
+                "type": "text"
+              }
+            ],
+            "isError": false,
+            "role": "toolResult",
+            "toolCallId": "<span:1>",
+            "toolName": "summarize_source"
+          }
+        ]
         output: {
-          "completed": true
+          "content": [
+            {
+              "text": "PROMPT_DONE",
+              "textSignature": "{\"v\":1,\"id\":\"msg_0f853fd4725c6abf016a705b79c4b881a286d3e4b2799b2c66\",\"phase\":\"final_answer\"}",
+              "type": "text"
+            }
+          ],
+          "role": "assistant"
         }
         metadata: {
-          "flue.operation": "compact",
+          "flue.api": "openai-responses",
+          "flue.input_message_offset": 5,
+          "flue.input_mode": "delta",
+          "flue.model": "gpt-5.4-nano",
+          "flue.provider": "openai",
           "flue.session": "main",
-          "provider": "flue"
+          "flue.stop_reason": "stop",
+          "flue.turn_purpose": "agent",
+          "model": "gpt-5.4-nano",
+          "provider": "openai"
         }
         metrics: {
-          "duration_ms": 0
+          "completion_tokens": 7,
+          "duration_ms": 0,
+          "estimated_cost": 0.00027595000000000007,
+          "prompt_cache_creation_tokens": 0,
+          "prompt_cached_tokens": 0,
+          "prompt_tokens": 1336,
+          "tokens": 1343
         }
-        └── compaction:manual [task]
-            input: {
-              "estimatedTokens": 1343,
-              "reason": "manual"
-            }
-            output: {
-              "messagesAfter": 2,
-              "messagesBefore": 8
-            }
-            metadata: {
-              "flue.compaction_reason": "manual",
-              "flue.session": "main",
-              "provider": "flue"
-            }
-            metrics: {
-              "duration_ms": 0,
-              "messages_after": 2,
-              "messages_before": 8
-            }
-            └── flue.turn [llm]
-                input: [
-                  {
-                    "content": [
-                      {
-                        "text": "<conversation>\n[User]: Complete this instrumented research flow. Call exactly one tool per turn and wait for each tool result before choosing the next tool. Step 1: call lookup with query \"flue instrumentation\". Step 2: use the lookup result id as lookupId and call web_search with query \"Braintrust Flue reasoning stream instrumentation\". Step 3: use the first web_search result url and call summarize_source. After summarize_source returns, reply with exactly PROMPT_DONE and no other text.\n\n[Assistant thinking]: \n\n[Assistant tool calls]: lookup(query=\"flue instrumentation\")\n\n[Tool result]: {\"id\":\"flue-session-2026\",\"query\":\"flue instrumentation\",\"topic\":\"session instrumentation\"}\n\n[Assistant tool calls]: web_search(lookupId=\"flue-session-2026\", query=\"Braintrust Flue reasoning stream instrumentation\")\n\n[Tool result]: {\"lookupId\":\"flue-session-2026\",\"query\":\"Braintrust Flue reasoning stream instrumentation\",\"results\":[{\"title\":\"Flue reasoning stream instrumentation\",\"url\":\"https://example.test/flue/reasoning-streams\"}]}\n\n[Assistant tool calls]: summarize_source(url=\"https://example.test/flue/reasoning-streams\")\n\n[Tool result]: {\"summary\":\"Flue emits reasoning, tool execution, and LLM turn events separately.\",\"url\":\"https://example.test/flue/reasoning-streams\"}\n</conversation>\n\nThis is the PREFIX of a turn that was too large to keep. The SUFFIX (recent work) is retained.\n\nSummarize the prefix to provide context for the retained suffix:\n\n## Original Request\n[What did the user ask for in this turn?]\n\n## Early Progress\n- [Key decisions and work done in the prefix]\n\n## Context for Suffix\n- [Information needed to understand the retained recent work]\n\nBe concise. Focus on what's needed to understand the kept suffix.",
-                        "type": "text"
-                      }
-                    ],
-                    "role": "user"
-                  }
-                ]
-                output: {
-                  "content": [
-                    {
-                      "text": "## Original Request\nThe user requested to complete an instrumented research flow by sequentially calling tools to gather information on \"flue instrumentation\" and \"Braintrust",
-                      "textSignature": "{\"v\":1,\"id\":\"msg_05d8394c58cbd55e016a705b7e9ec4819cb3c6467697d006d6\"}",
-                      "type": "text"
-                    }
-                  ],
-                  "role": "assistant"
-                }
-                metadata: {
-                  "flue.api": "openai-responses",
-                  "flue.model": "gpt-4o-mini",
-                  "flue.provider": "openai",
-                  "flue.session": "main",
-                  "flue.stop_reason": "length",
-                  "flue.turn_purpose": "compaction_prefix",
-                  "model": "gpt-4o-mini",
-                  "provider": "openai"
-                }
-                metrics: {
-                  "completion_tokens": 32,
-                  "duration_ms": 0,
-                  "estimated_cost": 0.00008774999999999999,
-                  "prompt_cache_creation_tokens": 0,
-                  "prompt_cached_tokens": 0,
-                  "prompt_tokens": 457,
-                  "tokens": 489
-                }

--- a/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v2-latest.span-tree.json
+++ b/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v2-latest.span-tree.json
@@ -38,6 +38,7 @@
             "flue.conversation_id": "<flue.conversation_id:2>",
             "flue.event_index": 15,
             "flue.harness": "default",
+            "flue.input_mode": "full",
             "flue.instance_id": "braintrust-e2e",
             "flue.is_error": false,
             "flue.model": "gpt-5.6-luna",
@@ -150,15 +151,6 @@
             {
               "content": [
                 {
-                  "text": "Exercise Flue 2 tool-use instrumentation and finish with PROMPT_DONE.",
-                  "type": "text"
-                }
-              ],
-              "role": "user"
-            },
-            {
-              "content": [
-                {
                   "arguments": {
                     "query": "Flue 2 instrumentation"
                   },
@@ -198,6 +190,8 @@
             "flue.conversation_id": "<flue.conversation_id:2>",
             "flue.event_index": 28,
             "flue.harness": "default",
+            "flue.input_message_offset": 1,
+            "flue.input_mode": "delta",
             "flue.instance_id": "braintrust-e2e",
             "flue.is_error": false,
             "flue.model": "gpt-5.6-luna",
@@ -206,86 +200,11 @@
             "flue.session": "default",
             "flue.stop_reason": "stop",
             "flue.submission_id": "<flue.submission_id:1>",
-            "flue.system_prompt": "Call the lookup tool exactly once with query Flue 2 instrumentation. Then reply with exactly PROMPT_DONE.\n\n## Available Agents\n\nNone. No subagents are currently declared, so the `task` tool has no valid `agent` value — do not call it unless an agent is introduced later in the conversation.\n\nDate: <timestamp>",
             "flue.turn_id": "<flue.turn_id:4>",
             "flue.turn_purpose": "agent",
             "model": "gpt-5.6-luna",
             "provider": "openai",
-            "reasoning": "low",
-            "tools": [
-              {
-                "description": "Delegate a focused task to a detached child agent with its own context. Use this for independent research, file exploration, or parallel work. Pass attachment IDs shown in the conversation to include those images. The task returns only its final answer to this conversation. Agents available for delegation are listed under \"Available Agents\" in the system prompt.",
-                "name": "task",
-                "parameters": {
-                  "properties": {
-                    "agent": {
-                      "description": "Subagent to run the task with, from the list of currently available agents. Agents that have been removed from the list are no longer usable (until re-introduced, if ever).",
-                      "minLength": 1,
-                      "type": "string",
-                      "~kind": "String"
-                    },
-                    "attachments": {
-                      "description": "Images from this conversation to include in the child agent prompt",
-                      "items": {
-                        "properties": {
-                          "id": {
-                            "description": "Attachment ID shown in the current conversation",
-                            "type": "string",
-                            "~kind": "String"
-                          }
-                        },
-                        "required": [
-                          "id"
-                        ],
-                        "type": "object",
-                        "~kind": "Object"
-                      },
-                      "type": "array",
-                      "~kind": "Array",
-                      "~optional": true
-                    },
-                    "cwd": {
-                      "description": "Working directory for the child agent. AGENTS.md and skills are discovered from here.",
-                      "type": "string",
-                      "~kind": "String",
-                      "~optional": true
-                    },
-                    "description": {
-                      "description": "Short human-readable label for the delegated work",
-                      "type": "string",
-                      "~kind": "String",
-                      "~optional": true
-                    },
-                    "prompt": {
-                      "description": "Focused instructions for the child agent",
-                      "type": "string",
-                      "~kind": "String"
-                    }
-                  },
-                  "required": [
-                    "prompt",
-                    "agent"
-                  ],
-                  "type": "object",
-                  "~kind": "Object"
-                }
-              },
-              {
-                "description": "Return the deterministic Flue instrumentation result.",
-                "name": "lookup",
-                "parameters": {
-                  "properties": {
-                    "query": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "query"
-                  ],
-                  "type": "object"
-                }
-              }
-            ]
+            "reasoning": "low"
           },
           "metrics": {
             "completion_tokens": 7,
@@ -380,6 +299,11 @@
       },
       "metrics": {
         "duration_ms": 0
+      },
+      "context": {
+        "caller_filename": "<node-internal>",
+        "caller_functionname": "<node-internal>",
+        "caller_lineno": 0
       }
     }
   ]

--- a/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v2-latest.span-tree.txt
+++ b/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v2-latest.span-tree.txt
@@ -28,6 +28,11 @@ span_tree:
     metrics: {
       "duration_ms": 0
     }
+    context: {
+      "caller_filename": "<node-internal>",
+      "caller_functionname": "<node-internal>",
+      "caller_lineno": 0
+    }
     ├── flue.turn [llm]
     │   input: [
     │     {
@@ -59,6 +64,7 @@ span_tree:
     │     "flue.conversation_id": "<flue.conversation_id:2>",
     │     "flue.event_index": 15,
     │     "flue.harness": "default",
+    │     "flue.input_mode": "full",
     │     "flue.instance_id": "braintrust-e2e",
     │     "flue.is_error": false,
     │     "flue.model": "gpt-5.6-luna",
@@ -167,15 +173,6 @@ span_tree:
     │     {
     │       "content": [
     │         {
-    │           "text": "Exercise Flue 2 tool-use instrumentation and finish with PROMPT_DONE.",
-    │           "type": "text"
-    │         }
-    │       ],
-    │       "role": "user"
-    │     },
-    │     {
-    │       "content": [
-    │         {
     │           "arguments": {
     │             "query": "Flue 2 instrumentation"
     │           },
@@ -215,6 +212,8 @@ span_tree:
     │     "flue.conversation_id": "<flue.conversation_id:2>",
     │     "flue.event_index": 28,
     │     "flue.harness": "default",
+    │     "flue.input_message_offset": 1,
+    │     "flue.input_mode": "delta",
     │     "flue.instance_id": "braintrust-e2e",
     │     "flue.is_error": false,
     │     "flue.model": "gpt-5.6-luna",
@@ -223,86 +222,11 @@ span_tree:
     │     "flue.session": "default",
     │     "flue.stop_reason": "stop",
     │     "flue.submission_id": "<flue.submission_id:1>",
-    │     "flue.system_prompt": "Call the lookup tool exactly once with query Flue 2 instrumentation. Then reply with exactly PROMPT_DONE.\n\n## Available Agents\n\nNone. No subagents are currently declared, so the `task` tool has no valid `agent` value — do not call it unless an agent is introduced later in the conversation.\n\nDate: <timestamp>",
     │     "flue.turn_id": "<flue.turn_id:4>",
     │     "flue.turn_purpose": "agent",
     │     "model": "gpt-5.6-luna",
     │     "provider": "openai",
-    │     "reasoning": "low",
-    │     "tools": [
-    │       {
-    │         "description": "Delegate a focused task to a detached child agent with its own context. Use this for independent research, file exploration, or parallel work. Pass attachment IDs shown in the conversation to include those images. The task returns only its final answer to this conversation. Agents available for delegation are listed under \"Available Agents\" in the system prompt.",
-    │         "name": "task",
-    │         "parameters": {
-    │           "properties": {
-    │             "agent": {
-    │               "description": "Subagent to run the task with, from the list of currently available agents. Agents that have been removed from the list are no longer usable (until re-introduced, if ever).",
-    │               "minLength": 1,
-    │               "type": "string",
-    │               "~kind": "String"
-    │             },
-    │             "attachments": {
-    │               "description": "Images from this conversation to include in the child agent prompt",
-    │               "items": {
-    │                 "properties": {
-    │                   "id": {
-    │                     "description": "Attachment ID shown in the current conversation",
-    │                     "type": "string",
-    │                     "~kind": "String"
-    │                   }
-    │                 },
-    │                 "required": [
-    │                   "id"
-    │                 ],
-    │                 "type": "object",
-    │                 "~kind": "Object"
-    │               },
-    │               "type": "array",
-    │               "~kind": "Array",
-    │               "~optional": true
-    │             },
-    │             "cwd": {
-    │               "description": "Working directory for the child agent. AGENTS.md and skills are discovered from here.",
-    │               "type": "string",
-    │               "~kind": "String",
-    │               "~optional": true
-    │             },
-    │             "description": {
-    │               "description": "Short human-readable label for the delegated work",
-    │               "type": "string",
-    │               "~kind": "String",
-    │               "~optional": true
-    │             },
-    │             "prompt": {
-    │               "description": "Focused instructions for the child agent",
-    │               "type": "string",
-    │               "~kind": "String"
-    │             }
-    │           },
-    │           "required": [
-    │             "prompt",
-    │             "agent"
-    │           ],
-    │           "type": "object",
-    │           "~kind": "Object"
-    │         }
-    │       },
-    │       {
-    │         "description": "Return the deterministic Flue instrumentation result.",
-    │         "name": "lookup",
-    │         "parameters": {
-    │           "properties": {
-    │             "query": {
-    │               "type": "string"
-    │             }
-    │           },
-    │           "required": [
-    │             "query"
-    │           ],
-    │           "type": "object"
-    │         }
-    │       }
-    │     ]
+    │     "reasoning": "low"
     │   }
     │   metrics: {
     │     "completion_tokens": 7,

--- a/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v2.span-tree.json
+++ b/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v2.span-tree.json
@@ -38,6 +38,7 @@
             "flue.conversation_id": "<flue.conversation_id:2>",
             "flue.event_index": 15,
             "flue.harness": "default",
+            "flue.input_mode": "full",
             "flue.instance_id": "braintrust-e2e",
             "flue.is_error": false,
             "flue.model": "gpt-5.6-luna",
@@ -150,15 +151,6 @@
             {
               "content": [
                 {
-                  "text": "Exercise Flue 2 tool-use instrumentation and finish with PROMPT_DONE.",
-                  "type": "text"
-                }
-              ],
-              "role": "user"
-            },
-            {
-              "content": [
-                {
                   "arguments": {
                     "query": "Flue 2 instrumentation"
                   },
@@ -198,6 +190,8 @@
             "flue.conversation_id": "<flue.conversation_id:2>",
             "flue.event_index": 28,
             "flue.harness": "default",
+            "flue.input_message_offset": 1,
+            "flue.input_mode": "delta",
             "flue.instance_id": "braintrust-e2e",
             "flue.is_error": false,
             "flue.model": "gpt-5.6-luna",
@@ -206,86 +200,11 @@
             "flue.session": "default",
             "flue.stop_reason": "stop",
             "flue.submission_id": "<flue.submission_id:1>",
-            "flue.system_prompt": "Call the lookup tool exactly once with query Flue 2 instrumentation. Then reply with exactly PROMPT_DONE.\n\n## Available Agents\n\nNone. No subagents are currently declared, so the `task` tool has no valid `agent` value — do not call it unless an agent is introduced later in the conversation.\n\nDate: <timestamp>",
             "flue.turn_id": "<flue.turn_id:4>",
             "flue.turn_purpose": "agent",
             "model": "gpt-5.6-luna",
             "provider": "openai",
-            "reasoning": "low",
-            "tools": [
-              {
-                "description": "Delegate a focused task to a detached child agent with its own context. Use this for independent research, file exploration, or parallel work. Pass attachment IDs shown in the conversation to include those images. The task returns only its final answer to this conversation. Agents available for delegation are listed under \"Available Agents\" in the system prompt.",
-                "name": "task",
-                "parameters": {
-                  "properties": {
-                    "agent": {
-                      "description": "Subagent to run the task with, from the list of currently available agents. Agents that have been removed from the list are no longer usable (until re-introduced, if ever).",
-                      "minLength": 1,
-                      "type": "string",
-                      "~kind": "String"
-                    },
-                    "attachments": {
-                      "description": "Images from this conversation to include in the child agent prompt",
-                      "items": {
-                        "properties": {
-                          "id": {
-                            "description": "Attachment ID shown in the current conversation",
-                            "type": "string",
-                            "~kind": "String"
-                          }
-                        },
-                        "required": [
-                          "id"
-                        ],
-                        "type": "object",
-                        "~kind": "Object"
-                      },
-                      "type": "array",
-                      "~kind": "Array",
-                      "~optional": true
-                    },
-                    "cwd": {
-                      "description": "Working directory for the child agent. AGENTS.md and skills are discovered from here.",
-                      "type": "string",
-                      "~kind": "String",
-                      "~optional": true
-                    },
-                    "description": {
-                      "description": "Short human-readable label for the delegated work",
-                      "type": "string",
-                      "~kind": "String",
-                      "~optional": true
-                    },
-                    "prompt": {
-                      "description": "Focused instructions for the child agent",
-                      "type": "string",
-                      "~kind": "String"
-                    }
-                  },
-                  "required": [
-                    "prompt",
-                    "agent"
-                  ],
-                  "type": "object",
-                  "~kind": "Object"
-                }
-              },
-              {
-                "description": "Return the deterministic Flue instrumentation result.",
-                "name": "lookup",
-                "parameters": {
-                  "properties": {
-                    "query": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "query"
-                  ],
-                  "type": "object"
-                }
-              }
-            ]
+            "reasoning": "low"
           },
           "metrics": {
             "completion_tokens": 7,
@@ -380,6 +299,11 @@
       },
       "metrics": {
         "duration_ms": 0
+      },
+      "context": {
+        "caller_filename": "<node-internal>",
+        "caller_functionname": "<node-internal>",
+        "caller_lineno": 0
       }
     }
   ]

--- a/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v2.span-tree.txt
+++ b/e2e/scenarios/flue-instrumentation/__snapshots__/flue-v2.span-tree.txt
@@ -28,6 +28,11 @@ span_tree:
     metrics: {
       "duration_ms": 0
     }
+    context: {
+      "caller_filename": "<node-internal>",
+      "caller_functionname": "<node-internal>",
+      "caller_lineno": 0
+    }
     ├── flue.turn [llm]
     │   input: [
     │     {
@@ -59,6 +64,7 @@ span_tree:
     │     "flue.conversation_id": "<flue.conversation_id:2>",
     │     "flue.event_index": 15,
     │     "flue.harness": "default",
+    │     "flue.input_mode": "full",
     │     "flue.instance_id": "braintrust-e2e",
     │     "flue.is_error": false,
     │     "flue.model": "gpt-5.6-luna",
@@ -167,15 +173,6 @@ span_tree:
     │     {
     │       "content": [
     │         {
-    │           "text": "Exercise Flue 2 tool-use instrumentation and finish with PROMPT_DONE.",
-    │           "type": "text"
-    │         }
-    │       ],
-    │       "role": "user"
-    │     },
-    │     {
-    │       "content": [
-    │         {
     │           "arguments": {
     │             "query": "Flue 2 instrumentation"
     │           },
@@ -215,6 +212,8 @@ span_tree:
     │     "flue.conversation_id": "<flue.conversation_id:2>",
     │     "flue.event_index": 28,
     │     "flue.harness": "default",
+    │     "flue.input_message_offset": 1,
+    │     "flue.input_mode": "delta",
     │     "flue.instance_id": "braintrust-e2e",
     │     "flue.is_error": false,
     │     "flue.model": "gpt-5.6-luna",
@@ -223,86 +222,11 @@ span_tree:
     │     "flue.session": "default",
     │     "flue.stop_reason": "stop",
     │     "flue.submission_id": "<flue.submission_id:1>",
-    │     "flue.system_prompt": "Call the lookup tool exactly once with query Flue 2 instrumentation. Then reply with exactly PROMPT_DONE.\n\n## Available Agents\n\nNone. No subagents are currently declared, so the `task` tool has no valid `agent` value — do not call it unless an agent is introduced later in the conversation.\n\nDate: <timestamp>",
     │     "flue.turn_id": "<flue.turn_id:4>",
     │     "flue.turn_purpose": "agent",
     │     "model": "gpt-5.6-luna",
     │     "provider": "openai",
-    │     "reasoning": "low",
-    │     "tools": [
-    │       {
-    │         "description": "Delegate a focused task to a detached child agent with its own context. Use this for independent research, file exploration, or parallel work. Pass attachment IDs shown in the conversation to include those images. The task returns only its final answer to this conversation. Agents available for delegation are listed under \"Available Agents\" in the system prompt.",
-    │         "name": "task",
-    │         "parameters": {
-    │           "properties": {
-    │             "agent": {
-    │               "description": "Subagent to run the task with, from the list of currently available agents. Agents that have been removed from the list are no longer usable (until re-introduced, if ever).",
-    │               "minLength": 1,
-    │               "type": "string",
-    │               "~kind": "String"
-    │             },
-    │             "attachments": {
-    │               "description": "Images from this conversation to include in the child agent prompt",
-    │               "items": {
-    │                 "properties": {
-    │                   "id": {
-    │                     "description": "Attachment ID shown in the current conversation",
-    │                     "type": "string",
-    │                     "~kind": "String"
-    │                   }
-    │                 },
-    │                 "required": [
-    │                   "id"
-    │                 ],
-    │                 "type": "object",
-    │                 "~kind": "Object"
-    │               },
-    │               "type": "array",
-    │               "~kind": "Array",
-    │               "~optional": true
-    │             },
-    │             "cwd": {
-    │               "description": "Working directory for the child agent. AGENTS.md and skills are discovered from here.",
-    │               "type": "string",
-    │               "~kind": "String",
-    │               "~optional": true
-    │             },
-    │             "description": {
-    │               "description": "Short human-readable label for the delegated work",
-    │               "type": "string",
-    │               "~kind": "String",
-    │               "~optional": true
-    │             },
-    │             "prompt": {
-    │               "description": "Focused instructions for the child agent",
-    │               "type": "string",
-    │               "~kind": "String"
-    │             }
-    │           },
-    │           "required": [
-    │             "prompt",
-    │             "agent"
-    │           ],
-    │           "type": "object",
-    │           "~kind": "Object"
-    │         }
-    │       },
-    │       {
-    │         "description": "Return the deterministic Flue instrumentation result.",
-    │         "name": "lookup",
-    │         "parameters": {
-    │           "properties": {
-    │             "query": {
-    │               "type": "string"
-    │             }
-    │           },
-    │           "required": [
-    │             "query"
-    │           ],
-    │           "type": "object"
-    │         }
-    │       }
-    │     ]
+    │     "reasoning": "low"
     │   }
     │   metrics: {
     │     "completion_tokens": 7,

--- a/e2e/scenarios/flue-instrumentation/assertions.ts
+++ b/e2e/scenarios/flue-instrumentation/assertions.ts
@@ -43,6 +43,8 @@ const SNAPSHOT_METADATA_KEYS = [
   "scenario",
   "flue.api",
   "flue.compaction_reason",
+  "flue.input_message_offset",
+  "flue.input_mode",
   "flue.model",
   "flue.operation",
   "flue.provider",
@@ -75,8 +77,15 @@ function snapshotFields(event: CapturedLogEvent): SpanTreeFields {
 }
 
 function findFlueOperation(events: CapturedLogEvent[], flueSpanName: string) {
-  const workflow = findLatestSpanByPrefix(events, "workflow:");
-  return findLatestChildSpan(events, flueSpanName, workflow?.span.id);
+  if (flueSpanName === "flue.prompt") {
+    return [...events]
+      .reverse()
+      .find(
+        (event) =>
+          event.span.name === flueSpanName && event.span.parentIds.length === 0,
+      );
+  }
+  return findLatestSpan(events, flueSpanName);
 }
 
 function findLatestSpanByPrefix(
@@ -306,6 +315,15 @@ export function defineFlueInstrumentationAssertions(options: {
       expect(findFlueOperation(events, "flue.prompt")?.output).toBe(
         "PROMPT_DONE",
       );
+      expect(findFlueOperation(events, "flue.prompt")?.span.parentIds).toEqual(
+        [],
+      );
+      expect(
+        findFlueOperation(events, "flue.prompt")?.row.metadata,
+      ).toMatchObject({
+        scenario: SCENARIO_NAME,
+        testRunId: expect.any(String),
+      });
       expect(findFlueOperation(events, "flue.skill")?.output).toBe(
         "SKILL_DONE",
       );

--- a/e2e/scenarios/flue-instrumentation/v2-assertions.ts
+++ b/e2e/scenarios/flue-instrumentation/v2-assertions.ts
@@ -95,6 +95,22 @@ export function defineFlueV2InstrumentationAssertions(options: {
           tokens: expect.any(Number),
         });
       }
+      expect(llmSpans[0]?.metadata).toMatchObject({
+        "flue.input_mode": "full",
+      });
+      expect(llmSpans[1]?.input).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ role: "assistant" }),
+          expect.objectContaining({ role: "toolResult" }),
+        ]),
+      );
+      expect(llmSpans[1]?.input).toHaveLength(2);
+      expect(llmSpans[1]?.metadata).toMatchObject({
+        "flue.input_message_offset": 1,
+        "flue.input_mode": "delta",
+      });
+      expect(llmSpans[1]?.metadata).not.toHaveProperty("flue.system_prompt");
+      expect(llmSpans[1]?.metadata).not.toHaveProperty("tools");
 
       expect(tool?.span.parentIds).toEqual([operation?.span.id]);
       expect(tool?.input).toEqual({ query: "Flue 2 instrumentation" });

--- a/js/src/instrumentation/plugins/flue-plugin.test.ts
+++ b/js/src/instrumentation/plugins/flue-plugin.test.ts
@@ -76,11 +76,17 @@ const { mockNewTracingChannel, mockTracingChannels } = vi.hoisted(() => {
 
 vi.mock("../../logger", () => ({
   BRAINTRUST_CURRENT_SPAN_STORE: mockCurrentSpanStoreSymbol,
+  NOOP_SPAN: {},
   flush: (...args: unknown[]) => mockFlush(...args),
   _internalGetGlobalState: () => ({
     contextManager: {
       [mockCurrentSpanStoreSymbol]: mockCurrentSpanStore,
       wrapSpanForStore: (span: unknown) => span,
+    },
+    idGenerator: {
+      getSpanId: () => "root-span-id",
+      getTraceId: () => "root-trace-id",
+      shareRootSpanId: () => false,
     },
   }),
   startSpan: (...args: unknown[]) => mockStartSpan(...args),
@@ -427,7 +433,8 @@ describe("Flue observe instrumentation", () => {
       },
       startTime: Date.parse(startedAt) / 1000,
     });
-    expect(operationSpan?.spanParents).toEqual([workflowSpan?.spanId]);
+    expect(operationSpan?.spanParents).toEqual([]);
+    expect(operationSpan?.rootSpanId).not.toBe(workflowSpan?.rootSpanId);
     expect(turnSpan?.spanParents).toEqual([operationSpan?.spanId]);
     expect(toolSpan?.spanParents).toEqual([operationSpan?.spanId]);
     expect(taskSpan?.spanParents).toEqual([operationSpan?.spanId]);
@@ -755,6 +762,133 @@ describe("Flue observe instrumentation", () => {
     );
   });
 
+  it("creates a user-turn trace with incremental LLM inputs", () => {
+    const emit = observeEvents();
+    const previousUser = { content: "Earlier request", role: "user" };
+    const previousAssistant = { content: "Earlier answer", role: "assistant" };
+    const currentUser = { content: "Research Flue", role: "user" };
+    const toolCall = {
+      content: [{ id: "tool-1", name: "lookup", type: "toolCall" }],
+      role: "assistant",
+    };
+    const toolResult = {
+      content: [{ text: "Flue result", type: "text" }],
+      role: "toolResult",
+      toolCallId: "tool-1",
+    };
+
+    emit({
+      input: { metadata: { scenario: "flue-instrumentation" } },
+      runId: "run-1",
+      type: "run_start",
+      workflowName: "research",
+    });
+    emit({
+      operationId: "op-1",
+      operationKind: "prompt",
+      runId: "run-1",
+      type: "operation_start",
+    });
+    emit({
+      input: {
+        messages: [previousUser, previousAssistant, currentUser],
+        systemPrompt: "Be precise",
+        tools: [{ name: "lookup" }],
+      },
+      operationId: "op-1",
+      purpose: "agent",
+      runId: "run-1",
+      turnId: "turn-1",
+      type: "turn_request",
+    });
+    emit({
+      operationId: "op-1",
+      output: toolCall,
+      purpose: "agent",
+      runId: "run-1",
+      turnId: "turn-1",
+      type: "turn",
+    });
+    emit({
+      input: {
+        messages: [
+          previousUser,
+          previousAssistant,
+          currentUser,
+          toolCall,
+          toolResult,
+        ],
+        systemPrompt: "Be precise",
+        tools: [{ name: "lookup" }],
+      },
+      operationId: "op-1",
+      purpose: "agent",
+      runId: "run-1",
+      turnId: "turn-1",
+      type: "turn_request",
+    });
+    emit({
+      operationId: "op-1",
+      output: { content: "done", role: "assistant" },
+      purpose: "agent",
+      runId: "run-1",
+      turnId: "turn-1",
+      type: "turn",
+    });
+    emit({
+      input: {
+        messages: [currentUser],
+        systemPrompt: "Use compacted context",
+        tools: [{ name: "search" }],
+      },
+      operationId: "op-1",
+      purpose: "agent",
+      runId: "run-1",
+      turnId: "turn-1",
+      type: "turn_request",
+    });
+
+    const workflowSpan = findSpan("workflow:research");
+    const operationSpan = findSpan("flue.prompt");
+    const turnSpans = spans.filter((span) => span.name === "flue.turn");
+
+    expect(operationSpan?.spanParents).toEqual([]);
+    expect(operationSpan?.rootSpanId).not.toBe(workflowSpan?.rootSpanId);
+    expect(operationSpan?.args.event.metadata).toMatchObject({
+      scenario: "flue-instrumentation",
+    });
+    expect(operationSpan?.log).toHaveBeenCalledWith({ input: [currentUser] });
+    expect(turnSpans).toHaveLength(3);
+    expect(turnSpans[0]?.args.event).toMatchObject({
+      input: [previousUser, previousAssistant, currentUser],
+      metadata: {
+        "flue.input_mode": "full",
+        "flue.system_prompt": "Be precise",
+        tools: [{ name: "lookup" }],
+      },
+    });
+    expect(turnSpans[1]?.args.event).toMatchObject({
+      input: [toolCall, toolResult],
+      metadata: {
+        "flue.input_message_offset": 3,
+        "flue.input_mode": "delta",
+      },
+    });
+    expect(turnSpans[1]?.args.event.metadata).not.toHaveProperty(
+      "flue.system_prompt",
+    );
+    expect(turnSpans[1]?.args.event.metadata).not.toHaveProperty("tools");
+    expect(turnSpans[2]?.args.event).toMatchObject({
+      input: [currentUser],
+      metadata: {
+        "flue.input_mode": "reset",
+        "flue.system_prompt": "Use compacted context",
+        tools: [{ name: "search" }],
+      },
+    });
+    expect(mockFlush).not.toHaveBeenCalled();
+  });
+
   it("flushes without awaiting when a run ends", () => {
     const emit = observeEvents();
     const pendingFlush = new Promise<void>(() => {});
@@ -962,6 +1096,14 @@ describe("Flue observe instrumentation", () => {
       type: "task_start",
     });
     emit({
+      operationId: "op-task-prompt",
+      operationKind: "prompt",
+      runId: "run-1",
+      session: "task:task-1",
+      taskId: "task-1",
+      type: "operation_start",
+    });
+    emit({
       durationMs: 5,
       isError: false,
       operationId: "op-task",
@@ -982,9 +1124,11 @@ describe("Flue observe instrumentation", () => {
 
     const workflowSpan = findSpan("workflow:research");
     const taskSpans = spans.filter((span) => span.name === "flue.task");
+    const nestedPromptSpan = findSpan("flue.prompt");
 
     expect(taskSpans).toHaveLength(1);
     expect(taskSpans[0]?.spanParents).toEqual([workflowSpan?.spanId]);
+    expect(nestedPromptSpan?.spanParents).toEqual([taskSpans[0]?.spanId]);
     expect(taskSpans[0]?.args.event.input).toBe("Reply with TASK_DONE");
     expect(taskSpans[0]?.log).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/js/src/instrumentation/plugins/flue-plugin.ts
+++ b/js/src/instrumentation/plugins/flue-plugin.ts
@@ -4,6 +4,7 @@ import type { ChannelMessage } from "../core/channel-definitions";
 import type { IsoChannelHandlers } from "../../isomorph";
 import {
   BRAINTRUST_CURRENT_SPAN_STORE,
+  NOOP_SPAN,
   flush,
   _internalGetGlobalState,
   startSpan as startBaseSpan,
@@ -62,6 +63,14 @@ type SpanState = {
   loggedInput?: boolean;
   metadata: Record<string, unknown>;
   span: Span;
+  turnInputState?: FlueTurnInputState;
+};
+
+type FlueTurnInputState = {
+  boundaryFingerprint?: string;
+  messageCount: number;
+  systemPromptFingerprint?: string;
+  toolsFingerprint?: string;
 };
 
 const FLUE_AUTO_STATE = Symbol.for("braintrust.flue.auto-state");
@@ -594,17 +603,25 @@ class FlueObserveBridge {
     }
 
     const metadata = {
+      ...(event.runId ? this.runsById.get(event.runId)?.metadata : {}),
       ...extractEventMetadata(event),
       "flue.operation": event.operationKind,
       provider: "flue",
     };
     const parent = this.parentSpanForEvent(event);
-    const span = startFlueSpan(parent, {
+    const args = {
       name: `flue.${event.operationKind}`,
       spanAttributes: { type: SpanTypeAttribute.TASK },
       startTime: eventTime(event.timestamp),
       event: { metadata },
-    });
+    } satisfies StartSpanArgs;
+    const runSpan = event.runId
+      ? this.runsById.get(event.runId)?.span
+      : undefined;
+    const span =
+      event.operationKind === "prompt" && (!parent || parent === runSpan)
+        ? startFlueRootSpan(args)
+        : startFlueSpan(parent, args);
 
     this.operationsById.set(event.operationId, { metadata, span });
   }
@@ -628,6 +645,11 @@ class FlueObserveBridge {
       ...(event.usage ? { "flue.usage": event.usage } : {}),
     };
 
+    const input = flueOperationInput(event);
+    if (!state.loggedInput && input !== undefined) {
+      safeLog(state.span, { input });
+      state.loggedInput = true;
+    }
     this.finishPendingChildrenForOperation(event, output);
     safeLog(state.span, {
       ...(event.isError
@@ -648,6 +670,10 @@ class FlueObserveBridge {
     }
 
     const input = flueTurnRequestInput(event);
+    const operation = event.operationId
+      ? this.operationsById.get(event.operationId)
+      : undefined;
+    const turnInput = prepareFlueTurnInput(event, input, operation);
     const model = flueTurnRequestModel(event);
     const provider = flueTurnRequestProvider(event);
     const api = flueTurnRequestApi(event);
@@ -660,10 +686,7 @@ class FlueObserveBridge {
       ...(provider ? { "flue.provider": provider } : {}),
       ...(event.purpose ? { "flue.turn_purpose": event.purpose } : {}),
       ...(reasoning ? { reasoning } : {}),
-      ...(input?.systemPrompt
-        ? { "flue.system_prompt": input.systemPrompt }
-        : {}),
-      ...(input?.tools ? { tools: input.tools } : {}),
+      ...turnInput.metadata,
     };
     const parent = this.parentSpanForTurn(event);
     const span = startFlueSpan(parent, {
@@ -671,12 +694,15 @@ class FlueObserveBridge {
       spanAttributes: { type: SpanTypeAttribute.LLM },
       startTime: eventTime(event.timestamp),
       event: {
-        input: input?.messages,
+        input: turnInput.messages,
         metadata,
       },
     });
 
-    this.logOperationInput(event.operationId, input?.messages ?? input);
+    this.logOperationInput(
+      event.operationId,
+      latestUserMessageInput(input?.messages),
+    );
     this.turnsByKey.set(key, { metadata, span });
   }
 
@@ -968,16 +994,25 @@ class FlueObserveBridge {
 
   private startSyntheticOperation(event: FlueOperationEvent): SpanState {
     const metadata = {
+      ...(event.runId ? this.runsById.get(event.runId)?.metadata : {}),
       ...extractEventMetadata(event),
       "flue.operation": event.operationKind,
       provider: "flue",
     };
-    const span = startFlueSpan(this.parentSpanForEvent(event), {
+    const args = {
       name: `flue.${event.operationKind}`,
       spanAttributes: { type: SpanTypeAttribute.TASK },
       startTime: eventTime(event.timestamp),
       event: { metadata },
-    });
+    } satisfies StartSpanArgs;
+    const parent = this.parentSpanForEvent(event);
+    const runSpan = event.runId
+      ? this.runsById.get(event.runId)?.span
+      : undefined;
+    const span =
+      event.operationKind === "prompt" && (!parent || parent === runSpan)
+        ? startFlueRootSpan(args)
+        : startFlueSpan(parent, args);
     return { metadata, span };
   }
 
@@ -1201,6 +1236,117 @@ function flueTurnRequestInput(
   return event.request?.input ?? event.input;
 }
 
+function prepareFlueTurnInput(
+  event: FlueTurnRequestEvent,
+  input: FlueTurnRequestEvent["input"],
+  operation: SpanState | undefined,
+): { messages: unknown[] | undefined; metadata: Record<string, unknown> } {
+  const messages = input?.messages;
+  const tracksUserTurn =
+    event.purpose === "agent" &&
+    operation?.metadata["flue.operation"] === "prompt" &&
+    Array.isArray(messages);
+  if (!tracksUserTurn) {
+    return {
+      messages,
+      metadata: {
+        ...(input?.systemPrompt
+          ? { "flue.system_prompt": input.systemPrompt }
+          : {}),
+        ...(input?.tools ? { tools: input.tools } : {}),
+      },
+    };
+  }
+
+  const previous = operation.turnInputState;
+  const previousMessageCount = previous?.messageCount ?? 0;
+  const boundaryFingerprint =
+    messages.length > 0
+      ? fingerprintJsonValue(messages[messages.length - 1])
+      : undefined;
+  const continuesPreviousInput =
+    previous !== undefined &&
+    messages.length >= previousMessageCount &&
+    (previousMessageCount === 0 ||
+      (previous.boundaryFingerprint !== undefined &&
+        previous.boundaryFingerprint ===
+          fingerprintJsonValue(messages[previousMessageCount - 1])));
+  const inputMode =
+    previous === undefined
+      ? "full"
+      : continuesPreviousInput
+        ? "delta"
+        : "reset";
+  const systemPromptFingerprint = fingerprintJsonValue(input?.systemPrompt);
+  const toolsFingerprint = fingerprintJsonValue(input?.tools);
+
+  operation.turnInputState = {
+    ...(boundaryFingerprint !== undefined ? { boundaryFingerprint } : {}),
+    messageCount: messages.length,
+    ...(systemPromptFingerprint !== undefined
+      ? { systemPromptFingerprint }
+      : {}),
+    ...(toolsFingerprint !== undefined ? { toolsFingerprint } : {}),
+  };
+
+  return {
+    messages: continuesPreviousInput
+      ? messages.slice(previousMessageCount)
+      : messages,
+    metadata: {
+      "flue.input_mode": inputMode,
+      ...(continuesPreviousInput
+        ? { "flue.input_message_offset": previousMessageCount }
+        : {}),
+      ...(input?.systemPrompt &&
+      (!continuesPreviousInput ||
+        systemPromptFingerprint !== previous?.systemPromptFingerprint)
+        ? { "flue.system_prompt": input.systemPrompt }
+        : {}),
+      ...(input?.tools &&
+      (!continuesPreviousInput ||
+        toolsFingerprint !== previous?.toolsFingerprint)
+        ? { tools: input.tools }
+        : {}),
+    },
+  };
+}
+
+function fingerprintJsonValue(value: unknown): string | undefined {
+  try {
+    const serialized = JSON.stringify(value);
+    if (serialized === undefined) {
+      return undefined;
+    }
+    let hash = 2166136261;
+    for (let i = 0; i < serialized.length; i++) {
+      hash = Math.imul(hash ^ serialized.charCodeAt(i), 16777619);
+    }
+    return `${serialized.length}:${hash >>> 0}`;
+  } catch {
+    return undefined;
+  }
+}
+
+function latestUserMessageInput(messages: unknown[] | undefined): unknown {
+  if (!messages) {
+    return undefined;
+  }
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (isObjectLike(message) && Reflect.get(message, "role") === "user") {
+      return [message];
+    }
+  }
+  return undefined;
+}
+
+function flueOperationInput(event: FlueOperationEvent): unknown {
+  return typeof event.agentInput?.text === "string"
+    ? [{ content: event.agentInput.text, role: "user" }]
+    : undefined;
+}
+
 function flueTurnRequestModel(event: FlueTurnRequestEvent): string | undefined {
   return event.request?.requestedModel ?? event.request?.model ?? event.model;
 }
@@ -1419,6 +1565,26 @@ function startFlueSpan(parent: Span | undefined, args: StartSpanArgs): Span {
     : startBaseSpan(
         withSpanInstrumentationName(args, INSTRUMENTATION_NAMES.FLUE),
       );
+}
+
+function startFlueRootSpan(args: StartSpanArgs): Span {
+  const state = _internalGetGlobalState();
+  const spanId = state.idGenerator.getSpanId();
+  const rootSpanId = state.idGenerator.shareRootSpanId()
+    ? spanId
+    : state.idGenerator.getTraceId();
+
+  return withCurrent(
+    NOOP_SPAN,
+    () =>
+      startBaseSpan({
+        ...withSpanInstrumentationName(args, INSTRUMENTATION_NAMES.FLUE),
+        parentSpanIds: { parentSpanIds: [], rootSpanId },
+        spanId,
+        state,
+      }),
+    state,
+  );
 }
 
 function runWithCurrentSpanStore<T>(


### PR DESCRIPTION
This might be slightly controversial but critical for situations with heavily restricted memory like cloudflare DOs.

This PR changes the flue instrumentation to only track full previous history inside the input of the first llm span of a turn. All subsequent spans just get the previous span(s) as input.

The obvious drawback here is that we are losing history rewriting during a turn but that is relatively unlikely to happen or be a pattern.