### PR TITLE
feat: Add DeepSeek Harness plugin

### DIFF
--- a/.changeset/deepseek-harness-plugin.md
+++ b/.changeset/deepseek-harness-plugin.md
@@ -1,0 +1,6 @@
+---
+"@braintrust/deepseek-harness": minor
+"braintrust": minor
+---
+
+feat: Add DeepSeek Harness plugin

--- a/.changeset/deepseek-harness-plugin.md
+++ b/.changeset/deepseek-harness-plugin.md
@@ -1,5 +1,5 @@
 ---
-"@braintrust/deepseek-harness": minor
+"@braintrust/deepseek-harness": major
 "braintrust": minor
 ---
 

--- a/.changeset/deepseek-harness-plugin.md
+++ b/.changeset/deepseek-harness-plugin.md
@@ -1,6 +1,5 @@
 ---
 "@braintrust/deepseek-harness": major
-"braintrust": minor
 ---
 
 feat: Add DeepSeek Harness plugin

--- a/e2e/config/pr-comment-scenarios.json
+++ b/e2e/config/pr-comment-scenarios.json
@@ -1,5 +1,20 @@
 [
   {
+    "scenarioDirName": "deepseek-harness-instrumentation",
+    "label": "DeepSeek Harness Instrumentation",
+    "metadataScenario": "deepseek-harness-instrumentation",
+    "variants": [
+      {
+        "variantKey": "deepseek-harness-v0",
+        "label": "v0.1 prerelease pinned"
+      },
+      {
+        "variantKey": "deepseek-harness-v0-latest",
+        "label": "v0.1 prerelease latest"
+      }
+    ]
+  },
+  {
     "scenarioDirName": "cloudflare-agents-instrumentation",
     "label": "Cloudflare Agents Instrumentation",
     "metadataScenario": "cloudflare-agents-instrumentation",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,6 +8,7 @@
     "test:e2e:record": "node ./scripts/run-record-tests.mjs"
   },
   "devDependencies": {
+    "@braintrust/deepseek-harness": "workspace:^",
     "@braintrust/langchain-js": "workspace:^",
     "@braintrust/otel": "workspace:^",
     "@braintrust/seinfeld": "workspace:^",

--- a/e2e/scenarios/deepseek-harness-instrumentation/__cassettes__/deepseek-harness-v0-latest.cassette.json
+++ b/e2e/scenarios/deepseek-harness-instrumentation/__cassettes__/deepseek-harness-v0-latest.cassette.json
@@ -1,0 +1,495 @@
+{
+  "entries": [
+    {
+      "callIndex": 0,
+      "id": "f792d70093ae4255",
+      "matchKey": "POST api.openai.com/v1/responses",
+      "recordedAt": "2026-08-17T13:50:18.212Z",
+      "request": {
+        "body": {
+          "kind": "json",
+          "value": {
+            "input": [
+              {
+                "content": "You are an AI agent powered by DeepSeek Harness.",
+                "role": "developer"
+              },
+              {
+                "content": [
+                  {
+                    "text": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+                    "type": "input_text"
+                  }
+                ],
+                "role": "user"
+              }
+            ],
+            "max_output_tokens": 2000,
+            "model": "gpt-5.6-luna",
+            "prompt_cache_key": "[REDACTED]",
+            "store": false,
+            "stream": true,
+            "tools": [
+              {
+                "description": "Return a deterministic lookup result",
+                "name": "lookup",
+                "parameters": {
+                  "properties": {
+                    "query": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["query"],
+                  "type": "object"
+                },
+                "strict": false,
+                "type": "function"
+              }
+            ]
+          }
+        },
+        "headers": {},
+        "method": "POST",
+        "url": "https://api.openai.com/v1/responses"
+      },
+      "response": {
+        "body": {
+          "chunks": [
+            "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_0a13641652e69e84016a83119967f881918a6c635c7f4ec51f\",\"object\":\"response\",\"created_at\":1786974617,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}",
+            "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_0a13641652e69e84016a83119967f881918a6c635c7f4ec51f\",\"object\":\"response\",\"created_at\":1786974617,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}",
+            "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_0a13641652e69e84016a83119a07b0819197c26e0e9217aeca\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_xMz0J1dziwIG1N40EjROvoLR\",\"name\":\"lookup\"},\"output_index\":0,\"sequence_number\":2}",
+            "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"\",\"item_id\":\"fc_0a13641652e69e84016a83119a07b0819197c26e0e9217aeca\",\"obfuscation\":\"ED8Lf9nE8VxeMi\",\"output_index\":0,\"sequence_number\":3}",
+            "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"query\",\"item_id\":\"fc_0a13641652e69e84016a83119a07b0819197c26e0e9217aeca\",\"obfuscation\":\"KNgbKIVeHj4\",\"output_index\":0,\"sequence_number\":4}",
+            "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"\\\":\\\"\",\"item_id\":\"fc_0a13641652e69e84016a83119a07b0819197c26e0e9217aeca\",\"obfuscation\":\"u3ZHBNYJDv5EJ\",\"output_index\":0,\"sequence_number\":5}",
+            "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"first\",\"item_id\":\"fc_0a13641652e69e84016a83119a07b0819197c26e0e9217aeca\",\"obfuscation\":\"G5eUhXKRcKh\",\"output_index\":0,\"sequence_number\":6}",
+            "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"\\\"}\",\"item_id\":\"fc_0a13641652e69e84016a83119a07b0819197c26e0e9217aeca\",\"obfuscation\":\"A5gEuI2rIOT9Uc\",\"output_index\":0,\"sequence_number\":7}",
+            "event: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"query\\\":\\\"first\\\"}\",\"item_id\":\"fc_0a13641652e69e84016a83119a07b0819197c26e0e9217aeca\",\"output_index\":0,\"sequence_number\":8}",
+            "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_0a13641652e69e84016a83119a07b0819197c26e0e9217aeca\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"query\\\":\\\"first\\\"}\",\"call_id\":\"call_xMz0J1dziwIG1N40EjROvoLR\",\"name\":\"lookup\"},\"output_index\":0,\"sequence_number\":9}",
+            "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_0a13641652e69e84016a83119967f881918a6c635c7f4ec51f\",\"object\":\"response\",\"created_at\":1786974617,\"status\":\"completed\",\"background\":false,\"completed_at\":1786974618,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[{\"id\":\"fc_0a13641652e69e84016a83119a07b0819197c26e0e9217aeca\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"query\\\":\\\"first\\\"}\",\"call_id\":\"call_xMz0J1dziwIG1N40EjROvoLR\",\"name\":\"lookup\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":73,\"input_tokens_details\":{\"cache_write_tokens\":0,\"cached_tokens\":0},\"output_tokens\":17,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":90},\"user\":null,\"metadata\":{}},\"sequence_number\":10}"
+          ],
+          "kind": "sse"
+        },
+        "headers": {
+          "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "a2c9259e5a8bc99f-IAD",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Mon, 17 Aug 2026 13:50:17 GMT",
+          "openai-organization": "braintrust-data",
+          "openai-processing-ms": "344",
+          "openai-project": "proj_vsCSXafhhByzWOThMrJcZiw9",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "set-cookie": "[REDACTED]",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "transfer-encoding": "chunked",
+          "x-content-type-options": "nosniff",
+          "x-ratelimit-limit-requests": "30000",
+          "x-ratelimit-limit-tokens": "180000000",
+          "x-ratelimit-remaining-requests": "29999",
+          "x-ratelimit-remaining-tokens": "179999493",
+          "x-ratelimit-reset-requests": "2ms",
+          "x-ratelimit-reset-tokens": "0s",
+          "x-request-id": "req_a4600634eccd4f74a3ec4a739f71c0d9"
+        },
+        "status": 200,
+        "statusText": "OK"
+      }
+    },
+    {
+      "callIndex": 1,
+      "id": "60261dcb6d9ec8a3",
+      "matchKey": "POST api.openai.com/v1/responses",
+      "recordedAt": "2026-08-17T13:50:18.898Z",
+      "request": {
+        "body": {
+          "kind": "json",
+          "value": {
+            "input": [
+              {
+                "content": "You are an AI agent powered by DeepSeek Harness.",
+                "role": "developer"
+              },
+              {
+                "content": [
+                  {
+                    "text": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+                    "type": "input_text"
+                  }
+                ],
+                "role": "user"
+              },
+              {
+                "arguments": "{\"query\":\"first\"}",
+                "call_id": "call_xMz0J1dziwIG1N40EjROvoLR",
+                "id": "fc_0a13641652e69e84016a83119a07b0819197c26e0e9217aeca",
+                "name": "lookup",
+                "type": "function_call"
+              },
+              {
+                "call_id": "call_xMz0J1dziwIG1N40EjROvoLR",
+                "output": "Lookup result for first",
+                "type": "function_call_output"
+              }
+            ],
+            "max_output_tokens": 2000,
+            "model": "gpt-5.6-luna",
+            "prompt_cache_key": "[REDACTED]",
+            "store": false,
+            "stream": true,
+            "tools": [
+              {
+                "description": "Return a deterministic lookup result",
+                "name": "lookup",
+                "parameters": {
+                  "properties": {
+                    "query": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["query"],
+                  "type": "object"
+                },
+                "strict": false,
+                "type": "function"
+              }
+            ]
+          }
+        },
+        "headers": {},
+        "method": "POST",
+        "url": "https://api.openai.com/v1/responses"
+      },
+      "response": {
+        "body": {
+          "chunks": [
+            "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_0a13641652e69e84016a83119a4ac08191b3f9a28f7e99fb25\",\"object\":\"response\",\"created_at\":1786974618,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}",
+            "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_0a13641652e69e84016a83119a4ac08191b3f9a28f7e99fb25\",\"object\":\"response\",\"created_at\":1786974618,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}",
+            "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_0a13641652e69e84016a83119ab1008191b4b60d0d4d777869\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"phase\":\"final_answer\",\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":2}",
+            "event: response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_0a13641652e69e84016a83119ab1008191b4b60d0d4d777869\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":3}",
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"First\",\"item_id\":\"msg_0a13641652e69e84016a83119ab1008191b4b60d0d4d777869\",\"logprobs\":[],\"obfuscation\":\"WWYT1wIZAVW\",\"output_index\":0,\"sequence_number\":4}",
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Harness\",\"item_id\":\"msg_0a13641652e69e84016a83119ab1008191b4b60d0d4d777869\",\"logprobs\":[],\"obfuscation\":\"1f7uJOws\",\"output_index\":0,\"sequence_number\":5}",
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" answer\",\"item_id\":\"msg_0a13641652e69e84016a83119ab1008191b4b60d0d4d777869\",\"logprobs\":[],\"obfuscation\":\"3Q7JyR26Z\",\"output_index\":0,\"sequence_number\":6}",
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0a13641652e69e84016a83119ab1008191b4b60d0d4d777869\",\"logprobs\":[],\"obfuscation\":\"C5AyKexA6qVVDir\",\"output_index\":0,\"sequence_number\":7}",
+            "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_0a13641652e69e84016a83119ab1008191b4b60d0d4d777869\",\"logprobs\":[],\"output_index\":0,\"sequence_number\":8,\"text\":\"First Harness answer.\"}",
+            "event: response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_0a13641652e69e84016a83119ab1008191b4b60d0d4d777869\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"First Harness answer.\"},\"sequence_number\":9}",
+            "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_0a13641652e69e84016a83119ab1008191b4b60d0d4d777869\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"First Harness answer.\"}],\"phase\":\"final_answer\",\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":10}",
+            "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_0a13641652e69e84016a83119a4ac08191b3f9a28f7e99fb25\",\"object\":\"response\",\"created_at\":1786974618,\"status\":\"completed\",\"background\":false,\"completed_at\":1786974618,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[{\"id\":\"msg_0a13641652e69e84016a83119ab1008191b4b60d0d4d777869\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"First Harness answer.\"}],\"phase\":\"final_answer\",\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":104,\"input_tokens_details\":{\"cache_write_tokens\":0,\"cached_tokens\":0},\"output_tokens\":8,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":112},\"user\":null,\"metadata\":{}},\"sequence_number\":11}"
+          ],
+          "kind": "sse"
+        },
+        "headers": {
+          "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "a2c925a40fcac99f-IAD",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Mon, 17 Aug 2026 13:50:18 GMT",
+          "openai-organization": "braintrust-data",
+          "openai-processing-ms": "193",
+          "openai-project": "proj_vsCSXafhhByzWOThMrJcZiw9",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "set-cookie": "[REDACTED]",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "transfer-encoding": "chunked",
+          "x-content-type-options": "nosniff",
+          "x-ratelimit-limit-requests": "30000",
+          "x-ratelimit-limit-tokens": "180000000",
+          "x-ratelimit-remaining-requests": "29999",
+          "x-ratelimit-remaining-tokens": "179999460",
+          "x-ratelimit-reset-requests": "2ms",
+          "x-ratelimit-reset-tokens": "0s",
+          "x-request-id": "req_25498980abfe4123a1efa08c05fa52fd"
+        },
+        "status": 200,
+        "statusText": "OK"
+      }
+    },
+    {
+      "callIndex": 2,
+      "id": "82f47701c4991d84",
+      "matchKey": "POST api.openai.com/v1/responses",
+      "recordedAt": "2026-08-17T13:50:19.720Z",
+      "request": {
+        "body": {
+          "kind": "json",
+          "value": {
+            "input": [
+              {
+                "content": "You are an AI agent powered by DeepSeek Harness.",
+                "role": "developer"
+              },
+              {
+                "content": [
+                  {
+                    "text": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+                    "type": "input_text"
+                  }
+                ],
+                "role": "user"
+              },
+              {
+                "arguments": "{\"query\":\"first\"}",
+                "call_id": "call_xMz0J1dziwIG1N40EjROvoLR",
+                "id": "fc_0a13641652e69e84016a83119a07b0819197c26e0e9217aeca",
+                "name": "lookup",
+                "type": "function_call"
+              },
+              {
+                "call_id": "call_xMz0J1dziwIG1N40EjROvoLR",
+                "output": "Lookup result for first",
+                "type": "function_call_output"
+              },
+              {
+                "content": [
+                  {
+                    "annotations": [],
+                    "text": "First Harness answer.",
+                    "type": "output_text"
+                  }
+                ],
+                "id": "msg_0a13641652e69e84016a83119ab1008191b4b60d0d4d777869",
+                "phase": "final_answer",
+                "role": "assistant",
+                "status": "completed",
+                "type": "message"
+              },
+              {
+                "content": [
+                  {
+                    "text": "Call lookup exactly once with query `second`. Then reply exactly: Second Harness answer.",
+                    "type": "input_text"
+                  }
+                ],
+                "role": "user"
+              }
+            ],
+            "max_output_tokens": 2000,
+            "model": "gpt-5.6-luna",
+            "prompt_cache_key": "[REDACTED]",
+            "store": false,
+            "stream": true,
+            "tools": [
+              {
+                "description": "Return a deterministic lookup result",
+                "name": "lookup",
+                "parameters": {
+                  "properties": {
+                    "query": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["query"],
+                  "type": "object"
+                },
+                "strict": false,
+                "type": "function"
+              }
+            ]
+          }
+        },
+        "headers": {},
+        "method": "POST",
+        "url": "https://api.openai.com/v1/responses"
+      },
+      "response": {
+        "body": {
+          "chunks": [
+            "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_0a13641652e69e84016a83119b021881918e355c37d5211cad\",\"object\":\"response\",\"created_at\":1786974619,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}",
+            "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_0a13641652e69e84016a83119b021881918e355c37d5211cad\",\"object\":\"response\",\"created_at\":1786974619,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}",
+            "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_0a13641652e69e84016a83119b8e308191965ec0472d468879\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_kag3c0Ow1SDDPCP1g6L3UM2d\",\"name\":\"lookup\"},\"output_index\":0,\"sequence_number\":2}",
+            "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"\",\"item_id\":\"fc_0a13641652e69e84016a83119b8e308191965ec0472d468879\",\"obfuscation\":\"3fCurRxBQ5HrJY\",\"output_index\":0,\"sequence_number\":3}",
+            "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"query\",\"item_id\":\"fc_0a13641652e69e84016a83119b8e308191965ec0472d468879\",\"obfuscation\":\"wR0QFduepDk\",\"output_index\":0,\"sequence_number\":4}",
+            "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"\\\":\\\"\",\"item_id\":\"fc_0a13641652e69e84016a83119b8e308191965ec0472d468879\",\"obfuscation\":\"VGSxTas5Bajdy\",\"output_index\":0,\"sequence_number\":5}",
+            "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"second\",\"item_id\":\"fc_0a13641652e69e84016a83119b8e308191965ec0472d468879\",\"obfuscation\":\"VY7oogeYzQ\",\"output_index\":0,\"sequence_number\":6}",
+            "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"\\\"}\",\"item_id\":\"fc_0a13641652e69e84016a83119b8e308191965ec0472d468879\",\"obfuscation\":\"PvN6IedH8CnySR\",\"output_index\":0,\"sequence_number\":7}",
+            "event: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"query\\\":\\\"second\\\"}\",\"item_id\":\"fc_0a13641652e69e84016a83119b8e308191965ec0472d468879\",\"output_index\":0,\"sequence_number\":8}",
+            "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_0a13641652e69e84016a83119b8e308191965ec0472d468879\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"query\\\":\\\"second\\\"}\",\"call_id\":\"call_kag3c0Ow1SDDPCP1g6L3UM2d\",\"name\":\"lookup\"},\"output_index\":0,\"sequence_number\":9}",
+            "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_0a13641652e69e84016a83119b021881918e355c37d5211cad\",\"object\":\"response\",\"created_at\":1786974619,\"status\":\"completed\",\"background\":false,\"completed_at\":1786974619,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[{\"id\":\"fc_0a13641652e69e84016a83119b8e308191965ec0472d468879\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"query\\\":\\\"second\\\"}\",\"call_id\":\"call_kag3c0Ow1SDDPCP1g6L3UM2d\",\"name\":\"lookup\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":135,\"input_tokens_details\":{\"cache_write_tokens\":0,\"cached_tokens\":0},\"output_tokens\":17,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":152},\"user\":null,\"metadata\":{}},\"sequence_number\":10}"
+          ],
+          "kind": "sse"
+        },
+        "headers": {
+          "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "a2c925a838e4c99f-IAD",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Mon, 17 Aug 2026 13:50:19 GMT",
+          "openai-organization": "braintrust-data",
+          "openai-processing-ms": "284",
+          "openai-project": "proj_vsCSXafhhByzWOThMrJcZiw9",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "set-cookie": "[REDACTED]",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "transfer-encoding": "chunked",
+          "x-content-type-options": "nosniff",
+          "x-ratelimit-limit-requests": "30000",
+          "x-ratelimit-limit-tokens": "180000000",
+          "x-ratelimit-remaining-requests": "29999",
+          "x-ratelimit-remaining-tokens": "179999430",
+          "x-ratelimit-reset-requests": "2ms",
+          "x-ratelimit-reset-tokens": "0s",
+          "x-request-id": "req_17f93bbc30e1403484aec0b5448efe7c"
+        },
+        "status": 200,
+        "statusText": "OK"
+      }
+    },
+    {
+      "callIndex": 3,
+      "id": "cfa2ae757313ab18",
+      "matchKey": "POST api.openai.com/v1/responses",
+      "recordedAt": "2026-08-17T13:50:20.442Z",
+      "request": {
+        "body": {
+          "kind": "json",
+          "value": {
+            "input": [
+              {
+                "content": "You are an AI agent powered by DeepSeek Harness.",
+                "role": "developer"
+              },
+              {
+                "content": [
+                  {
+                    "text": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+                    "type": "input_text"
+                  }
+                ],
+                "role": "user"
+              },
+              {
+                "arguments": "{\"query\":\"first\"}",
+                "call_id": "call_xMz0J1dziwIG1N40EjROvoLR",
+                "id": "fc_0a13641652e69e84016a83119a07b0819197c26e0e9217aeca",
+                "name": "lookup",
+                "type": "function_call"
+              },
+              {
+                "call_id": "call_xMz0J1dziwIG1N40EjROvoLR",
+                "output": "Lookup result for first",
+                "type": "function_call_output"
+              },
+              {
+                "content": [
+                  {
+                    "annotations": [],
+                    "text": "First Harness answer.",
+                    "type": "output_text"
+                  }
+                ],
+                "id": "msg_0a13641652e69e84016a83119ab1008191b4b60d0d4d777869",
+                "phase": "final_answer",
+                "role": "assistant",
+                "status": "completed",
+                "type": "message"
+              },
+              {
+                "content": [
+                  {
+                    "text": "Call lookup exactly once with query `second`. Then reply exactly: Second Harness answer.",
+                    "type": "input_text"
+                  }
+                ],
+                "role": "user"
+              },
+              {
+                "arguments": "{\"query\":\"second\"}",
+                "call_id": "call_kag3c0Ow1SDDPCP1g6L3UM2d",
+                "id": "fc_0a13641652e69e84016a83119b8e308191965ec0472d468879",
+                "name": "lookup",
+                "type": "function_call"
+              },
+              {
+                "call_id": "call_kag3c0Ow1SDDPCP1g6L3UM2d",
+                "output": "Lookup result for second",
+                "type": "function_call_output"
+              }
+            ],
+            "max_output_tokens": 2000,
+            "model": "gpt-5.6-luna",
+            "prompt_cache_key": "[REDACTED]",
+            "store": false,
+            "stream": true,
+            "tools": [
+              {
+                "description": "Return a deterministic lookup result",
+                "name": "lookup",
+                "parameters": {
+                  "properties": {
+                    "query": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["query"],
+                  "type": "object"
+                },
+                "strict": false,
+                "type": "function"
+              }
+            ]
+          }
+        },
+        "headers": {},
+        "method": "POST",
+        "url": "https://api.openai.com/v1/responses"
+      },
+      "response": {
+        "body": {
+          "chunks": [
+            "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_0a13641652e69e84016a83119bdad48191ba57ef65ee373184\",\"object\":\"response\",\"created_at\":1786974619,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}",
+            "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_0a13641652e69e84016a83119bdad48191ba57ef65ee373184\",\"object\":\"response\",\"created_at\":1786974619,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}",
+            "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_0a13641652e69e84016a83119c39b48191b2bcc057dd366539\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"phase\":\"final_answer\",\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":2}",
+            "event: response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_0a13641652e69e84016a83119c39b48191b2bcc057dd366539\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":3}",
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Second\",\"item_id\":\"msg_0a13641652e69e84016a83119c39b48191b2bcc057dd366539\",\"logprobs\":[],\"obfuscation\":\"r0xIRZLE0N\",\"output_index\":0,\"sequence_number\":4}",
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Harness\",\"item_id\":\"msg_0a13641652e69e84016a83119c39b48191b2bcc057dd366539\",\"logprobs\":[],\"obfuscation\":\"K4Jqk7FH\",\"output_index\":0,\"sequence_number\":5}",
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" answer\",\"item_id\":\"msg_0a13641652e69e84016a83119c39b48191b2bcc057dd366539\",\"logprobs\":[],\"obfuscation\":\"Fa8MwQTEP\",\"output_index\":0,\"sequence_number\":6}",
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0a13641652e69e84016a83119c39b48191b2bcc057dd366539\",\"logprobs\":[],\"obfuscation\":\"dzyhjrk59GcNMl8\",\"output_index\":0,\"sequence_number\":7}",
+            "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_0a13641652e69e84016a83119c39b48191b2bcc057dd366539\",\"logprobs\":[],\"output_index\":0,\"sequence_number\":8,\"text\":\"Second Harness answer.\"}",
+            "event: response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_0a13641652e69e84016a83119c39b48191b2bcc057dd366539\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Second Harness answer.\"},\"sequence_number\":9}",
+            "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_0a13641652e69e84016a83119c39b48191b2bcc057dd366539\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Second Harness answer.\"}],\"phase\":\"final_answer\",\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":10}",
+            "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_0a13641652e69e84016a83119bdad48191ba57ef65ee373184\",\"object\":\"response\",\"created_at\":1786974619,\"status\":\"completed\",\"background\":false,\"completed_at\":1786974620,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[{\"id\":\"msg_0a13641652e69e84016a83119c39b48191b2bcc057dd366539\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Second Harness answer.\"}],\"phase\":\"final_answer\",\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":166,\"input_tokens_details\":{\"cache_write_tokens\":0,\"cached_tokens\":0},\"output_tokens\":8,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":174},\"user\":null,\"metadata\":{}},\"sequence_number\":11}"
+          ],
+          "kind": "sse"
+        },
+        "headers": {
+          "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "a2c925ad5d07c99f-IAD",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Mon, 17 Aug 2026 13:50:20 GMT",
+          "openai-organization": "braintrust-data",
+          "openai-processing-ms": "306",
+          "openai-project": "proj_vsCSXafhhByzWOThMrJcZiw9",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "set-cookie": "[REDACTED]",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "transfer-encoding": "chunked",
+          "x-content-type-options": "nosniff",
+          "x-ratelimit-limit-requests": "30000",
+          "x-ratelimit-limit-tokens": "180000000",
+          "x-ratelimit-remaining-requests": "29999",
+          "x-ratelimit-remaining-tokens": "179999400",
+          "x-ratelimit-reset-requests": "2ms",
+          "x-ratelimit-reset-tokens": "0s",
+          "x-request-id": "req_5aed9d19cba14ee1a616ebdebda79434"
+        },
+        "status": 200,
+        "statusText": "OK"
+      }
+    }
+  ],
+  "meta": {
+    "createdAt": "2026-08-17T13:50:20.482Z"
+  }
+}

