### PR TITLE
feat: Use `apiKey` arg in `loadPrompt`

### DIFF
--- a/.changeset/use-api-key-in-load-prompt.md
+++ b/.changeset/use-api-key-in-load-prompt.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+feat: Use `apiKey` arg in `loadPrompt`

--- a/js/src/logger.test.ts
+++ b/js/src/logger.test.ts
@@ -7,7 +7,9 @@ import {
   initDataset,
   initLogger,
   Prompt,
+  RemoteEvalParameters,
   BraintrustState,
+  FailedHTTPResponse,
   loadPrompt,
   loadParameters,
   wrapTraced,
@@ -23,11 +25,22 @@ import {
 
 import { configureNode } from "./node/config";
 import { type GitMetadataSettingsType as GitMetadataSettings } from "./generated_types";
-import { writeFile, unlink } from "node:fs/promises";
+import { rm, writeFile, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { SpanComponentsV4 } from "../util/span_identifier_v4";
 import { SpanCache } from "./span-cache";
+import {
+  PromptCache,
+  type PromptDiskCacheEntry,
+  type PromptMemoryCacheEntry,
+} from "./prompt-cache/prompt-cache";
+import {
+  ParametersCache,
+  type ParametersMemoryCacheEntry,
+} from "./prompt-cache/parameters-cache";
+import { DiskCache } from "./prompt-cache/disk-cache";
+import { LRUCache } from "./lru-cache";
 
 configureNode();
 
@@ -1842,7 +1855,7 @@ test("init surfaces dataset environment lookup errors instead of falling back to
   vi.restoreAllMocks();
 });
 
-describe("loader version precedence", () => {
+describe("prompt and parameters loaders", () => {
   let state: BraintrustState;
   let getJson: ReturnType<typeof vi.spyOn>;
   const promptRow = {
@@ -1918,6 +1931,45 @@ describe("loader version precedence", () => {
     };
   };
 
+  function jsonResponse(data: unknown): Response {
+    return new Response(JSON.stringify(data), {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  function loginResponse(
+    ...organizations: Array<{
+      id: string;
+      name: string;
+      apiUrl: string;
+    }>
+  ): Response {
+    return jsonResponse({
+      org_info: organizations.map(({ id, name, apiUrl }) => ({
+        id,
+        name,
+        api_url: apiUrl,
+        proxy_url: apiUrl,
+      })),
+    });
+  }
+
+  function serverErrorResponse(): Response {
+    return new Response("Server error", {
+      status: 500,
+      statusText: "Internal Server Error",
+    });
+  }
+
+  function unreadableResponse(init?: ResponseInit): Response {
+    const body = new ReadableStream({
+      start(controller) {
+        controller.error(new TypeError("Response body disconnected"));
+      },
+    });
+    return new Response(body, init);
+  }
+
   beforeEach(async () => {
     state = await _exportsForTestingOnly.simulateLoginForTests();
     vi.spyOn(state, "login").mockResolvedValue(state as any);
@@ -1963,6 +2015,726 @@ describe("loader version precedence", () => {
 
     expect(getJson).toHaveBeenCalledWith(`v1/prompt/${promptRow.id}`, {
       version: "v1",
+    });
+  });
+
+  describe("credential and cache isolation", () => {
+    test("loadPrompt uses an explicit API key without changing the existing login", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          loginResponse({
+            id: "prompt-org-id",
+            name: "test-org-name",
+            apiUrl: "https://prompt-api.test",
+          }),
+        )
+        .mockResolvedValueOnce(jsonResponse({ objects: [promptRow] }))
+        .mockResolvedValueOnce(serverErrorResponse());
+      const globalCacheGet = vi.spyOn(state.promptCache, "get");
+      const globalCacheSet = vi.spyOn(state.promptCache, "set");
+
+      const options = {
+        projectName: "test-project",
+        slug: "saved-prompt",
+        apiKey: "prompt-api-key",
+        fetch: fetchMock,
+      };
+
+      await loadPrompt(options);
+      const cachedPrompt = await loadPrompt(options);
+
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        "https://braintrust.dev/api/apikey/login",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "Bearer prompt-api-key",
+          }),
+        }),
+      );
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        expect.stringMatching(/^https:\/\/prompt-api\.test\/v1\/prompt\?/),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "Bearer prompt-api-key",
+          }),
+        }),
+      );
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        3,
+        expect.stringMatching(/^https:\/\/prompt-api\.test\/v1\/prompt\?/),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "Bearer prompt-api-key",
+          }),
+        }),
+      );
+      expect(
+        fetchMock.mock.calls.filter(([url]) =>
+          String(url).endsWith("/api/apikey/login"),
+        ),
+      ).toHaveLength(1);
+      expect(cachedPrompt.id).toBe(promptRow.id);
+      expect(getJson).not.toHaveBeenCalled();
+      expect(globalCacheGet).not.toHaveBeenCalled();
+      expect(globalCacheSet).not.toHaveBeenCalled();
+      expect(state.loginToken).toBe("___TEST_API_KEY__THIS_IS_NOT_REAL___");
+    });
+
+    test("loadPrompt falls back when the response body stream fails", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          loginResponse({
+            id: "prompt-org-id",
+            name: "test-org-name",
+            apiUrl: "https://prompt-api.test",
+          }),
+        )
+        .mockResolvedValueOnce(jsonResponse({ objects: [promptRow] }))
+        .mockResolvedValueOnce(
+          unreadableResponse({
+            headers: { "Content-Type": "application/json" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response("not JSON", {
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      const options = {
+        projectName: "test-project",
+        slug: "saved-prompt",
+        apiKey: "prompt-api-key",
+        fetch: fetchMock,
+        state,
+      };
+
+      await loadPrompt(options);
+
+      expect((await loadPrompt(options)).id).toBe(promptRow.id);
+      await expect(loadPrompt(options)).rejects.toBeInstanceOf(SyntaxError);
+    });
+
+    test("logged-in loadPrompt falls back on transport failures", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse({ objects: [promptRow] }))
+        .mockRejectedValueOnce(new TypeError("Network unavailable"))
+        .mockResolvedValueOnce(
+          unreadableResponse({
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      state.setFetch(fetchMock as unknown as typeof globalThis.fetch);
+      const options = {
+        projectName: "test-project",
+        slug: "saved-prompt",
+        state,
+      };
+
+      await loadPrompt(options);
+
+      expect((await loadPrompt(options)).id).toBe(promptRow.id);
+      expect((await loadPrompt(options)).id).toBe(promptRow.id);
+    });
+
+    test("loadPrompt preserves authentication failures when the error body stream fails", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          loginResponse({
+            id: "prompt-org-id",
+            name: "test-org-name",
+            apiUrl: "https://prompt-api.test",
+          }),
+        )
+        .mockResolvedValueOnce(jsonResponse({ objects: [promptRow] }))
+        .mockResolvedValueOnce(
+          unreadableResponse({
+            status: 401,
+            statusText: "Unauthorized",
+          }),
+        );
+      const options = {
+        projectName: "test-project",
+        slug: "saved-prompt",
+        apiKey: "prompt-api-key",
+        fetch: fetchMock,
+        state,
+      };
+
+      await loadPrompt(options);
+
+      await expect(loadPrompt(options)).rejects.toMatchObject({
+        status: 401,
+        text: "Unauthorized",
+        data: "Unable to read response body",
+        cause: expect.any(TypeError),
+      });
+    });
+
+    test("loader credential sessions only retain the authenticated connection", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        loginResponse({
+          id: "prompt-org-id",
+          name: "test-org-name",
+          apiUrl: "https://prompt-api.test",
+        }),
+      );
+      const options = await state._internalResolveLoaderLoginOptions({
+        apiKey: "prompt-api-key",
+        fetch: fetchMock as unknown as typeof globalThis.fetch,
+      });
+
+      const requestState = await state._internalGetLoaderState(options);
+
+      expect(requestState).not.toBeInstanceOf(BraintrustState);
+      expect(requestState).toEqual(
+        expect.objectContaining({
+          appUrl: "https://braintrust.dev",
+          orgId: "prompt-org-id",
+          apiConn: expect.any(Function),
+        }),
+      );
+      expect(requestState).not.toHaveProperty("promptCache");
+      expect(requestState).not.toHaveProperty("spanCache");
+    });
+
+    test("loadPrompt keeps explicit API key caches isolated", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          loginResponse({
+            id: "prompt-org-id",
+            name: "test-org-name",
+            apiUrl: "https://prompt-api.test",
+          }),
+        )
+        .mockResolvedValueOnce(jsonResponse({ objects: [promptRow] }))
+        .mockResolvedValueOnce(
+          loginResponse({
+            id: "prompt-org-id",
+            name: "test-org-name",
+            apiUrl: "https://prompt-api.test",
+          }),
+        )
+        .mockResolvedValueOnce(serverErrorResponse());
+
+      await loadPrompt({
+        projectName: "test-project",
+        slug: "saved-prompt",
+        apiKey: "first-prompt-api-key",
+        fetch: fetchMock,
+      });
+
+      await expect(
+        loadPrompt({
+          projectName: "test-project",
+          slug: "saved-prompt",
+          apiKey: "second-prompt-api-key",
+          fetch: fetchMock,
+        }),
+      ).rejects.toThrow("not found on server or in local cache");
+    });
+
+    test("loadPrompt resolves explicit credentials against state login defaults", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          loginResponse(
+            {
+              id: "other-org-id",
+              name: "other-org",
+              apiUrl: "https://other-api.test",
+            },
+            {
+              id: "self-hosted-org-id",
+              name: "self-hosted-org",
+              apiUrl: "https://api.self-hosted.test",
+            },
+          ),
+        )
+        .mockResolvedValueOnce(jsonResponse({ objects: [promptRow] }));
+      const selfHostedState = new BraintrustState({
+        appUrl: "https://app.self-hosted.test",
+        orgName: "self-hosted-org",
+        fetch: fetchMock as unknown as typeof globalThis.fetch,
+        noExitFlush: true,
+      });
+
+      expect(selfHostedState.appUrl).toBeNull();
+      await loadPrompt({
+        projectName: "test-project",
+        slug: "saved-prompt",
+        apiKey: "self-hosted-api-key",
+        state: selfHostedState,
+      });
+
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        "https://app.self-hosted.test/api/apikey/login",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "Bearer self-hosted-api-key",
+          }),
+        }),
+      );
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        expect.stringMatching(
+          /^https:\/\/api\.self-hosted\.test\/v1\/prompt\?/,
+        ),
+        expect.any(Object),
+      );
+    });
+
+    test("loader credential overrides reuse connection defaults without inheriting the active organization", async () => {
+      const activeFetch = vi.fn();
+      const loggedInState = BraintrustState.deserialize(
+        {
+          appUrl: "https://active-app.test",
+          appPublicUrl: "https://active-app.test",
+          orgName: "active-org",
+          orgId: "active-org-id",
+          apiUrl: "https://active-api.test",
+          proxyUrl: "https://active-api.test",
+          loginToken: "active-api-key",
+        },
+        {
+          fetch: activeFetch as unknown as typeof globalThis.fetch,
+          noExitFlush: true,
+        },
+      );
+
+      const apiKeyOverride =
+        await loggedInState._internalResolveLoaderLoginOptions({
+          apiKey: "request-api-key",
+        });
+      expect(apiKeyOverride).toEqual(
+        expect.objectContaining({
+          apiKey: "request-api-key",
+          appUrl: "https://active-app.test",
+          fetch: activeFetch,
+        }),
+      );
+      expect(apiKeyOverride.orgName).toBeUndefined();
+      expect(apiKeyOverride.existingState).toBeUndefined();
+
+      activeFetch
+        .mockResolvedValueOnce(
+          loginResponse({
+            id: "request-org-id",
+            name: "request-org",
+            apiUrl: "https://request-api.test",
+          }),
+        )
+        .mockResolvedValueOnce(jsonResponse({ objects: [promptRow] }));
+      await loadPrompt({
+        projectName: "test-project",
+        slug: "saved-prompt",
+        apiKey: "request-api-key",
+        state: loggedInState,
+      });
+
+      const appUrlOverride =
+        await loggedInState._internalResolveLoaderLoginOptions({
+          appUrl: "https://request-app.test",
+        });
+      expect(appUrlOverride).toEqual(
+        expect.objectContaining({
+          apiKey: "active-api-key",
+          appUrl: "https://request-app.test",
+          orgName: "active-org",
+          fetch: activeFetch,
+        }),
+      );
+      expect(appUrlOverride.existingState).toBeUndefined();
+
+      const replacementFetch = vi.fn().mockResolvedValue(
+        loginResponse({
+          id: "replacement-org-id",
+          name: "replacement-org",
+          apiUrl: "https://replacement-api.test",
+        }),
+      );
+      await loggedInState.login({
+        apiKey: "replacement-api-key",
+        fetch: replacementFetch as unknown as typeof globalThis.fetch,
+        forceLogin: true,
+      });
+
+      const overrideAfterRelogin =
+        await loggedInState._internalResolveLoaderLoginOptions({
+          apiKey: "another-request-api-key",
+        });
+      expect(overrideAfterRelogin.fetch).toBe(replacementFetch);
+    });
+
+    test("loader cache namespaces follow the active login organization selector", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        loginResponse({
+          id: "second-org-id",
+          name: "second-org",
+          apiUrl: "https://second-api.test",
+        }),
+      );
+      const switchingState = new BraintrustState({
+        apiKey: "shared-api-key",
+        orgName: "first-org",
+        fetch: fetchMock as unknown as typeof globalThis.fetch,
+        noExitFlush: true,
+      });
+
+      await switchingState.login({
+        orgName: "second-org",
+        forceLogin: true,
+      });
+      const options = await switchingState._internalResolveLoaderLoginOptions(
+        {},
+      );
+
+      expect(options.orgName).toBe("second-org");
+      expect(options.credentialCacheNamespace).toBe(
+        JSON.stringify([
+          "loader-credential",
+          "https://www.braintrust.dev",
+          "second-org",
+          "shared-api-key",
+        ]),
+      );
+    });
+
+    test("loadPrompt uses the persistent credential cache after a transient login failure", async () => {
+      const cacheDir = join(
+        tmpdir(),
+        `load-prompt-login-fallback-${Date.now()}-${Math.random()}`,
+      );
+      const onlineFetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          loginResponse({
+            id: "prompt-org-id",
+            name: "prompt-org-name",
+            apiUrl: "https://prompt-api.test",
+          }),
+        )
+        .mockResolvedValueOnce(jsonResponse({ objects: [promptRow] }));
+
+      try {
+        const onlineState = new BraintrustState({
+          appUrl: "https://braintrust.test",
+          apiKey: "prompt-api-key",
+          fetch: onlineFetch as unknown as typeof globalThis.fetch,
+          noExitFlush: true,
+        });
+        const onlineDiskCache = new DiskCache<PromptDiskCacheEntry>({
+          cacheDir,
+          logWarnings: false,
+        });
+        const diskCacheSet = vi.spyOn(onlineDiskCache, "set");
+        onlineState.promptCache = new PromptCache({
+          diskCache: onlineDiskCache,
+        });
+        await onlineState.login({});
+        await loadPrompt({
+          projectName: "test-project",
+          slug: "saved-prompt",
+          state: onlineState,
+        });
+        expect(diskCacheSet).toHaveBeenCalledOnce();
+        expect(diskCacheSet.mock.calls[0][1].resolvedOrgIdentity).toBe(
+          JSON.stringify([
+            "loader-org",
+            "https://braintrust.test",
+            "prompt-org-id",
+          ]),
+        );
+        expect(diskCacheSet.mock.calls[0][1].resolvedOrgIdentity).not.toContain(
+          "prompt-api-key",
+        );
+
+        const offlineFetch = vi
+          .fn()
+          .mockRejectedValue(new TypeError("Network unavailable"));
+        const offlineState = new BraintrustState({
+          appUrl: "https://braintrust.test",
+          fetch: offlineFetch as unknown as typeof globalThis.fetch,
+          noExitFlush: true,
+        });
+        offlineState.promptCache = new PromptCache({
+          diskCache: new DiskCache({ cacheDir, logWarnings: false }),
+        });
+
+        const cachedPrompt = await loadPrompt({
+          projectName: "test-project",
+          slug: "saved-prompt",
+          apiKey: "prompt-api-key",
+          state: offlineState,
+        });
+
+        expect(cachedPrompt.id).toBe(promptRow.id);
+        expect(offlineFetch).toHaveBeenCalledOnce();
+
+        const rejectedFetch = vi.fn().mockResolvedValue(
+          new Response("Invalid API key", {
+            status: 401,
+            statusText: "Unauthorized",
+          }),
+        );
+        const rejectedState = new BraintrustState({
+          appUrl: "https://braintrust.test",
+          fetch: rejectedFetch as unknown as typeof globalThis.fetch,
+          noExitFlush: true,
+        });
+        rejectedState.promptCache = new PromptCache({
+          diskCache: new DiskCache({ cacheDir, logWarnings: false }),
+        });
+
+        await expect(
+          loadPrompt({
+            projectName: "test-project",
+            slug: "saved-prompt",
+            apiKey: "prompt-api-key",
+            state: rejectedState,
+          }),
+        ).rejects.toThrow("401: Unauthorized");
+      } finally {
+        await rm(cacheDir, { recursive: true, force: true });
+      }
+    });
+
+    test("loadPrompt isolates ambient caches after forceLogin switches organizations", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          loginResponse({
+            id: "first-org-id",
+            name: "first-org",
+            apiUrl: "https://first-api.test",
+          }),
+        )
+        .mockResolvedValueOnce(jsonResponse({ objects: [promptRow] }))
+        .mockResolvedValueOnce(
+          loginResponse({
+            id: "second-org-id",
+            name: "second-org",
+            apiUrl: "https://second-api.test",
+          }),
+        )
+        .mockResolvedValueOnce(serverErrorResponse());
+      const switchingState = new BraintrustState({
+        apiKey: "first-api-key",
+        fetch: fetchMock as unknown as typeof globalThis.fetch,
+        noExitFlush: true,
+      });
+      switchingState.promptCache = new PromptCache({
+        memoryCache: new LRUCache<string, PromptMemoryCacheEntry>({ max: 10 }),
+      });
+
+      await switchingState.login({});
+      await loadPrompt({
+        projectName: "test-project",
+        slug: "saved-prompt",
+        state: switchingState,
+      });
+      await switchingState.login({
+        apiKey: "second-api-key",
+        forceLogin: true,
+      });
+
+      await expect(
+        loadPrompt({
+          projectName: "test-project",
+          slug: "saved-prompt",
+          state: switchingState,
+        }),
+      ).rejects.toThrow("not found on server or in local cache");
+    });
+
+    test("loadPrompt does not read legacy unnamespaced cache entries", async () => {
+      state.promptCache = new PromptCache({
+        memoryCache: new LRUCache<string, PromptMemoryCacheEntry>({ max: 10 }),
+      });
+      await state.promptCache.set(
+        {
+          projectName: "test-project",
+          slug: "saved-prompt",
+          version: "latest",
+        },
+        new Prompt(promptRow, {}, false),
+      );
+      getJson.mockRejectedValue(
+        new FailedHTTPResponse(500, "Internal Server Error", "Unavailable"),
+      );
+
+      await expect(
+        loadPrompt({
+          projectName: "test-project",
+          slug: "saved-prompt",
+          state,
+        }),
+      ).rejects.toThrow("not found on server or in local cache");
+    });
+
+    test("loadPrompt never falls back on ambient authentication rejection", async () => {
+      getJson
+        .mockResolvedValueOnce({ objects: [promptRow] })
+        .mockRejectedValueOnce(
+          Object.assign(new Error("401: Unauthorized (Invalid API key)"), {
+            status: 401,
+          }),
+        );
+
+      await loadPrompt({
+        projectName: "test-project",
+        slug: "saved-prompt",
+        state,
+      });
+
+      await expect(
+        loadPrompt({
+          projectName: "test-project",
+          slug: "saved-prompt",
+          state,
+        }),
+      ).rejects.toThrow("401: Unauthorized");
+    });
+
+    test("loadPrompt never falls back when the requested organization is unavailable", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          loginResponse({
+            id: "prompt-org-id",
+            name: "prompt-org-name",
+            apiUrl: "https://prompt-api.test",
+          }),
+        )
+        .mockResolvedValueOnce(jsonResponse({ objects: [promptRow] }))
+        .mockResolvedValueOnce(
+          loginResponse({
+            id: "other-org-id",
+            name: "other-org-name",
+            apiUrl: "https://other-api.test",
+          }),
+        );
+      const scopedState = new BraintrustState({
+        apiKey: "prompt-api-key",
+        orgName: "prompt-org-name",
+        fetch: fetchMock as unknown as typeof globalThis.fetch,
+        noExitFlush: true,
+      });
+
+      await loadPrompt({
+        projectName: "test-project",
+        slug: "saved-prompt",
+        state: scopedState,
+      });
+
+      await expect(
+        loadPrompt({
+          projectName: "test-project",
+          slug: "saved-prompt",
+          forceLogin: true,
+          state: scopedState,
+        }),
+      ).rejects.toThrow(
+        "Organization prompt-org-name not found. Must be one of other-org-name",
+      );
+    });
+
+    test("loadParameters uses request-local credentials and isolated caches", async () => {
+      state.parametersCache = new ParametersCache({
+        memoryCache: new LRUCache<string, ParametersMemoryCacheEntry>({
+          max: 10,
+        }),
+      });
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          loginResponse({
+            id: "parameters-org-id",
+            name: "test-org-name",
+            apiUrl: "https://parameters-api.test",
+          }),
+        )
+        .mockResolvedValueOnce(jsonResponse({ objects: [parametersRow] }))
+        .mockResolvedValueOnce(
+          loginResponse({
+            id: "parameters-org-id",
+            name: "test-org-name",
+            apiUrl: "https://parameters-api.test",
+          }),
+        )
+        .mockResolvedValueOnce(serverErrorResponse());
+
+      await loadParameters({
+        projectName: "test-project",
+        slug: "saved-parameters",
+        apiKey: "first-parameters-api-key",
+        fetch: fetchMock,
+        state,
+      });
+
+      await expect(
+        loadParameters({
+          projectName: "test-project",
+          slug: "saved-parameters",
+          apiKey: "second-parameters-api-key",
+          fetch: fetchMock,
+          state,
+        }),
+      ).rejects.toThrow("not found on server or in local cache");
+      expect(state.loginToken).toBe("___TEST_API_KEY__THIS_IS_NOT_REAL___");
+    });
+
+    test("loadParameters never falls back on ambient authentication rejection", async () => {
+      getJson
+        .mockResolvedValueOnce({ objects: [parametersRow] })
+        .mockRejectedValueOnce(
+          new FailedHTTPResponse(403, "Forbidden", "Revoked API key"),
+        );
+
+      await loadParameters({
+        projectName: "test-project",
+        slug: "saved-parameters",
+        state,
+      });
+
+      await expect(
+        loadParameters({
+          projectName: "test-project",
+          slug: "saved-parameters",
+          state,
+        }),
+      ).rejects.toThrow("403: Forbidden");
+    });
+
+    test("resolved parameter caches validate the organization identity", async () => {
+      const cache = new ParametersCache({
+        memoryCache: new LRUCache<string, ParametersMemoryCacheEntry>({
+          max: 10,
+        }),
+      });
+      const parameters = new RemoteEvalParameters(parametersRow);
+      const key = {
+        projectName: "test-project",
+        slug: "saved-parameters",
+        version: "latest",
+      };
+
+      await cache.withNamespace("credential", "first-org").set(key, parameters);
+
+      expect(
+        await cache.withNamespace("credential", "first-org").get(key),
+      ).toBe(parameters);
+      expect(await cache.withNamespace("credential").get(key)).toBe(parameters);
+      expect(
+        await cache.withNamespace("credential", "second-org").get(key),
+      ).toBeUndefined();
     });
   });
 
