### PR TITLE
fix: Pass id and tags to scorer

### DIFF
--- a/.changeset/pass-id-tags-to-scorer.md
+++ b/.changeset/pass-id-tags-to-scorer.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+fix: Pass id and tags to scorer

--- a/js/src/framework.test.ts
+++ b/js/src/framework.test.ts
@@ -150,6 +150,43 @@ test("expected (read/write) is passed to task", async () => {
   });
 });
 
+test("EvalCase id and tags are passed to scorers", async () => {
+  let scorerArgs: { id?: string; tags?: string[] } | undefined;
+
+  await runEvaluator(
+    null,
+    {
+      projectName: "proj",
+      evalName: "eval",
+      data: [
+        {
+          id: "dataset-row-id",
+          input: 1,
+          expected: 2,
+          tags: ["dataset-tag"],
+        },
+      ],
+      task: async (input: number) => input * 2,
+      scores: [
+        ({ id, tags }) => {
+          scorerArgs = { id, tags };
+          return 1;
+        },
+      ],
+    },
+    new NoopProgressReporter(),
+    [],
+    undefined,
+    undefined,
+    true,
+  );
+
+  expect(scorerArgs).toEqual({
+    id: "dataset-row-id",
+    tags: ["dataset-tag"],
+  });
+});
+
 function makeTestScorer(
   name: string,
   willError?: boolean,

--- a/js/src/framework.ts
+++ b/js/src/framework.ts
@@ -1323,10 +1323,12 @@ async function runEvaluatorInternal(
             }
 
             const scoringArgs = {
+              id: datum.id,
               input: datum.input,
               expected: "expected" in datum ? datum.expected : undefined,
               metadata,
               output,
+              tags,
               trace,
             };
             const { trace: _trace, ...scoringArgsForLogging } = scoringArgs;


### PR DESCRIPTION
closes SDK-139