### PR TITLE
fix: Don't ignore `noTraceIO` for `wrapTraced` around plain functions

### DIFF
--- a/.changeset/fix-wrap-traced-no-trace-io.md
+++ b/.changeset/fix-wrap-traced-no-trace-io.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+fix: Don't ignore `noTraceIO` for `wrapTraced` around plain functions

--- a/js/src/logger.test.ts
+++ b/js/src/logger.test.ts
@@ -2495,6 +2495,71 @@ describe("isGeneratorFunction and isAsyncGeneratorFunction utilities", () => {
   });
 });
 
+describe("wrapTraced noTraceIO", () => {
+  let memoryLogger: any;
+
+  beforeEach(async () => {
+    await _exportsForTestingOnly.simulateLoginForTests();
+    memoryLogger = _exportsForTestingOnly.useTestBackgroundLogger();
+  });
+
+  afterEach(() => {
+    _exportsForTestingOnly.clearTestBackgroundLogger();
+    _exportsForTestingOnly.simulateLogoutForTests();
+  });
+
+  test("preserves manually logged input and output for async functions", async () => {
+    initLogger({ projectName: "test", projectId: "test-project-id" });
+
+    const callModel = wrapTraced(
+      async (request: { input: string }) => {
+        const response = { output: "manual output", metadata: "extra" };
+        currentSpan().log({
+          input: request.input,
+          output: response.output,
+        });
+        return response;
+      },
+      { noTraceIO: true },
+    );
+
+    await callModel({ input: "manual input" });
+
+    await memoryLogger.flush();
+    const logs = await memoryLogger.drain();
+    expect(logs).toHaveLength(1);
+    expect(logs[0].input).toBe("manual input");
+    expect(logs[0].output).toBe("manual output");
+  });
+
+  test("preserves manually logged input and output for synchronous functions", async () => {
+    initLogger({ projectName: "test", projectId: "test-project-id" });
+
+    const callModel = wrapTraced(
+      (request: { input: string }) => {
+        const response = { output: "manual output", metadata: "extra" };
+        currentSpan().log({
+          input: request.input,
+          output: response.output,
+        });
+        return response;
+      },
+      { noTraceIO: true, asyncFlush: true },
+    );
+
+    expect(callModel({ input: "manual input" })).toEqual({
+      output: "manual output",
+      metadata: "extra",
+    });
+
+    await memoryLogger.flush();
+    const logs = await memoryLogger.drain();
+    expect(logs).toHaveLength(1);
+    expect(logs[0].input).toBe("manual input");
+    expect(logs[0].output).toBe("manual output");
+  });
+});
+
 describe("wrapTraced generator support", () => {
   let memoryLogger: any;
   let originalEnv: string | undefined;

--- a/js/src/logger.ts
+++ b/js/src/logger.ts
@@ -6289,13 +6289,13 @@ export function wrapTraced<
   if (args?.asyncFlush) {
     return ((...fnArgs: Parameters<F>) =>
       traced((span) => {
-        if (!hasExplicitInput) {
+        if (!args?.noTraceIO && !hasExplicitInput) {
           span.log({ input: fnArgs });
         }
 
         const output = fn(...fnArgs);
 
-        if (!hasExplicitOutput) {
+        if (!args?.noTraceIO && !hasExplicitOutput) {
           if (output instanceof Promise) {
             return (async () => {
               const result = await output;
@@ -6312,7 +6312,7 @@ export function wrapTraced<
   } else {
     return ((...fnArgs: Parameters<F>) =>
       traced(async (span) => {
-        if (!hasExplicitInput) {
+        if (!args?.noTraceIO && !hasExplicitInput) {
           span.log({ input: fnArgs });
         }
 
@@ -6320,7 +6320,7 @@ export function wrapTraced<
 
         const output = await outputResult;
 
-        if (!hasExplicitOutput) {
+        if (!args?.noTraceIO && !hasExplicitOutput) {
           span.log({ output });
         }
 


### PR DESCRIPTION
closes [SDK-233](https://linear.app/braintrustdata/issue/SDK-233/typescript-sdk-wraptraced-notraceio-ignored-for-normal-functions)