@@ -2214,6 +2986,17 @@ describe("HTTPConnection POST retries", () => {
       state.apiConn().post("btql", {}, { signal: controller.signal }, 3),
     ).rejects.toBe(controller.signal.reason);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("preserves POST transport failures", async () => {
+    const state = await _exportsForTestingOnly.simulateLoginForTests();
+    const transportError = new TypeError("Network unavailable");
+    const fetchMock = vi.fn().mockRejectedValue(transportError);
+    state.setFetch(fetchMock as unknown as typeof globalThis.fetch);
+
+    await expect(state.apiConn().post("write", {})).rejects.toBe(
+      transportError,
+    );
   });
 });
 

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -165,8 +165,17 @@ import {
 } from "./functions/stream";
 import iso, { IsoAsyncLocalStorage } from "./isomorph";
 import { createCacheLayers } from "./prompt-cache/cache-config";
-import { PromptCache } from "./prompt-cache/prompt-cache";
-import { ParametersCache } from "./prompt-cache/parameters-cache";
+import {
+  PromptCache,
+  type PromptDiskCacheEntry,
+  type PromptMemoryCacheEntry,
+} from "./prompt-cache/prompt-cache";
+import {
+  ParametersCache,
+  type ParametersDiskCacheEntry,
+  type ParametersMemoryCacheEntry,
+} from "./prompt-cache/parameters-cache";
+import { LRUCache } from "./lru-cache";
 import {
   addAzureBlobHeaders,
   getCurrentUnixTimestamp,
@@ -715,6 +724,23 @@ export type SerializedBraintrustState = z.infer<typeof loginSchema>;
 let stateNonce = 0;
 
 const V1_PROXY_SUFFIX = "/v1/proxy";
+const LOADER_LOGIN_CACHE_MAX = 16;
+
+type ResolvedLoaderLoginOptions = Required<
+  Pick<LoginOptions, "apiKey" | "appUrl" | "fetch">
+> &
+  Pick<LoginOptions, "orgName"> & {
+    forceLogin?: boolean;
+    credentialCacheNamespace: string;
+    existingState?: BraintrustState;
+  };
+
+type LoaderCacheViews = {
+  promptCache: PromptCache;
+  parametersCache: ParametersCache;
+};
+
+type LoaderRequestState = Pick<BraintrustState, "appUrl" | "orgId" | "apiConn">;
 
 // proxyUrl may point at the universal proxy (`{apiUrl}/v1/proxy`) for
 // EU/self-hosted orgs, but proxyConn only targets Braintrust API endpoints
@@ -766,8 +792,18 @@ export class BraintrustState {
   private _otelFlushCallback: (() => Promise<void>) | null = null;
   public spanOriginEnvironment: SpanOriginEnvironment | undefined;
   private traceContextSigningSecret: string | undefined;
+  private loaderLoginCache = new WeakMap<
+    typeof globalThis.fetch,
+    LRUCache<string, Promise<LoaderRequestState>>
+  >();
 
-  constructor(private loginParams: LoginOptions) {
+  private readonly loginParams: LoginOptions;
+  private activeLoginOrgNameSelector: string | undefined;
+
+  constructor(loginParams: LoginOptions) {
+    this.loginParams = { ...loginParams };
+    this.activeLoginOrgNameSelector =
+      loginParams.orgName ?? iso.getEnv("BRAINTRUST_ORG_NAME");
     this.id = `${new Date().toLocaleString()}-${stateNonce++}`; // This is for debugging. uuidv4() breaks on platforms like Cloudflare.
     this.currentExperiment = undefined;
     this.currentLogger = undefined;
@@ -802,7 +838,10 @@ export class BraintrustState {
 
     this.resetLoginInfo();
 
-    const { memoryCache, diskCache } = createCacheLayers<Prompt>({
+    const { memoryCache, diskCache } = createCacheLayers<
+      PromptMemoryCacheEntry,
+      PromptDiskCacheEntry
+    >({
       memoryMaxEnvVar: "BRAINTRUST_PROMPT_CACHE_MEMORY_MAX",
       diskCacheDirEnvVar: "BRAINTRUST_PROMPT_CACHE_DIR",
       diskMaxEnvVar: "BRAINTRUST_PROMPT_CACHE_DISK_MAX",
@@ -814,13 +853,15 @@ export class BraintrustState {
     const {
       memoryCache: parametersMemoryCache,
       diskCache: parametersDiskCache,
-    } = createCacheLayers<RemoteEvalParameters>({
-      memoryMaxEnvVar: "BRAINTRUST_PARAMETERS_CACHE_MEMORY_MAX",
-      diskCacheDirEnvVar: "BRAINTRUST_PARAMETERS_CACHE_DIR",
-      diskMaxEnvVar: "BRAINTRUST_PARAMETERS_CACHE_DISK_MAX",
-      getDefaultDiskCacheDir: () =>
-        `${iso.getEnv("HOME") ?? iso.homedir!()}/.braintrust/parameters_cache`,
-    });
+    } = createCacheLayers<ParametersMemoryCacheEntry, ParametersDiskCacheEntry>(
+      {
+        memoryMaxEnvVar: "BRAINTRUST_PARAMETERS_CACHE_MEMORY_MAX",
+        diskCacheDirEnvVar: "BRAINTRUST_PARAMETERS_CACHE_DIR",
+        diskMaxEnvVar: "BRAINTRUST_PARAMETERS_CACHE_DISK_MAX",
+        getDefaultDiskCacheDir: () =>
+          `${iso.getEnv("HOME") ?? iso.homedir!()}/.braintrust/parameters_cache`,
+      },
+    );
     this.parametersCache = new ParametersCache({
       memoryCache: parametersMemoryCache,
       diskCache: parametersDiskCache,
@@ -864,6 +905,146 @@ export class BraintrustState {
     this._appConn = null;
     this._apiConn = null;
     this._proxyConn = null;
+    this.loaderLoginCache = new WeakMap();
+  }
+
+  /** @internal */
+  public async _internalResolveLoaderLoginOptions({
+    apiKey,
+    appUrl,
+    orgName,
+    fetch,
+    forceLogin,
+  }: Pick<LoginOptions, "apiKey" | "appUrl" | "orgName" | "fetch"> & {
+    forceLogin?: boolean;
+  }): Promise<ResolvedLoaderLoginOptions> {
+    const resolvedAppUrl =
+      appUrl ??
+      (this.loggedIn ? (this.appUrl ?? undefined) : undefined) ??
+      this.loginParams.appUrl ??
+      iso.getEnv("BRAINTRUST_APP_URL") ??
+      "https://www.braintrust.dev";
+    const resolvedApiKey =
+      apiKey ??
+      (this.loggedIn ? (this.loginToken ?? undefined) : undefined) ??
+      this.loginParams.apiKey ??
+      (await iso.getBraintrustApiKey());
+    if (!resolvedApiKey) {
+      throw new Error(
+        "Please specify an api key (e.g. by setting BRAINTRUST_API_KEY).",
+      );
+    }
+    const normalizedApiKey = HTTPConnection.sanitize_token(resolvedApiKey);
+    const usesActiveCredential =
+      this.loggedIn && normalizedApiKey === this.loginToken;
+    const requestedOrgName =
+      orgName ??
+      (usesActiveCredential ? this.activeLoginOrgNameSelector : undefined) ??
+      this.loginParams.orgName ??
+      iso.getEnv("BRAINTRUST_ORG_NAME");
+    const resolvedOrgName =
+      orgName ??
+      (usesActiveCredential ? (this.orgName ?? undefined) : undefined) ??
+      requestedOrgName;
+    const resolvedFetch =
+      fetch ??
+      (this.loggedIn ? this.fetch : undefined) ??
+      this.loginParams.fetch ??
+      globalThis.fetch;
+    const credentialCacheNamespace = JSON.stringify([
+      "loader-credential",
+      resolvedAppUrl,
+      requestedOrgName,
+      normalizedApiKey,
+    ]);
+
+    return {
+      apiKey: normalizedApiKey,
+      appUrl: resolvedAppUrl,
+      orgName: resolvedOrgName,
+      fetch: resolvedFetch,
+      forceLogin,
+      credentialCacheNamespace,
+      existingState:
+        !forceLogin &&
+        usesActiveCredential &&
+        resolvedAppUrl === this.appUrl &&
+        resolvedOrgName === this.orgName &&
+        resolvedFetch === this.fetch
+          ? this
+          : undefined,
+    };
+  }
+
+  /** @internal */
+  public _internalGetLoaderCacheViews(
+    loginOptions: ResolvedLoaderLoginOptions,
+    requestState?: LoaderRequestState,
+  ): LoaderCacheViews {
+    const expectedResolvedOrgIdentity =
+      requestState?.orgId && requestState.appUrl
+        ? JSON.stringify([
+            "loader-org",
+            requestState.appUrl,
+            requestState.orgId,
+          ])
+        : undefined;
+
+    return {
+      promptCache: this.promptCache.withNamespace(
+        loginOptions.credentialCacheNamespace,
+        expectedResolvedOrgIdentity,
+      ),
+      parametersCache: this.parametersCache.withNamespace(
+        loginOptions.credentialCacheNamespace,
+        expectedResolvedOrgIdentity,
+      ),
+    };
+  }
+
+  /** @internal */
+  public async _internalGetLoaderState({
+    apiKey,
+    appUrl,
+    orgName,
+    fetch,
+    forceLogin,
+    existingState,
+  }: ResolvedLoaderLoginOptions) {
+    if (existingState) {
+      return existingState;
+    }
+
+    let cache = this.loaderLoginCache.get(fetch);
+    if (!cache) {
+      cache = new LRUCache({ max: LOADER_LOGIN_CACHE_MAX });
+      this.loaderLoginCache.set(fetch, cache);
+    }
+
+    const cacheKey = JSON.stringify([appUrl, orgName, apiKey]);
+    if (!forceLogin) {
+      const cachedState = cache.get(cacheKey);
+      if (cachedState) {
+        return cachedState;
+      }
+    }
+
+    const statePromise = loginToLoaderRequestState({
+      orgName,
+      apiKey,
+      appUrl,
+      fetch,
+    });
+    cache.set(cacheKey, statePromise);
+
+    try {
+      return await statePromise;
+    } catch (error) {
+      if (cache.get(cacheKey) === statePromise) {
+        cache.delete(cacheKey);
+      }
+      throw error;
+    }
   }
 
   public resetIdGenState() {
@@ -920,6 +1101,8 @@ export class BraintrustState {
     this.debugLogLevel = other.debugLogLevel;
     this.debugLogLevelConfigured = other.debugLogLevelConfigured;
     this.traceContextSigningSecret = other.traceContextSigningSecret;
+    this.fetch = other.fetch;
+    this.activeLoginOrgNameSelector = other.activeLoginOrgNameSelector;
     setGlobalDebugLogLevel(
       this.debugLogLevelConfigured ? (this.debugLogLevel ?? false) : undefined,
     );
@@ -1248,25 +1431,95 @@ export class FailedHTTPResponse extends Error {
   public status: number;
   public text: string;
   public data: string;
+  public readonly cause?: unknown;
 
-  constructor(status: number, text: string, data: string) {
+  constructor(status: number, text: string, data: string, cause?: unknown) {
     super(`${status}: ${text} (${data})`);
     this.status = status;
     this.text = text;
     this.data = data;
+    this.cause = cause;
   }
+}
+
+class HTTPTransportError extends Error {
+  public readonly cause: unknown;
+
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause));
+    this.name = "HTTPTransportError";
+    this.cause = cause;
+  }
+}
+
+const httpTransportErrorCauses = new WeakSet<object>();
+
+function recordHTTPTransportError(error: unknown): void {
+  if (
+    (typeof error === "object" && error !== null) ||
+    typeof error === "function"
+  ) {
+    httpTransportErrorCauses.add(error);
+  }
+}
+
+function rethrowHTTPTransportError(
+  error: unknown,
+  classifyTransportErrors: boolean,
+): never {
+  if (classifyTransportErrors) {
+    throw new HTTPTransportError(error);
+  }
+  recordHTTPTransportError(error);
+  throw error;
+}
+
+function isLoaderCacheFallbackError(error: unknown): boolean {
+  if (error instanceof FailedHTTPResponse) {
+    return error.status === 408 || error.status === 429 || error.status >= 500;
+  }
+
+  if (error instanceof HTTPTransportError) {
+    return true;
+  }
+
+  return (
+    ((typeof error === "object" && error !== null) ||
+      typeof error === "function") &&
+    httpTransportErrorCauses.has(error)
+  );
+}
+
+async function readJSONResponse(
+  response: Response,
+  classifyTransportErrors = false,
+) {
+  let data: string;
+  try {
+    data = await response.text();
+  } catch (error) {
+    rethrowHTTPTransportError(error, classifyTransportErrors);
+  }
+  return JSON.parse(data);
 }
 
 async function checkResponse(resp: Response) {
   if (resp.ok) {
     return resp;
-  } else {
+  }
+
+  let data: string;
+  try {
+    data = await resp.text();
+  } catch (error) {
     throw new FailedHTTPResponse(
       resp.status,
       resp.statusText,
-      await resp.text(),
+      "Unable to read response body",
+      error,
     );
   }
+  throw new FailedHTTPResponse(resp.status, resp.statusText, data);
 }
 
 class HTTPConnection {
@@ -1275,7 +1528,11 @@ class HTTPConnection {
   headers: Record<string, string>;
   fetch: typeof globalThis.fetch;
 
-  constructor(base_url: string, fetch: typeof globalThis.fetch) {
+  constructor(
+    base_url: string,
+    fetch: typeof globalThis.fetch,
+    private readonly classifyTransportErrors = false,
+  ) {
     this.base_url = base_url;
     this.token = null;
     this.headers = {};
@@ -1347,9 +1604,10 @@ class HTTPConnection {
     // so we need to bind it again.
     const this_fetch = this.fetch;
     const this_headers = this.headers;
-    return await checkResponse(
+    let response: Response;
+    try {
       // Using toString() here makes it work with isomorphic fetch
-      await this_fetch(url.toString(), {
+      response = await this_fetch(url.toString(), {
         headers: {
           Accept: "application/json",
           ...this_headers,
@@ -1357,8 +1615,14 @@ class HTTPConnection {
         },
         keepalive: true,
         ...rest,
-      }),
-    );
+      });
+    } catch (error) {
+      if (config?.signal?.aborted) {
+        throw getAbortReason(config.signal);
+      }
+      rethrowHTTPTransportError(error, this.classifyTransportErrors);
+    }
+    return await checkResponse(response);
   }
 
   async post(
@@ -1377,8 +1641,9 @@ class HTTPConnection {
     const tries = retries + 1;
     for (let i = 0; i < tries; i++) {
       try {
-        return await checkResponse(
-          await this_fetch(_urljoin(this_base_url, path), {
+        let response: Response;
+        try {
+          response = await this_fetch(_urljoin(this_base_url, path), {
             method: "POST",
             headers: {
               Accept: "application/json",
@@ -1394,8 +1659,14 @@ class HTTPConnection {
                   : undefined,
             keepalive: true,
             ...rest,
-          }),
-        );
+          });
+        } catch (error) {
+          if (config?.signal?.aborted) {
+            throw getAbortReason(config.signal);
+          }
+          rethrowHTTPTransportError(error, this.classifyTransportErrors);
+        }
+        return await checkResponse(response);
       } catch (error) {
         if (config?.signal?.aborted) {
           throw getAbortReason(config.signal);
@@ -1429,7 +1700,7 @@ class HTTPConnection {
     for (let i = 0; i < tries; i++) {
       try {
         const resp = await this.get(`${object_type}`, args);
-        return await resp.json();
+        return await readJSONResponse(resp, this.classifyTransportErrors);
       } catch (e) {
         if (i < tries - 1) {
           debugLogger.debug(
@@ -1458,7 +1729,7 @@ class HTTPConnection {
     const resp = await this.post(`${object_type}`, args, {
       headers: { "Content-Type": "application/json" },
     });
-    return await resp.json();
+    return await readJSONResponse(resp, this.classifyTransportErrors);
   }
 
   // Custom inspect for Node.js console.log
@@ -4807,6 +5078,39 @@ type LoadParametersImplementationOptions = LoadParametersBaseOptions & {
   environment?: string;
 };
 
+type LoaderRequestResult<T> =
+  | ({ ok: true; response: T } & LoaderCacheViews)
+  | ({ ok: false; error: unknown } & LoaderCacheViews);
+
+async function runCredentialScopedLoaderRequest<T>(
+  state: BraintrustState,
+  loginOptions: Pick<
+    FullLoginOptions,
+    "apiKey" | "appUrl" | "orgName" | "fetch" | "forceLogin"
+  >,
+  request: (requestState: LoaderRequestState) => Promise<T>,
+): Promise<LoaderRequestResult<T>> {
+  const resolvedLoginOptions =
+    await state._internalResolveLoaderLoginOptions(loginOptions);
+  let cacheViews = state._internalGetLoaderCacheViews(resolvedLoginOptions);
+
+  try {
+    const requestState =
+      await state._internalGetLoaderState(resolvedLoginOptions);
+    cacheViews = state._internalGetLoaderCacheViews(
+      resolvedLoginOptions,
+      requestState,
+    );
+    return {
+      ok: true,
+      response: await request(requestState),
+      ...cacheViews,
+    };
+  } catch (error) {
+    return { ok: false, error, ...cacheViews };
+  }
+}
+
 /**
  * Load a prompt from the specified project.
  *
@@ -4820,7 +5124,7 @@ type LoadParametersImplementationOptions = LoadParametersBaseOptions & {
  * @param options.defaults (Optional) A dictionary of default values to use when rendering the prompt. Prompt values will override these defaults.
  * @param options.noTrace If true, do not include logging metadata for this prompt when build() is called.
  * @param options.appUrl The URL of the Braintrust App. Defaults to https://www.braintrust.dev.
- * @param options.apiKey The API key to use. If the parameter is not specified, will try to use the `BRAINTRUST_API_KEY` environment variable. In Node.js,
+ * @param options.apiKey The API key to use for this request, independently of any existing global login. If the parameter is not specified, will use an existing login or try the `BRAINTRUST_API_KEY` environment variable. In Node.js,
  * if that is unset, will try the nearest `.env.braintrust` file in the current working directory or parent directories. If no API key is specified, will prompt the user to login.
  * @param options.orgName (Optional) The name of a specific organization to connect to. This is useful if you belong to multiple.
  * @returns The prompt object.
@@ -4865,33 +5169,37 @@ export async function loadPrompt({
   }
 
   const state = stateArg ?? _globalState;
-  let response;
-  try {
-    await state.login({
-      orgName,
-      apiKey,
-      appUrl,
-      fetch,
-      forceLogin,
-    });
-    if (id) {
-      // Load prompt by ID using the /v1/prompt/{id} endpoint
-      response = await state
-        .apiConn()
-        .get_json(`v1/prompt/${id}`, versionOrEnvironment);
-      // Wrap single prompt response in objects array to match list API format
-      if (response) {
-        response = { objects: [response] };
+  const result = await runCredentialScopedLoaderRequest(
+    state,
+    { orgName, apiKey, appUrl, fetch, forceLogin },
+    async (requestState) => {
+      let response;
+      if (id) {
+        // Load prompt by ID using the /v1/prompt/{id} endpoint
+        response = await requestState
+          .apiConn()
+          .get_json(`v1/prompt/${id}`, versionOrEnvironment);
+        // Wrap single prompt response in objects array to match list API format
+        if (response) {
+          response = { objects: [response] };
+        }
+      } else {
+        response = await requestState.apiConn().get_json("v1/prompt", {
+          project_name: projectName,
+          project_id: projectId,
+          slug,
+          ...versionOrEnvironment,
+        });
       }
-    } else {
-      response = await state.apiConn().get_json("v1/prompt", {
-        project_name: projectName,
-        project_id: projectId,
-        slug,
-        ...versionOrEnvironment,
-      });
+      return response;
+    },
+  );
+  const { promptCache } = result;
+  if (!result.ok) {
+    const e = result.error;
+    if (!isLoaderCacheFallbackError(e)) {
+      throw e;
     }
-  } catch (e) {
     // If environment or version was specified, don't fall back to cache
     if (version || environment) {
       throw new Error(`Prompt not found with specified parameters: ${e}`);
@@ -4902,14 +5210,14 @@ export async function loadPrompt({
       .warn("Failed to load prompt, attempting to fall back to cache:", e);
     let prompt;
     if (id) {
-      prompt = await state.promptCache.get({ id });
+      prompt = await promptCache.get({ id });
       if (!prompt) {
         throw new Error(
           `Prompt with id ${id} not found (not found on server or in local cache): ${e}`,
         );
       }
     } else {
-      prompt = await state.promptCache.get({
+      prompt = await promptCache.get({
         slug,
         projectId,
         projectName,
@@ -4925,6 +5233,7 @@ export async function loadPrompt({
     }
     return prompt;
   }
+  const { response } = result;
 
   if (!("objects" in response) || response.objects.length === 0) {
     if (id) {
@@ -4952,9 +5261,9 @@ export async function loadPrompt({
   const prompt = new Prompt(metadata, defaults || {}, noTrace);
   try {
     if (id) {
-      await state.promptCache.set({ id }, prompt);
+      await promptCache.set({ id }, prompt);
     } else if (slug) {
-      await state.promptCache.set(
+      await promptCache.set(
         { slug, projectId, projectName, version: version ?? "latest" },
         prompt,
       );
@@ -4976,7 +5285,7 @@ export async function loadPrompt({
  * @param options.environment Fetch the version of the parameters assigned to the specified environment (e.g. "production", "staging"). If both `version` and `environment` are provided, `version` takes precedence.
  * @param options.id The id of specific parameters to load. If specified, this takes precedence over all other parameters (project and slug).
  * @param options.appUrl The URL of the Braintrust App. Defaults to https://www.braintrust.dev.
- * @param options.apiKey The API key to use. If the parameter is not specified, will try to use the `BRAINTRUST_API_KEY` environment variable. In Node.js, if that is unset, will try the nearest `.env.braintrust` file in the current working directory or parent directories.
+ * @param options.apiKey The API key to use for this request, independently of any existing global login. If the parameter is not specified, will use an existing login or try the `BRAINTRUST_API_KEY` environment variable. In Node.js, if that is unset, will try the nearest `.env.braintrust` file in the current working directory or parent directories.
  * @param options.orgName (Optional) The name of a specific organization to connect to. This is useful if you belong to multiple.
  * @returns The parameters object.
  * @throws If the parameters are not found.
@@ -5040,32 +5349,36 @@ export async function loadParameters<
   }
 
   const state = stateArg ?? _globalState;
-  let response;
-  try {
-    await state.login({
-      orgName,
-      apiKey,
-      appUrl,
-      fetch,
-      forceLogin,
-    });
-    if (id) {
-      response = await state.apiConn().get_json(`v1/function/${id}`, {
-        ...versionOrEnvironment,
-      });
-      if (response) {
-        response = { objects: [response] };
+  const result = await runCredentialScopedLoaderRequest(
+    state,
+    { orgName, apiKey, appUrl, fetch, forceLogin },
+    async (requestState) => {
+      let response;
+      if (id) {
+        response = await requestState.apiConn().get_json(`v1/function/${id}`, {
+          ...versionOrEnvironment,
+        });
+        if (response) {
+          response = { objects: [response] };
+        }
+      } else {
+        response = await requestState.apiConn().get_json("v1/function", {
+          project_name: projectName,
+          project_id: projectId,
+          slug,
+          function_type: "parameters",
+          ...versionOrEnvironment,
+        });
       }
-    } else {
-      response = await state.apiConn().get_json("v1/function", {
-        project_name: projectName,
-        project_id: projectId,
-        slug,
-        function_type: "parameters",
-        ...versionOrEnvironment,
-      });
+      return response;
+    },
+  );
+  const { parametersCache } = result;
+  if (!result.ok) {
+    const e = result.error;
+    if (!isLoaderCacheFallbackError(e)) {
+      throw e;
     }
-  } catch (e) {
     if (version || environment) {
       throw new Error(`Parameters not found with specified parameters: ${e}`);
     }
@@ -5075,14 +5388,14 @@ export async function loadParameters<
       .warn("Failed to load parameters, attempting to fall back to cache:", e);
     let parameters;
     if (id) {
-      parameters = await state.parametersCache.get({ id });
+      parameters = await parametersCache.get({ id });
       if (!parameters) {
         throw new Error(
           `Parameters with id ${id} not found (not found on server or in local cache): ${e}`,
         );
       }
     } else {
-      parameters = await state.parametersCache.get({
+      parameters = await parametersCache.get({
         slug,
         projectId,
         projectName,
@@ -5099,6 +5412,7 @@ export async function loadParameters<
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     return parameters as RemoteEvalParameters<true, true, InferParameters<S>>;
   }
+  const { response } = result;
 
   if (!("objects" in response) || response.objects.length === 0) {
     if (id) {
@@ -5126,9 +5440,9 @@ export async function loadParameters<
   const parameters = new RemoteEvalParameters(metadata);
   try {
     if (id) {
-      await state.parametersCache.set({ id }, parameters);
+      await parametersCache.set({ id }, parameters);
     } else if (slug) {
-      await state.parametersCache.set(
+      await parametersCache.set(
         { slug, projectId, projectName, version: version ?? "latest" },
         parameters,
       );
@@ -5262,6 +5576,59 @@ export async function login(
   return state;
 }
 
+async function loginToLoaderRequestState({
+  appUrl,
+  apiKey,
+  orgName,
+  fetch,
+}: Required<Pick<LoginOptions, "appUrl" | "apiKey" | "fetch">> &
+  Pick<LoginOptions, "orgName">): Promise<LoaderRequestState> {
+  let orgId: string;
+  let apiUrl: string;
+
+  if (apiKey === TEST_API_KEY) {
+    orgId = "test-org-id";
+    apiUrl = "https://braintrust.dev/fake-api-url";
+  } else {
+    let loginResponse: Response;
+    try {
+      loginResponse = await fetch(_urljoin(appUrl, `/api/apikey/login`), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+      });
+    } catch (error) {
+      throw new HTTPTransportError(error);
+    }
+
+    const info = await readJSONResponse(
+      await checkResponse(loginResponse),
+      true,
+    );
+    const org = selectLoginOrg(info.org_info, orgName);
+    orgId = org.id;
+    apiUrl = iso.getEnv("BRAINTRUST_API_URL") ?? org.api_url;
+    if (!apiUrl) {
+      throw new Error(
+        orgName
+          ? `Unable to log into organization '${orgName}'. Are you sure this credential is scoped to the organization?`
+          : "Unable to log into any organization with the provided credential.",
+      );
+    }
+  }
+
+  const apiConnection = new HTTPConnection(apiUrl, fetch, true);
+  apiConnection.set_token(apiKey);
+  apiConnection.make_long_lived();
+  return {
+    appUrl,
+    orgId,
+    apiConn: () => apiConnection,
+  };
+}
+
 export async function loginToState(options: LoginOptions = {}) {
   const {
     appUrl = iso.getEnv("BRAINTRUST_APP_URL") || "https://www.braintrust.dev",
@@ -5300,16 +5667,18 @@ export async function loginToState(options: LoginOptions = {}) {
     _saveOrgInfo(state, testOrgInfo, testOrgInfo[0].name);
     return state;
   } else {
-    const resp = await checkResponse(
-      await fetch(_urljoin(state.appUrl, `/api/apikey/login`), {
+    const loginResponse = await fetch(
+      _urljoin(state.appUrl, `/api/apikey/login`),
+      {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${apiKey}`,
         },
-      }),
+      },
     );
-    const info = await resp.json();
+    const resp = await checkResponse(loginResponse);
+    const info = await readJSONResponse(resp);
 
     _saveOrgInfo(state, info.org_info, orgName);
     if (!state.apiUrl) {
@@ -6523,33 +6892,35 @@ export function withParent<R>(
 
 function _saveOrgInfo(
   state: BraintrustState,
-  org_info: any,
-  org_name: string | undefined,
+  orgInfo: any,
+  orgName: string | undefined,
 ) {
-  if (org_info.length === 0) {
+  const org = selectLoginOrg(orgInfo, orgName);
+  state.orgId = org.id;
+  state.orgName = org.name;
+  state.apiUrl = iso.getEnv("BRAINTRUST_API_URL") ?? org.api_url;
+  state.proxyUrl = iso.getEnv("BRAINTRUST_PROXY_URL") ?? org.proxy_url;
+  state.gitMetadataSettings = org.git_metadata || undefined;
+}
+
+function selectLoginOrg(orgInfo: any, orgName: string | undefined) {
+  if (orgInfo.length === 0) {
     throw new LoginInvalidOrgError(
       "This user is not part of any organizations.",
     );
   }
 
-  for (const org of org_info) {
-    if (org_name === undefined || org.name === org_name) {
-      state.orgId = org.id;
-      state.orgName = org.name;
-      state.apiUrl = iso.getEnv("BRAINTRUST_API_URL") ?? org.api_url;
-      state.proxyUrl = iso.getEnv("BRAINTRUST_PROXY_URL") ?? org.proxy_url;
-      state.gitMetadataSettings = org.git_metadata || undefined;
-      break;
+  for (const org of orgInfo) {
+    if (orgName === undefined || org.name === orgName) {
+      return org;
     }
   }
 
-  if (state.orgId === undefined) {
-    throw new LoginInvalidOrgError(
-      `Organization ${org_name} not found. Must be one of ${org_info
-        .map((x: any) => x.name)
-        .join(", ")}`,
-    );
-  }
+  throw new LoginInvalidOrgError(
+    `Organization ${orgName} not found. Must be one of ${orgInfo
+      .map((org: any) => org.name)
+      .join(", ")}`,
+  );
 }
 
 function validateTags(tags: readonly string[]) {
@@ -9323,6 +9694,16 @@ export class Prompt<
       "__braintrust_prompt_marker" in data
     );
   }
+
+  /** @internal */
+  public _internalSerializeForCache() {
+    return {
+      metadata: this.metadata,
+      defaults: this.defaults,
+      noTrace: this.noTrace,
+    };
+  }
+
   public static fromPromptData(
     name: string,
     promptData: PromptData,
@@ -9383,6 +9764,11 @@ export class RemoteEvalParameters<
   public get data(): T {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     return (this.metadata.function_data.data ?? {}) as T;
+  }
+
+  /** @internal */
+  public _internalSerializeForCache() {
+    return { metadata: this.metadata };
   }
 
   public validate(data: unknown): boolean {

--- a/js/src/prompt-cache/cache-config.ts
+++ b/js/src/prompt-cache/cache-config.ts
@@ -55,7 +55,7 @@ function parsePositiveIntegerEnv(envVar: string, defaultValue: number): number {
   return Number.isInteger(value) && value > 0 ? value : defaultValue;
 }
 
-export function createCacheLayers<T>({
+export function createCacheLayers<MemoryEntry, DiskEntry = MemoryEntry>({
   memoryMaxEnvVar,
   diskCacheDirEnvVar,
   diskMaxEnvVar,
@@ -66,13 +66,13 @@ export function createCacheLayers<T>({
   diskMaxEnvVar: string;
   getDefaultDiskCacheDir: () => string;
 }): {
-  memoryCache?: LRUCache<string, T>;
-  diskCache?: DiskCache<T>;
+  memoryCache?: LRUCache<string, MemoryEntry>;
+  diskCache?: DiskCache<DiskEntry>;
 } {
   const mode = parseCacheMode();
   const memoryCache =
     mode === "mixed" || mode === "memory"
-      ? new LRUCache<string, T>({
+      ? new LRUCache<string, MemoryEntry>({
           max: parsePositiveIntegerEnv(
             memoryMaxEnvVar,
             DEFAULT_CACHE_MEMORY_MAX,
@@ -80,10 +80,10 @@ export function createCacheLayers<T>({
         })
       : undefined;
 
-  let diskCache: DiskCache<T> | undefined;
+  let diskCache: DiskCache<DiskEntry> | undefined;
   if (mode === "mixed" || mode === "disk") {
     if (canUseDiskCache()) {
-      diskCache = new DiskCache<T>({
+      diskCache = new DiskCache<DiskEntry>({
         cacheDir: iso.getEnv(diskCacheDirEnvVar) ?? getDefaultDiskCacheDir(),
         max: parsePositiveIntegerEnv(diskMaxEnvVar, DEFAULT_CACHE_DISK_MAX),
       });

--- a/js/src/prompt-cache/parameters-cache.test.ts
+++ b/js/src/prompt-cache/parameters-cache.test.ts
@@ -1,0 +1,69 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+import { tmpdir } from "os";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { RemoteEvalParameters } from "../logger";
+import { configureNode } from "../node/config";
+import { DiskCache } from "./disk-cache";
+import {
+  ParametersCache,
+  type ParametersDiskCacheEntry,
+} from "./parameters-cache";
+
+describe("ParametersCache", () => {
+  configureNode();
+
+  let cacheDir: string;
+
+  beforeEach(() => {
+    cacheDir = path.join(
+      tmpdir(),
+      `parameters-cache-test-${Date.now()}-${Math.random()}`,
+    );
+  });
+
+  afterEach(async () => {
+    await fs.rm(cacheDir, { recursive: true, force: true });
+  });
+
+  it("reconstructs parameters loaded from disk", async () => {
+    const key = {
+      projectId: "55555555-5555-4555-8555-555555555555",
+      slug: "saved-parameters",
+      version: "v1",
+    };
+    const parameters = new RemoteEvalParameters({
+      id: "44444444-4444-4444-8444-444444444444",
+      _xact_id: "v1",
+      project_id: key.projectId,
+      name: "Saved parameters",
+      slug: key.slug,
+      description: null,
+      function_type: "parameters",
+      function_data: {
+        type: "parameters",
+        data: { prefix: "hello" },
+        __schema: {
+          type: "object",
+          properties: { prefix: { type: "string" } },
+          required: ["prefix"],
+        },
+      },
+    });
+    const diskCache = new DiskCache<ParametersDiskCacheEntry>({
+      cacheDir,
+      logWarnings: false,
+    });
+
+    await new ParametersCache({ diskCache }).set(key, parameters);
+    const result = await new ParametersCache({ diskCache }).get(key);
+
+    expect(result).toBeInstanceOf(RemoteEvalParameters);
+    expect(result?.data).toEqual({ prefix: "hello" });
+    expect(result?.schema).toEqual({
+      type: "object",
+      properties: { prefix: { type: "string" } },
+      required: ["prefix"],
+    });
+  });
+});

--- a/js/src/prompt-cache/parameters-cache.ts
+++ b/js/src/prompt-cache/parameters-cache.ts
@@ -10,62 +10,110 @@ interface ParametersKey {
   id?: string;
 }
 
-function createCacheKey(key: ParametersKey): string {
+function createCacheKey(key: ParametersKey, namespace?: string): string {
+  let cacheKey: string;
   if (key.id) {
-    return `parameters:id:${key.id}`;
+    cacheKey = `parameters:id:${key.id}`;
+  } else {
+    const prefix = key.projectId ?? key.projectName;
+    if (!prefix) {
+      throw new Error("Either projectId or projectName must be provided");
+    }
+    if (!key.slug) {
+      throw new Error("Slug must be provided when not using ID");
+    }
+    cacheKey = `parameters:${prefix}:${key.slug}:${key.version ?? "latest"}`;
   }
-
-  const prefix = key.projectId ?? key.projectName;
-  if (!prefix) {
-    throw new Error("Either projectId or projectName must be provided");
-  }
-  if (!key.slug) {
-    throw new Error("Slug must be provided when not using ID");
-  }
-  return `parameters:${prefix}:${key.slug}:${key.version ?? "latest"}`;
+  return namespace === undefined
+    ? cacheKey
+    : `${namespace.length}:${namespace}:${cacheKey}`;
 }
 
+export type ParametersMemoryCacheEntry = {
+  value: RemoteEvalParameters;
+  resolvedOrgIdentity?: string;
+};
+
+export type ParametersDiskCacheEntry = {
+  value: ReturnType<RemoteEvalParameters["_internalSerializeForCache"]>;
+  resolvedOrgIdentity?: string;
+};
+
 export class ParametersCache {
-  private readonly memoryCache?: LRUCache<string, RemoteEvalParameters>;
-  private readonly diskCache?: DiskCache<RemoteEvalParameters>;
+  private readonly memoryCache?: LRUCache<string, ParametersMemoryCacheEntry>;
+  private readonly diskCache?: DiskCache<ParametersDiskCacheEntry>;
+  private readonly namespace?: string;
+  private readonly expectedResolvedOrgIdentity?: string;
 
   constructor(options: {
-    memoryCache?: LRUCache<string, RemoteEvalParameters>;
-    diskCache?: DiskCache<RemoteEvalParameters>;
+    memoryCache?: LRUCache<string, ParametersMemoryCacheEntry>;
+    diskCache?: DiskCache<ParametersDiskCacheEntry>;
+    namespace?: string;
+    expectedResolvedOrgIdentity?: string;
   }) {
     this.memoryCache = options.memoryCache;
     this.diskCache = options.diskCache;
+    this.namespace = options.namespace;
+    this.expectedResolvedOrgIdentity = options.expectedResolvedOrgIdentity;
+  }
+
+  withNamespace(
+    namespace: string,
+    expectedResolvedOrgIdentity?: string,
+  ): ParametersCache {
+    return new ParametersCache({
+      memoryCache: this.memoryCache,
+      diskCache: this.diskCache,
+      namespace,
+      expectedResolvedOrgIdentity,
+    });
   }
 
   async get(key: ParametersKey): Promise<RemoteEvalParameters | undefined> {
-    const cacheKey = createCacheKey(key);
-
+    const cacheKey = createCacheKey(key, this.namespace);
     if (this.memoryCache) {
-      const memoryParams = this.memoryCache.get(cacheKey);
-      if (memoryParams !== undefined) {
-        return memoryParams;
+      const memoryEntry = this.memoryCache.get(cacheKey);
+      if (
+        memoryEntry !== undefined &&
+        (this.expectedResolvedOrgIdentity === undefined ||
+          memoryEntry.resolvedOrgIdentity === this.expectedResolvedOrgIdentity)
+      ) {
+        return memoryEntry.value;
       }
     }
 
     if (this.diskCache) {
-      const diskParams = await this.diskCache.get(cacheKey);
-      if (!diskParams) {
+      const diskEntry = await this.diskCache.get(cacheKey);
+      if (
+        !diskEntry ||
+        (this.expectedResolvedOrgIdentity !== undefined &&
+          diskEntry.resolvedOrgIdentity !== this.expectedResolvedOrgIdentity)
+      ) {
         return undefined;
       }
-      this.memoryCache?.set(cacheKey, diskParams);
-      return diskParams;
+      const diskParameters = new RemoteEvalParameters(diskEntry.value.metadata);
+      this.memoryCache?.set(cacheKey, {
+        value: diskParameters,
+        resolvedOrgIdentity: diskEntry.resolvedOrgIdentity,
+      });
+      return diskParameters;
     }
 
     return undefined;
   }
 
   async set(key: ParametersKey, value: RemoteEvalParameters): Promise<void> {
-    const cacheKey = createCacheKey(key);
-
-    this.memoryCache?.set(cacheKey, value);
-
+    const cacheKey = createCacheKey(key, this.namespace);
+    const memoryEntry = {
+      value,
+      resolvedOrgIdentity: this.expectedResolvedOrgIdentity,
+    };
+    this.memoryCache?.set(cacheKey, memoryEntry);
     if (this.diskCache) {
-      await this.diskCache.set(cacheKey, value);
+      await this.diskCache.set(cacheKey, {
+        value: value._internalSerializeForCache(),
+        resolvedOrgIdentity: this.expectedResolvedOrgIdentity,
+      });
     }
   }
 }

--- a/js/src/prompt-cache/prompt-cache.test.ts
+++ b/js/src/prompt-cache/prompt-cache.test.ts
@@ -1,6 +1,10 @@
 import * as fs from "fs/promises";
 import * as path from "path";
-import { PromptCache } from "./prompt-cache";
+import {
+  PromptCache,
+  type PromptDiskCacheEntry,
+  type PromptMemoryCacheEntry,
+} from "./prompt-cache";
 import { Prompt } from "../logger";
 import { tmpdir } from "os";
 import { beforeEach, describe, it, afterEach, expect } from "vitest";
@@ -43,8 +47,8 @@ describe("PromptCache", () => {
     // Create a unique temporary directory for each test.
     cacheDir = path.join(tmpdir(), `prompt-cache-test-${Date.now()}`);
     cache = new PromptCache({
-      memoryCache: new LRUCache<string, Prompt>({ max: 2 }),
-      diskCache: new DiskCache<Prompt>({
+      memoryCache: new LRUCache<string, PromptMemoryCacheEntry>({ max: 2 }),
+      diskCache: new DiskCache<PromptDiskCacheEntry>({
         cacheDir,
         max: 5,
         logWarnings: false,
@@ -83,6 +87,7 @@ describe("PromptCache", () => {
       // Original prompt should now be on disk but not in memory.
       const result = await cache.get(testKey);
       expect(result).toEqual(testPrompt);
+      expect(result).toBeInstanceOf(Prompt);
     });
 
     it("should return undefined for non-existent prompts", async () => {
@@ -121,6 +126,43 @@ describe("PromptCache", () => {
 
       expect(result1?.projectId).toBe(testKey.projectId);
       expect(result2?.projectId).toBe("different-project");
+    });
+
+    it("should isolate entries in different namespaces", async () => {
+      const firstCache = cache.withNamespace("first-api-key");
+      const secondCache = cache.withNamespace("second-api-key");
+
+      await firstCache.set(testKey, testPrompt);
+
+      expect(await firstCache.get(testKey)).toEqual(testPrompt);
+      expect(await secondCache.get(testKey)).toBeUndefined();
+      expect(await cache.get(testKey)).toBeUndefined();
+    });
+
+    it("should validate resolved identities within a credential namespace", async () => {
+      const firstCache = cache.withNamespace("credential", "first-org");
+      const secondCache = cache.withNamespace("credential", "second-org");
+
+      await firstCache.set(testKey, testPrompt);
+
+      expect(await firstCache.get(testKey)).toEqual(testPrompt);
+      expect(await cache.withNamespace("credential").get(testKey)).toEqual(
+        testPrompt,
+      );
+      expect(await secondCache.get(testKey)).toBeUndefined();
+    });
+
+    it("should retain a scoped entry when the cache size is one", async () => {
+      const singleEntryCache = new PromptCache({
+        memoryCache: new LRUCache<string, PromptMemoryCacheEntry>({ max: 1 }),
+      }).withNamespace("credential", "first-org");
+
+      await singleEntryCache.set(testKey, testPrompt);
+
+      expect(await singleEntryCache.get(testKey)).toBe(testPrompt);
+      expect(
+        await singleEntryCache.withNamespace("credential").get(testKey),
+      ).toBe(testPrompt);
     });
 
     it("should throw error if neither projectId nor projectName is provided", async () => {
@@ -238,7 +280,7 @@ describe("PromptCache", () => {
       );
       const brokenCache = new PromptCache({
         memoryCache: new LRUCache({ max: 2 }),
-        diskCache: new DiskCache<Prompt>({
+        diskCache: new DiskCache<PromptDiskCacheEntry>({
           cacheDir: nonExistentDir,
           max: 5,
           mkdir: false,
@@ -260,7 +302,7 @@ describe("PromptCache", () => {
       // Create a new cache instance with empty memory cache.
       const newCache = new PromptCache({
         memoryCache: new LRUCache({ max: 2 }),
-        diskCache: new DiskCache<Prompt>({
+        diskCache: new DiskCache<PromptDiskCacheEntry>({
           cacheDir,
           max: 5,
           logWarnings: false,
@@ -296,7 +338,7 @@ describe("PromptCache", () => {
       // Create a new cache instance (empty memory cache).
       const newCache = new PromptCache({
         memoryCache: new LRUCache({ max: 2 }),
-        diskCache: new DiskCache<Prompt>({
+        diskCache: new DiskCache<PromptDiskCacheEntry>({
           cacheDir,
           max: 5,
           logWarnings: false,

--- a/js/src/prompt-cache/prompt-cache.ts
+++ b/js/src/prompt-cache/prompt-cache.ts
@@ -34,26 +34,40 @@ export interface PromptKey {
   id?: string;
 }
 
+export type PromptMemoryCacheEntry = {
+  value: Prompt;
+  resolvedOrgIdentity?: string;
+};
+
+export type PromptDiskCacheEntry = {
+  value: ReturnType<Prompt["_internalSerializeForCache"]>;
+  resolvedOrgIdentity?: string;
+};
+
 /**
  * Creates a unique cache key from prompt key.
  * @param key - The prompt key to convert into a cache key.
  * @returns A string that uniquely identifies the prompt in the cache.
  * @throws {Error} If neither projectId nor projectName is provided (when not using id).
  */
-function createCacheKey(key: PromptKey): string {
+function createCacheKey(key: PromptKey, namespace?: string): string {
+  let cacheKey: string;
   if (key.id) {
     // When caching by ID, we don't need project or slug
-    return `id:${key.id}`;
+    cacheKey = `id:${key.id}`;
+  } else {
+    const prefix = key.projectId ?? key.projectName;
+    if (!prefix) {
+      throw new Error("Either projectId or projectName must be provided");
+    }
+    if (!key.slug) {
+      throw new Error("Slug must be provided when not using ID");
+    }
+    cacheKey = `${prefix}:${key.slug}:${key.version ?? "latest"}`;
   }
-
-  const prefix = key.projectId ?? key.projectName;
-  if (!prefix) {
-    throw new Error("Either projectId or projectName must be provided");
-  }
-  if (!key.slug) {
-    throw new Error("Slug must be provided when not using ID");
-  }
-  return `${prefix}:${key.slug}:${key.version ?? "latest"}`;
+  return namespace === undefined
+    ? cacheKey
+    : `${namespace.length}:${namespace}:${cacheKey}`;
 }
 
 /**
@@ -62,15 +76,37 @@ function createCacheKey(key: PromptKey): string {
  * This cache can use either layer independently, both layers together, or no layers.
  */
 export class PromptCache {
-  private readonly memoryCache?: LRUCache<string, Prompt>;
-  private readonly diskCache?: DiskCache<Prompt>;
+  private readonly memoryCache?: LRUCache<string, PromptMemoryCacheEntry>;
+  private readonly diskCache?: DiskCache<PromptDiskCacheEntry>;
+  private readonly namespace?: string;
+  private readonly expectedResolvedOrgIdentity?: string;
 
   constructor(options: {
-    memoryCache?: LRUCache<string, Prompt>;
-    diskCache?: DiskCache<Prompt>;
+    memoryCache?: LRUCache<string, PromptMemoryCacheEntry>;
+    diskCache?: DiskCache<PromptDiskCacheEntry>;
+    namespace?: string;
+    expectedResolvedOrgIdentity?: string;
   }) {
     this.memoryCache = options.memoryCache;
     this.diskCache = options.diskCache;
+    this.namespace = options.namespace;
+    this.expectedResolvedOrgIdentity = options.expectedResolvedOrgIdentity;
+  }
+
+  /**
+   * Returns a cache view that shares the same storage layers but isolates all
+   * entries under the provided namespace.
+   */
+  withNamespace(
+    namespace: string,
+    expectedResolvedOrgIdentity?: string,
+  ): PromptCache {
+    return new PromptCache({
+      memoryCache: this.memoryCache,
+      diskCache: this.diskCache,
+      namespace,
+      expectedResolvedOrgIdentity,
+    });
   }
 
   /**
@@ -78,24 +114,37 @@ export class PromptCache {
    * First checks the in-memory LRU cache, then falls back to checking the disk cache if available.
    */
   async get(key: PromptKey): Promise<Prompt | undefined> {
-    const cacheKey = createCacheKey(key);
-
-    // First check memory cache.
+    const cacheKey = createCacheKey(key, this.namespace);
     if (this.memoryCache) {
-      const memoryPrompt = this.memoryCache.get(cacheKey);
-      if (memoryPrompt !== undefined) {
-        return memoryPrompt;
+      const memoryEntry = this.memoryCache.get(cacheKey);
+      if (
+        memoryEntry !== undefined &&
+        (this.expectedResolvedOrgIdentity === undefined ||
+          memoryEntry.resolvedOrgIdentity === this.expectedResolvedOrgIdentity)
+      ) {
+        return memoryEntry.value;
       }
     }
 
-    // If not in memory and disk cache exists, check disk cache.
     if (this.diskCache) {
-      const diskPrompt = await this.diskCache.get(cacheKey);
-      if (!diskPrompt) {
+      const diskEntry = await this.diskCache.get(cacheKey);
+      if (
+        !diskEntry ||
+        (this.expectedResolvedOrgIdentity !== undefined &&
+          diskEntry.resolvedOrgIdentity !== this.expectedResolvedOrgIdentity)
+      ) {
         return undefined;
       }
-      // Store in memory cache if available.
-      this.memoryCache?.set(cacheKey, diskPrompt);
+      const serializedPrompt = diskEntry.value;
+      const diskPrompt = new Prompt(
+        serializedPrompt.metadata,
+        serializedPrompt.defaults,
+        serializedPrompt.noTrace,
+      );
+      this.memoryCache?.set(cacheKey, {
+        value: diskPrompt,
+        resolvedOrgIdentity: diskEntry.resolvedOrgIdentity,
+      });
       return diskPrompt;
     }
 
@@ -111,14 +160,17 @@ export class PromptCache {
    * @throws If there is an error writing to the disk cache.
    */
   async set(key: PromptKey, value: Prompt): Promise<void> {
-    const cacheKey = createCacheKey(key);
-
-    // Update memory cache if available.
-    this.memoryCache?.set(cacheKey, value);
-
-    // Update disk cache if available.
+    const cacheKey = createCacheKey(key, this.namespace);
+    const memoryEntry = {
+      value,
+      resolvedOrgIdentity: this.expectedResolvedOrgIdentity,
+    };
+    this.memoryCache?.set(cacheKey, memoryEntry);
     if (this.diskCache) {
-      await this.diskCache.set(cacheKey, value);
+      await this.diskCache.set(cacheKey, {
+        value: value._internalSerializeForCache(),
+        resolvedOrgIdentity: this.expectedResolvedOrgIdentity,
+      });
     }
   }
 }


### PR DESCRIPTION
closes [SDK-143](https://linear.app/braintrustdata/issue/SDK-143)

Much of the changes are cache invalidations for switched api keys.