--- a/e2e/scenarios/deepseek-harness-instrumentation/__cassettes__/deepseek-harness-v0.cassette.json
+++ b/e2e/scenarios/deepseek-harness-instrumentation/__cassettes__/deepseek-harness-v0.cassette.json
@@ -1,0 +1,495 @@
+{
+  "entries": [
+    {
+      "callIndex": 0,
+      "id": "f792d70093ae4255",
+      "matchKey": "POST api.openai.com/v1/responses",
+      "recordedAt": "2026-08-17T13:50:09.580Z",
+      "request": {
+        "body": {
+          "kind": "json",
+          "value": {
+            "input": [
+              {
+                "content": "You are an AI agent powered by DeepSeek Harness.",
+                "role": "developer"
+              },
+              {
+                "content": [
+                  {
+                    "text": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+                    "type": "input_text"
+                  }
+                ],
+                "role": "user"
+              }
+            ],
+            "max_output_tokens": 2000,
+            "model": "gpt-5.6-luna",
+            "prompt_cache_key": "[REDACTED]",
+            "store": false,
+            "stream": true,
+            "tools": [
+              {
+                "description": "Return a deterministic lookup result",
+                "name": "lookup",
+                "parameters": {
+                  "properties": {
+                    "query": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["query"],
+                  "type": "object"
+                },
+                "strict": false,
+                "type": "function"
+              }
+            ]
+          }
+        },
+        "headers": {},
+        "method": "POST",
+        "url": "https://api.openai.com/v1/responses"
+      },
+      "response": {
+        "body": {
+          "chunks": [
+            "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_0f61927da1eefd26016a83119095948191bf5d4c83a29f5266\",\"object\":\"response\",\"created_at\":1786974608,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}",
+            "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_0f61927da1eefd26016a83119095948191bf5d4c83a29f5266\",\"object\":\"response\",\"created_at\":1786974608,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}",
+            "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_0f61927da1eefd26016a8311915e24819198db51b965325b6a\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_GSOaMKXu3uekczmgnfsDTKkm\",\"name\":\"lookup\"},\"output_index\":0,\"sequence_number\":2}",
+            "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"\",\"item_id\":\"fc_0f61927da1eefd26016a8311915e24819198db51b965325b6a\",\"obfuscation\":\"vVmByHLBUZ988I\",\"output_index\":0,\"sequence_number\":3}",
+            "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"query\",\"item_id\":\"fc_0f61927da1eefd26016a8311915e24819198db51b965325b6a\",\"obfuscation\":\"ADL0xfULATC\",\"output_index\":0,\"sequence_number\":4}",
+            "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"\\\":\\\"\",\"item_id\":\"fc_0f61927da1eefd26016a8311915e24819198db51b965325b6a\",\"obfuscation\":\"ujQHyKIBGKmnI\",\"output_index\":0,\"sequence_number\":5}",
+            "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"first\",\"item_id\":\"fc_0f61927da1eefd26016a8311915e24819198db51b965325b6a\",\"obfuscation\":\"GNPOYJ2mpcx\",\"output_index\":0,\"sequence_number\":6}",
+            "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"\\\"}\",\"item_id\":\"fc_0f61927da1eefd26016a8311915e24819198db51b965325b6a\",\"obfuscation\":\"iXYJR7eefJFy2f\",\"output_index\":0,\"sequence_number\":7}",
+            "event: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"query\\\":\\\"first\\\"}\",\"item_id\":\"fc_0f61927da1eefd26016a8311915e24819198db51b965325b6a\",\"output_index\":0,\"sequence_number\":8}",
+            "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_0f61927da1eefd26016a8311915e24819198db51b965325b6a\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"query\\\":\\\"first\\\"}\",\"call_id\":\"call_GSOaMKXu3uekczmgnfsDTKkm\",\"name\":\"lookup\"},\"output_index\":0,\"sequence_number\":9}",
+            "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_0f61927da1eefd26016a83119095948191bf5d4c83a29f5266\",\"object\":\"response\",\"created_at\":1786974608,\"status\":\"completed\",\"background\":false,\"completed_at\":1786974609,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[{\"id\":\"fc_0f61927da1eefd26016a8311915e24819198db51b965325b6a\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"query\\\":\\\"first\\\"}\",\"call_id\":\"call_GSOaMKXu3uekczmgnfsDTKkm\",\"name\":\"lookup\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":73,\"input_tokens_details\":{\"cache_write_tokens\":0,\"cached_tokens\":0},\"output_tokens\":17,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":90},\"user\":null,\"metadata\":{}},\"sequence_number\":10}"
+          ],
+          "kind": "sse"
+        },
+        "headers": {
+          "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "a2c925630d58c99f-IAD",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Mon, 17 Aug 2026 13:50:08 GMT",
+          "openai-organization": "braintrust-data",
+          "openai-processing-ms": "435",
+          "openai-project": "proj_vsCSXafhhByzWOThMrJcZiw9",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "set-cookie": "[REDACTED]",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "transfer-encoding": "chunked",
+          "x-content-type-options": "nosniff",
+          "x-ratelimit-limit-requests": "30000",
+          "x-ratelimit-limit-tokens": "180000000",
+          "x-ratelimit-remaining-requests": "29999",
+          "x-ratelimit-remaining-tokens": "179999493",
+          "x-ratelimit-reset-requests": "2ms",
+          "x-ratelimit-reset-tokens": "0s",
+          "x-request-id": "req_ecc8174ed87f4928b0369a994cae6839"
+        },
+        "status": 200,
+        "statusText": "OK"
+      }
+    },
+    {
+      "callIndex": 1,
+      "id": "315848d8de4e8b4a",
+      "matchKey": "POST api.openai.com/v1/responses",
+      "recordedAt": "2026-08-17T13:50:10.423Z",
+      "request": {
+        "body": {
+          "kind": "json",
+          "value": {
+            "input": [
+              {
+                "content": "You are an AI agent powered by DeepSeek Harness.",
+                "role": "developer"
+              },
+              {
+                "content": [
+                  {
+                    "text": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+                    "type": "input_text"
+                  }
+                ],
+                "role": "user"
+              },
+              {
+                "arguments": "{\"query\":\"first\"}",
+                "call_id": "call_GSOaMKXu3uekczmgnfsDTKkm",
+                "id": "fc_0f61927da1eefd26016a8311915e24819198db51b965325b6a",
+                "name": "lookup",
+                "type": "function_call"
+              },
+              {
+                "call_id": "call_GSOaMKXu3uekczmgnfsDTKkm",
+                "output": "Lookup result for first",
+                "type": "function_call_output"
+              }
+            ],
+            "max_output_tokens": 2000,
+            "model": "gpt-5.6-luna",
+            "prompt_cache_key": "[REDACTED]",
+            "store": false,
+            "stream": true,
+            "tools": [
+              {
+                "description": "Return a deterministic lookup result",
+                "name": "lookup",
+                "parameters": {
+                  "properties": {
+                    "query": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["query"],
+                  "type": "object"
+                },
+                "strict": false,
+                "type": "function"
+              }
+            ]
+          }
+        },
+        "headers": {},
+        "method": "POST",
+        "url": "https://api.openai.com/v1/responses"
+      },
+      "response": {
+        "body": {
+          "chunks": [
+            "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_0f61927da1eefd26016a831191b2308191a948b9243b720988\",\"object\":\"response\",\"created_at\":1786974609,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}",
+            "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_0f61927da1eefd26016a831191b2308191a948b9243b720988\",\"object\":\"response\",\"created_at\":1786974609,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}",
+            "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_0f61927da1eefd26016a83119231248191b15a1b2870456d4a\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"phase\":\"final_answer\",\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":2}",
+            "event: response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_0f61927da1eefd26016a83119231248191b15a1b2870456d4a\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":3}",
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"First\",\"item_id\":\"msg_0f61927da1eefd26016a83119231248191b15a1b2870456d4a\",\"logprobs\":[],\"obfuscation\":\"xon1XZSB8sC\",\"output_index\":0,\"sequence_number\":4}",
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Harness\",\"item_id\":\"msg_0f61927da1eefd26016a83119231248191b15a1b2870456d4a\",\"logprobs\":[],\"obfuscation\":\"ExDK0BkM\",\"output_index\":0,\"sequence_number\":5}",
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" answer\",\"item_id\":\"msg_0f61927da1eefd26016a83119231248191b15a1b2870456d4a\",\"logprobs\":[],\"obfuscation\":\"dGkxAgpfh\",\"output_index\":0,\"sequence_number\":6}",
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0f61927da1eefd26016a83119231248191b15a1b2870456d4a\",\"logprobs\":[],\"obfuscation\":\"H0i5Vpr34BgnMH6\",\"output_index\":0,\"sequence_number\":7}",
+            "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_0f61927da1eefd26016a83119231248191b15a1b2870456d4a\",\"logprobs\":[],\"output_index\":0,\"sequence_number\":8,\"text\":\"First Harness answer.\"}",
+            "event: response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_0f61927da1eefd26016a83119231248191b15a1b2870456d4a\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"First Harness answer.\"},\"sequence_number\":9}",
+            "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_0f61927da1eefd26016a83119231248191b15a1b2870456d4a\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"First Harness answer.\"}],\"phase\":\"final_answer\",\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":10}",
+            "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_0f61927da1eefd26016a831191b2308191a948b9243b720988\",\"object\":\"response\",\"created_at\":1786974609,\"status\":\"completed\",\"background\":false,\"completed_at\":1786974610,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[{\"id\":\"msg_0f61927da1eefd26016a83119231248191b15a1b2870456d4a\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"First Harness answer.\"}],\"phase\":\"final_answer\",\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":104,\"input_tokens_details\":{\"cache_write_tokens\":0,\"cached_tokens\":0},\"output_tokens\":8,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":112},\"user\":null,\"metadata\":{}},\"sequence_number\":11}"
+          ],
+          "kind": "sse"
+        },
+        "headers": {
+          "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "a2c9256e293cc99f-IAD",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Mon, 17 Aug 2026 13:50:10 GMT",
+          "openai-organization": "braintrust-data",
+          "openai-processing-ms": "365",
+          "openai-project": "proj_vsCSXafhhByzWOThMrJcZiw9",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "set-cookie": "[REDACTED]",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "transfer-encoding": "chunked",
+          "x-content-type-options": "nosniff",
+          "x-ratelimit-limit-requests": "30000",
+          "x-ratelimit-limit-tokens": "180000000",
+          "x-ratelimit-remaining-requests": "29999",
+          "x-ratelimit-remaining-tokens": "179999463",
+          "x-ratelimit-reset-requests": "2ms",
+          "x-ratelimit-reset-tokens": "0s",
+          "x-request-id": "req_45681b49d65c46a08653f7f5ab0cc942"
+        },
+        "status": 200,
+        "statusText": "OK"
+      }
+    },
+    {
+      "callIndex": 2,
+      "id": "91030f4ecfc7cae9",
+      "matchKey": "POST api.openai.com/v1/responses",
+      "recordedAt": "2026-08-17T13:50:13.128Z",
+      "request": {
+        "body": {
+          "kind": "json",
+          "value": {
+            "input": [
+              {
+                "content": "You are an AI agent powered by DeepSeek Harness.",
+                "role": "developer"
+              },
+              {
+                "content": [
+                  {
+                    "text": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+                    "type": "input_text"
+                  }
+                ],
+                "role": "user"
+              },
+              {
+                "arguments": "{\"query\":\"first\"}",
+                "call_id": "call_GSOaMKXu3uekczmgnfsDTKkm",
+                "id": "fc_0f61927da1eefd26016a8311915e24819198db51b965325b6a",
+                "name": "lookup",
+                "type": "function_call"
+              },
+              {
+                "call_id": "call_GSOaMKXu3uekczmgnfsDTKkm",
+                "output": "Lookup result for first",
+                "type": "function_call_output"
+              },
+              {
+                "content": [
+                  {
+                    "annotations": [],
+                    "text": "First Harness answer.",
+                    "type": "output_text"
+                  }
+                ],
+                "id": "msg_0f61927da1eefd26016a83119231248191b15a1b2870456d4a",
+                "phase": "final_answer",
+                "role": "assistant",
+                "status": "completed",
+                "type": "message"
+              },
+              {
+                "content": [
+                  {
+                    "text": "Call lookup exactly once with query `second`. Then reply exactly: Second Harness answer.",
+                    "type": "input_text"
+                  }
+                ],
+                "role": "user"
+              }
+            ],
+            "max_output_tokens": 2000,
+            "model": "gpt-5.6-luna",
+            "prompt_cache_key": "[REDACTED]",
+            "store": false,
+            "stream": true,
+            "tools": [
+              {
+                "description": "Return a deterministic lookup result",
+                "name": "lookup",
+                "parameters": {
+                  "properties": {
+                    "query": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["query"],
+                  "type": "object"
+                },
+                "strict": false,
+                "type": "function"
+              }
+            ]
+          }
+        },
+        "headers": {},
+        "method": "POST",
+        "url": "https://api.openai.com/v1/responses"
+      },
+      "response": {
+        "body": {
+          "chunks": [
+            "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_0f61927da1eefd26016a8311928c0c8191a5cffbf6a37c1877\",\"object\":\"response\",\"created_at\":1786974610,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}",
+            "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_0f61927da1eefd26016a8311928c0c8191a5cffbf6a37c1877\",\"object\":\"response\",\"created_at\":1786974610,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}",
+            "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_0f61927da1eefd26016a831194eb248191a66cc2f008ae8a8b\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_z74tDpYKFyDloXJLobkqa1rQ\",\"name\":\"lookup\"},\"output_index\":0,\"sequence_number\":2}",
+            "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"\",\"item_id\":\"fc_0f61927da1eefd26016a831194eb248191a66cc2f008ae8a8b\",\"obfuscation\":\"Gukpdz2JfcOPrW\",\"output_index\":0,\"sequence_number\":3}",
+            "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"query\",\"item_id\":\"fc_0f61927da1eefd26016a831194eb248191a66cc2f008ae8a8b\",\"obfuscation\":\"WTuqesOKi1f\",\"output_index\":0,\"sequence_number\":4}",
+            "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"\\\":\\\"\",\"item_id\":\"fc_0f61927da1eefd26016a831194eb248191a66cc2f008ae8a8b\",\"obfuscation\":\"TXegEhK5NhZp7\",\"output_index\":0,\"sequence_number\":5}",
+            "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"second\",\"item_id\":\"fc_0f61927da1eefd26016a831194eb248191a66cc2f008ae8a8b\",\"obfuscation\":\"OEIlJjr5zU\",\"output_index\":0,\"sequence_number\":6}",
+            "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"\\\"}\",\"item_id\":\"fc_0f61927da1eefd26016a831194eb248191a66cc2f008ae8a8b\",\"obfuscation\":\"cX0BLvGKeXCSzp\",\"output_index\":0,\"sequence_number\":7}",
+            "event: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"query\\\":\\\"second\\\"}\",\"item_id\":\"fc_0f61927da1eefd26016a831194eb248191a66cc2f008ae8a8b\",\"output_index\":0,\"sequence_number\":8}",
+            "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_0f61927da1eefd26016a831194eb248191a66cc2f008ae8a8b\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"query\\\":\\\"second\\\"}\",\"call_id\":\"call_z74tDpYKFyDloXJLobkqa1rQ\",\"name\":\"lookup\"},\"output_index\":0,\"sequence_number\":9}",
+            "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_0f61927da1eefd26016a8311928c0c8191a5cffbf6a37c1877\",\"object\":\"response\",\"created_at\":1786974610,\"status\":\"completed\",\"background\":false,\"completed_at\":1786974613,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[{\"id\":\"fc_0f61927da1eefd26016a831194eb248191a66cc2f008ae8a8b\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"query\\\":\\\"second\\\"}\",\"call_id\":\"call_z74tDpYKFyDloXJLobkqa1rQ\",\"name\":\"lookup\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":135,\"input_tokens_details\":{\"cache_write_tokens\":0,\"cached_tokens\":0},\"output_tokens\":17,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":152},\"user\":null,\"metadata\":{}},\"sequence_number\":10}"
+          ],
+          "kind": "sse"
+        },
+        "headers": {
+          "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "a2c925734d81c99f-IAD",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Mon, 17 Aug 2026 13:50:10 GMT",
+          "openai-organization": "braintrust-data",
+          "openai-processing-ms": "380",
+          "openai-project": "proj_vsCSXafhhByzWOThMrJcZiw9",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "set-cookie": "[REDACTED]",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "transfer-encoding": "chunked",
+          "x-content-type-options": "nosniff",
+          "x-ratelimit-limit-requests": "30000",
+          "x-ratelimit-limit-tokens": "180000000",
+          "x-ratelimit-remaining-requests": "29999",
+          "x-ratelimit-remaining-tokens": "179999430",
+          "x-ratelimit-reset-requests": "2ms",
+          "x-ratelimit-reset-tokens": "0s",
+          "x-request-id": "req_ba0d4a6d201b4645a2b9a5f1cecff949"
+        },
+        "status": 200,
+        "statusText": "OK"
+      }
+    },
+    {
+      "callIndex": 3,
+      "id": "d4e4ba836856d0d1",
+      "matchKey": "POST api.openai.com/v1/responses",
+      "recordedAt": "2026-08-17T13:50:14.302Z",
+      "request": {
+        "body": {
+          "kind": "json",
+          "value": {
+            "input": [
+              {
+                "content": "You are an AI agent powered by DeepSeek Harness.",
+                "role": "developer"
+              },
+              {
+                "content": [
+                  {
+                    "text": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+                    "type": "input_text"
+                  }
+                ],
+                "role": "user"
+              },
+              {
+                "arguments": "{\"query\":\"first\"}",
+                "call_id": "call_GSOaMKXu3uekczmgnfsDTKkm",
+                "id": "fc_0f61927da1eefd26016a8311915e24819198db51b965325b6a",
+                "name": "lookup",
+                "type": "function_call"
+              },
+              {
+                "call_id": "call_GSOaMKXu3uekczmgnfsDTKkm",
+                "output": "Lookup result for first",
+                "type": "function_call_output"
+              },
+              {
+                "content": [
+                  {
+                    "annotations": [],
+                    "text": "First Harness answer.",
+                    "type": "output_text"
+                  }
+                ],
+                "id": "msg_0f61927da1eefd26016a83119231248191b15a1b2870456d4a",
+                "phase": "final_answer",
+                "role": "assistant",
+                "status": "completed",
+                "type": "message"
+              },
+              {
+                "content": [
+                  {
+                    "text": "Call lookup exactly once with query `second`. Then reply exactly: Second Harness answer.",
+                    "type": "input_text"
+                  }
+                ],
+                "role": "user"
+              },
+              {
+                "arguments": "{\"query\":\"second\"}",
+                "call_id": "call_z74tDpYKFyDloXJLobkqa1rQ",
+                "id": "fc_0f61927da1eefd26016a831194eb248191a66cc2f008ae8a8b",
+                "name": "lookup",
+                "type": "function_call"
+              },
+              {
+                "call_id": "call_z74tDpYKFyDloXJLobkqa1rQ",
+                "output": "Lookup result for second",
+                "type": "function_call_output"
+              }
+            ],
+            "max_output_tokens": 2000,
+            "model": "gpt-5.6-luna",
+            "prompt_cache_key": "[REDACTED]",
+            "store": false,
+            "stream": true,
+            "tools": [
+              {
+                "description": "Return a deterministic lookup result",
+                "name": "lookup",
+                "parameters": {
+                  "properties": {
+                    "query": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["query"],
+                  "type": "object"
+                },
+                "strict": false,
+                "type": "function"
+              }
+            ]
+          }
+        },
+        "headers": {},
+        "method": "POST",
+        "url": "https://api.openai.com/v1/responses"
+      },
+      "response": {
+        "body": {
+          "chunks": [
+            "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_0f61927da1eefd26016a83119539048191a33eafdb1892cf61\",\"object\":\"response\",\"created_at\":1786974613,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}",
+            "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_0f61927da1eefd26016a83119539048191a33eafdb1892cf61\",\"object\":\"response\",\"created_at\":1786974613,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}",
+            "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_0f61927da1eefd26016a831196172c8191a5256e87454b535b\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"phase\":\"final_answer\",\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":2}",
+            "event: response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_0f61927da1eefd26016a831196172c8191a5256e87454b535b\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":3}",
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Second\",\"item_id\":\"msg_0f61927da1eefd26016a831196172c8191a5256e87454b535b\",\"logprobs\":[],\"obfuscation\":\"GrTNCRvPCp\",\"output_index\":0,\"sequence_number\":4}",
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Harness\",\"item_id\":\"msg_0f61927da1eefd26016a831196172c8191a5256e87454b535b\",\"logprobs\":[],\"obfuscation\":\"mQnNktvY\",\"output_index\":0,\"sequence_number\":5}",
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" answer\",\"item_id\":\"msg_0f61927da1eefd26016a831196172c8191a5256e87454b535b\",\"logprobs\":[],\"obfuscation\":\"JodAeAPGT\",\"output_index\":0,\"sequence_number\":6}",
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0f61927da1eefd26016a831196172c8191a5256e87454b535b\",\"logprobs\":[],\"obfuscation\":\"h67ObCH6rN0MeoQ\",\"output_index\":0,\"sequence_number\":7}",
+            "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_0f61927da1eefd26016a831196172c8191a5256e87454b535b\",\"logprobs\":[],\"output_index\":0,\"sequence_number\":8,\"text\":\"Second Harness answer.\"}",
+            "event: response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_0f61927da1eefd26016a831196172c8191a5256e87454b535b\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Second Harness answer.\"},\"sequence_number\":9}",
+            "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_0f61927da1eefd26016a831196172c8191a5256e87454b535b\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Second Harness answer.\"}],\"phase\":\"final_answer\",\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":10}",
+            "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_0f61927da1eefd26016a83119539048191a33eafdb1892cf61\",\"object\":\"response\",\"created_at\":1786974613,\"status\":\"completed\",\"background\":false,\"completed_at\":1786974614,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":2000,\"max_tool_calls\":null,\"model\":\"gpt-5.6-luna\",\"moderation\":null,\"output\":[{\"id\":\"msg_0f61927da1eefd26016a831196172c8191a5256e87454b535b\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Second Harness answer.\"}],\"phase\":\"final_answer\",\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":\"deepseek-harness-e2e-session\",\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"all_turns\",\"effort\":\"medium\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":false,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Return a deterministic lookup result\",\"name\":\"lookup\",\"output_schema\":null,\"parameters\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":166,\"input_tokens_details\":{\"cache_write_tokens\":0,\"cached_tokens\":0},\"output_tokens\":8,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":174},\"user\":null,\"metadata\":{}},\"sequence_number\":11}"
+          ],
+          "kind": "sse"
+        },
+        "headers": {
+          "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "a2c925842c77c99f-IAD",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Mon, 17 Aug 2026 13:50:13 GMT",
+          "openai-organization": "braintrust-data",
+          "openai-processing-ms": "718",
+          "openai-project": "proj_vsCSXafhhByzWOThMrJcZiw9",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "set-cookie": "[REDACTED]",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "transfer-encoding": "chunked",
+          "x-content-type-options": "nosniff",
+          "x-ratelimit-limit-requests": "30000",
+          "x-ratelimit-limit-tokens": "180000000",
+          "x-ratelimit-remaining-requests": "29999",
+          "x-ratelimit-remaining-tokens": "179999400",
+          "x-ratelimit-reset-requests": "2ms",
+          "x-ratelimit-reset-tokens": "0s",
+          "x-request-id": "req_d0073535320c4dab90ef90de621a2097"
+        },
+        "status": 200,
+        "statusText": "OK"
+      }
+    }
+  ],
+  "meta": {
+    "createdAt": "2026-08-17T13:50:14.340Z"
+  }
+}

--- a/e2e/scenarios/deepseek-harness-instrumentation/__snapshots__/deepseek-harness-v0-latest.span-tree.json
+++ b/e2e/scenarios/deepseek-harness-instrumentation/__snapshots__/deepseek-harness-v0-latest.span-tree.json
@@ -1,0 +1,416 @@
+{
+  "span_tree": [
+    {
+      "name": "deepseek_harness.turn",
+      "type": "task",
+      "children": [
+        {
+          "name": "deepseek_harness.step",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": "You are an AI agent powered by DeepSeek Harness.",
+              "role": "system"
+            },
+            {
+              "content": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+              "role": "user"
+            }
+          ],
+          "output": [
+            {
+              "finish_reason": "tool_calls",
+              "index": 0,
+              "message": {
+                "content": "",
+                "role": "assistant",
+                "tool_calls": [
+                  {
+                    "function": {
+                      "arguments": "{\"query\":\"first\"}",
+                      "name": "lookup"
+                    },
+                    "id": "<span:1>",
+                    "type": "function"
+                  }
+                ]
+              }
+            }
+          ],
+          "metadata": {
+            "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+            "max_tokens": 2000,
+            "model": "gpt-5.6-luna",
+            "provider": "openai",
+            "tools": [
+              {
+                "function": {
+                  "description": "Return a deterministic lookup result",
+                  "name": "lookup",
+                  "parameters": {
+                    "properties": {
+                      "query": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "query"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "type": "function"
+              }
+            ]
+          },
+          "metrics": {
+            "completion_tokens": 17,
+            "prompt_tokens": 73,
+            "time_to_first_token": 0,
+            "tokens": 90
+          }
+        },
+        {
+          "name": "lookup",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "query": "first"
+          },
+          "output": "Lookup result for first",
+          "metadata": {
+            "deepseek_harness.call_id": "<deepseek_harness.call_id:2>",
+            "deepseek_harness.session_id": "<deepseek_harness.session_id:1>"
+          }
+        },
+        {
+          "name": "deepseek_harness.step",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": "You are an AI agent powered by DeepSeek Harness.",
+              "role": "system"
+            },
+            {
+              "content": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+              "role": "user"
+            },
+            {
+              "content": "",
+              "role": "assistant",
+              "tool_calls": [
+                {
+                  "function": {
+                    "arguments": "{\"query\":\"first\"}",
+                    "name": "lookup"
+                  },
+                  "id": "<span:1>",
+                  "type": "function"
+                }
+              ]
+            },
+            {
+              "content": "Lookup result for first",
+              "role": "tool",
+              "tool_call_id": "call_xMz0J1dziwIG1N40EjROvoLR|fc_0a13641652e69e84016a83119a07b0819197c26e0e9217aeca"
+            }
+          ],
+          "output": [
+            {
+              "finish_reason": "stop",
+              "index": 0,
+              "message": {
+                "content": "First Harness answer.",
+                "role": "assistant"
+              }
+            }
+          ],
+          "metadata": {
+            "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+            "max_tokens": 2000,
+            "model": "gpt-5.6-luna",
+            "provider": "openai",
+            "tools": [
+              {
+                "function": {
+                  "description": "Return a deterministic lookup result",
+                  "name": "lookup",
+                  "parameters": {
+                    "properties": {
+                      "query": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "query"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "type": "function"
+              }
+            ]
+          },
+          "metrics": {
+            "completion_tokens": 8,
+            "prompt_tokens": 104,
+            "time_to_first_token": 0,
+            "tokens": 112
+          }
+        }
+      ],
+      "input": [
+        {
+          "content": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+          "role": "user"
+        }
+      ],
+      "output": "First Harness answer.",
+      "metadata": {
+        "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+        "deepseek_harness.stop_reason": "completed",
+        "deepseek_harness.turn": 1
+      },
+      "metrics": {
+        "completion_tokens": 25,
+        "prompt_tokens": 177,
+        "tokens": 202
+      }
+    },
+    {
+      "name": "deepseek_harness.turn",
+      "type": "task",
+      "children": [
+        {
+          "name": "deepseek_harness.step",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": "You are an AI agent powered by DeepSeek Harness.",
+              "role": "system"
+            },
+            {
+              "content": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+              "role": "user"
+            },
+            {
+              "content": "",
+              "role": "assistant",
+              "tool_calls": [
+                {
+                  "function": {
+                    "arguments": "{\"query\":\"first\"}",
+                    "name": "lookup"
+                  },
+                  "id": "<span:1>",
+                  "type": "function"
+                }
+              ]
+            },
+            {
+              "content": "Lookup result for first",
+              "role": "tool",
+              "tool_call_id": "call_xMz0J1dziwIG1N40EjROvoLR|fc_0a13641652e69e84016a83119a07b0819197c26e0e9217aeca"
+            },
+            {
+              "content": "First Harness answer.",
+              "role": "assistant"
+            },
+            {
+              "content": "Call lookup exactly once with query `second`. Then reply exactly: Second Harness answer.",
+              "role": "user"
+            }
+          ],
+          "output": [
+            {
+              "finish_reason": "tool_calls",
+              "index": 0,
+              "message": {
+                "content": "",
+                "role": "assistant",
+                "tool_calls": [
+                  {
+                    "function": {
+                      "arguments": "{\"query\":\"second\"}",
+                      "name": "lookup"
+                    },
+                    "id": "<span:1>",
+                    "type": "function"
+                  }
+                ]
+              }
+            }
+          ],
+          "metadata": {
+            "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+            "max_tokens": 2000,
+            "model": "gpt-5.6-luna",
+            "provider": "openai",
+            "tools": [
+              {
+                "function": {
+                  "description": "Return a deterministic lookup result",
+                  "name": "lookup",
+                  "parameters": {
+                    "properties": {
+                      "query": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "query"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "type": "function"
+              }
+            ]
+          },
+          "metrics": {
+            "completion_tokens": 17,
+            "prompt_tokens": 135,
+            "time_to_first_token": 0,
+            "tokens": 152
+          }
+        },
+        {
+          "name": "lookup",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "query": "second"
+          },
+          "output": "Lookup result for second",
+          "metadata": {
+            "deepseek_harness.call_id": "<deepseek_harness.call_id:2>",
+            "deepseek_harness.session_id": "<deepseek_harness.session_id:1>"
+          }
+        },
+        {
+          "name": "deepseek_harness.step",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": "You are an AI agent powered by DeepSeek Harness.",
+              "role": "system"
+            },
+            {
+              "content": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+              "role": "user"
+            },
+            {
+              "content": "",
+              "role": "assistant",
+              "tool_calls": [
+                {
+                  "function": {
+                    "arguments": "{\"query\":\"first\"}",
+                    "name": "lookup"
+                  },
+                  "id": "<span:1>",
+                  "type": "function"
+                }
+              ]
+            },
+            {
+              "content": "Lookup result for first",
+              "role": "tool",
+              "tool_call_id": "call_xMz0J1dziwIG1N40EjROvoLR|fc_0a13641652e69e84016a83119a07b0819197c26e0e9217aeca"
+            },
+            {
+              "content": "First Harness answer.",
+              "role": "assistant"
+            },
+            {
+              "content": "Call lookup exactly once with query `second`. Then reply exactly: Second Harness answer.",
+              "role": "user"
+            },
+            {
+              "content": "",
+              "role": "assistant",
+              "tool_calls": [
+                {
+                  "function": {
+                    "arguments": "{\"query\":\"second\"}",
+                    "name": "lookup"
+                  },
+                  "id": "<span:2>",
+                  "type": "function"
+                }
+              ]
+            },
+            {
+              "content": "Lookup result for second",
+              "role": "tool",
+              "tool_call_id": "call_kag3c0Ow1SDDPCP1g6L3UM2d|fc_0a13641652e69e84016a83119b8e308191965ec0472d468879"
+            }
+          ],
+          "output": [
+            {
+              "finish_reason": "stop",
+              "index": 0,
+              "message": {
+                "content": "Second Harness answer.",
+                "role": "assistant"
+              }
+            }
+          ],
+          "metadata": {
+            "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+            "max_tokens": 2000,
+            "model": "gpt-5.6-luna",
+            "provider": "openai",
+            "tools": [
+              {
+                "function": {
+                  "description": "Return a deterministic lookup result",
+                  "name": "lookup",
+                  "parameters": {
+                    "properties": {
+                      "query": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "query"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "type": "function"
+              }
+            ]
+          },
+          "metrics": {
+            "completion_tokens": 8,
+            "prompt_tokens": 166,
+            "time_to_first_token": 0,
+            "tokens": 174
+          }
+        }
+      ],
+      "input": [
+        {
+          "content": "Call lookup exactly once with query `second`. Then reply exactly: Second Harness answer.",
+          "role": "user"
+        }
+      ],
+      "output": "Second Harness answer.",
+      "metadata": {
+        "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+        "deepseek_harness.stop_reason": "completed",
+        "deepseek_harness.turn": 2
+      },
+      "metrics": {
+        "completion_tokens": 25,
+        "prompt_tokens": 301,
+        "tokens": 326
+      }
+    }
+  ]
+}

--- a/e2e/scenarios/deepseek-harness-instrumentation/__snapshots__/deepseek-harness-v0-latest.span-tree.json
+++ b/e2e/scenarios/deepseek-harness-instrumentation/__snapshots__/deepseek-harness-v0-latest.span-tree.json
@@ -171,7 +171,9 @@
       "metadata": {
         "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
         "deepseek_harness.stop_reason": "completed",
-        "deepseek_harness.turn": 1
+        "deepseek_harness.turn": 1,
+        "scenario": "deepseek-harness-instrumentation",
+        "testRunId": "<run:1>"
       },
       "metrics": {
         "completion_tokens": 25,
@@ -404,7 +406,9 @@
       "metadata": {
         "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
         "deepseek_harness.stop_reason": "completed",
-        "deepseek_harness.turn": 2
+        "deepseek_harness.turn": 2,
+        "scenario": "deepseek-harness-instrumentation",
+        "testRunId": "<run:1>"
       },
       "metrics": {
         "completion_tokens": 25,

--- a/e2e/scenarios/deepseek-harness-instrumentation/__snapshots__/deepseek-harness-v0-latest.span-tree.txt
+++ b/e2e/scenarios/deepseek-harness-instrumentation/__snapshots__/deepseek-harness-v0-latest.span-tree.txt
@@ -1,0 +1,379 @@
+span_tree:
+├── deepseek_harness.turn [task]
+│   input: [
+│     {
+│       "content": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+│       "role": "user"
+│     }
+│   ]
+│   output: "First Harness answer."
+│   metadata: {
+│     "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+│     "deepseek_harness.stop_reason": "completed",
+│     "deepseek_harness.turn": 1
+│   }
+│   metrics: {
+│     "completion_tokens": 25,
+│     "prompt_tokens": 177,
+│     "tokens": 202
+│   }
+│   ├── deepseek_harness.step [llm]
+│   │   input: [
+│   │     {
+│   │       "content": "You are an AI agent powered by DeepSeek Harness.",
+│   │       "role": "system"
+│   │     },
+│   │     {
+│   │       "content": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+│   │       "role": "user"
+│   │     }
+│   │   ]
+│   │   output: [
+│   │     {
+│   │       "finish_reason": "tool_calls",
+│   │       "index": 0,
+│   │       "message": {
+│   │         "content": "",
+│   │         "role": "assistant",
+│   │         "tool_calls": [
+│   │           {
+│   │             "function": {
+│   │               "arguments": "{\"query\":\"first\"}",
+│   │               "name": "lookup"
+│   │             },
+│   │             "id": "<span:1>",
+│   │             "type": "function"
+│   │           }
+│   │         ]
+│   │       }
+│   │     }
+│   │   ]
+│   │   metadata: {
+│   │     "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+│   │     "max_tokens": 2000,
+│   │     "model": "gpt-5.6-luna",
+│   │     "provider": "openai",
+│   │     "tools": [
+│   │       {
+│   │         "function": {
+│   │           "description": "Return a deterministic lookup result",
+│   │           "name": "lookup",
+│   │           "parameters": {
+│   │             "properties": {
+│   │               "query": {
+│   │                 "type": "string"
+│   │               }
+│   │             },
+│   │             "required": [
+│   │               "query"
+│   │             ],
+│   │             "type": "object"
+│   │           }
+│   │         },
+│   │         "type": "function"
+│   │       }
+│   │     ]
+│   │   }
+│   │   metrics: {
+│   │     "completion_tokens": 17,
+│   │     "prompt_tokens": 73,
+│   │     "time_to_first_token": 0,
+│   │     "tokens": 90
+│   │   }
+│   ├── lookup [tool]
+│   │   input: {
+│   │     "query": "first"
+│   │   }
+│   │   output: "Lookup result for first"
+│   │   metadata: {
+│   │     "deepseek_harness.call_id": "<deepseek_harness.call_id:2>",
+│   │     "deepseek_harness.session_id": "<deepseek_harness.session_id:1>"
+│   │   }
+│   └── deepseek_harness.step [llm]
+│       input: [
+│         {
+│           "content": "You are an AI agent powered by DeepSeek Harness.",
+│           "role": "system"
+│         },
+│         {
+│           "content": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+│           "role": "user"
+│         },
+│         {
+│           "content": "",
+│           "role": "assistant",
+│           "tool_calls": [
+│             {
+│               "function": {
+│                 "arguments": "{\"query\":\"first\"}",
+│                 "name": "lookup"
+│               },
+│               "id": "<span:1>",
+│               "type": "function"
+│             }
+│           ]
+│         },
+│         {
+│           "content": "Lookup result for first",
+│           "role": "tool",
+│           "tool_call_id": "call_xMz0J1dziwIG1N40EjROvoLR|fc_0a13641652e69e84016a83119a07b0819197c26e0e9217aeca"
+│         }
+│       ]
+│       output: [
+│         {
+│           "finish_reason": "stop",
+│           "index": 0,
+│           "message": {
+│             "content": "First Harness answer.",
+│             "role": "assistant"
+│           }
+│         }
+│       ]
+│       metadata: {
+│         "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+│         "max_tokens": 2000,
+│         "model": "gpt-5.6-luna",
+│         "provider": "openai",
+│         "tools": [
+│           {
+│             "function": {
+│               "description": "Return a deterministic lookup result",
+│               "name": "lookup",
+│               "parameters": {
+│                 "properties": {
+│                   "query": {
+│                     "type": "string"
+│                   }
+│                 },
+│                 "required": [
+│                   "query"
+│                 ],
+│                 "type": "object"
+│               }
+│             },
+│             "type": "function"
+│           }
+│         ]
+│       }
+│       metrics: {
+│         "completion_tokens": 8,
+│         "prompt_tokens": 104,
+│         "time_to_first_token": 0,
+│         "tokens": 112
+│       }
+└── deepseek_harness.turn [task]
+    input: [
+      {
+        "content": "Call lookup exactly once with query `second`. Then reply exactly: Second Harness answer.",
+        "role": "user"
+      }
+    ]
+    output: "Second Harness answer."
+    metadata: {
+      "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+      "deepseek_harness.stop_reason": "completed",
+      "deepseek_harness.turn": 2
+    }
+    metrics: {
+      "completion_tokens": 25,
+      "prompt_tokens": 301,
+      "tokens": 326
+    }
+    ├── deepseek_harness.step [llm]
+    │   input: [
+    │     {
+    │       "content": "You are an AI agent powered by DeepSeek Harness.",
+    │       "role": "system"
+    │     },
+    │     {
+    │       "content": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+    │       "role": "user"
+    │     },
+    │     {
+    │       "content": "",
+    │       "role": "assistant",
+    │       "tool_calls": [
+    │         {
+    │           "function": {
+    │             "arguments": "{\"query\":\"first\"}",
+    │             "name": "lookup"
+    │           },
+    │           "id": "<span:1>",
+    │           "type": "function"
+    │         }
+    │       ]
+    │     },
+    │     {
+    │       "content": "Lookup result for first",
+    │       "role": "tool",
+    │       "tool_call_id": "call_xMz0J1dziwIG1N40EjROvoLR|fc_0a13641652e69e84016a83119a07b0819197c26e0e9217aeca"
+    │     },
+    │     {
+    │       "content": "First Harness answer.",
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": "Call lookup exactly once with query `second`. Then reply exactly: Second Harness answer.",
+    │       "role": "user"
+    │     }
+    │   ]
+    │   output: [
+    │     {
+    │       "finish_reason": "tool_calls",
+    │       "index": 0,
+    │       "message": {
+    │         "content": "",
+    │         "role": "assistant",
+    │         "tool_calls": [
+    │           {
+    │             "function": {
+    │               "arguments": "{\"query\":\"second\"}",
+    │               "name": "lookup"
+    │             },
+    │             "id": "<span:1>",
+    │             "type": "function"
+    │           }
+    │         ]
+    │       }
+    │     }
+    │   ]
+    │   metadata: {
+    │     "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+    │     "max_tokens": 2000,
+    │     "model": "gpt-5.6-luna",
+    │     "provider": "openai",
+    │     "tools": [
+    │       {
+    │         "function": {
+    │           "description": "Return a deterministic lookup result",
+    │           "name": "lookup",
+    │           "parameters": {
+    │             "properties": {
+    │               "query": {
+    │                 "type": "string"
+    │               }
+    │             },
+    │             "required": [
+    │               "query"
+    │             ],
+    │             "type": "object"
+    │           }
+    │         },
+    │         "type": "function"
+    │       }
+    │     ]
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 17,
+    │     "prompt_tokens": 135,
+    │     "time_to_first_token": 0,
+    │     "tokens": 152
+    │   }
+    ├── lookup [tool]
+    │   input: {
+    │     "query": "second"
+    │   }
+    │   output: "Lookup result for second"
+    │   metadata: {
+    │     "deepseek_harness.call_id": "<deepseek_harness.call_id:2>",
+    │     "deepseek_harness.session_id": "<deepseek_harness.session_id:1>"
+    │   }
+    └── deepseek_harness.step [llm]
+        input: [
+          {
+            "content": "You are an AI agent powered by DeepSeek Harness.",
+            "role": "system"
+          },
+          {
+            "content": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+            "role": "user"
+          },
+          {
+            "content": "",
+            "role": "assistant",
+            "tool_calls": [
+              {
+                "function": {
+                  "arguments": "{\"query\":\"first\"}",
+                  "name": "lookup"
+                },
+                "id": "<span:1>",
+                "type": "function"
+              }
+            ]
+          },
+          {
+            "content": "Lookup result for first",
+            "role": "tool",
+            "tool_call_id": "call_xMz0J1dziwIG1N40EjROvoLR|fc_0a13641652e69e84016a83119a07b0819197c26e0e9217aeca"
+          },
+          {
+            "content": "First Harness answer.",
+            "role": "assistant"
+          },
+          {
+            "content": "Call lookup exactly once with query `second`. Then reply exactly: Second Harness answer.",
+            "role": "user"
+          },
+          {
+            "content": "",
+            "role": "assistant",
+            "tool_calls": [
+              {
+                "function": {
+                  "arguments": "{\"query\":\"second\"}",
+                  "name": "lookup"
+                },
+                "id": "<span:2>",
+                "type": "function"
+              }
+            ]
+          },
+          {
+            "content": "Lookup result for second",
+            "role": "tool",
+            "tool_call_id": "call_kag3c0Ow1SDDPCP1g6L3UM2d|fc_0a13641652e69e84016a83119b8e308191965ec0472d468879"
+          }
+        ]
+        output: [
+          {
+            "finish_reason": "stop",
+            "index": 0,
+            "message": {
+              "content": "Second Harness answer.",
+              "role": "assistant"
+            }
+          }
+        ]
+        metadata: {
+          "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+          "max_tokens": 2000,
+          "model": "gpt-5.6-luna",
+          "provider": "openai",
+          "tools": [
+            {
+              "function": {
+                "description": "Return a deterministic lookup result",
+                "name": "lookup",
+                "parameters": {
+                  "properties": {
+                    "query": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "query"
+                  ],
+                  "type": "object"
+                }
+              },
+              "type": "function"
+            }
+          ]
+        }
+        metrics: {
+          "completion_tokens": 8,
+          "prompt_tokens": 166,
+          "time_to_first_token": 0,
+          "tokens": 174
+        }

--- a/e2e/scenarios/deepseek-harness-instrumentation/__snapshots__/deepseek-harness-v0-latest.span-tree.txt
+++ b/e2e/scenarios/deepseek-harness-instrumentation/__snapshots__/deepseek-harness-v0-latest.span-tree.txt
@@ -10,7 +10,9 @@ span_tree:
 │   metadata: {
 │     "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
 │     "deepseek_harness.stop_reason": "completed",
-│     "deepseek_harness.turn": 1
+│     "deepseek_harness.turn": 1,
+│     "scenario": "deepseek-harness-instrumentation",
+│     "testRunId": "<run:1>"
 │   }
 │   metrics: {
 │     "completion_tokens": 25,
@@ -172,7 +174,9 @@ span_tree:
     metadata: {
       "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
       "deepseek_harness.stop_reason": "completed",
-      "deepseek_harness.turn": 2
+      "deepseek_harness.turn": 2,
+      "scenario": "deepseek-harness-instrumentation",
+      "testRunId": "<run:1>"
     }
     metrics: {
       "completion_tokens": 25,

--- a/e2e/scenarios/deepseek-harness-instrumentation/__snapshots__/deepseek-harness-v0.span-tree.json
+++ b/e2e/scenarios/deepseek-harness-instrumentation/__snapshots__/deepseek-harness-v0.span-tree.json
@@ -1,0 +1,416 @@
+{
+  "span_tree": [
+    {
+      "name": "deepseek_harness.turn",
+      "type": "task",
+      "children": [
+        {
+          "name": "deepseek_harness.step",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": "You are an AI agent powered by DeepSeek Harness.",
+              "role": "system"
+            },
+            {
+              "content": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+              "role": "user"
+            }
+          ],
+          "output": [
+            {
+              "finish_reason": "tool_calls",
+              "index": 0,
+              "message": {
+                "content": "",
+                "role": "assistant",
+                "tool_calls": [
+                  {
+                    "function": {
+                      "arguments": "{\"query\":\"first\"}",
+                      "name": "lookup"
+                    },
+                    "id": "<span:1>",
+                    "type": "function"
+                  }
+                ]
+              }
+            }
+          ],
+          "metadata": {
+            "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+            "max_tokens": 2000,
+            "model": "gpt-5.6-luna",
+            "provider": "openai",
+            "tools": [
+              {
+                "function": {
+                  "description": "Return a deterministic lookup result",
+                  "name": "lookup",
+                  "parameters": {
+                    "properties": {
+                      "query": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "query"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "type": "function"
+              }
+            ]
+          },
+          "metrics": {
+            "completion_tokens": 17,
+            "prompt_tokens": 73,
+            "time_to_first_token": 0,
+            "tokens": 90
+          }
+        },
+        {
+          "name": "lookup",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "query": "first"
+          },
+          "output": "Lookup result for first",
+          "metadata": {
+            "deepseek_harness.call_id": "<deepseek_harness.call_id:2>",
+            "deepseek_harness.session_id": "<deepseek_harness.session_id:1>"
+          }
+        },
+        {
+          "name": "deepseek_harness.step",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": "You are an AI agent powered by DeepSeek Harness.",
+              "role": "system"
+            },
+            {
+              "content": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+              "role": "user"
+            },
+            {
+              "content": "",
+              "role": "assistant",
+              "tool_calls": [
+                {
+                  "function": {
+                    "arguments": "{\"query\":\"first\"}",
+                    "name": "lookup"
+                  },
+                  "id": "<span:1>",
+                  "type": "function"
+                }
+              ]
+            },
+            {
+              "content": "Lookup result for first",
+              "role": "tool",
+              "tool_call_id": "call_GSOaMKXu3uekczmgnfsDTKkm|fc_0f61927da1eefd26016a8311915e24819198db51b965325b6a"
+            }
+          ],
+          "output": [
+            {
+              "finish_reason": "stop",
+              "index": 0,
+              "message": {
+                "content": "First Harness answer.",
+                "role": "assistant"
+              }
+            }
+          ],
+          "metadata": {
+            "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+            "max_tokens": 2000,
+            "model": "gpt-5.6-luna",
+            "provider": "openai",
+            "tools": [
+              {
+                "function": {
+                  "description": "Return a deterministic lookup result",
+                  "name": "lookup",
+                  "parameters": {
+                    "properties": {
+                      "query": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "query"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "type": "function"
+              }
+            ]
+          },
+          "metrics": {
+            "completion_tokens": 8,
+            "prompt_tokens": 104,
+            "time_to_first_token": 0,
+            "tokens": 112
+          }
+        }
+      ],
+      "input": [
+        {
+          "content": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+          "role": "user"
+        }
+      ],
+      "output": "First Harness answer.",
+      "metadata": {
+        "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+        "deepseek_harness.stop_reason": "completed",
+        "deepseek_harness.turn": 1
+      },
+      "metrics": {
+        "completion_tokens": 25,
+        "prompt_tokens": 177,
+        "tokens": 202
+      }
+    },
+    {
+      "name": "deepseek_harness.turn",
+      "type": "task",
+      "children": [
+        {
+          "name": "deepseek_harness.step",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": "You are an AI agent powered by DeepSeek Harness.",
+              "role": "system"
+            },
+            {
+              "content": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+              "role": "user"
+            },
+            {
+              "content": "",
+              "role": "assistant",
+              "tool_calls": [
+                {
+                  "function": {
+                    "arguments": "{\"query\":\"first\"}",
+                    "name": "lookup"
+                  },
+                  "id": "<span:1>",
+                  "type": "function"
+                }
+              ]
+            },
+            {
+              "content": "Lookup result for first",
+              "role": "tool",
+              "tool_call_id": "call_GSOaMKXu3uekczmgnfsDTKkm|fc_0f61927da1eefd26016a8311915e24819198db51b965325b6a"
+            },
+            {
+              "content": "First Harness answer.",
+              "role": "assistant"
+            },
+            {
+              "content": "Call lookup exactly once with query `second`. Then reply exactly: Second Harness answer.",
+              "role": "user"
+            }
+          ],
+          "output": [
+            {
+              "finish_reason": "tool_calls",
+              "index": 0,
+              "message": {
+                "content": "",
+                "role": "assistant",
+                "tool_calls": [
+                  {
+                    "function": {
+                      "arguments": "{\"query\":\"second\"}",
+                      "name": "lookup"
+                    },
+                    "id": "<span:1>",
+                    "type": "function"
+                  }
+                ]
+              }
+            }
+          ],
+          "metadata": {
+            "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+            "max_tokens": 2000,
+            "model": "gpt-5.6-luna",
+            "provider": "openai",
+            "tools": [
+              {
+                "function": {
+                  "description": "Return a deterministic lookup result",
+                  "name": "lookup",
+                  "parameters": {
+                    "properties": {
+                      "query": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "query"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "type": "function"
+              }
+            ]
+          },
+          "metrics": {
+            "completion_tokens": 17,
+            "prompt_tokens": 135,
+            "time_to_first_token": 0,
+            "tokens": 152
+          }
+        },
+        {
+          "name": "lookup",
+          "type": "tool",
+          "children": [],
+          "input": {
+            "query": "second"
+          },
+          "output": "Lookup result for second",
+          "metadata": {
+            "deepseek_harness.call_id": "<deepseek_harness.call_id:2>",
+            "deepseek_harness.session_id": "<deepseek_harness.session_id:1>"
+          }
+        },
+        {
+          "name": "deepseek_harness.step",
+          "type": "llm",
+          "children": [],
+          "input": [
+            {
+              "content": "You are an AI agent powered by DeepSeek Harness.",
+              "role": "system"
+            },
+            {
+              "content": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+              "role": "user"
+            },
+            {
+              "content": "",
+              "role": "assistant",
+              "tool_calls": [
+                {
+                  "function": {
+                    "arguments": "{\"query\":\"first\"}",
+                    "name": "lookup"
+                  },
+                  "id": "<span:1>",
+                  "type": "function"
+                }
+              ]
+            },
+            {
+              "content": "Lookup result for first",
+              "role": "tool",
+              "tool_call_id": "call_GSOaMKXu3uekczmgnfsDTKkm|fc_0f61927da1eefd26016a8311915e24819198db51b965325b6a"
+            },
+            {
+              "content": "First Harness answer.",
+              "role": "assistant"
+            },
+            {
+              "content": "Call lookup exactly once with query `second`. Then reply exactly: Second Harness answer.",
+              "role": "user"
+            },
+            {
+              "content": "",
+              "role": "assistant",
+              "tool_calls": [
+                {
+                  "function": {
+                    "arguments": "{\"query\":\"second\"}",
+                    "name": "lookup"
+                  },
+                  "id": "<span:2>",
+                  "type": "function"
+                }
+              ]
+            },
+            {
+              "content": "Lookup result for second",
+              "role": "tool",
+              "tool_call_id": "call_z74tDpYKFyDloXJLobkqa1rQ|fc_0f61927da1eefd26016a831194eb248191a66cc2f008ae8a8b"
+            }
+          ],
+          "output": [
+            {
+              "finish_reason": "stop",
+              "index": 0,
+              "message": {
+                "content": "Second Harness answer.",
+                "role": "assistant"
+              }
+            }
+          ],
+          "metadata": {
+            "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+            "max_tokens": 2000,
+            "model": "gpt-5.6-luna",
+            "provider": "openai",
+            "tools": [
+              {
+                "function": {
+                  "description": "Return a deterministic lookup result",
+                  "name": "lookup",
+                  "parameters": {
+                    "properties": {
+                      "query": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "query"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "type": "function"
+              }
+            ]
+          },
+          "metrics": {
+            "completion_tokens": 8,
+            "prompt_tokens": 166,
+            "time_to_first_token": 0,
+            "tokens": 174
+          }
+        }
+      ],
+      "input": [
+        {
+          "content": "Call lookup exactly once with query `second`. Then reply exactly: Second Harness answer.",
+          "role": "user"
+        }
+      ],
+      "output": "Second Harness answer.",
+      "metadata": {
+        "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+        "deepseek_harness.stop_reason": "completed",
+        "deepseek_harness.turn": 2
+      },
+      "metrics": {
+        "completion_tokens": 25,
+        "prompt_tokens": 301,
+        "tokens": 326
+      }
+    }
+  ]
+}

--- a/e2e/scenarios/deepseek-harness-instrumentation/__snapshots__/deepseek-harness-v0.span-tree.json
+++ b/e2e/scenarios/deepseek-harness-instrumentation/__snapshots__/deepseek-harness-v0.span-tree.json
@@ -171,7 +171,9 @@
       "metadata": {
         "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
         "deepseek_harness.stop_reason": "completed",
-        "deepseek_harness.turn": 1
+        "deepseek_harness.turn": 1,
+        "scenario": "deepseek-harness-instrumentation",
+        "testRunId": "<run:1>"
       },
       "metrics": {
         "completion_tokens": 25,
@@ -404,7 +406,9 @@
       "metadata": {
         "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
         "deepseek_harness.stop_reason": "completed",
-        "deepseek_harness.turn": 2
+        "deepseek_harness.turn": 2,
+        "scenario": "deepseek-harness-instrumentation",
+        "testRunId": "<run:1>"
       },
       "metrics": {
         "completion_tokens": 25,

--- a/e2e/scenarios/deepseek-harness-instrumentation/__snapshots__/deepseek-harness-v0.span-tree.txt
+++ b/e2e/scenarios/deepseek-harness-instrumentation/__snapshots__/deepseek-harness-v0.span-tree.txt
@@ -1,0 +1,379 @@
+span_tree:
+├── deepseek_harness.turn [task]
+│   input: [
+│     {
+│       "content": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+│       "role": "user"
+│     }
+│   ]
+│   output: "First Harness answer."
+│   metadata: {
+│     "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+│     "deepseek_harness.stop_reason": "completed",
+│     "deepseek_harness.turn": 1
+│   }
+│   metrics: {
+│     "completion_tokens": 25,
+│     "prompt_tokens": 177,
+│     "tokens": 202
+│   }
+│   ├── deepseek_harness.step [llm]
+│   │   input: [
+│   │     {
+│   │       "content": "You are an AI agent powered by DeepSeek Harness.",
+│   │       "role": "system"
+│   │     },
+│   │     {
+│   │       "content": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+│   │       "role": "user"
+│   │     }
+│   │   ]
+│   │   output: [
+│   │     {
+│   │       "finish_reason": "tool_calls",
+│   │       "index": 0,
+│   │       "message": {
+│   │         "content": "",
+│   │         "role": "assistant",
+│   │         "tool_calls": [
+│   │           {
+│   │             "function": {
+│   │               "arguments": "{\"query\":\"first\"}",
+│   │               "name": "lookup"
+│   │             },
+│   │             "id": "<span:1>",
+│   │             "type": "function"
+│   │           }
+│   │         ]
+│   │       }
+│   │     }
+│   │   ]
+│   │   metadata: {
+│   │     "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+│   │     "max_tokens": 2000,
+│   │     "model": "gpt-5.6-luna",
+│   │     "provider": "openai",
+│   │     "tools": [
+│   │       {
+│   │         "function": {
+│   │           "description": "Return a deterministic lookup result",
+│   │           "name": "lookup",
+│   │           "parameters": {
+│   │             "properties": {
+│   │               "query": {
+│   │                 "type": "string"
+│   │               }
+│   │             },
+│   │             "required": [
+│   │               "query"
+│   │             ],
+│   │             "type": "object"
+│   │           }
+│   │         },
+│   │         "type": "function"
+│   │       }
+│   │     ]
+│   │   }
+│   │   metrics: {
+│   │     "completion_tokens": 17,
+│   │     "prompt_tokens": 73,
+│   │     "time_to_first_token": 0,
+│   │     "tokens": 90
+│   │   }
+│   ├── lookup [tool]
+│   │   input: {
+│   │     "query": "first"
+│   │   }
+│   │   output: "Lookup result for first"
+│   │   metadata: {
+│   │     "deepseek_harness.call_id": "<deepseek_harness.call_id:2>",
+│   │     "deepseek_harness.session_id": "<deepseek_harness.session_id:1>"
+│   │   }
+│   └── deepseek_harness.step [llm]
+│       input: [
+│         {
+│           "content": "You are an AI agent powered by DeepSeek Harness.",
+│           "role": "system"
+│         },
+│         {
+│           "content": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+│           "role": "user"
+│         },
+│         {
+│           "content": "",
+│           "role": "assistant",
+│           "tool_calls": [
+│             {
+│               "function": {
+│                 "arguments": "{\"query\":\"first\"}",
+│                 "name": "lookup"
+│               },
+│               "id": "<span:1>",
+│               "type": "function"
+│             }
+│           ]
+│         },
+│         {
+│           "content": "Lookup result for first",
+│           "role": "tool",
+│           "tool_call_id": "call_GSOaMKXu3uekczmgnfsDTKkm|fc_0f61927da1eefd26016a8311915e24819198db51b965325b6a"
+│         }
+│       ]
+│       output: [
+│         {
+│           "finish_reason": "stop",
+│           "index": 0,
+│           "message": {
+│             "content": "First Harness answer.",
+│             "role": "assistant"
+│           }
+│         }
+│       ]
+│       metadata: {
+│         "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+│         "max_tokens": 2000,
+│         "model": "gpt-5.6-luna",
+│         "provider": "openai",
+│         "tools": [
+│           {
+│             "function": {
+│               "description": "Return a deterministic lookup result",
+│               "name": "lookup",
+│               "parameters": {
+│                 "properties": {
+│                   "query": {
+│                     "type": "string"
+│                   }
+│                 },
+│                 "required": [
+│                   "query"
+│                 ],
+│                 "type": "object"
+│               }
+│             },
+│             "type": "function"
+│           }
+│         ]
+│       }
+│       metrics: {
+│         "completion_tokens": 8,
+│         "prompt_tokens": 104,
+│         "time_to_first_token": 0,
+│         "tokens": 112
+│       }
+└── deepseek_harness.turn [task]
+    input: [
+      {
+        "content": "Call lookup exactly once with query `second`. Then reply exactly: Second Harness answer.",
+        "role": "user"
+      }
+    ]
+    output: "Second Harness answer."
+    metadata: {
+      "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+      "deepseek_harness.stop_reason": "completed",
+      "deepseek_harness.turn": 2
+    }
+    metrics: {
+      "completion_tokens": 25,
+      "prompt_tokens": 301,
+      "tokens": 326
+    }
+    ├── deepseek_harness.step [llm]
+    │   input: [
+    │     {
+    │       "content": "You are an AI agent powered by DeepSeek Harness.",
+    │       "role": "system"
+    │     },
+    │     {
+    │       "content": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+    │       "role": "user"
+    │     },
+    │     {
+    │       "content": "",
+    │       "role": "assistant",
+    │       "tool_calls": [
+    │         {
+    │           "function": {
+    │             "arguments": "{\"query\":\"first\"}",
+    │             "name": "lookup"
+    │           },
+    │           "id": "<span:1>",
+    │           "type": "function"
+    │         }
+    │       ]
+    │     },
+    │     {
+    │       "content": "Lookup result for first",
+    │       "role": "tool",
+    │       "tool_call_id": "call_GSOaMKXu3uekczmgnfsDTKkm|fc_0f61927da1eefd26016a8311915e24819198db51b965325b6a"
+    │     },
+    │     {
+    │       "content": "First Harness answer.",
+    │       "role": "assistant"
+    │     },
+    │     {
+    │       "content": "Call lookup exactly once with query `second`. Then reply exactly: Second Harness answer.",
+    │       "role": "user"
+    │     }
+    │   ]
+    │   output: [
+    │     {
+    │       "finish_reason": "tool_calls",
+    │       "index": 0,
+    │       "message": {
+    │         "content": "",
+    │         "role": "assistant",
+    │         "tool_calls": [
+    │           {
+    │             "function": {
+    │               "arguments": "{\"query\":\"second\"}",
+    │               "name": "lookup"
+    │             },
+    │             "id": "<span:1>",
+    │             "type": "function"
+    │           }
+    │         ]
+    │       }
+    │     }
+    │   ]
+    │   metadata: {
+    │     "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+    │     "max_tokens": 2000,
+    │     "model": "gpt-5.6-luna",
+    │     "provider": "openai",
+    │     "tools": [
+    │       {
+    │         "function": {
+    │           "description": "Return a deterministic lookup result",
+    │           "name": "lookup",
+    │           "parameters": {
+    │             "properties": {
+    │               "query": {
+    │                 "type": "string"
+    │               }
+    │             },
+    │             "required": [
+    │               "query"
+    │             ],
+    │             "type": "object"
+    │           }
+    │         },
+    │         "type": "function"
+    │       }
+    │     ]
+    │   }
+    │   metrics: {
+    │     "completion_tokens": 17,
+    │     "prompt_tokens": 135,
+    │     "time_to_first_token": 0,
+    │     "tokens": 152
+    │   }
+    ├── lookup [tool]
+    │   input: {
+    │     "query": "second"
+    │   }
+    │   output: "Lookup result for second"
+    │   metadata: {
+    │     "deepseek_harness.call_id": "<deepseek_harness.call_id:2>",
+    │     "deepseek_harness.session_id": "<deepseek_harness.session_id:1>"
+    │   }
+    └── deepseek_harness.step [llm]
+        input: [
+          {
+            "content": "You are an AI agent powered by DeepSeek Harness.",
+            "role": "system"
+          },
+          {
+            "content": "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+            "role": "user"
+          },
+          {
+            "content": "",
+            "role": "assistant",
+            "tool_calls": [
+              {
+                "function": {
+                  "arguments": "{\"query\":\"first\"}",
+                  "name": "lookup"
+                },
+                "id": "<span:1>",
+                "type": "function"
+              }
+            ]
+          },
+          {
+            "content": "Lookup result for first",
+            "role": "tool",
+            "tool_call_id": "call_GSOaMKXu3uekczmgnfsDTKkm|fc_0f61927da1eefd26016a8311915e24819198db51b965325b6a"
+          },
+          {
+            "content": "First Harness answer.",
+            "role": "assistant"
+          },
+          {
+            "content": "Call lookup exactly once with query `second`. Then reply exactly: Second Harness answer.",
+            "role": "user"
+          },
+          {
+            "content": "",
+            "role": "assistant",
+            "tool_calls": [
+              {
+                "function": {
+                  "arguments": "{\"query\":\"second\"}",
+                  "name": "lookup"
+                },
+                "id": "<span:2>",
+                "type": "function"
+              }
+            ]
+          },
+          {
+            "content": "Lookup result for second",
+            "role": "tool",
+            "tool_call_id": "call_z74tDpYKFyDloXJLobkqa1rQ|fc_0f61927da1eefd26016a831194eb248191a66cc2f008ae8a8b"
+          }
+        ]
+        output: [
+          {
+            "finish_reason": "stop",
+            "index": 0,
+            "message": {
+              "content": "Second Harness answer.",
+              "role": "assistant"
+            }
+          }
+        ]
+        metadata: {
+          "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
+          "max_tokens": 2000,
+          "model": "gpt-5.6-luna",
+          "provider": "openai",
+          "tools": [
+            {
+              "function": {
+                "description": "Return a deterministic lookup result",
+                "name": "lookup",
+                "parameters": {
+                  "properties": {
+                    "query": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "query"
+                  ],
+                  "type": "object"
+                }
+              },
+              "type": "function"
+            }
+          ]
+        }
+        metrics: {
+          "completion_tokens": 8,
+          "prompt_tokens": 166,
+          "time_to_first_token": 0,
+          "tokens": 174
+        }

--- a/e2e/scenarios/deepseek-harness-instrumentation/__snapshots__/deepseek-harness-v0.span-tree.txt
+++ b/e2e/scenarios/deepseek-harness-instrumentation/__snapshots__/deepseek-harness-v0.span-tree.txt
@@ -10,7 +10,9 @@ span_tree:
 │   metadata: {
 │     "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
 │     "deepseek_harness.stop_reason": "completed",
-│     "deepseek_harness.turn": 1
+│     "deepseek_harness.turn": 1,
+│     "scenario": "deepseek-harness-instrumentation",
+│     "testRunId": "<run:1>"
 │   }
 │   metrics: {
 │     "completion_tokens": 25,
@@ -172,7 +174,9 @@ span_tree:
     metadata: {
       "deepseek_harness.session_id": "<deepseek_harness.session_id:1>",
       "deepseek_harness.stop_reason": "completed",
-      "deepseek_harness.turn": 2
+      "deepseek_harness.turn": 2,
+      "scenario": "deepseek-harness-instrumentation",
+      "testRunId": "<run:1>"
     }
     metrics: {
       "completion_tokens": 25,

--- a/e2e/scenarios/deepseek-harness-instrumentation/cassette-filter.mjs
+++ b/e2e/scenarios/deepseek-harness-instrumentation/cassette-filter.mjs
@@ -1,0 +1,12 @@
+// @ts-check
+/** @type {import("@braintrust/seinfeld").FilterSpec} */
+export const filter = [
+  "default",
+  {
+    ignoreBodyFields: [
+      // DeepSeek Harness derives this from the session id, while the paranoid
+      // cassette redactor replaces prompt-cache identifiers in recordings.
+      "prompt_cache_key",
+    ],
+  },
+];

--- a/e2e/scenarios/deepseek-harness-instrumentation/package.json
+++ b/e2e/scenarios/deepseek-harness-instrumentation/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "deepseek-harness-instrumentation-scenario",
+  "private": true,
+  "type": "module",
+  "braintrustScenario": {
+    "bump": {
+      "dependencies": {
+        "deepseek-harness-v0-latest": {
+          "package": "@deepseek-ai/dsh-agent-spine-demo",
+          "range": ">=0.1.0-rc.6 <0.2.0-0",
+          "allowPrerelease": true
+        }
+      }
+    }
+  },
+  "dependencies": {
+    "@deepseek-ai/cordis": "4.0.1",
+    "@deepseek-ai/dsh-agent": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-llm": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-llm-pi-ai": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-session": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-tools": "0.1.0-rc.6",
+    "deepseek-harness-v0": "npm:@deepseek-ai/dsh-agent-spine-demo@0.1.0-rc.6",
+    "deepseek-harness-v0-latest": "npm:@deepseek-ai/dsh-agent-spine-demo@0.1.0-rc.6"
+  }
+}

--- a/e2e/scenarios/deepseek-harness-instrumentation/pnpm-lock.yaml
+++ b/e2e/scenarios/deepseek-harness-instrumentation/pnpm-lock.yaml
@@ -1,0 +1,1777 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@deepseek-ai/cordis':
+        specifier: 4.0.1
+        version: 4.0.1
+      '@deepseek-ai/dsh-agent':
+        specifier: 0.1.0-rc.6
+        version: 0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998)
+      '@deepseek-ai/dsh-llm':
+        specifier: 0.1.0-rc.6
+        version: 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-llm-pi-ai':
+        specifier: 0.1.0-rc.6
+        version: 0.1.0-rc.6(26913dd566c6a5950e814922778593b3)
+      '@deepseek-ai/dsh-session':
+        specifier: 0.1.0-rc.6
+        version: 0.1.0-rc.6(7c206068df7621a084f2df242cb8569b)
+      '@deepseek-ai/dsh-tools':
+        specifier: 0.1.0-rc.6
+        version: 0.1.0-rc.6(8d36de2abc377789f904eb7ef80e4732)
+      deepseek-harness-v0:
+        specifier: npm:@deepseek-ai/dsh-agent-spine-demo@0.1.0-rc.6
+        version: '@deepseek-ai/dsh-agent-spine-demo@0.1.0-rc.6(9b69b72802ed1efaf6bc86b8782928f3)'
+      deepseek-harness-v0-latest:
+        specifier: npm:@deepseek-ai/dsh-agent-spine-demo@0.1.0-rc.6
+        version: '@deepseek-ai/dsh-agent-spine-demo@0.1.0-rc.6(9b69b72802ed1efaf6bc86b8782928f3)'
+
+packages:
+
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.8':
+    resolution: {integrity: sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.69':
+    resolution: {integrity: sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.71':
+    resolution: {integrity: sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.14':
+    resolution: {integrity: sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.76':
+    resolution: {integrity: sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.80':
+    resolution: {integrity: sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.69':
+    resolution: {integrity: sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.13':
+    resolution: {integrity: sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.75':
+    resolution: {integrity: sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.33':
+    resolution: {integrity: sha512-1Dd5WyEE2Kb3HvY44u7Ob16ST2W6iutOqsQ8Y2hUmsL2mAH/STlGS1dS9h3IOE6L7Ld3AR2HzKJ6XeCMOw8Peg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.28':
+    resolution: {integrity: sha512-Z1EDXnS01P7H5jVrUx+/dBqV0m7dta7bSxLclkOuDuS93pNNQm0IcT4YLUbuvWKPYNxbI8aTG0p5Br30GSKDgA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.51':
+    resolution: {integrity: sha512-jdgP3jR5Q96j1jjZ98GGwpGg1CBNFIO2YE+vXg8cg8PvNY4NvgQNYJsqDaRX2PYv5gSUX/+C0D58Fhspj9ELMQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.43':
+    resolution: {integrity: sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.45':
+    resolution: {integrity: sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1048.0':
+    resolution: {integrity: sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1111.0':
+    resolution: {integrity: sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.4':
+    resolution: {integrity: sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.10':
+    resolution: {integrity: sha512-ycwH6Zd2GhuSqdXX9ihbCjeGTB6xOJs+O3+Jb8/zDG9978XU80qs75dfkPJRMNKe5MvBZPuNeFpd4JZKPoUF4g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.39':
+    resolution: {integrity: sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@deepseek-ai/cordis-plugin-timer@1.1.3':
+    resolution: {integrity: sha512-IOkey1VNmJwYa5U8bksyMOnM7mtirqjjbWLr3xA8QybLMK0sMooG3a6iJwtvd8P3MFwo3FQibEg+JPixp37MEw==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+
+  '@deepseek-ai/cordis@4.0.1':
+    resolution: {integrity: sha512-YBdskTU2Po1kru3GgcUWUbkTsPMA9LkSQDAY8rBkFJeajdgcQad3QPJZE26JyK99Xb6HaASvoXg2DSUTeN/0Nw==}
+    hasBin: true
+    peerDependencies:
+      '@deepseek-ai/cordis-plugin-include': ^1.0.6
+      '@deepseek-ai/cordis-plugin-loader': ^1.0.2
+    peerDependenciesMeta:
+      '@deepseek-ai/cordis-plugin-include':
+        optional: true
+      '@deepseek-ai/cordis-plugin-loader':
+        optional: true
+
+  '@deepseek-ai/cosmokit@1.8.2':
+    resolution: {integrity: sha512-muBOKtSrUKU5m/xpq8ZXWL6hQ/jgd4PhU2PqH97bcxIiLEJfNwZOGQEx4t/aS/GgxRAR+ra9pMHPMtTHU4sqqA==}
+
+  '@deepseek-ai/dsh-agent-instructions@0.1.0-rc.6':
+    resolution: {integrity: sha512-RCd3UWJI7b3X6EUnxnqwOFiMWh1PzRRg9GrVt4G0tVNDIxeYX+RF2FTbOrslIOkOCZxG3BlI2M/bZ6yQmB4Vwg==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-fs': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-home-paths': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-session': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-tools': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-agent-loop@0.1.0-rc.6':
+    resolution: {integrity: sha512-yShuKIMW360H14L4y13j3gz3Ix1s/3lwEEpfJW4hnFAE09h9Z4yJA7UfTQmQdzMRMnuj4uWFPw0e0BbapnkFuw==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-scope': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-session': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-session-persistence': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-settings': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-system-prompt': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-tools': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-agent-spine-demo@0.1.0-rc.6':
+    resolution: {integrity: sha512-urMS7CReaddhybJZCaPA8oI4VbD/A+62mLTOb2E4b8EKgZ55sMsOGfpkMZmFIs9nqJqxdFUmcxPXWKVMVtpb5w==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/cordis-plugin-timer': ^1.1.3
+      '@deepseek-ai/dsh-agent': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-agent-instructions': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-agent-loop': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-goal': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-goal-round-driver': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-home-paths': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-jobs-local': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-llm-retry': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-scope': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-session': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-session-title': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-shell-env': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-skill': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-skill-filesystem': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-system-prompt': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-tool-bash': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-tool-goal': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-tool-jobs': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-tool-skill': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-tools': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-agent@0.1.0-rc.6':
+    resolution: {integrity: sha512-vtqq2pWTrzn0dKfj5kREZRpP82AwtGjGx9V1lYnKvF+Uc/a8zyWbSvjDE7V1d3YQAQJzs2cWO31hURWDekDXIA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-scope': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-session': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-system-prompt': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-typert-protocol': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-attachment@0.1.0-rc.7':
+    resolution: {integrity: sha512-rsR/xVNOGIig8gXxhrKnkd6YD7aYliGtA/e7b4DlPawMpLhsItAh0HQ832n8LJn1aGZxKf68y9PRgzfljsveOQ==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-brand': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-brand@0.1.0-rc.7':
+    resolution: {integrity: sha512-P7+w0fN40yXXQkV360p6jQi63pcl68OOWebNGN5gf8w8sguvni2mA1cU8RLZzDkRNFSZD+BCw3D4uWYM+hhh7A==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-code-runtime@0.1.0-rc.7':
+    resolution: {integrity: sha512-vzW82eU4so0qJQ/XS7BGBUSguJMAgEOW3GaJJW0g+W5ysBJg+UC/Jjo1Np8mPjSpjjl4eoyXpshJzrwjoxCpRg==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-credentials@0.1.0-rc.7':
+    resolution: {integrity: sha512-24oY36x90GN3QG2BASlryjzsO5eLA1U9vsvH1tPtBRJ1pBC6JqnW2v0SfDI/pcMT0ZbWo0uEATiik8rrv6xRpA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-brand': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-fs@0.1.0-rc.7':
+    resolution: {integrity: sha512-l4jEcfjrV7hWTQo6sH0oXntg4pz1nVuDXRcprps6NhZ0/OOer/9SzUx7J9aLnLeX9XDtExXsFbxkXW5Js3ZFwg==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-brand': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-sandbox': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-goal-round-driver@0.1.0-rc.7':
+    resolution: {integrity: sha512-PWIaza45vFqqrf8bYyw5tPgEXRqLliHqAn3uKEwui8b1hM6UHJtApq1jX83PO4gtJZs/yAnRK6LCbaS5VJBC9A==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-goal': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-session': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-goal@0.1.0-rc.7':
+    resolution: {integrity: sha512-/pI2o0YcP21ReT+OQx7aA8SyUsnuEHxTQtMbu3DvN9ChvaFeptCTXGvHWocwVtzEEi48mdvAXF4Mx0Ptj1LJYA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-brand': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-scope': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-session': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-session-projection': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-typert-protocol': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-home-paths@0.1.0-rc.7':
+    resolution: {integrity: sha512-9Bu0eAbPw/FfCNpiX9hvyP5wedMUUQBc2sVTtU+xtH27/iUPxXoamFtBt3ydBJUeuVhja/leuhJ/d3MRhXO9fQ==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-invariants@0.1.0-rc.7':
+    resolution: {integrity: sha512-PnO1F4aZGUmqZPyuPJpBUfQ4DZmjCGCNGr0yuN2iURTP/e6h0kGnTNTYgR2NqMvAtpP66WNiHhvH2LMqumk1+A==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+
+  '@deepseek-ai/dsh-jobs-local@0.1.0-rc.7':
+    resolution: {integrity: sha512-DAC8i+sshAkXPI8IcrUp5O6cOOkLLsKsD7mAcorFFbQjcPVBLdeRmtko3E1J9Jmf79IjoAvKVE+J+y84km9yKA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-jobs': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-scope': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-timeout': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-jobs@0.1.0-rc.7':
+    resolution: {integrity: sha512-+omM89dEsaiAL1XtsSTMmRF46POp5g25Qs5KVj+Zfrk7whlXjLXwFiaukt/htdVdHIOM51qM+tCleqlHOU0Chw==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-brand': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-session': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-launch-environment@0.1.0-rc.7':
+    resolution: {integrity: sha512-ATVyi47hyAWFINOxi8TGurRF8rShW/WzqWKqjxEQU5gLZbWtAMgkpAc+hwlyo/lXytGaj5cMXyzeyjpD6URHFg==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-llm-pi-ai@0.1.0-rc.6':
+    resolution: {integrity: sha512-5RvzkpVCYLg9A3IGdm04px7XOaF/xikuMLe2toBY4A0qtJraXiZtUN1QBOL9i6u7DTOLG9oHP/USsbWRpyI+1Q==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-attachment': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-credentials': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-launch-environment': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-settings': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-timeout': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-llm-retry@0.1.0-rc.7':
+    resolution: {integrity: sha512-yyn5Yqth6vdScgmcYDF7L3a1jbfcu2y205HyTx9d84H+eU+h9m8k0Mc+1l8VCJbv9GILPCvoijP8wFTPDas7gQ==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-brand': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-session': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-timeout': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-llm@0.1.0-rc.6':
+    resolution: {integrity: sha512-kuFGC8bHlzGTwlRxQhXjf3CYWl8M4NzH+EYIkrW8rri4iMc9W53xrdvkil5No/DUlMm8g1u7GdeiWYFy0TMvtA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-attachment': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-brand': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-timeout': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-output-retention@0.1.0-rc.7':
+    resolution: {integrity: sha512-bhmSfXIaLWLrYwC4ziMZ7GkNy5i9ltGBvlNZ5eB7NZoDAMh0Du7pKkMY+oqm2ajvx5O5qiFkHEhYoypRpEB56g==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-sandbox-policy@0.1.0-rc.7':
+    resolution: {integrity: sha512-TnOy1SnnSNPVZyw9UFNwQ7eE2lGxQBU6kye7+aAwDbNvSnudCJDEnQJhjTvGewHWA6PYA0O60XERKcCQAnK+dw==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-sandbox': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-session': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-system-prompt': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-sandbox@0.1.0-rc.7':
+    resolution: {integrity: sha512-he43z39/SC8cMzPDsoP7EEXiXKjav3VClj/U943pxycvRL78JGkNEQQjv21n5mnuto0ti/gFBquybSI4sBAFqA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-session': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-scope@0.1.0-rc.7':
+    resolution: {integrity: sha512-8gn+sANXhpv+9egbNwq49/uI3XhbmB33obo9yMyzyzruan3zFoxeH4UV54jTC2hjbu8gFNPsyNam9AAtRV8/Cg==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-session-persistence@0.1.0-rc.7':
+    resolution: {integrity: sha512-NFH1uIGQDgMFOijgAv8lLWRiY3eHFEZW2alwuHlu4C32P4+jdChh9fjPlzBar3ZZTq0ZW0qWCdbYZS02DNxsvA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-brand': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-session': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-timeout': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-session-projection@0.1.0-rc.7':
+    resolution: {integrity: sha512-BXehLYt6wYnV0PNNhv5GECePkH1w+1yuu/R63d2tdYdUQ7XVrd6tu5hMwfTH0P9AnBDxJir08FRu2WKO69JypA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-session': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-session-title@0.1.0-rc.7':
+    resolution: {integrity: sha512-jhFiZa/C58zchuJkBodnkiPil7AEK8mHfB/hMOAW3N/7tUg5nbMLBERNqHdDMbIrvhTndrF4SN9qy+ltUf0cOQ==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-brand': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-session': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-session-projection': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-session@0.1.0-rc.6':
+    resolution: {integrity: sha512-8tu8I6VWC7050GAUXWhcEWQw4pakALQc8TlhKr52m7Y4+kIKeNt3FBgP86PaGPBtpK0p5zUPRQNkFpzZbBdxyw==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-brand': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-scope': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-typert-protocol': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-settings@0.1.0-rc.7':
+    resolution: {integrity: sha512-cS1+StK2xIVykrskw+KrO+hKJxYaVVgY2Jex2we5zASTNLHYCj74WQluPlaFjFgnXoZ1RYz8HNXL5/Ho6h1Ynw==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-brand': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/schemastery': ^3.18.1
+
+  '@deepseek-ai/dsh-shell-env@0.1.0-rc.7':
+    resolution: {integrity: sha512-joSBNw/d54gq/VjkHLGSJ6y/Qr+594sObF4ApbJi2eEopx41L0Ky7kNW/W7cbrGIIN3KBGRDdiGv1s1paWzsMw==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-home-paths': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-session-persistence': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-shell': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-tools': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-shell@0.1.0-rc.7':
+    resolution: {integrity: sha512-in3ifbq80tn5cf1ICBBsRdwKjURB0g0dIRdCVUgl/GDqCdC/S0TjMLXw4nmFdCssYLm7JbG5a59BfJG0KFuz6Q==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-sandbox': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-settings': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-subprocess': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-skill-filesystem@0.1.0-rc.7':
+    resolution: {integrity: sha512-i95xycP3vkz4IZnIO4BTzGNB6waKl1M5AsW2x04C0FIqLa4BSILvVUVwqcbwpBZm7Cd/KF50Q050au3NvauGrw==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-fs': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-home-paths': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-skill': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-skill@0.1.0-rc.7':
+    resolution: {integrity: sha512-tDaqB1TOs27fSt6FZdjvPs4THXAFKoKOEgQG+iFUv63O5bm+glyLY3K1LTK8JeofB4lg3+4JIAeWRslnLJH57w==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-scope': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-subprocess@0.1.0-rc.7':
+    resolution: {integrity: sha512-xiHD61S2trIZ0CzhSMgXxZJVyJ2c76DkX4eqP3Of4mBEnm6C7g7FChII6uL0z5v1bnOnTmpHzwPX8YCwqb7dbg==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-system-prompt@0.1.0-rc.7':
+    resolution: {integrity: sha512-Rair2ZkzgoIIr+UstYVYeqeUgORNPIW1LNcsXz3Zjglx4FGjsmzs0UALdNYvSBpBvCLNmt4E6+XQIrBbS/s9jw==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-scope': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-timeout@0.1.0-rc.7':
+    resolution: {integrity: sha512-Ufl9G7zP7Tky/zkXscavEiolEfAwutfbPeLb5sUU/tPQlDykhh1NwGrarNJ11fdR723zmA/3co4LgxtDtWCOEQ==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-tool-bash@0.1.0-rc.7':
+    resolution: {integrity: sha512-nfc0SI3Xk36rgIOLmTBDSrSTN3Ufp9Wvefta/M82kbBCo6fesB4lst+VAw74039jzHUboXc2gwQ/j5rRcOpiuw==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-jobs': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-sandbox': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-sandbox-policy': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-shell': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-shell-env': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-system-prompt': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-tools': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-user-approval': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-tool-goal@0.1.0-rc.7':
+    resolution: {integrity: sha512-bQTVYD7nAtddefQZvvoKsoRHehA/hAHIPbNRdY+L97HVwKnowg5rlcUn/v+MJFQ1NPaTrTAfVQiHXGKEeeI9tA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-goal': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-session': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-system-prompt': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-tools': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-tool-jobs@0.1.0-rc.7':
+    resolution: {integrity: sha512-n/YcmHVTBrN3soZqzMElsnzIQoClOS3U1n5oqpg+oPyesMehpp7DFjdqh7kCZGEmI8chtq4AhYsPUWTPo85G7g==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-jobs': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-output-retention': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-system-prompt': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-tools': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-tool-skill@0.1.0-rc.7':
+    resolution: {integrity: sha512-AnXLgiDXq8qB196qq4LnJ6rC5ukoPA4WZH+ILSFpLm59owkfwJLS9rGsfP+PGqiTN7NhoZtAwGmZoYCdSDi0kA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-skill': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-tools': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-tools@0.1.0-rc.6':
+    resolution: {integrity: sha512-Tu08EPK3JyK0iNjH4FGzu/1uADynNSS6SmwOLdfytUN0YNqwNuKFSt2OJUg19famNlTgy992DcHfDu0T+gLXFg==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-code-runtime': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-scope': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-session': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-system-prompt': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-user-approval': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-typert-protocol@0.1.0-rc.6':
+    resolution: {integrity: sha512-weWzN8r01YCkoDCAM7BsKw2YhRrD4zL8N2SAZu9hovYtXSq8xHXsP4Zh8RLYIlYcuotjyff/6hic+0TJPd14YA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-user-approval@0.1.0-rc.7':
+    resolution: {integrity: sha512-kYMpU6eg1m1BcfSC4FLWUcNH/QAE8tcu0WRkQzqzoCw8bK/Nl3dqHtd2qSVzI/emIviTulM5I230e4wPi/kuVg==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-brand': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-scope': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-session': ^0.1.0-rc.7
+      '@deepseek-ai/dsh-system-prompt': ^0.1.0-rc.7
+
+  '@deepseek-ai/schemastery@3.18.1':
+    resolution: {integrity: sha512-Qn0FCSwCQnpnj6SB31I6i2sIKgKWnkbJM8O0EU91Gv2UsYVvtZTl6IA0sCwk2e2MZf5S8w5hpq9QkeVvK9qwxg==}
+
+  '@earendil-works/pi-ai@0.82.1':
+    resolution: {integrity: sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@google/genai@1.52.0':
+    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
+  '@mistralai/mistralai@2.2.6':
+    resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
+
+  '@smithy/core@3.33.2':
+    resolution: {integrity: sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.5.2':
+    resolution: {integrity: sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.7.2':
+    resolution: {integrity: sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.11.2':
+    resolution: {integrity: sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.7.3':
+    resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.7.2':
+    resolution: {integrity: sha512-P7Ki6px6OOrxVtx8K7nLmyx4SlXUW/uTKDdMG44UHefmPGSRMBKe2v+TM59WdLcpUIrBrnuCsIqiM2MbsZjmhw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.17.2':
+    resolution: {integrity: sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/node@26.2.0':
+    resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
+
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
+  gaxios@7.3.1:
+    resolution: {integrity: sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+
+  google-auth-library@10.9.1:
+    resolution: {integrity: sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  openai@6.26.0:
+    resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
+  partial-json@0.1.7:
+    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
+
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
+    engines: {node: '>=12.0.0'}
+
+  readdirp@5.1.1:
+    resolution: {integrity: sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==}
+    engines: {node: '>= 20.19.0'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typebox@1.1.38:
+    resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+snapshots:
+
+  '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.4.3
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.974.4
+      '@aws-sdk/util-locate-window': 3.965.10
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.974.4
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.974.4
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-node': 3.972.80
+      '@aws-sdk/eventstream-handler-node': 3.972.33
+      '@aws-sdk/middleware-eventstream': 3.972.28
+      '@aws-sdk/middleware-websocket': 3.972.51
+      '@aws-sdk/token-providers': 3.1048.0
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.977.8':
+    dependencies:
+      '@aws-sdk/types': 3.974.4
+      '@aws-sdk/xml-builder': 3.972.39
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.33.2
+      '@smithy/signature-v4': 5.7.2
+      '@smithy/types': 4.17.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.69':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.71':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.14':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-env': 3.972.69
+      '@aws-sdk/credential-provider-http': 3.972.71
+      '@aws-sdk/credential-provider-login': 3.972.76
+      '@aws-sdk/credential-provider-process': 3.972.69
+      '@aws-sdk/credential-provider-sso': 3.973.13
+      '@aws-sdk/credential-provider-web-identity': 3.972.75
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.76':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.80':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.69
+      '@aws-sdk/credential-provider-http': 3.972.71
+      '@aws-sdk/credential-provider-ini': 3.973.14
+      '@aws-sdk/credential-provider-process': 3.972.69
+      '@aws-sdk/credential-provider-sso': 3.973.13
+      '@aws-sdk/credential-provider-web-identity': 3.972.75
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.69':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.13':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/token-providers': 3.1111.0
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.75':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/eventstream-handler-node@3.972.33':
+    dependencies:
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.28':
+    dependencies:
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.51':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/signature-v4': 5.7.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.43':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/signature-v4-multi-region': 3.996.45
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.45':
+    dependencies:
+      '@aws-sdk/types': 3.974.4
+      '@smithy/signature-v4': 5.7.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1048.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1111.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.4':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.10':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.39':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
+
+  '@babel/runtime@7.29.7': {}
+
+  '@deepseek-ai/cordis-plugin-timer@1.1.3(@deepseek-ai/cordis@4.0.1)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/cosmokit': 1.8.2
+
+  '@deepseek-ai/cordis@4.0.1':
+    dependencies:
+      '@deepseek-ai/cosmokit': 1.8.2
+      '@standard-schema/spec': 1.1.0
+
+  '@deepseek-ai/cosmokit@1.8.2': {}
+
+  '@deepseek-ai/dsh-agent-instructions@0.1.0-rc.6(de8ab69b58aa43dc084394a2d1346949)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998)
+      '@deepseek-ai/dsh-fs': 0.1.0-rc.7(b82ac0ef39fc7097fee1c05444ef04b9)
+      '@deepseek-ai/dsh-home-paths': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(7c206068df7621a084f2df242cb8569b)
+      '@deepseek-ai/dsh-tools': 0.1.0-rc.6(8d36de2abc377789f904eb7ef80e4732)
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-agent-loop@0.1.0-rc.6(4d3ee0fe26eb97dbb5fd2d208c255979)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(7c206068df7621a084f2df242cb8569b)
+      '@deepseek-ai/dsh-session-persistence': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-settings': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-tools': 0.1.0-rc.6(8d36de2abc377789f904eb7ef80e4732)
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-agent-spine-demo@0.1.0-rc.6(9b69b72802ed1efaf6bc86b8782928f3)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/cordis-plugin-timer': 1.1.3(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998)
+      '@deepseek-ai/dsh-agent-instructions': 0.1.0-rc.6(de8ab69b58aa43dc084394a2d1346949)
+      '@deepseek-ai/dsh-agent-loop': 0.1.0-rc.6(4d3ee0fe26eb97dbb5fd2d208c255979)
+      '@deepseek-ai/dsh-goal': 0.1.0-rc.7(ac7bc8890c6307ab621c94b18ecc52b6)
+      '@deepseek-ai/dsh-goal-round-driver': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998))(@deepseek-ai/dsh-goal@0.1.0-rc.7(ac7bc8890c6307ab621c94b18ecc52b6))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b))
+      '@deepseek-ai/dsh-home-paths': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-jobs-local': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-jobs@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b)))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-llm-retry': 0.1.0-rc.7(8d2b26894c9230108eb1efe1529c8b15)
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(7c206068df7621a084f2df242cb8569b)
+      '@deepseek-ai/dsh-session-title': 0.1.0-rc.7(52253d4903d6c6ca4dd91884cffdd5d5)
+      '@deepseek-ai/dsh-shell-env': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-home-paths@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session-persistence@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-shell@0.1.0-rc.7(c033612e626be46e9b5864cde3a5d132))(@deepseek-ai/dsh-tools@0.1.0-rc.6(8d36de2abc377789f904eb7ef80e4732))
+      '@deepseek-ai/dsh-skill': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-skill-filesystem': 0.1.0-rc.7(b6776fa2973383a9f2b15f71b10d30b4)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-tool-bash': 0.1.0-rc.7(16bdad6a331f7f5809319a813c4458ff)
+      '@deepseek-ai/dsh-tool-goal': 0.1.0-rc.7(564f0f7c9dd3beea3304d826b17134c7)
+      '@deepseek-ai/dsh-tool-jobs': 0.1.0-rc.7(7d8a5c2ed205d23a70da75475414b860)
+      '@deepseek-ai/dsh-tool-skill': 0.1.0-rc.7(2a7362c663b1bcb607c1f7959a4fe27f)
+      '@deepseek-ai/dsh-tools': 0.1.0-rc.6(8d36de2abc377789f904eb7ef80e4732)
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-agent@0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(7c206068df7621a084f2df242cb8569b)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+
+  '@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-code-runtime@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-credentials@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-fs@0.1.0-rc.7(b82ac0ef39fc7097fee1c05444ef04b9)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-sandbox': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b))
+
+  '@deepseek-ai/dsh-goal-round-driver@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998))(@deepseek-ai/dsh-goal@0.1.0-rc.7(ac7bc8890c6307ab621c94b18ecc52b6))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998)
+      '@deepseek-ai/dsh-goal': 0.1.0-rc.7(ac7bc8890c6307ab621c94b18ecc52b6)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(7c206068df7621a084f2df242cb8569b)
+
+  '@deepseek-ai/dsh-goal@0.1.0-rc.7(ac7bc8890c6307ab621c94b18ecc52b6)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998)
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(7c206068df7621a084f2df242cb8569b)
+      '@deepseek-ai/dsh-session-projection': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b))
+      '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/schemastery': 3.18.1
+      zod: 4.4.3
+
+  '@deepseek-ai/dsh-home-paths@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-jobs-local@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-jobs@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b)))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-jobs': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-timeout': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-jobs@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998)
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(7c206068df7621a084f2df242cb8569b)
+
+  '@deepseek-ai/dsh-launch-environment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-llm-pi-ai@0.1.0-rc.6(26913dd566c6a5950e814922778593b3)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-attachment': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-credentials': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-launch-environment': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-settings': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
+      '@deepseek-ai/dsh-timeout': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/schemastery': 3.18.1
+      '@earendil-works/pi-ai': 0.82.1(ws@8.21.3)(zod@4.4.3)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@deepseek-ai/dsh-llm-retry@0.1.0-rc.7(8d2b26894c9230108eb1efe1529c8b15)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998)
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(7c206068df7621a084f2df242cb8569b)
+      '@deepseek-ai/dsh-timeout': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-attachment': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-timeout': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-output-retention@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-sandbox-policy@0.1.0-rc.7(969c67fb9bd0fd387a74080625090103)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-sandbox': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(7c206068df7621a084f2df242cb8569b)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-sandbox@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(7c206068df7621a084f2df242cb8569b)
+
+  '@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-session-persistence@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(7c206068df7621a084f2df242cb8569b)
+      '@deepseek-ai/dsh-timeout': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+
+  '@deepseek-ai/dsh-session-projection@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(7c206068df7621a084f2df242cb8569b)
+      zod: 4.4.3
+
+  '@deepseek-ai/dsh-session-title@0.1.0-rc.7(52253d4903d6c6ca4dd91884cffdd5d5)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(7c206068df7621a084f2df242cb8569b)
+      '@deepseek-ai/dsh-session-projection': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b))
+      '@deepseek-ai/schemastery': 3.18.1
+      zod: 4.4.3
+
+  '@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+
+  '@deepseek-ai/dsh-settings@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-shell-env@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-home-paths@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session-persistence@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-shell@0.1.0-rc.7(c033612e626be46e9b5864cde3a5d132))(@deepseek-ai/dsh-tools@0.1.0-rc.6(8d36de2abc377789f904eb7ef80e4732))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-home-paths': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-session-persistence': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-shell': 0.1.0-rc.7(c033612e626be46e9b5864cde3a5d132)
+      '@deepseek-ai/dsh-tools': 0.1.0-rc.6(8d36de2abc377789f904eb7ef80e4732)
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-shell@0.1.0-rc.7(c033612e626be46e9b5864cde3a5d132)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-sandbox': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b))
+      '@deepseek-ai/dsh-settings': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
+      '@deepseek-ai/dsh-subprocess': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+
+  '@deepseek-ai/dsh-skill-filesystem@0.1.0-rc.7(b6776fa2973383a9f2b15f71b10d30b4)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-fs': 0.1.0-rc.7(b82ac0ef39fc7097fee1c05444ef04b9)
+      '@deepseek-ai/dsh-home-paths': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-skill': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/schemastery': 3.18.1
+      chokidar: 5.0.0
+      yaml: 2.9.0
+
+  '@deepseek-ai/dsh-skill@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-subprocess@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-system-prompt@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-tool-bash@0.1.0-rc.7(16bdad6a331f7f5809319a813c4458ff)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-jobs': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b))
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-sandbox': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b))
+      '@deepseek-ai/dsh-sandbox-policy': 0.1.0-rc.7(969c67fb9bd0fd387a74080625090103)
+      '@deepseek-ai/dsh-shell': 0.1.0-rc.7(c033612e626be46e9b5864cde3a5d132)
+      '@deepseek-ai/dsh-shell-env': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-home-paths@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session-persistence@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-shell@0.1.0-rc.7(c033612e626be46e9b5864cde3a5d132))(@deepseek-ai/dsh-tools@0.1.0-rc.6(8d36de2abc377789f904eb7ef80e4732))
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-tools': 0.1.0-rc.6(8d36de2abc377789f904eb7ef80e4732)
+      '@deepseek-ai/dsh-user-approval': 0.1.0-rc.7(f0406b3681aecbc4270827e359dcd55d)
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-tool-goal@0.1.0-rc.7(564f0f7c9dd3beea3304d826b17134c7)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998)
+      '@deepseek-ai/dsh-goal': 0.1.0-rc.7(ac7bc8890c6307ab621c94b18ecc52b6)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(7c206068df7621a084f2df242cb8569b)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-tools': 0.1.0-rc.6(8d36de2abc377789f904eb7ef80e4732)
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-tool-jobs@0.1.0-rc.7(7d8a5c2ed205d23a70da75475414b860)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-jobs': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.6(7c206068df7621a084f2df242cb8569b))
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-output-retention': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-tools': 0.1.0-rc.6(8d36de2abc377789f904eb7ef80e4732)
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-tool-skill@0.1.0-rc.7(2a7362c663b1bcb607c1f7959a4fe27f)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-skill': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-tools': 0.1.0-rc.6(8d36de2abc377789f904eb7ef80e4732)
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-tools@0.1.0-rc.6(8d36de2abc377789f904eb7ef80e4732)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998)
+      '@deepseek-ai/dsh-code-runtime': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(7c206068df7621a084f2df242cb8569b)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-user-approval': 0.1.0-rc.7(f0406b3681aecbc4270827e359dcd55d)
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-typert-protocol@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-user-approval@0.1.0-rc.7(f0406b3681aecbc4270827e359dcd55d)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(0b30f02db9c316d5c7e45c50c9805998)
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(7c206068df7621a084f2df242cb8569b)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/schemastery@3.18.1':
+    dependencies:
+      '@deepseek-ai/cosmokit': 1.8.2
+      '@standard-schema/spec': 1.1.0
+
+  '@earendil-works/pi-ai@0.82.1(ws@8.21.3)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.26.0(ws@8.21.3)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@google/genai@1.52.0':
+    dependencies:
+      google-auth-library: 10.9.1
+      p-retry: 4.6.2
+      protobufjs: 7.6.5
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/semantic-conventions': 1.43.0
+      ws: 8.21.3
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
+
+  '@smithy/core@3.33.2':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.5.2':
+    dependencies:
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.7.2':
+    dependencies:
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.11.2':
+    dependencies:
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.3':
+    dependencies:
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.7.2':
+    dependencies:
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/types@4.17.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/node@26.2.0':
+    dependencies:
+      undici-types: 8.3.0
+
+  '@types/retry@0.12.0': {}
+
+  agent-base@7.1.4: {}
+
+  base64-js@1.5.1: {}
+
+  bignumber.js@9.3.1: {}
+
+  bowser@2.14.1: {}
+
+  buffer-equal-constant-time@1.0.1: {}
+
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.1.1
+
+  data-uri-to-buffer@4.0.1: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  extend@3.0.2: {}
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
+  gaxios@7.3.1:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.3.1
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  google-auth-library@10.9.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.3.1
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
+  long@5.3.2: {}
+
+  ms@2.1.3: {}
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
+  openai@6.26.0(ws@8.21.3)(zod@4.4.3):
+    optionalDependencies:
+      ws: 8.21.3
+      zod: 4.4.3
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
+  partial-json@0.1.7: {}
+
+  protobufjs@7.6.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 26.2.0
+      long: 5.3.2
+
+  readdirp@5.1.1: {}
+
+  retry@0.13.1: {}
+
+  safe-buffer@5.2.1: {}
+
+  ts-algebra@2.0.0: {}
+
+  tslib@2.8.1: {}
+
+  typebox@1.1.38: {}
+
+  undici-types@8.3.0: {}
+
+  web-streams-polyfill@3.3.3: {}
+
+  ws@8.21.3: {}
+
+  yaml@2.9.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod@4.4.3: {}

--- a/e2e/scenarios/deepseek-harness-instrumentation/scenario.test.ts
+++ b/e2e/scenarios/deepseek-harness-instrumentation/scenario.test.ts
@@ -1,0 +1,156 @@
+import { beforeAll, describe, expect, test } from "vitest";
+import { resolveFileSnapshotPath } from "../../helpers/file-snapshot";
+import type { CapturedLogEvent } from "../../helpers/mock-braintrust-server";
+import {
+  prepareScenarioDir,
+  readInstalledPackageVersion,
+  resolveScenarioDir,
+  withScenarioHarness,
+} from "../../helpers/scenario-harness";
+import { matchSpanTreeSnapshot } from "../../helpers/span-tree";
+import {
+  findAllSpans,
+  findChildSpans,
+  findLatestChildSpan,
+  spanInstrumentationName,
+} from "../../helpers/trace-selectors";
+
+const originalScenarioDir = resolveScenarioDir(import.meta.url);
+const scenarioDir = await prepareScenarioDir({
+  scenarioDir: originalScenarioDir,
+});
+const scenarios = await Promise.all(
+  [
+    {
+      dependencyName: "deepseek-harness-v0",
+      label: "v0.1 prerelease pinned",
+      variantKey: "deepseek-harness-v0",
+    },
+    {
+      dependencyName: "deepseek-harness-v0-latest",
+      label: "v0.1 prerelease latest",
+      variantKey: "deepseek-harness-v0-latest",
+    },
+  ].map(async (scenario) => ({
+    ...scenario,
+    version: await readInstalledPackageVersion(
+      scenarioDir,
+      scenario.dependencyName,
+    ),
+  })),
+);
+const TIMEOUT_MS = 120_000;
+
+describe.sequential("DeepSeek Harness instrumentation variants", () => {
+  for (const scenario of scenarios) {
+    describe(`${scenario.label} (${scenario.version})`, () => {
+      let events: CapturedLogEvent[] = [];
+
+      beforeAll(async () => {
+        await withScenarioHarness(
+          async ({ events: harnessEvents, runScenarioDir }) => {
+            await runScenarioDir({
+              entry: "scenario.ts",
+              env: {
+                DEEPSEEK_HARNESS_PACKAGE: scenario.dependencyName,
+                NODE_ENV: "development",
+              },
+              runContext: {
+                originalScenarioDir,
+                variantKey: scenario.variantKey,
+              },
+              scenarioDir,
+              timeoutMs: TIMEOUT_MS,
+            });
+            events = harnessEvents();
+          },
+        );
+      }, TIMEOUT_MS);
+
+      test("captures each user turn as an independent trace", async () => {
+        const turns = findAllSpans(events, "deepseek_harness.turn");
+        const first = turns.find(
+          (turn) =>
+            Array.isArray(turn.input) &&
+            turn.input[0]?.content ===
+              "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+        );
+        const second = turns.find(
+          (turn) =>
+            Array.isArray(turn.input) &&
+            turn.input[0]?.content ===
+              "Call lookup exactly once with query `second`. Then reply exactly: Second Harness answer.",
+        );
+
+        expect(turns).toHaveLength(2);
+        expect(first?.span.type).toBe("task");
+        expect(second?.span.type).toBe("task");
+        expect(first?.span.parentIds).toEqual([]);
+        expect(second?.span.parentIds).toEqual([]);
+        expect(first?.span.rootId).not.toEqual(second?.span.rootId);
+        expect(first?.metadata?.["deepseek_harness.session_id"]).toEqual(
+          second?.metadata?.["deepseek_harness.session_id"],
+        );
+        expect(first?.output).toBe("First Harness answer.");
+        expect(second?.output).toBe("Second Harness answer.");
+
+        for (const root of [first, second]) {
+          const steps = findChildSpans(
+            events,
+            "deepseek_harness.step",
+            root?.span.id,
+          );
+          const lookup = findLatestChildSpan(events, "lookup", root?.span.id);
+          expect(steps).toHaveLength(2);
+          expect(steps.map((step) => step.span.type)).toEqual(["llm", "llm"]);
+          expect(steps.map((step) => step.metadata?.provider)).toEqual([
+            "openai",
+            "openai",
+          ]);
+          expect(steps.map((step) => step.metadata?.model)).toEqual([
+            "gpt-5.6-luna",
+            "gpt-5.6-luna",
+          ]);
+          expect(steps[0]?.output).toMatchObject([
+            {
+              finish_reason: "tool_calls",
+              message: {
+                tool_calls: [
+                  { function: { name: "lookup" }, type: "function" },
+                ],
+              },
+            },
+          ]);
+          expect(lookup?.span.type).toBe("tool");
+          expect(lookup?.span.parentIds).toEqual([root?.span.id]);
+          expect(lookup?.output).toEqual(
+            expect.stringContaining("Lookup result"),
+          );
+          expect(root?.metrics?.tokens).toEqual(expect.any(Number));
+          expect(root?.metrics?.prompt_tokens).toEqual(expect.any(Number));
+          expect(root?.metrics?.completion_tokens).toEqual(expect.any(Number));
+        }
+
+        for (const event of events) {
+          expect(spanInstrumentationName(event)).toBe("deepseek-harness");
+        }
+
+        await matchSpanTreeSnapshot(
+          events,
+          resolveFileSnapshotPath(
+            import.meta.url,
+            `${scenario.variantKey}.span-tree.json`,
+          ),
+          {
+            normalize: {
+              additionalProviderIdKeys: [
+                "deepseek_harness.call_id",
+                "deepseek_harness.session_id",
+              ],
+            },
+          },
+        );
+      });
+    });
+  }
+});

--- a/e2e/scenarios/deepseek-harness-instrumentation/scenario.test.ts
+++ b/e2e/scenarios/deepseek-harness-instrumentation/scenario.test.ts
@@ -91,6 +91,14 @@ describe.sequential("DeepSeek Harness instrumentation variants", () => {
         expect(first?.metadata?.["deepseek_harness.session_id"]).toEqual(
           second?.metadata?.["deepseek_harness.session_id"],
         );
+        expect(first?.metadata?.scenario).toBe(
+          "deepseek-harness-instrumentation",
+        );
+        expect(first?.metadata?.testRunId).toMatch(/^e2e-/);
+        expect(second?.metadata?.scenario).toBe(
+          "deepseek-harness-instrumentation",
+        );
+        expect(second?.metadata?.testRunId).toBe(first?.metadata?.testRunId);
         expect(first?.output).toBe("First Harness answer.");
         expect(second?.output).toBe("Second Harness answer.");
 

--- a/e2e/scenarios/deepseek-harness-instrumentation/scenario.ts
+++ b/e2e/scenarios/deepseek-harness-instrumentation/scenario.ts
@@ -1,0 +1,102 @@
+import { Context } from "@deepseek-ai/cordis";
+import { createUserMessage } from "@deepseek-ai/dsh-llm";
+import * as llmPiAi from "@deepseek-ai/dsh-llm-pi-ai";
+import { SessionId } from "@deepseek-ai/dsh-session";
+import { defineTool } from "@deepseek-ai/dsh-tools";
+import * as braintrustPlugin from "@braintrust/deepseek-harness";
+import {
+  getTestRunId,
+  runMain,
+  scopedName,
+} from "../../helpers/scenario-runtime";
+
+async function main(): Promise<void> {
+  const spinePackage =
+    process.env.DEEPSEEK_HARNESS_PACKAGE ?? "deepseek-harness-v0-latest";
+  const spine = await import(spinePackage);
+  const ctx = new Context();
+
+  await ctx.plugin(spine, {
+    agents: [],
+    goals: false,
+    skills: { enabled: false },
+    toolBash: false,
+    toolJobs: false,
+    workspaceContext: false,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  await ctx.plugin(llmPiAi, {
+    providers: {
+      openai: {
+        apiKeyEnv: "OPENAI_API_KEY",
+        baseURL: process.env.OPENAI_BASE_URL,
+        models: [
+          {
+            id: "gpt-5.6-luna",
+            contextWindow: 1_050_000,
+            maxTokens: 128_000,
+            reasoningEfforts: {
+              off: undefined,
+              low: "low",
+              medium: "medium",
+              high: "high",
+              xhigh: "xhigh",
+              max: "max",
+            },
+          },
+        ],
+      },
+    },
+  });
+  await ctx.plugin(braintrustPlugin, {
+    projectName: scopedName(
+      "e2e-deepseek-harness-instrumentation",
+      getTestRunId(),
+    ),
+  });
+  await new Promise((resolve) => setTimeout(resolve, 25));
+
+  ctx.tools.register(
+    defineTool({
+      name: "lookup",
+      description: "Return a deterministic lookup result",
+      parameters: { query: { type: "string", required: true } },
+      output: {
+        schema: { type: "string" },
+        render: (_args, value) => [{ type: "text", text: value }],
+      },
+      async execute(args) {
+        return `Lookup result for ${args.query}`;
+      },
+    }),
+  );
+
+  const handle = await ctx.agents.create({
+    sessionId: SessionId("deepseek-harness-e2e-session"),
+    meta: { cwd: process.cwd() },
+    agentOptions: {
+      provider: "openai",
+      model: "gpt-5.6-luna",
+      maxTokens: 2_000,
+    },
+  });
+
+  for (const prompt of [
+    "Call lookup exactly once with query `first`. Then reply exactly: First Harness answer.",
+    "Call lookup exactly once with query `second`. Then reply exactly: Second Harness answer.",
+  ]) {
+    handle.agent.followup(
+      createUserMessage({
+        content: [{ type: "text", text: prompt }],
+        source: { kind: "user" },
+      }),
+    );
+    await handle.agent.whenIdle();
+  }
+
+  await handle.dispose();
+  await ctx.fiber.dispose();
+}
+
+runMain(main);

--- a/e2e/scenarios/deepseek-harness-instrumentation/scenario.ts
+++ b/e2e/scenarios/deepseek-harness-instrumentation/scenario.ts
@@ -54,6 +54,10 @@ async function main(): Promise<void> {
       "e2e-deepseek-harness-instrumentation",
       getTestRunId(),
     ),
+    metadata: {
+      scenario: "deepseek-harness-instrumentation",
+      testRunId: getTestRunId(),
+    },
   });
   await new Promise((resolve) => setTimeout(resolve, 25));
 

--- a/integrations/deepseek-harness/README.md
+++ b/integrations/deepseek-harness/README.md
@@ -23,6 +23,7 @@ To override the defaults, add the following entry to the profile's
 ```yaml
 - id: braintrust
   config:
+    apiKey: <your-api-key>
     projectName: DeepSeek Harness
 ```
 

--- a/integrations/deepseek-harness/README.md
+++ b/integrations/deepseek-harness/README.md
@@ -1,0 +1,26 @@
+# Braintrust for DeepSeek Harness
+
+Trace each DeepSeek Harness user turn, model call, and tool execution in
+Braintrust. Each top-level user turn is reported as its own trace, even when
+multiple turns belong to the same Harness session.
+
+## Install
+
+```bash
+npm install @braintrust/deepseek-harness
+```
+
+Set `BRAINTRUST_API_KEY`, then add the plugin to your Harness profile patch:
+
+```yaml
+- insert:
+    - id: braintrust
+      name: "@braintrust/deepseek-harness"
+      config:
+        projectName: DeepSeek Harness
+```
+
+The optional configuration fields are `projectName`, `orgName`, and `appUrl`.
+`projectName` defaults to `DeepSeek Harness`. Authentication always uses the
+standard Braintrust environment configuration; API keys are not accepted in
+the YAML configuration.

--- a/integrations/deepseek-harness/README.md
+++ b/integrations/deepseek-harness/README.md
@@ -25,10 +25,13 @@ To override the defaults, add the following entry to the profile's
   config:
     apiKey: <your-api-key>
     projectName: DeepSeek Harness
+    metadata:
+      environment: production
 ```
 
-The optional configuration fields are `apiKey`, `projectName`, `orgName`, and
-`appUrl`. `projectName` defaults to `DeepSeek Harness`. You can set `apiKey`
+The optional configuration fields are `apiKey`, `projectName`, `metadata`,
+`orgName`, and `appUrl`. `metadata` is added to every top-level user-turn trace,
+and `projectName` defaults to `DeepSeek Harness`. You can set `apiKey`
 under **Settings > Plugins** in Harness; it is declared as a secret field so
 the settings UI handles it as a credential. A configured `apiKey` takes
 precedence over the `BRAINTRUST_API_KEY` environment variable.

--- a/integrations/deepseek-harness/README.md
+++ b/integrations/deepseek-harness/README.md
@@ -7,20 +7,27 @@ multiple turns belong to the same Harness session.
 ## Install
 
 ```bash
-npm install @braintrust/deepseek-harness
+export BRAINTRUST_API_KEY=<your-api-key>
+dsh plugin --profile web add @braintrust/deepseek-harness
 ```
 
-Set `BRAINTRUST_API_KEY`, then add the plugin to your Harness profile patch:
+The command installs the package and activates its bundled Cordis patch for the
+`web` profile. Replace `web` with the Harness profile you want to instrument.
+The plugin reads `BRAINTRUST_API_KEY` when no API key is configured in Harness.
+
+## Configure
+
+To override the defaults, add the following entry to the profile's
+`cordis.patch.yml`:
 
 ```yaml
-- insert:
-    - id: braintrust
-      name: "@braintrust/deepseek-harness"
-      config:
-        projectName: DeepSeek Harness
+- id: braintrust
+  config:
+    projectName: DeepSeek Harness
 ```
 
-The optional configuration fields are `projectName`, `orgName`, and `appUrl`.
-`projectName` defaults to `DeepSeek Harness`. Authentication always uses the
-standard Braintrust environment configuration; API keys are not accepted in
-the YAML configuration.
+The optional configuration fields are `apiKey`, `projectName`, `orgName`, and
+`appUrl`. `projectName` defaults to `DeepSeek Harness`. You can set `apiKey`
+under **Settings > Plugins** in Harness; it is declared as a secret field so
+the settings UI handles it as a credential. A configured `apiKey` takes
+precedence over the `BRAINTRUST_API_KEY` environment variable.

--- a/integrations/deepseek-harness/cordis.patch.yml
+++ b/integrations/deepseek-harness/cordis.patch.yml
@@ -1,0 +1,3 @@
+- insert:
+    - id: braintrust
+      name: "@braintrust/deepseek-harness"

--- a/integrations/deepseek-harness/package.json
+++ b/integrations/deepseek-harness/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@braintrust/deepseek-harness",
+  "version": "0.1.0",
+  "description": "Braintrust tracing plugin for DeepSeek Harness",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "module": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./cordis.patch.yml": "./cordis.patch.yml"
+  },
+  "files": [
+    "dist/**/*",
+    "cordis.patch.yml",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "check:typings": "tsc --noEmit",
+    "watch": "tsup --watch",
+    "clean": "rm -r dist/*",
+    "test": "vitest run",
+    "yalc:publish": "yalc publish"
+  },
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    }
+  },
+  "license": "MIT",
+  "peerDependencies": {
+    "@deepseek-ai/cordis": ">=4.0.1",
+    "@deepseek-ai/dsh-llm": ">=0.1.0-rc.6 <0.2.0",
+    "@deepseek-ai/dsh-session": ">=0.1.0-rc.6 <0.2.0",
+    "@deepseek-ai/dsh-tools": ">=0.1.0-rc.6 <0.2.0",
+    "@deepseek-ai/schemastery": ">=3.18.1",
+    "braintrust": ">=3.0.0"
+  },
+  "devDependencies": {
+    "@deepseek-ai/cordis": "4.0.1",
+    "@deepseek-ai/dsh-llm": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-session": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-tools": "0.1.0-rc.6",
+    "@deepseek-ai/schemastery": "3.18.1",
+    "@types/node": "^22.15.21",
+    "braintrust": "workspace:^",
+    "tsup": "^8.5.1",
+    "typescript": "^5.5.4",
+    "vitest": "4.1.5"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/braintrustdata/braintrust-sdk-javascript.git",
+    "directory": "integrations/deepseek-harness"
+  },
+  "homepage": "https://www.braintrust.dev/docs",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
+  }
+}

--- a/integrations/deepseek-harness/package.json
+++ b/integrations/deepseek-harness/package.json
@@ -34,22 +34,37 @@
     }
   },
   "license": "MIT",
+  "dependencies": {
+    "@deepseek-ai/schemastery": "^3.18.1",
+    "braintrust": "workspace:^",
+    "zod": "^3.25.34 || ^4.0"
+  },
   "peerDependencies": {
     "@deepseek-ai/cordis": ">=4.0.1",
     "@deepseek-ai/dsh-llm": ">=0.1.0-rc.6 <0.2.0",
     "@deepseek-ai/dsh-session": ">=0.1.0-rc.6 <0.2.0",
-    "@deepseek-ai/dsh-tools": ">=0.1.0-rc.6 <0.2.0",
-    "@deepseek-ai/schemastery": ">=3.18.1",
-    "braintrust": ">=3.0.0"
+    "@deepseek-ai/dsh-tools": ">=0.1.0-rc.6 <0.2.0"
+  },
+  "peerDependenciesMeta": {
+    "@deepseek-ai/cordis": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-llm": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-session": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-tools": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "4.0.1",
     "@deepseek-ai/dsh-llm": "0.1.0-rc.6",
     "@deepseek-ai/dsh-session": "0.1.0-rc.6",
     "@deepseek-ai/dsh-tools": "0.1.0-rc.6",
-    "@deepseek-ai/schemastery": "3.18.1",
     "@types/node": "^22.15.21",
-    "braintrust": "workspace:^",
     "tsup": "^8.5.1",
     "typescript": "^5.5.4",
     "vitest": "4.1.5"

--- a/integrations/deepseek-harness/src/index.test.ts
+++ b/integrations/deepseek-harness/src/index.test.ts
@@ -35,12 +35,15 @@ const mock = vi.hoisted(() => {
     startSpan: (args: Record<PropertyKey, unknown>) => new MockSpan(args),
     flush: vi.fn(async () => undefined),
   };
+  const initLogger = vi.fn(() => logger);
 
   return {
+    initLogger,
     logger,
     reset() {
       nextId = 0;
       spans.length = 0;
+      initLogger.mockClear();
       logger.flush.mockClear();
     },
     spans,
@@ -48,17 +51,17 @@ const mock = vi.hoisted(() => {
 });
 
 vi.mock("braintrust", () => ({
-  initLogger: vi.fn(() => mock.logger),
+  initLogger: mock.initLogger,
   NOOP_SPAN: {},
   withCurrent: <R>(_span: unknown, callback: () => R): R => callback(),
 }));
 
 import type { Context } from "@deepseek-ai/cordis";
-import { apply } from "./index";
+import { apply, Config as ConfigSchema, type Config } from "./index";
 
 type Listener = (...args: any[]) => any;
 
-function createContext() {
+function createContext(config: Config = {}) {
   const listeners = new Map<string, Listener>();
   let cleanup: (() => Promise<void>) | undefined;
   const warnings: string[] = [];
@@ -72,7 +75,7 @@ function createContext() {
       return () => undefined;
     },
   };
-  apply(ctx as unknown as Context);
+  apply(ctx as unknown as Context, config);
   return {
     cleanup: () => cleanup?.(),
     listener: (event: string) => {
@@ -104,6 +107,17 @@ async function consume(iterable: AsyncIterable<unknown>): Promise<unknown[]> {
 
 describe("DeepSeek Harness plugin", () => {
   beforeEach(() => mock.reset());
+
+  test("accepts an API key as a secret plugin setting", () => {
+    createContext({ apiKey: "secret-key" });
+
+    expect(mock.initLogger).toHaveBeenCalledWith({
+      apiKey: "secret-key",
+      projectName: "DeepSeek Harness",
+      setCurrent: false,
+    });
+    expect(ConfigSchema.dict?.apiKey?.meta.role).toBe("secret");
+  });
 
   test("creates a separate root trace for each user turn", async () => {
     const harness = createContext();

--- a/integrations/deepseek-harness/src/index.test.ts
+++ b/integrations/deepseek-harness/src/index.test.ts
@@ -1,0 +1,344 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mock = vi.hoisted(() => {
+  let nextId = 0;
+  const spans: MockSpan[] = [];
+
+  class MockSpan {
+    readonly id = `span-${++nextId}`;
+    readonly parent?: MockSpan;
+    readonly args: Record<PropertyKey, unknown>;
+    readonly logs: Record<string, unknown>[] = [];
+    ended = false;
+
+    constructor(args: Record<PropertyKey, unknown>, parent?: MockSpan) {
+      this.args = args;
+      this.parent = parent;
+      spans.push(this);
+    }
+
+    startSpan(args: Record<PropertyKey, unknown>): MockSpan {
+      return new MockSpan(args, this);
+    }
+
+    log(event: Record<string, unknown>): void {
+      this.logs.push(event);
+    }
+
+    end(): number {
+      this.ended = true;
+      return Date.now() / 1000;
+    }
+  }
+
+  const logger = {
+    startSpan: (args: Record<PropertyKey, unknown>) => new MockSpan(args),
+    flush: vi.fn(async () => undefined),
+  };
+
+  return {
+    logger,
+    reset() {
+      nextId = 0;
+      spans.length = 0;
+      logger.flush.mockClear();
+    },
+    spans,
+  };
+});
+
+vi.mock("braintrust", () => ({
+  initLogger: vi.fn(() => mock.logger),
+  NOOP_SPAN: {},
+  withCurrent: <R>(_span: unknown, callback: () => R): R => callback(),
+}));
+
+import type { Context } from "@deepseek-ai/cordis";
+import { apply } from "./index";
+
+type Listener = (...args: any[]) => any;
+
+function createContext() {
+  const listeners = new Map<string, Listener>();
+  let cleanup: (() => Promise<void>) | undefined;
+  const warnings: string[] = [];
+  const ctx = {
+    logger: { warn: (message: string) => warnings.push(message) },
+    on(event: string, listener: Listener) {
+      listeners.set(event, listener);
+    },
+    effect(register: () => () => Promise<void>) {
+      cleanup = register();
+      return () => undefined;
+    },
+  };
+  apply(ctx as unknown as Context);
+  return {
+    cleanup: () => cleanup?.(),
+    listener: (event: string) => {
+      const listener = listeners.get(event);
+      if (!listener) throw new Error(`Missing listener for ${event}`);
+      return listener;
+    },
+    warnings,
+  };
+}
+
+function session(id = "session-1", parentSession?: string) {
+  return { id, header: { id, parentSession } };
+}
+
+function userMessage(text: string) {
+  return {
+    role: "user",
+    content: [{ type: "text", text }],
+    source: { kind: "user" },
+  };
+}
+
+async function consume(iterable: AsyncIterable<unknown>): Promise<unknown[]> {
+  const values: unknown[] = [];
+  for await (const value of iterable) values.push(value);
+  return values;
+}
+
+describe("DeepSeek Harness plugin", () => {
+  beforeEach(() => mock.reset());
+
+  test("creates a separate root trace for each user turn", async () => {
+    const harness = createContext();
+    const currentSession = session();
+    const onSessionEvent = harness.listener("session/event");
+    const onLlmStream = harness.listener("llm/stream");
+    const onToolExecute = harness.listener("tools/execute");
+
+    onSessionEvent(currentSession, {
+      type: "turn/start",
+      data: { turn: 1 },
+    });
+    onSessionEvent(currentSession, {
+      type: "user/message",
+      data: userMessage("first turn"),
+    });
+
+    const chunks = [
+      { type: "text-delta", index: 0, text: "hello" },
+      { type: "block-end", index: 0, block: { type: "text", text: "hello" } },
+      {
+        type: "usage",
+        usage: {
+          inputTokens: 5,
+          outputTokens: 3,
+          cacheReadTokens: 2,
+          cacheWriteTokens: 1,
+          reasoningTokens: 1,
+        },
+      },
+      { type: "finish", reason: { kind: "stop" } },
+    ];
+    const stream = onLlmStream(
+      {
+        provider: "replay",
+        model: "replay-model",
+        system: "Be helpful",
+        messages: [userMessage("first turn")],
+        sessionId: currentSession.id,
+      },
+      () =>
+        (async function* () {
+          yield* chunks;
+        })(),
+    );
+    expect(await consume(stream)).toEqual(chunks);
+
+    const token = Symbol("tool");
+    const result = await onToolExecute(
+      {
+        callId: "call-1",
+        name: "read_file",
+        arguments: { path: "README.md" },
+        agent: { session: currentSession },
+        token,
+      },
+      async () => ({
+        isError: false,
+        value: { text: "contents" },
+        content: [{ type: "text", text: "contents" }],
+      }),
+    );
+    expect(result.value).toEqual({ text: "contents" });
+
+    onSessionEvent(currentSession, {
+      type: "assistant/message",
+      data: {
+        turn: 1,
+        step: 1,
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "hello" }],
+          source: { kind: "model" },
+        },
+      },
+    });
+    onSessionEvent(currentSession, {
+      type: "turn/end",
+      data: { turn: 1, reason: { kind: "completed" } },
+    });
+
+    onSessionEvent(currentSession, {
+      type: "turn/start",
+      data: { turn: 2 },
+    });
+    onSessionEvent(currentSession, {
+      type: "user/message",
+      data: userMessage("second turn"),
+    });
+    onSessionEvent(currentSession, {
+      type: "turn/end",
+      data: { turn: 2, reason: { kind: "completed" } },
+    });
+
+    const turns = mock.spans.filter(
+      (span) => span.args.name === "deepseek_harness.turn",
+    );
+    expect(turns).toHaveLength(2);
+    expect(turns.map((turn) => turn.parent)).toEqual([undefined, undefined]);
+    expect(turns.map((turn) => turn.id)).toEqual(["span-1", "span-4"]);
+    expect(turns.every((turn) => turn.ended)).toBe(true);
+    expect(
+      turns[0]?.args[Symbol.for("braintrust.spanInstrumentationName")],
+    ).toBe("deepseek-harness");
+
+    const llm = mock.spans.find(
+      (span) => span.args.name === "deepseek_harness.step",
+    );
+    const tool = mock.spans.find((span) => span.args.name === "read_file");
+    expect(llm?.parent).toBe(turns[0]);
+    expect(tool?.parent).toBe(turns[0]);
+    expect(llm?.logs).toContainEqual({
+      metrics: {
+        tokens: 11,
+        prompt_tokens: 8,
+        completion_tokens: 3,
+        completion_reasoning_tokens: 1,
+        prompt_cached_tokens: 2,
+        prompt_cache_creation_tokens: 1,
+      },
+      output: [
+        {
+          index: 0,
+          message: { role: "assistant", content: "hello" },
+          finish_reason: "stop",
+        },
+      ],
+    });
+    expect(turns[0]?.logs).toContainEqual({
+      output: "hello",
+      metrics: {
+        tokens: 11,
+        prompt_tokens: 8,
+        completion_tokens: 3,
+        completion_reasoning_tokens: 1,
+        prompt_cached_tokens: 2,
+        prompt_cache_creation_tokens: 1,
+      },
+      metadata: { "deepseek_harness.stop_reason": "completed" },
+    });
+  });
+
+  test("nests a child-session turn beneath its delegation tool", async () => {
+    const harness = createContext();
+    const parent = session("parent");
+    const child = session("child", "parent");
+    const onSessionEvent = harness.listener("session/event");
+
+    onSessionEvent(parent, { type: "turn/start", data: { turn: 1 } });
+    const token = Symbol("delegate");
+    await harness.listener("tools/execute")(
+      {
+        callId: "delegate-1",
+        name: "delegate",
+        arguments: { prompt: "research" },
+        agent: { session: parent },
+        token,
+      },
+      async () => {
+        harness.listener("session/created")(child);
+        onSessionEvent(child, { type: "turn/start", data: { turn: 1 } });
+        onSessionEvent(child, {
+          type: "turn/end",
+          data: { turn: 1, reason: { kind: "completed" } },
+        });
+        return { isError: false, value: "done", content: [] };
+      },
+    );
+
+    const delegation = mock.spans.find((span) => span.args.name === "delegate");
+    const childTurn = mock.spans.find(
+      (span) =>
+        span.args.name === "deepseek_harness.turn" &&
+        span.parent === delegation,
+    );
+    expect(childTurn).toBeDefined();
+    expect(childTurn?.ended).toBe(true);
+  });
+
+  test("preserves model and tool failures", async () => {
+    const harness = createContext();
+    const currentSession = session();
+    harness.listener("session/event")(currentSession, {
+      type: "turn/start",
+      data: { turn: 1 },
+    });
+
+    const modelError = new Error("model exploded");
+    const stream = harness.listener("llm/stream")(
+      {
+        provider: "replay",
+        model: "replay-model",
+        messages: [],
+        sessionId: currentSession.id,
+      },
+      () =>
+        (async function* () {
+          throw modelError;
+        })(),
+    );
+    await expect(consume(stream)).rejects.toBe(modelError);
+
+    const toolError = new Error("tool exploded");
+    await expect(
+      harness.listener("tools/execute")(
+        {
+          callId: "call-1",
+          name: "broken_tool",
+          arguments: {},
+          agent: { session: currentSession },
+          token: Symbol("broken"),
+        },
+        async () => {
+          throw toolError;
+        },
+      ),
+    ).rejects.toBe(toolError);
+
+    expect(
+      mock.spans.find((span) => span.args.name === "deepseek_harness.step")
+        ?.logs,
+    ).toContainEqual({ error: modelError });
+    expect(
+      mock.spans.find((span) => span.args.name === "broken_tool")?.logs,
+    ).toContainEqual({ error: toolError });
+  });
+
+  test("closes unfinished turns and flushes on disposal", async () => {
+    const harness = createContext();
+    harness.listener("session/event")(session(), {
+      type: "turn/start",
+      data: { turn: 1 },
+    });
+    await harness.cleanup();
+    expect(mock.spans[0]?.ended).toBe(true);
+    expect(mock.logger.flush).toHaveBeenCalledOnce();
+  });
+});

--- a/integrations/deepseek-harness/src/index.test.ts
+++ b/integrations/deepseek-harness/src/index.test.ts
@@ -2,7 +2,20 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const mock = vi.hoisted(() => {
   let nextId = 0;
+  const attachments: MockAttachment[] = [];
   const spans: MockSpan[] = [];
+
+  class MockAttachment {
+    constructor(
+      readonly params: {
+        data: ArrayBuffer;
+        filename: string;
+        contentType: string;
+      },
+    ) {
+      attachments.push(this);
+    }
+  }
 
   class MockSpan {
     readonly id = `span-${++nextId}`;
@@ -38,10 +51,13 @@ const mock = vi.hoisted(() => {
   const initLogger = vi.fn(() => logger);
 
   return {
+    Attachment: MockAttachment,
+    attachments,
     initLogger,
     logger,
     reset() {
       nextId = 0;
+      attachments.length = 0;
       spans.length = 0;
       initLogger.mockClear();
       logger.flush.mockClear();
@@ -51,6 +67,7 @@ const mock = vi.hoisted(() => {
 });
 
 vi.mock("braintrust", () => ({
+  Attachment: mock.Attachment,
   initLogger: mock.initLogger,
   NOOP_SPAN: {},
   withCurrent: <R>(_span: unknown, callback: () => R): R => callback(),
@@ -65,7 +82,18 @@ function createContext(config: Config = {}) {
   const listeners = new Map<string, Listener>();
   let cleanup: (() => Promise<void>) | undefined;
   const warnings: string[] = [];
+  const readImage = vi.fn(
+    async (ref: {
+      attachmentId: string;
+      mediaType: string;
+      bytes: number;
+      width: number;
+      height: number;
+      name?: string;
+    }) => ({ ref, data: new Uint8Array([1, 2, 3]) }),
+  );
   const ctx = {
+    attachments: { readImage },
     logger: { warn: (message: string) => warnings.push(message) },
     on(event: string, listener: Listener) {
       listeners.set(event, listener);
@@ -83,6 +111,7 @@ function createContext(config: Config = {}) {
       if (!listener) throw new Error(`Missing listener for ${event}`);
       return listener;
     },
+    readImage,
     warnings,
   };
 }
@@ -117,6 +146,182 @@ describe("DeepSeek Harness plugin", () => {
       setCurrent: false,
     });
     expect(ConfigSchema.dict?.apiKey?.meta.role).toBe("secret");
+  });
+
+  test("only logs the supported tool definition fields", async () => {
+    const harness = createContext();
+    const stream = harness.listener("llm/stream")(
+      {
+        provider: "replay",
+        model: "replay-model",
+        messages: [],
+        tools: [
+          {
+            name: "lookup",
+            description: "Look something up",
+            parameters: { type: "object" },
+            handler: () => "must not be logged",
+          },
+        ],
+      },
+      () =>
+        (async function* () {
+          yield { type: "finish", reason: { kind: "stop" } };
+        })(),
+    );
+    await consume(stream);
+
+    expect(mock.spans[0]?.args).toMatchObject({
+      event: {
+        metadata: {
+          tools: [
+            {
+              type: "function",
+              function: {
+                name: "lookup",
+                description: "Look something up",
+                parameters: { type: "object" },
+              },
+            },
+          ],
+        },
+      },
+    });
+    expect(
+      (
+        mock.spans[0]?.args.event as {
+          metadata: { tools: { function: Record<string, unknown> }[] };
+        }
+      ).metadata.tools[0]?.function,
+    ).not.toHaveProperty("handler");
+  });
+
+  test("converts Harness image references to Braintrust attachments", async () => {
+    const harness = createContext();
+    const currentSession = session();
+    const image = {
+      attachmentId: "image-1",
+      mediaType: "image/png",
+      bytes: 3,
+      width: 1,
+      height: 1,
+      name: "diagram.png",
+    };
+    const message = {
+      role: "user",
+      content: [
+        { type: "text", text: "describe this" },
+        { type: "image", attachment: image },
+      ],
+      source: { kind: "user" },
+    };
+
+    harness.listener("session/event")(currentSession, {
+      type: "turn/start",
+      data: { turn: 1 },
+    });
+    harness.listener("session/event")(currentSession, {
+      type: "user/message",
+      data: message,
+    });
+    await consume(
+      harness.listener("llm/stream")(
+        {
+          provider: "replay",
+          model: "replay-model",
+          messages: [message],
+          sessionId: currentSession.id,
+        },
+        () =>
+          (async function* () {
+            yield { type: "finish", reason: { kind: "stop" } };
+          })(),
+      ),
+    );
+    await harness.listener("session/flush")(currentSession);
+
+    expect(harness.readImage).toHaveBeenCalledOnce();
+    expect(harness.readImage).toHaveBeenCalledWith(image);
+    expect(mock.attachments).toHaveLength(1);
+    expect(mock.attachments[0]?.params).toMatchObject({
+      filename: "diagram.png",
+      contentType: "image/png",
+    });
+    expect(new Uint8Array(mock.attachments[0]?.params.data ?? [])).toEqual(
+      new Uint8Array([1, 2, 3]),
+    );
+
+    const expectedImagePart = {
+      type: "image_url",
+      image_url: { url: mock.attachments[0] },
+    };
+    const turn = mock.spans.find(
+      (span) => span.args.name === "deepseek_harness.turn",
+    );
+    const model = mock.spans.find(
+      (span) => span.args.name === "deepseek_harness.step",
+    );
+    expect(turn?.logs).toContainEqual({
+      input: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "describe this" }, expectedImagePart],
+        },
+      ],
+    });
+    expect(model?.logs).toContainEqual({
+      input: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "describe this" }, expectedImagePart],
+        },
+      ],
+    });
+  });
+
+  test("preserves Harness image references when attachment conversion fails", async () => {
+    const harness = createContext();
+    const image = {
+      attachmentId: "image-1",
+      mediaType: "image/png",
+      bytes: 3,
+      width: 1,
+      height: 1,
+    };
+    harness.readImage.mockRejectedValueOnce(new Error("storage unavailable"));
+
+    await consume(
+      harness.listener("llm/stream")(
+        {
+          provider: "replay",
+          model: "replay-model",
+          messages: [
+            {
+              role: "user",
+              content: [{ type: "image", attachment: image }],
+              source: { kind: "user" },
+            },
+          ],
+        },
+        () =>
+          (async function* () {
+            yield { type: "finish", reason: { kind: "stop" } };
+          })(),
+      ),
+    );
+    await harness.listener("session/flush")(session());
+
+    expect(mock.spans[0]?.logs).toContainEqual({
+      input: [
+        {
+          role: "user",
+          content: [{ type: "image", attachment: image }],
+        },
+      ],
+    });
+    expect(harness.warnings).toContainEqual(
+      "Braintrust could not convert a Harness image attachment: Error: storage unavailable",
+    );
   });
 
   test("creates a separate root trace for each user turn", async () => {

--- a/integrations/deepseek-harness/src/index.test.ts
+++ b/integrations/deepseek-harness/src/index.test.ts
@@ -196,6 +196,38 @@ describe("DeepSeek Harness plugin", () => {
     ).not.toHaveProperty("handler");
   });
 
+  test("adds configured metadata to every top-level turn", () => {
+    const harness = createContext({
+      metadata: { scenario: "deepseek-harness", testRunId: "e2e-123" },
+    });
+    const currentSession = session();
+    const onSessionEvent = harness.listener("session/event");
+
+    onSessionEvent(currentSession, {
+      type: "turn/start",
+      data: { turn: 1 },
+    });
+    onSessionEvent(currentSession, {
+      type: "turn/start",
+      data: { turn: 2 },
+    });
+
+    const turns = mock.spans.filter(
+      (span) => span.args.name === "deepseek_harness.turn",
+    );
+    expect(turns).toHaveLength(2);
+    for (const turn of turns) {
+      expect(turn.args).toMatchObject({
+        event: {
+          metadata: {
+            scenario: "deepseek-harness",
+            testRunId: "e2e-123",
+          },
+        },
+      });
+    }
+  });
+
   test("converts Harness image references to Braintrust attachments", async () => {
     const harness = createContext();
     const currentSession = session();

--- a/integrations/deepseek-harness/src/index.ts
+++ b/integrations/deepseek-harness/src/index.ts
@@ -1,14 +1,24 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { randomUUID } from "node:crypto";
 import type { Context } from "@deepseek-ai/cordis";
+// Load the Harness packages' compile-time Cordis event augmentations.
 import type {} from "@deepseek-ai/dsh-llm";
 import type {} from "@deepseek-ai/dsh-session";
 import type {} from "@deepseek-ai/dsh-tools";
 import z from "@deepseek-ai/schemastery";
-import { initLogger, NOOP_SPAN, withCurrent } from "braintrust";
+import {
+  Attachment,
+  initLogger,
+  NOOP_SPAN,
+  withCurrent,
+  type Span,
+  type StartSpanArgs,
+} from "braintrust";
 import type {
+  HarnessAttachmentStore,
   HarnessContentBlock,
   HarnessGenerateOptions,
+  HarnessImageAttachmentRef,
   HarnessMessage,
   HarnessSession,
   HarnessSessionEvent,
@@ -46,35 +56,6 @@ export const Config: z<Config> = z.object({
   appUrl: z.string(),
 });
 
-interface BraintrustEvent {
-  input?: unknown;
-  output?: unknown;
-  error?: unknown;
-  metadata?: Record<string, unknown>;
-  metrics?: Record<string, unknown>;
-}
-
-interface BraintrustStartSpanArgs {
-  name?: string;
-  type?: "task" | "llm" | "tool";
-  event?: BraintrustEvent;
-  spanId?: string;
-  parentSpanIds?:
-    | { rootSpanId: string; spanId: string }
-    | { rootSpanId: string; parentSpanIds: string[] };
-}
-
-interface BraintrustSpan {
-  startSpan(args: BraintrustStartSpanArgs): BraintrustSpan;
-  log(event: BraintrustEvent): void;
-  end(): number;
-}
-
-interface BraintrustLogger {
-  startSpan(args: BraintrustStartSpanArgs): BraintrustSpan;
-  flush(): Promise<void>;
-}
-
 type TokenMetrics = Record<string, number> & {
   tokens: number;
   prompt_tokens: number;
@@ -87,14 +68,14 @@ type TokenMetrics = Record<string, number> & {
 interface TurnState {
   readonly sessionId: string;
   readonly turn: number;
-  readonly span: BraintrustSpan;
-  readonly input: unknown[];
+  readonly span: Span;
+  readonly input: Promise<Record<string, unknown>>[];
   metrics: TokenMetrics;
   output?: string;
 }
 
 interface ToolState {
-  readonly span: BraintrustSpan;
+  readonly span: Span;
   readonly turn?: TurnState;
 }
 
@@ -111,7 +92,7 @@ interface AssistantAccumulator {
   failure?: string;
 }
 
-function spanArgs(args: BraintrustStartSpanArgs): BraintrustStartSpanArgs {
+function spanArgs(args: StartSpanArgs): StartSpanArgs {
   return Object.assign(args, {
     [INSTRUMENTATION_SYMBOL]: INSTRUMENTATION_NAME,
   });
@@ -124,40 +105,58 @@ function contentText(blocks: readonly HarnessContentBlock[]): string {
     .join("");
 }
 
-function normalizeBlocks(blocks: readonly HarnessContentBlock[]): unknown {
+async function normalizeBlocks(
+  blocks: readonly HarnessContentBlock[],
+  resolveImage: (
+    ref: HarnessImageAttachmentRef,
+  ) => Promise<Attachment | undefined>,
+): Promise<unknown> {
   if (blocks.length === 0) return "";
   if (blocks.every((block) => block.type === "text")) {
     return contentText(blocks);
   }
-  return blocks.map((block) => {
-    switch (block.type) {
-      case "text":
-        return { type: "text", text: block.text ?? "" };
-      case "reasoning":
-        return { type: "reasoning", text: block.text ?? "" };
-      case "tool-call":
-        return {
-          type: "tool_call",
-          id: block.id,
-          name: block.name,
-          arguments: block.arguments,
-        };
-      case "tool-result":
-        return {
-          type: "tool_result",
-          tool_call_id: block.toolCallId,
-          content: normalizeBlocks(block.content ?? []),
-          ...(block.isError ? { is_error: true } : {}),
-        };
-      case "image":
-        return { type: "image", attachment: block.attachment };
-      default:
-        return { type: block.type };
-    }
-  });
+  return Promise.all(
+    blocks.map(async (block) => {
+      switch (block.type) {
+        case "text":
+          return { type: "text", text: block.text ?? "" };
+        case "reasoning":
+          return { type: "reasoning", text: block.text ?? "" };
+        case "tool-call":
+          return {
+            type: "tool_call",
+            id: block.id,
+            name: block.name,
+            arguments: block.arguments,
+          };
+        case "tool-result":
+          return {
+            type: "tool_result",
+            tool_call_id: block.toolCallId,
+            content: await normalizeBlocks(block.content ?? [], resolveImage),
+            ...(block.isError ? { is_error: true } : {}),
+          };
+        case "image": {
+          const attachment = block.attachment
+            ? await resolveImage(block.attachment)
+            : undefined;
+          return attachment
+            ? { type: "image_url", image_url: { url: attachment } }
+            : { type: "image", attachment: block.attachment };
+        }
+        default:
+          return { type: block.type };
+      }
+    }),
+  );
 }
 
-function normalizeMessage(message: HarnessMessage): Record<string, unknown> {
+async function normalizeMessage(
+  message: HarnessMessage,
+  resolveImage: (
+    ref: HarnessImageAttachmentRef,
+  ) => Promise<Attachment | undefined>,
+): Promise<Record<string, unknown>> {
   const toolResult = message.content.find(
     (block) => block.type === "tool-result",
   );
@@ -165,7 +164,7 @@ function normalizeMessage(message: HarnessMessage): Record<string, unknown> {
     return {
       role: "tool",
       tool_call_id: toolResult.toolCallId ?? message.source?.callId,
-      content: normalizeBlocks(toolResult.content ?? []),
+      content: await normalizeBlocks(toolResult.content ?? [], resolveImage),
     };
   }
 
@@ -188,15 +187,24 @@ function normalizeMessage(message: HarnessMessage): Record<string, unknown> {
       }));
     if (calls.length > 0) normalized.tool_calls = calls;
   } else {
-    normalized.content = normalizeBlocks(message.content);
+    normalized.content = await normalizeBlocks(message.content, resolveImage);
   }
   return normalized;
 }
 
-function normalizeInput(options: HarnessGenerateOptions): unknown[] {
+async function normalizeInput(
+  options: HarnessGenerateOptions,
+  resolveImage: (
+    ref: HarnessImageAttachmentRef,
+  ) => Promise<Attachment | undefined>,
+): Promise<unknown[]> {
   return [
     ...(options.system ? [{ role: "system", content: options.system }] : []),
-    ...options.messages.map(normalizeMessage),
+    ...(await Promise.all(
+      options.messages.map((message) =>
+        normalizeMessage(message, resolveImage),
+      ),
+    )),
   ];
 }
 
@@ -363,12 +371,14 @@ export function apply(ctx: Context, config: Config = {}): void {
     ...(config.orgName ? { orgName: config.orgName } : {}),
     ...(config.appUrl ? { appUrl: config.appUrl } : {}),
     setCurrent: false,
-  }) as BraintrustLogger;
+  });
   const turns = new Map<string, Map<number, TurnState>>();
   const activeTurns = new Map<string, TurnState>();
-  const childParents = new Map<string, BraintrustSpan>();
-  const toolSpans = new Map<symbol, BraintrustSpan>();
+  const childParents = new Map<string, Span>();
+  const toolSpans = new Map<symbol, Span>();
   const toolContext = new AsyncLocalStorage<ToolState>();
+  const attachmentCache = new Map<string, Promise<Attachment>>();
+  const pendingLogs = new Set<Promise<void>>();
 
   const warn = (message: string, error: unknown): void => {
     try {
@@ -378,10 +388,55 @@ export function apply(ctx: Context, config: Config = {}): void {
     }
   };
 
-  const startChild = (
-    parent: BraintrustSpan | undefined,
-    args: BraintrustStartSpanArgs,
-  ): BraintrustSpan => {
+  const resolveImage = async (
+    ref: HarnessImageAttachmentRef,
+  ): Promise<Attachment | undefined> => {
+    const attachmentStore = (
+      ctx as Context & { attachments?: HarnessAttachmentStore }
+    ).attachments;
+    if (!attachmentStore) {
+      warn(
+        "Braintrust could not convert a Harness image attachment",
+        new Error("Harness attachment service is unavailable"),
+      );
+      return undefined;
+    }
+    const key = String(ref.attachmentId);
+    let pending = attachmentCache.get(key);
+    if (!pending) {
+      pending = attachmentStore.readImage(ref).then((stored) => {
+        const mediaType = stored.ref.mediaType;
+        return new Attachment({
+          data: new Uint8Array(stored.data).buffer,
+          filename:
+            stored.ref.name ??
+            `attachment.${mediaType === "image/jpeg" ? "jpg" : mediaType.slice("image/".length)}`,
+          contentType: mediaType,
+        });
+      });
+      attachmentCache.set(key, pending);
+    }
+    try {
+      return await pending;
+    } catch (error) {
+      attachmentCache.delete(key);
+      warn("Braintrust could not convert a Harness image attachment", error);
+      return undefined;
+    }
+  };
+
+  const trackPendingLog = (pending: Promise<void>): void => {
+    pendingLogs.add(pending);
+    void pending.finally(() => pendingLogs.delete(pending));
+  };
+
+  const flushPendingLogs = async (): Promise<void> => {
+    while (pendingLogs.size > 0) {
+      await Promise.allSettled([...pendingLogs]);
+    }
+  };
+
+  const startChild = (parent: Span | undefined, args: StartSpanArgs): Span => {
     if (parent) return parent.startSpan(spanArgs(args));
     const spanId = randomUUID();
     return withCurrent(NOOP_SPAN, () =>
@@ -462,8 +517,16 @@ export function apply(ctx: Context, config: Config = {}): void {
       if (event.type === "user/message") {
         const message = eventMessage(event.data);
         if (message) {
-          state.input.push(normalizeMessage(message));
-          state.span.log({ input: state.input });
+          state.input.push(normalizeMessage(message, resolveImage));
+          const pending = Promise.all(state.input)
+            .then((input) => state.span.log({ input }))
+            .catch((error) =>
+              warn(
+                "Braintrust could not normalize a Harness turn input",
+                error,
+              ),
+            );
+          trackPendingLog(pending);
         }
       } else if (event.type === "assistant/message") {
         const message = eventMessage(event.data);
@@ -497,9 +560,14 @@ export function apply(ctx: Context, config: Config = {}): void {
     }
   });
 
+  ctx.on("session/flush", async () => {
+    await flushPendingLogs();
+    attachmentCache.clear();
+  });
+
   ctx.on("llm/stream", (rawOptions, next) => {
     const options = rawOptions as unknown as HarnessGenerateOptions;
-    let span: BraintrustSpan | undefined;
+    let span: Span | undefined;
     let turn: TurnState | undefined;
     try {
       turn = options.sessionId
@@ -515,11 +583,15 @@ export function apply(ctx: Context, config: Config = {}): void {
           ? { max_tokens: options.maxTokens }
           : {}),
         ...(options.stop !== undefined ? { stop: options.stop } : {}),
-        ...(options.tools !== undefined
+        ...(options.tools && options.tools.length > 0
           ? {
               tools: options.tools.map((tool) => ({
                 type: "function",
-                function: tool,
+                function: {
+                  name: tool.name,
+                  description: tool.description,
+                  parameters: tool.parameters,
+                },
               })),
             }
           : {}),
@@ -533,8 +605,15 @@ export function apply(ctx: Context, config: Config = {}): void {
       span = startChild(turn?.span, {
         name: "deepseek_harness.step",
         type: "llm",
-        event: { input: normalizeInput(options), metadata },
+        event: { metadata },
       });
+      const modelSpan = span;
+      const pending = normalizeInput(options, resolveImage)
+        .then((input) => modelSpan.log({ input }))
+        .catch((error) =>
+          warn("Braintrust could not normalize a Harness model input", error),
+        );
+      trackPendingLog(pending);
     } catch (error) {
       warn("Braintrust could not start a Harness model span", error);
     }
@@ -614,7 +693,7 @@ export function apply(ctx: Context, config: Config = {}): void {
 
   ctx.on("tools/execute", async (rawExec, next) => {
     const exec = rawExec as unknown as HarnessToolExecution;
-    let span: BraintrustSpan | undefined;
+    let span: Span | undefined;
     let turn: TurnState | undefined;
     try {
       const sessionId = exec.agent?.session.id;
@@ -644,21 +723,35 @@ export function apply(ctx: Context, config: Config = {}): void {
         : next());
       if (span) {
         const normalized = result as unknown as HarnessToolResult;
-        span.log({
-          output:
-            normalized.value !== undefined
-              ? normalized.value
-              : normalizeBlocks(normalized.content ?? []),
-          ...(normalized.isError
-            ? {
-                error: new Error(
-                  normalized.error?.message ||
-                    contentText(normalized.content ?? []) ||
-                    "Harness tool failed",
-                ),
-              }
-            : {}),
-        });
+        const error = normalized.isError
+          ? new Error(
+              normalized.error?.message ||
+                contentText(normalized.content ?? []) ||
+                "Harness tool failed",
+            )
+          : undefined;
+        if (normalized.value !== undefined) {
+          span.log({
+            output: normalized.value,
+            ...(error ? { error } : {}),
+          });
+        } else {
+          const toolSpan = span;
+          const pending = normalizeBlocks(
+            normalized.content ?? [],
+            resolveImage,
+          )
+            .then((output) =>
+              toolSpan.log({ output, ...(error ? { error } : {}) }),
+            )
+            .catch((loggingError) =>
+              warn(
+                "Braintrust could not normalize a Harness tool output",
+                loggingError,
+              ),
+            );
+          trackPendingLog(pending);
+        }
       }
       return result;
     } catch (error) {
@@ -699,6 +792,8 @@ export function apply(ctx: Context, config: Config = {}): void {
       childParents.clear();
       toolSpans.clear();
       try {
+        await flushPendingLogs();
+        attachmentCache.clear();
         await logger.flush();
       } catch (error) {
         warn("Braintrust could not flush Harness traces", error);

--- a/integrations/deepseek-harness/src/index.ts
+++ b/integrations/deepseek-harness/src/index.ts
@@ -43,6 +43,8 @@ export interface Config {
   apiKey?: string;
   /** Braintrust project receiving Harness traces. */
   projectName?: string;
+  /** Metadata added to every top-level Harness turn trace. */
+  metadata?: Record<string, unknown>;
   /** Optional Braintrust organization name. */
   orgName?: string;
   /** Optional Braintrust deployment URL. */
@@ -52,6 +54,7 @@ export interface Config {
 export const Config: z<Config> = z.object({
   apiKey: z.string().role("secret"),
   projectName: z.string().default(DEFAULT_PROJECT_NAME),
+  metadata: z.dict(z.any()),
   orgName: z.string(),
   appUrl: z.string(),
 });
@@ -483,6 +486,7 @@ export function apply(ctx: Context, config: Config = {}): void {
           type: "task",
           event: {
             metadata: {
+              ...config.metadata,
               "deepseek_harness.session_id": sessionId,
               "deepseek_harness.turn": turn,
               ...(session.header.parentSession

--- a/integrations/deepseek-harness/src/index.ts
+++ b/integrations/deepseek-harness/src/index.ts
@@ -1,0 +1,705 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { randomUUID } from "node:crypto";
+import type { Context } from "@deepseek-ai/cordis";
+import type {} from "@deepseek-ai/dsh-llm";
+import type {} from "@deepseek-ai/dsh-session";
+import type {} from "@deepseek-ai/dsh-tools";
+import z from "@deepseek-ai/schemastery";
+import { initLogger, NOOP_SPAN, withCurrent } from "braintrust";
+import type {
+  HarnessContentBlock,
+  HarnessGenerateOptions,
+  HarnessMessage,
+  HarnessSession,
+  HarnessSessionEvent,
+  HarnessStreamChunk,
+  HarnessToolExecution,
+  HarnessToolResult,
+  HarnessUsage,
+} from "./vendor";
+
+const DEFAULT_PROJECT_NAME = "DeepSeek Harness";
+const INSTRUMENTATION_NAME = "deepseek-harness";
+const INSTRUMENTATION_SYMBOL = Symbol.for("braintrust.spanInstrumentationName");
+
+/** Stable Cordis plugin name. */
+export const name = "braintrust";
+
+/** Harness services whose event seams this plugin instruments. */
+export const inject = ["sessions", "llm", "tools"];
+
+export interface Config {
+  /** Braintrust project receiving Harness traces. */
+  projectName?: string;
+  /** Optional Braintrust organization name. */
+  orgName?: string;
+  /** Optional Braintrust deployment URL. */
+  appUrl?: string;
+}
+
+export const Config: z<Config> = z.object({
+  projectName: z.string().default(DEFAULT_PROJECT_NAME),
+  orgName: z.string(),
+  appUrl: z.string(),
+});
+
+interface BraintrustEvent {
+  input?: unknown;
+  output?: unknown;
+  error?: unknown;
+  metadata?: Record<string, unknown>;
+  metrics?: Record<string, unknown>;
+}
+
+interface BraintrustStartSpanArgs {
+  name?: string;
+  type?: "task" | "llm" | "tool";
+  event?: BraintrustEvent;
+  spanId?: string;
+  parentSpanIds?:
+    | { rootSpanId: string; spanId: string }
+    | { rootSpanId: string; parentSpanIds: string[] };
+}
+
+interface BraintrustSpan {
+  startSpan(args: BraintrustStartSpanArgs): BraintrustSpan;
+  log(event: BraintrustEvent): void;
+  end(): number;
+}
+
+interface BraintrustLogger {
+  startSpan(args: BraintrustStartSpanArgs): BraintrustSpan;
+  flush(): Promise<void>;
+}
+
+type TokenMetrics = Record<string, number> & {
+  tokens: number;
+  prompt_tokens: number;
+  completion_tokens: number;
+  completion_reasoning_tokens?: number;
+  prompt_cached_tokens?: number;
+  prompt_cache_creation_tokens?: number;
+};
+
+interface TurnState {
+  readonly sessionId: string;
+  readonly turn: number;
+  readonly span: BraintrustSpan;
+  readonly input: unknown[];
+  metrics: TokenMetrics;
+  output?: string;
+}
+
+interface ToolState {
+  readonly span: BraintrustSpan;
+  readonly turn?: TurnState;
+}
+
+interface AssistantAccumulator {
+  readonly blocks: Map<number, HarnessContentBlock>;
+  readonly text: Map<number, string>;
+  readonly reasoning: Map<number, string>;
+  readonly toolCalls: Map<
+    number,
+    { id: string; name: string; arguments: string }
+  >;
+  usage?: HarnessUsage;
+  finishReason?: string;
+  failure?: string;
+}
+
+function spanArgs(args: BraintrustStartSpanArgs): BraintrustStartSpanArgs {
+  return Object.assign(args, {
+    [INSTRUMENTATION_SYMBOL]: INSTRUMENTATION_NAME,
+  });
+}
+
+function contentText(blocks: readonly HarnessContentBlock[]): string {
+  return blocks
+    .filter((block) => block.type === "text" && typeof block.text === "string")
+    .map((block) => block.text)
+    .join("");
+}
+
+function normalizeBlocks(blocks: readonly HarnessContentBlock[]): unknown {
+  if (blocks.length === 0) return "";
+  if (blocks.every((block) => block.type === "text")) {
+    return contentText(blocks);
+  }
+  return blocks.map((block) => {
+    switch (block.type) {
+      case "text":
+        return { type: "text", text: block.text ?? "" };
+      case "reasoning":
+        return { type: "reasoning", text: block.text ?? "" };
+      case "tool-call":
+        return {
+          type: "tool_call",
+          id: block.id,
+          name: block.name,
+          arguments: block.arguments,
+        };
+      case "tool-result":
+        return {
+          type: "tool_result",
+          tool_call_id: block.toolCallId,
+          content: normalizeBlocks(block.content ?? []),
+          ...(block.isError ? { is_error: true } : {}),
+        };
+      case "image":
+        return { type: "image", attachment: block.attachment };
+      default:
+        return { type: block.type };
+    }
+  });
+}
+
+function normalizeMessage(message: HarnessMessage): Record<string, unknown> {
+  const toolResult = message.content.find(
+    (block) => block.type === "tool-result",
+  );
+  if (toolResult) {
+    return {
+      role: "tool",
+      tool_call_id: toolResult.toolCallId ?? message.source?.callId,
+      content: normalizeBlocks(toolResult.content ?? []),
+    };
+  }
+
+  const normalized: Record<string, unknown> = { role: message.role };
+  if (message.role === "assistant") {
+    normalized.content = contentText(message.content);
+    const reasoning = message.content
+      .filter(
+        (block) => block.type === "reasoning" && typeof block.text === "string",
+      )
+      .map((block) => block.text)
+      .join("");
+    if (reasoning) normalized.reasoning = [{ content: reasoning }];
+    const calls = message.content
+      .filter((block) => block.type === "tool-call")
+      .map((block) => ({
+        id: block.id,
+        type: "function",
+        function: { name: block.name, arguments: block.arguments },
+      }));
+    if (calls.length > 0) normalized.tool_calls = calls;
+  } else {
+    normalized.content = normalizeBlocks(message.content);
+  }
+  return normalized;
+}
+
+function normalizeInput(options: HarnessGenerateOptions): unknown[] {
+  return [
+    ...(options.system ? [{ role: "system", content: options.system }] : []),
+    ...options.messages.map(normalizeMessage),
+  ];
+}
+
+function usageMetrics(usage: HarnessUsage): TokenMetrics {
+  const promptTokens =
+    usage.inputTokens +
+    (usage.cacheReadTokens ?? 0) +
+    (usage.cacheWriteTokens ?? 0);
+  const metrics: TokenMetrics = {
+    prompt_tokens: promptTokens,
+    completion_tokens: usage.outputTokens,
+    tokens: promptTokens + usage.outputTokens,
+  };
+  if (usage.reasoningTokens !== undefined) {
+    metrics.completion_reasoning_tokens = usage.reasoningTokens;
+  }
+  if (usage.cacheReadTokens !== undefined) {
+    metrics.prompt_cached_tokens = usage.cacheReadTokens;
+  }
+  if (usage.cacheWriteTokens !== undefined) {
+    metrics.prompt_cache_creation_tokens = usage.cacheWriteTokens;
+  }
+  return metrics;
+}
+
+function addMetrics(target: TokenMetrics, incoming: TokenMetrics): void {
+  target.prompt_tokens += incoming.prompt_tokens;
+  target.completion_tokens += incoming.completion_tokens;
+  target.tokens += incoming.tokens;
+  for (const key of [
+    "completion_reasoning_tokens",
+    "prompt_cached_tokens",
+    "prompt_cache_creation_tokens",
+  ] as const) {
+    if (incoming[key] !== undefined) {
+      target[key] = (target[key] ?? 0) + incoming[key];
+    }
+  }
+}
+
+function emptyMetrics(): TokenMetrics {
+  return { tokens: 0, prompt_tokens: 0, completion_tokens: 0 };
+}
+
+function consumeChunk(
+  accumulator: AssistantAccumulator,
+  chunk: HarnessStreamChunk,
+): void {
+  switch (chunk.type) {
+    case "text-delta":
+      accumulator.text.set(
+        chunk.index,
+        `${accumulator.text.get(chunk.index) ?? ""}${chunk.text}`,
+      );
+      break;
+    case "reasoning-delta":
+      accumulator.reasoning.set(
+        chunk.index,
+        `${accumulator.reasoning.get(chunk.index) ?? ""}${chunk.text}`,
+      );
+      break;
+    case "tool-call-delta": {
+      const current = accumulator.toolCalls.get(chunk.index);
+      accumulator.toolCalls.set(chunk.index, {
+        id: chunk.id,
+        name: chunk.name ?? current?.name ?? "",
+        arguments: `${current?.arguments ?? ""}${chunk.argumentsDelta}`,
+      });
+      break;
+    }
+    case "block-end":
+      accumulator.blocks.set(chunk.index, chunk.block);
+      break;
+    case "usage":
+      accumulator.usage = chunk.usage;
+      break;
+    case "finish":
+      accumulator.finishReason = chunk.reason.kind;
+      accumulator.failure = chunk.reason.failure?.message;
+      break;
+  }
+}
+
+function normalizeOutput(accumulator: AssistantAccumulator): unknown[] {
+  const completed = [...accumulator.blocks.entries()].sort(
+    ([left], [right]) => left - right,
+  );
+  const text =
+    completed
+      .filter(([, block]) => block.type === "text")
+      .map(([, block]) => block.text ?? "")
+      .join("") ||
+    [...accumulator.text.entries()]
+      .sort(([left], [right]) => left - right)
+      .map(([, value]) => value)
+      .join("");
+  const reasoning =
+    completed
+      .filter(([, block]) => block.type === "reasoning")
+      .map(([, block]) => block.text ?? "")
+      .join("") ||
+    [...accumulator.reasoning.entries()]
+      .sort(([left], [right]) => left - right)
+      .map(([, value]) => value)
+      .join("");
+  const completedCalls = completed
+    .filter(([, block]) => block.type === "tool-call")
+    .map(([, block]) => ({
+      id: block.id,
+      name: block.name ?? "",
+      arguments: block.arguments ?? "",
+    }));
+  const calls =
+    completedCalls.length > 0
+      ? completedCalls
+      : [...accumulator.toolCalls.entries()]
+          .sort(([left], [right]) => left - right)
+          .map(([, call]) => call);
+  const message: Record<string, unknown> = {
+    role: "assistant",
+    content: text,
+  };
+  if (reasoning) message.reasoning = [{ content: reasoning }];
+  if (calls.length > 0) {
+    message.tool_calls = calls.map((call) => ({
+      id: call.id,
+      type: "function",
+      function: { name: call.name, arguments: call.arguments },
+    }));
+  }
+  const reason = accumulator.finishReason;
+  return [
+    {
+      index: 0,
+      message,
+      finish_reason:
+        reason === "tool-calls"
+          ? "tool_calls"
+          : reason === "max-tokens"
+            ? "length"
+            : reason === "error" || reason === "aborted"
+              ? reason
+              : "stop",
+    },
+  ];
+}
+
+function eventMessage(
+  data: Record<string, unknown>,
+): HarnessMessage | undefined {
+  const candidate = "message" in data ? data.message : data;
+  if (!candidate || typeof candidate !== "object") return undefined;
+  const message = candidate as Partial<HarnessMessage>;
+  return Array.isArray(message.content) && typeof message.role === "string"
+    ? (message as HarnessMessage)
+    : undefined;
+}
+
+/** Install Braintrust tracing into a DeepSeek Harness Cordis context. */
+export function apply(ctx: Context, config: Config = {}): void {
+  const logger = initLogger({
+    projectName: config.projectName ?? DEFAULT_PROJECT_NAME,
+    ...(config.orgName ? { orgName: config.orgName } : {}),
+    ...(config.appUrl ? { appUrl: config.appUrl } : {}),
+    setCurrent: false,
+  }) as BraintrustLogger;
+  const turns = new Map<string, Map<number, TurnState>>();
+  const activeTurns = new Map<string, TurnState>();
+  const childParents = new Map<string, BraintrustSpan>();
+  const toolSpans = new Map<symbol, BraintrustSpan>();
+  const toolContext = new AsyncLocalStorage<ToolState>();
+
+  const warn = (message: string, error: unknown): void => {
+    try {
+      ctx.logger.warn(`${message}: ${String(error)}`);
+    } catch {
+      // Diagnostics must never affect Harness execution.
+    }
+  };
+
+  const startChild = (
+    parent: BraintrustSpan | undefined,
+    args: BraintrustStartSpanArgs,
+  ): BraintrustSpan => {
+    if (parent) return parent.startSpan(spanArgs(args));
+    const spanId = randomUUID();
+    return withCurrent(NOOP_SPAN, () =>
+      logger.startSpan(
+        spanArgs({
+          ...args,
+          spanId,
+          parentSpanIds: { parentSpanIds: [], rootSpanId: randomUUID() },
+        }),
+      ),
+    );
+  };
+
+  ctx.on("session/created", (rawSession) => {
+    try {
+      const session = rawSession as unknown as HarnessSession;
+      const currentTool = toolContext.getStore();
+      if (session.header.parentSession && currentTool) {
+        childParents.set(session.id, currentTool.span);
+      }
+    } catch (error) {
+      warn("Braintrust could not correlate a Harness child session", error);
+    }
+  });
+
+  ctx.on("session/disposed", (rawSession) => {
+    const session = rawSession as unknown as HarnessSession;
+    childParents.delete(String(session.id));
+  });
+
+  ctx.on("session/event", (rawSession, rawEvent) => {
+    try {
+      const session = rawSession as unknown as HarnessSession;
+      const event = rawEvent as unknown as HarnessSessionEvent;
+      const sessionId = String(session.id);
+      if (event.type === "turn/start") {
+        const turn = Number(event.data.turn);
+        if (!Number.isSafeInteger(turn)) return;
+        const parent = session.header.parentSession
+          ? childParents.get(sessionId)
+          : undefined;
+        const span = startChild(parent, {
+          name: "deepseek_harness.turn",
+          type: "task",
+          event: {
+            metadata: {
+              "deepseek_harness.session_id": sessionId,
+              "deepseek_harness.turn": turn,
+              ...(session.header.parentSession
+                ? {
+                    "deepseek_harness.parent_session_id":
+                      session.header.parentSession,
+                  }
+                : {}),
+            },
+          },
+        });
+        const state: TurnState = {
+          sessionId,
+          turn,
+          span,
+          input: [],
+          metrics: emptyMetrics(),
+        };
+        const sessionTurns = turns.get(sessionId) ?? new Map();
+        sessionTurns.set(turn, state);
+        turns.set(sessionId, sessionTurns);
+        activeTurns.set(sessionId, state);
+        return;
+      }
+
+      const eventTurn = Number(event.data.turn);
+      const state = Number.isSafeInteger(eventTurn)
+        ? turns.get(sessionId)?.get(eventTurn)
+        : activeTurns.get(sessionId);
+      if (!state) return;
+
+      if (event.type === "user/message") {
+        const message = eventMessage(event.data);
+        if (message) {
+          state.input.push(normalizeMessage(message));
+          state.span.log({ input: state.input });
+        }
+      } else if (event.type === "assistant/message") {
+        const message = eventMessage(event.data);
+        if (message) state.output = contentText(message.content);
+      } else if (event.type === "turn/end") {
+        const reason = event.data.reason as
+          | { kind?: string; error?: { message?: string } }
+          | undefined;
+        state.span.log({
+          ...(state.output !== undefined ? { output: state.output } : {}),
+          metrics: state.metrics,
+          ...(reason?.kind === "error"
+            ? {
+                error: new Error(
+                  reason.error?.message ?? "Harness turn failed",
+                ),
+              }
+            : {}),
+          metadata: {
+            "deepseek_harness.stop_reason": reason?.kind ?? "unknown",
+          },
+        });
+        state.span.end();
+        const sessionTurns = turns.get(sessionId);
+        sessionTurns?.delete(state.turn);
+        if (sessionTurns?.size === 0) turns.delete(sessionId);
+        if (activeTurns.get(sessionId) === state) activeTurns.delete(sessionId);
+      }
+    } catch (error) {
+      warn("Braintrust could not process a Harness session event", error);
+    }
+  });
+
+  ctx.on("llm/stream", (rawOptions, next) => {
+    const options = rawOptions as unknown as HarnessGenerateOptions;
+    let span: BraintrustSpan | undefined;
+    let turn: TurnState | undefined;
+    try {
+      turn = options.sessionId
+        ? activeTurns.get(String(options.sessionId))
+        : undefined;
+      const metadata: Record<string, unknown> = {
+        model: options.model,
+        provider: options.provider,
+        ...(options.temperature !== undefined
+          ? { temperature: options.temperature }
+          : {}),
+        ...(options.maxTokens !== undefined
+          ? { max_tokens: options.maxTokens }
+          : {}),
+        ...(options.stop !== undefined ? { stop: options.stop } : {}),
+        ...(options.tools !== undefined
+          ? {
+              tools: options.tools.map((tool) => ({
+                type: "function",
+                function: tool,
+              })),
+            }
+          : {}),
+        ...(options.sessionId
+          ? { "deepseek_harness.session_id": String(options.sessionId) }
+          : {}),
+        ...(options.purpose
+          ? { "deepseek_harness.purpose": options.purpose }
+          : {}),
+      };
+      span = startChild(turn?.span, {
+        name: "deepseek_harness.step",
+        type: "llm",
+        event: { input: normalizeInput(options), metadata },
+      });
+    } catch (error) {
+      warn("Braintrust could not start a Harness model span", error);
+    }
+
+    let iterable: AsyncIterable<HarnessStreamChunk>;
+    try {
+      iterable = next() as AsyncIterable<HarnessStreamChunk>;
+    } catch (error) {
+      try {
+        span?.log({ error });
+        span?.end();
+      } catch (loggingError) {
+        warn(
+          "Braintrust could not close a rejected Harness model span",
+          loggingError,
+        );
+      }
+      throw error;
+    }
+    if (!span) return iterable as never;
+    const modelSpan = span;
+    const startedAt = Date.now();
+    const accumulator: AssistantAccumulator = {
+      blocks: new Map(),
+      text: new Map(),
+      reasoning: new Map(),
+      toolCalls: new Map(),
+    };
+
+    return (async function* () {
+      let firstChunk = true;
+      try {
+        for await (const chunk of iterable) {
+          if (firstChunk) {
+            firstChunk = false;
+            modelSpan.log({
+              metrics: { time_to_first_token: (Date.now() - startedAt) / 1000 },
+            });
+          }
+          try {
+            consumeChunk(accumulator, chunk);
+          } catch (error) {
+            warn(
+              "Braintrust could not accumulate a Harness model chunk",
+              error,
+            );
+          }
+          yield chunk;
+        }
+        const metrics = accumulator.usage
+          ? usageMetrics(accumulator.usage)
+          : undefined;
+        modelSpan.log({
+          output: normalizeOutput(accumulator),
+          ...(metrics ? { metrics } : {}),
+          ...(accumulator.failure
+            ? { error: new Error(accumulator.failure) }
+            : {}),
+        });
+        if (metrics && turn) addMetrics(turn.metrics, metrics);
+      } catch (error) {
+        try {
+          modelSpan.log({ error });
+        } catch (loggingError) {
+          warn("Braintrust could not log a Harness model error", loggingError);
+        }
+        throw error;
+      } finally {
+        try {
+          modelSpan.end();
+        } catch (error) {
+          warn("Braintrust could not end a Harness model span", error);
+        }
+      }
+    })() as never;
+  });
+
+  ctx.on("tools/execute", async (rawExec, next) => {
+    const exec = rawExec as unknown as HarnessToolExecution;
+    let span: BraintrustSpan | undefined;
+    let turn: TurnState | undefined;
+    try {
+      const sessionId = exec.agent?.session.id;
+      turn = sessionId ? activeTurns.get(String(sessionId)) : undefined;
+      const parent = exec.parent ? toolSpans.get(exec.parent) : turn?.span;
+      span = startChild(parent, {
+        name: exec.name,
+        type: "tool",
+        event: {
+          input: exec.arguments,
+          metadata: {
+            ...(sessionId
+              ? { "deepseek_harness.session_id": String(sessionId) }
+              : {}),
+            "deepseek_harness.call_id": String(exec.callId),
+          },
+        },
+      });
+      toolSpans.set(exec.token, span);
+    } catch (error) {
+      warn("Braintrust could not start a Harness tool span", error);
+    }
+
+    try {
+      const result = await (span
+        ? toolContext.run({ span, turn }, () => next())
+        : next());
+      if (span) {
+        const normalized = result as unknown as HarnessToolResult;
+        span.log({
+          output:
+            normalized.value !== undefined
+              ? normalized.value
+              : normalizeBlocks(normalized.content ?? []),
+          ...(normalized.isError
+            ? {
+                error: new Error(
+                  normalized.error?.message ||
+                    contentText(normalized.content ?? []) ||
+                    "Harness tool failed",
+                ),
+              }
+            : {}),
+        });
+      }
+      return result;
+    } catch (error) {
+      try {
+        span?.log({ error });
+      } catch (loggingError) {
+        warn("Braintrust could not log a Harness tool error", loggingError);
+      }
+      throw error;
+    } finally {
+      if (span) {
+        toolSpans.delete(exec.token);
+        try {
+          span.end();
+        } catch (error) {
+          warn("Braintrust could not end a Harness tool span", error);
+        }
+      }
+    }
+  });
+
+  ctx.effect(
+    () => async () => {
+      for (const sessionTurns of turns.values()) {
+        for (const turn of sessionTurns.values()) {
+          try {
+            turn.span.end();
+          } catch (error) {
+            warn(
+              "Braintrust could not close an unfinished Harness turn",
+              error,
+            );
+          }
+        }
+      }
+      turns.clear();
+      activeTurns.clear();
+      childParents.clear();
+      toolSpans.clear();
+      try {
+        await logger.flush();
+      } catch (error) {
+        warn("Braintrust could not flush Harness traces", error);
+      }
+    },
+    "braintrust: flush Harness traces",
+  );
+}

--- a/integrations/deepseek-harness/src/index.ts
+++ b/integrations/deepseek-harness/src/index.ts
@@ -29,6 +29,8 @@ export const name = "braintrust";
 export const inject = ["sessions", "llm", "tools"];
 
 export interface Config {
+  /** Braintrust API key. Falls back to BRAINTRUST_API_KEY when omitted. */
+  apiKey?: string;
   /** Braintrust project receiving Harness traces. */
   projectName?: string;
   /** Optional Braintrust organization name. */
@@ -38,6 +40,7 @@ export interface Config {
 }
 
 export const Config: z<Config> = z.object({
+  apiKey: z.string().role("secret"),
   projectName: z.string().default(DEFAULT_PROJECT_NAME),
   orgName: z.string(),
   appUrl: z.string(),
@@ -355,6 +358,7 @@ function eventMessage(
 /** Install Braintrust tracing into a DeepSeek Harness Cordis context. */
 export function apply(ctx: Context, config: Config = {}): void {
   const logger = initLogger({
+    ...(config.apiKey ? { apiKey: config.apiKey } : {}),
     projectName: config.projectName ?? DEFAULT_PROJECT_NAME,
     ...(config.orgName ? { orgName: config.orgName } : {}),
     ...(config.appUrl ? { appUrl: config.appUrl } : {}),

--- a/integrations/deepseek-harness/src/vendor.ts
+++ b/integrations/deepseek-harness/src/vendor.ts
@@ -1,0 +1,111 @@
+/** Minimal DeepSeek Harness shapes consumed by the instrumentation. */
+
+export interface HarnessContentBlock {
+  readonly type: string;
+  readonly text?: string;
+  readonly id?: string;
+  readonly name?: string;
+  readonly arguments?: string;
+  readonly toolCallId?: string;
+  readonly content?: readonly HarnessContentBlock[];
+  readonly isError?: boolean;
+  readonly attachment?: unknown;
+}
+
+export interface HarnessMessage {
+  readonly role: "system" | "user" | "assistant";
+  readonly content: readonly HarnessContentBlock[];
+  readonly source?: {
+    readonly kind?: string;
+    readonly provider?: string;
+    readonly model?: string;
+    readonly callId?: string;
+  };
+}
+
+export interface HarnessUsage {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadTokens?: number;
+  readonly cacheWriteTokens?: number;
+  readonly reasoningTokens?: number;
+}
+
+export type HarnessStreamChunk =
+  | {
+      readonly type: "text-delta";
+      readonly index: number;
+      readonly text: string;
+    }
+  | {
+      readonly type: "reasoning-delta";
+      readonly index: number;
+      readonly text: string;
+    }
+  | {
+      readonly type: "tool-call-delta";
+      readonly index: number;
+      readonly id: string;
+      readonly name?: string;
+      readonly argumentsDelta: string;
+    }
+  | {
+      readonly type: "block-end";
+      readonly index: number;
+      readonly block: HarnessContentBlock;
+    }
+  | { readonly type: "usage"; readonly usage: HarnessUsage }
+  | {
+      readonly type: "finish";
+      readonly reason: {
+        readonly kind: string;
+        readonly failure?: { readonly message?: string };
+      };
+    };
+
+export interface HarnessGenerateOptions {
+  readonly provider: string;
+  readonly model: string;
+  readonly messages: readonly HarnessMessage[];
+  readonly system?: string;
+  readonly tools?: readonly {
+    readonly name: string;
+    readonly description: string;
+    readonly parameters: Record<string, unknown>;
+  }[];
+  readonly temperature?: number;
+  readonly maxTokens?: number;
+  readonly stop?: readonly string[];
+  readonly sessionId?: string;
+  readonly purpose?: "compaction" | "session-title";
+}
+
+export interface HarnessSession {
+  readonly id: string;
+  readonly header: {
+    readonly id: string;
+    readonly parentSession?: string;
+    readonly delegationDepth?: number;
+  };
+}
+
+export interface HarnessSessionEvent {
+  readonly type: string;
+  readonly data: Record<string, unknown>;
+}
+
+export interface HarnessToolExecution {
+  readonly callId: string;
+  readonly name: string;
+  readonly arguments: unknown;
+  readonly agent?: { readonly session: HarnessSession };
+  readonly parent?: symbol;
+  readonly token: symbol;
+}
+
+export interface HarnessToolResult {
+  readonly isError: boolean;
+  readonly value?: unknown;
+  readonly content: readonly HarnessContentBlock[];
+  readonly error?: { readonly message?: string; readonly code?: string };
+}

--- a/integrations/deepseek-harness/src/vendor.ts
+++ b/integrations/deepseek-harness/src/vendor.ts
@@ -9,7 +9,22 @@ export interface HarnessContentBlock {
   readonly toolCallId?: string;
   readonly content?: readonly HarnessContentBlock[];
   readonly isError?: boolean;
-  readonly attachment?: unknown;
+  readonly attachment?: HarnessImageAttachmentRef;
+}
+
+export interface HarnessImageAttachmentRef {
+  readonly attachmentId: string;
+  readonly mediaType: "image/png" | "image/jpeg" | "image/webp" | "image/gif";
+  readonly bytes: number;
+  readonly width: number;
+  readonly height: number;
+  readonly name?: string;
+}
+
+export interface HarnessAttachmentStore {
+  readImage(
+    ref: HarnessImageAttachmentRef,
+  ): Promise<{ ref: HarnessImageAttachmentRef; data: Uint8Array }>;
 }
 
 export interface HarnessMessage {

--- a/integrations/deepseek-harness/tsconfig.json
+++ b/integrations/deepseek-harness/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "lib": ["es2022"],
+    "module": "commonjs",
+    "target": "es2022",
+    "moduleResolution": "node",
+    "strict": true,
+    "noUnusedLocals": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["."],
+  "exclude": ["node_modules/**", "**/dist/**"]
+}

--- a/integrations/deepseek-harness/tsup.config.ts
+++ b/integrations/deepseek-harness/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig([
+  {
+    entry: ["src/index.ts"],
+    format: ["cjs", "esm"],
+    outDir: "dist",
+    dts: true,
+  },
+]);

--- a/js/src/span-origin.ts
+++ b/js/src/span-origin.ts
@@ -18,6 +18,7 @@ export const INSTRUMENTATION_NAMES = {
   CLOUDFLARE_THINK: "cloudflare-think",
   COHERE: "cohere",
   CURSOR_SDK: "cursor-sdk",
+  DEEPSEEK_HARNESS: "deepseek-harness",
   EVE: "eve",
   FLUE: "flue",
   GENKIT: "genkit",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,16 @@ importers:
         version: 5.9.3
 
   integrations/deepseek-harness:
+    dependencies:
+      '@deepseek-ai/schemastery':
+        specifier: ^3.18.1
+        version: 3.18.1
+      braintrust:
+        specifier: workspace:^
+        version: link:../../js
+      zod:
+        specifier: ^3.25.34 || ^4.0
+        version: 3.25.76
     devDependencies:
       '@deepseek-ai/cordis':
         specifier: 4.0.1
@@ -158,15 +168,9 @@ importers:
       '@deepseek-ai/dsh-tools':
         specifier: 0.1.0-rc.6
         version: 0.1.0-rc.6(f8724372086ccc1457fc84e7becee2e0)
-      '@deepseek-ai/schemastery':
-        specifier: 3.18.1
-        version: 3.18.1
       '@types/node':
         specifier: ^22.15.21
         version: 22.19.1
-      braintrust:
-        specifier: workspace:^
-        version: link:../../js
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.19)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
 
   e2e:
     devDependencies:
+      '@braintrust/deepseek-harness':
+        specifier: workspace:^
+        version: link:../integrations/deepseek-harness
       '@braintrust/langchain-js':
         specifier: workspace:^
         version: link:../integrations/langchain-js
@@ -140,6 +143,39 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
+
+  integrations/deepseek-harness:
+    devDependencies:
+      '@deepseek-ai/cordis':
+        specifier: 4.0.1
+        version: 4.0.1
+      '@deepseek-ai/dsh-llm':
+        specifier: 0.1.0-rc.6
+        version: 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session':
+        specifier: 0.1.0-rc.6
+        version: 0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6)
+      '@deepseek-ai/dsh-tools':
+        specifier: 0.1.0-rc.6
+        version: 0.1.0-rc.6(f8724372086ccc1457fc84e7becee2e0)
+      '@deepseek-ai/schemastery':
+        specifier: 3.18.1
+        version: 3.18.1
+      '@types/node':
+        specifier: ^22.15.21
+        version: 22.19.1
+      braintrust:
+        specifier: workspace:^
+        version: link:../../js
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.19)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.3
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.19.1)(msw@2.13.6(@types/node@22.19.1)(typescript@5.9.3))(vite@8.1.5(@types/node@22.19.1)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
 
   integrations/langchain-js:
     devDependencies:
@@ -689,6 +725,129 @@ packages:
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
+
+  '@deepseek-ai/cordis@4.0.1':
+    resolution: {integrity: sha512-YBdskTU2Po1kru3GgcUWUbkTsPMA9LkSQDAY8rBkFJeajdgcQad3QPJZE26JyK99Xb6HaASvoXg2DSUTeN/0Nw==}
+    hasBin: true
+    peerDependencies:
+      '@deepseek-ai/cordis-plugin-include': ^1.0.6
+      '@deepseek-ai/cordis-plugin-loader': ^1.0.2
+    peerDependenciesMeta:
+      '@deepseek-ai/cordis-plugin-include':
+        optional: true
+      '@deepseek-ai/cordis-plugin-loader':
+        optional: true
+
+  '@deepseek-ai/cosmokit@1.8.2':
+    resolution: {integrity: sha512-muBOKtSrUKU5m/xpq8ZXWL6hQ/jgd4PhU2PqH97bcxIiLEJfNwZOGQEx4t/aS/GgxRAR+ra9pMHPMtTHU4sqqA==}
+
+  '@deepseek-ai/dsh-agent@0.1.0-rc.6':
+    resolution: {integrity: sha512-vtqq2pWTrzn0dKfj5kREZRpP82AwtGjGx9V1lYnKvF+Uc/a8zyWbSvjDE7V1d3YQAQJzs2cWO31hURWDekDXIA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-scope': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-session': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-system-prompt': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-typert-protocol': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-attachment@0.1.0-rc.6':
+    resolution: {integrity: sha512-3P6N17NQ8jqSQGzeCs+svCIqArU8oq0YmgEAo+axN9aVuUDferWU4DLRSX59UGpmyldX4LQn81toA+c+DqMcHg==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-brand': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-brand@0.1.0-rc.6':
+    resolution: {integrity: sha512-E8j9Nby24qP4rfrdcfc7bpt1CHpGT3tYmycOJJkEOH4ptIdT1m2ro9nmnSd5CWYukTr64A77vjm2WGqHRI92UA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-code-runtime@0.1.0-rc.6':
+    resolution: {integrity: sha512-aw8D4IOeMo11A3uxQeE4LFoW3bvaQnVkGFqqtS+lsINDARrOCJHXLUgecoKpys+Lc5erZZ4UQDnymJmL4OCcKA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-invariants@0.1.0-rc.6':
+    resolution: {integrity: sha512-WfEfOi99a4cpOugRAHTBSTnesLieu3ist1q9PXDXFBHX++K1rAl9+sB7YrdnbB8LH0UOY532gS9xJUYU6w0SLw==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+
+  '@deepseek-ai/dsh-llm@0.1.0-rc.6':
+    resolution: {integrity: sha512-kuFGC8bHlzGTwlRxQhXjf3CYWl8M4NzH+EYIkrW8rri4iMc9W53xrdvkil5No/DUlMm8g1u7GdeiWYFy0TMvtA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-attachment': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-brand': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-timeout': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-scope@0.1.0-rc.6':
+    resolution: {integrity: sha512-UlDLV4syLoJinNg9imhXrSAHrdaTa5Ff8gg46rzjFJGPUOhAk3DZff0hryT5OhrBi0A5Tj92qVpg2pRVvxnUzQ==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-session@0.1.0-rc.6':
+    resolution: {integrity: sha512-8tu8I6VWC7050GAUXWhcEWQw4pakALQc8TlhKr52m7Y4+kIKeNt3FBgP86PaGPBtpK0p5zUPRQNkFpzZbBdxyw==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-brand': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-scope': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-typert-protocol': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-system-prompt@0.1.0-rc.6':
+    resolution: {integrity: sha512-E7g+XChh4q4/wX++v56z1pV4SA1Rtz42xkznLPPi9FlXrrzJxwHMOUzBZ9Rz3Y1kLhQ++HJG3ZatmNx3rjFilg==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-scope': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-timeout@0.1.0-rc.6':
+    resolution: {integrity: sha512-CUean0fAnfsJVszFEip7PsU/S26W+JfDFfsza2dCtlw8n6xlkbHA9Gjxdk2aTwqDGCgXEPkRW7mYkdJ0n6FR7w==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-tools@0.1.0-rc.6':
+    resolution: {integrity: sha512-Tu08EPK3JyK0iNjH4FGzu/1uADynNSS6SmwOLdfytUN0YNqwNuKFSt2OJUg19famNlTgy992DcHfDu0T+gLXFg==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-code-runtime': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-scope': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-session': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-system-prompt': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-user-approval': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-typert-protocol@0.1.0-rc.6':
+    resolution: {integrity: sha512-weWzN8r01YCkoDCAM7BsKw2YhRrD4zL8N2SAZu9hovYtXSq8xHXsP4Zh8RLYIlYcuotjyff/6hic+0TJPd14YA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-user-approval@0.1.0-rc.6':
+    resolution: {integrity: sha512-9rnkSDGOpu2XUeGwbPeTzVUTFWTND1PMPM5L/ZQPptV5yyZlQiNxM2rCC6OdL+ZVerwxEqrRhZIQn/KVtQfKag==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-brand': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-llm': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-scope': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-session': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-system-prompt': ^0.1.0-rc.6
+
+  '@deepseek-ai/schemastery@3.18.1':
+    resolution: {integrity: sha512-Qn0FCSwCQnpnj6SB31I6i2sIKgKWnkbJM8O0EU91Gv2UsYVvtZTl6IA0sCwk2e2MZf5S8w5hpq9QkeVvK9qwxg==}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -4561,6 +4720,115 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
+  '@deepseek-ai/cordis@4.0.1':
+    dependencies:
+      '@deepseek-ai/cosmokit': 1.8.2
+      '@standard-schema/spec': 1.1.0
+
+  '@deepseek-ai/cosmokit@1.8.2': {}
+
+  '@deepseek-ai/dsh-agent@0.1.0-rc.6(b0514d7a320728b6d8f5a31eb3960e10)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+
+  '@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-code-runtime@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-attachment': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-timeout': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-session@0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+
+  '@deepseek-ai/dsh-system-prompt@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-tools@0.1.0-rc.6(f8724372086ccc1457fc84e7becee2e0)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(b0514d7a320728b6d8f5a31eb3960e10)
+      '@deepseek-ai/dsh-code-runtime': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-user-approval': 0.1.0-rc.6(dbdaba06c174c5e30e3a58edf3cc27a9)
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-typert-protocol@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-user-approval@0.1.0-rc.6(dbdaba06c174c5e30e3a58edf3cc27a9)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(b0514d7a320728b6d8f5a31eb3960e10)
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/schemastery@3.18.1':
+    dependencies:
+      '@deepseek-ai/cosmokit': 1.8.2
+      '@standard-schema/spec': 1.1.0
+
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
@@ -5798,6 +6066,15 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.13.6(@types/node@22.19.1)(typescript@5.5.4)
+      vite: 8.1.5(@types/node@22.19.1)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.5(msw@2.13.6(@types/node@22.19.1)(typescript@5.9.3))(vite@8.1.5(@types/node@22.19.1)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.13.6(@types/node@22.19.1)(typescript@5.9.3)
       vite: 8.1.5(@types/node@22.19.1)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.5':
@@ -7155,6 +7432,32 @@ snapshots:
       - '@types/node'
     optional: true
 
+  msw@2.13.6(@types/node@22.19.1)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 6.0.12(@types/node@22.19.1)
+      '@mswjs/interceptors': 0.41.6
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.13.2
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.8
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.6.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
   mustache@4.2.0: {}
 
   mute-stream@3.0.0: {}
@@ -8155,6 +8458,34 @@ snapshots:
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(msw@2.13.6(@types/node@22.19.1)(typescript@5.5.4))(vite@8.1.5(@types/node@22.19.1)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.5(@types/node@22.19.1)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 22.19.1
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.19.1)(msw@2.13.6(@types/node@22.19.1)(typescript@5.9.3))(vite@8.1.5(@types/node@22.19.1)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(msw@2.13.6(@types/node@22.19.1)(typescript@5.9.3))(vite@8.1.5(@types/node@22.19.1)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5

--- a/scripts/release/_shared.mjs
+++ b/scripts/release/_shared.mjs
@@ -15,6 +15,10 @@ export const DOCS_HOMEPAGE = "https://www.braintrust.dev/docs";
 export const PUBLISHABLE_PACKAGES = [
   { dir: "js", name: "braintrust" },
   { dir: "integrations/browser-js", name: "@braintrust/browser" },
+  {
+    dir: "integrations/deepseek-harness",
+    name: "@braintrust/deepseek-harness",
+  },
   { dir: "integrations/langchain-js", name: "@braintrust/langchain-js" },
   { dir: "integrations/openai-agents-js", name: "@braintrust/openai-agents" },
   { dir: "integrations/otel-js", name: "@braintrust/otel" },


### PR DESCRIPTION
Adds a `@braintrust/deepseek-harness` package.

The package can be installe as a plugin via the deepseek harness cli (seems to be the canonical way for now) to trace everything that the deepseek harness does.

Reports each user turn as a separate trace with nested spans for model calls, tool executions, and delegated child sessions. It captures model inputs and outputs, token usage, reasoning, tool calls, errors, and relevant Harness metadata.

## Installation

```bash
dsh plugin --profile web add @braintrust/deepseek-harness
```

Optional settings can be configured through the Harness plugin UI or `cordis.patch.yml`:

```yaml
- id: braintrust
  config:
    apiKey: <your-api-key>
    projectName: DeepSeek Harness
```

The API key is declared as a secret setting. When omitted, the plugin uses `BRAINTRUST_API_KEY`.