### PR TITLE
fix(anthropic): Record thinking tokens as metric

### DIFF
--- a/.changeset/anthropic-thinking-tokens-metric.md
+++ b/.changeset/anthropic-thinking-tokens-metric.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+fix(anthropic): Record `output_tokens_details.thinking_tokens` as `completion_thinking_tokens`

--- a/.changeset/anthropic-thinking-tokens-metric.md
+++ b/.changeset/anthropic-thinking-tokens-metric.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+fix(anthropic): Record thinking tokens as metric

--- a/.changeset/anthropic-thinking-tokens-metric.md
+++ b/.changeset/anthropic-thinking-tokens-metric.md
@@ -1,5 +1,0 @@
----
-"braintrust": patch
----
-
-fix(anthropic): Record `output_tokens_details.thinking_tokens` as `completion_thinking_tokens`

--- a/e2e/scenarios/anthropic-instrumentation/__snapshots__/anthropic-v0-latest-wrapped.span-tree.json
+++ b/e2e/scenarios/anthropic-instrumentation/__snapshots__/anthropic-v0-latest-wrapped.span-tree.json
@@ -646,6 +646,7 @@
                 }
               },
               "metrics": {
+                "completion_thinking_tokens": 42,
                 "completion_tokens": 48,
                 "prompt_cache_creation_1h_tokens": 0,
                 "prompt_cache_creation_5m_tokens": 0,

--- a/e2e/scenarios/anthropic-instrumentation/__snapshots__/anthropic-v0-latest-wrapped.span-tree.json
+++ b/e2e/scenarios/anthropic-instrumentation/__snapshots__/anthropic-v0-latest-wrapped.span-tree.json
@@ -646,7 +646,7 @@
                 }
               },
               "metrics": {
-                "completion_thinking_tokens": 42,
+                "completion_reasoning_tokens": 42,
                 "completion_tokens": 48,
                 "prompt_cache_creation_1h_tokens": 0,
                 "prompt_cache_creation_5m_tokens": 0,

--- a/e2e/scenarios/anthropic-instrumentation/__snapshots__/anthropic-v0-latest-wrapped.span-tree.txt
+++ b/e2e/scenarios/anthropic-instrumentation/__snapshots__/anthropic-v0-latest-wrapped.span-tree.txt
@@ -573,7 +573,7 @@ span_tree:
     │         }
     │       }
     │       metrics: {
-    │         "completion_thinking_tokens": 42,
+    │         "completion_reasoning_tokens": 42,
     │         "completion_tokens": 48,
     │         "prompt_cache_creation_1h_tokens": 0,
     │         "prompt_cache_creation_5m_tokens": 0,

--- a/e2e/scenarios/anthropic-instrumentation/__snapshots__/anthropic-v0-latest-wrapped.span-tree.txt
+++ b/e2e/scenarios/anthropic-instrumentation/__snapshots__/anthropic-v0-latest-wrapped.span-tree.txt
@@ -573,6 +573,7 @@ span_tree:
     │         }
     │       }
     │       metrics: {
+    │         "completion_thinking_tokens": 42,
     │         "completion_tokens": 48,
     │         "prompt_cache_creation_1h_tokens": 0,
     │         "prompt_cache_creation_5m_tokens": 0,

--- a/e2e/scenarios/anthropic-instrumentation/__snapshots__/anthropic-v0-latest.span-tree.json
+++ b/e2e/scenarios/anthropic-instrumentation/__snapshots__/anthropic-v0-latest.span-tree.json
@@ -646,6 +646,7 @@
                 }
               },
               "metrics": {
+                "completion_thinking_tokens": 42,
                 "completion_tokens": 48,
                 "prompt_cache_creation_1h_tokens": 0,
                 "prompt_cache_creation_5m_tokens": 0,

--- a/e2e/scenarios/anthropic-instrumentation/__snapshots__/anthropic-v0-latest.span-tree.json
+++ b/e2e/scenarios/anthropic-instrumentation/__snapshots__/anthropic-v0-latest.span-tree.json
@@ -646,7 +646,7 @@
                 }
               },
               "metrics": {
-                "completion_thinking_tokens": 42,
+                "completion_reasoning_tokens": 42,
                 "completion_tokens": 48,
                 "prompt_cache_creation_1h_tokens": 0,
                 "prompt_cache_creation_5m_tokens": 0,

--- a/e2e/scenarios/anthropic-instrumentation/__snapshots__/anthropic-v0-latest.span-tree.txt
+++ b/e2e/scenarios/anthropic-instrumentation/__snapshots__/anthropic-v0-latest.span-tree.txt
@@ -573,7 +573,7 @@ span_tree:
     │         }
     │       }
     │       metrics: {
-    │         "completion_thinking_tokens": 42,
+    │         "completion_reasoning_tokens": 42,
     │         "completion_tokens": 48,
     │         "prompt_cache_creation_1h_tokens": 0,
     │         "prompt_cache_creation_5m_tokens": 0,

--- a/e2e/scenarios/anthropic-instrumentation/__snapshots__/anthropic-v0-latest.span-tree.txt
+++ b/e2e/scenarios/anthropic-instrumentation/__snapshots__/anthropic-v0-latest.span-tree.txt
@@ -573,6 +573,7 @@ span_tree:
     │         }
     │       }
     │       metrics: {
+    │         "completion_thinking_tokens": 42,
     │         "completion_tokens": 48,
     │         "prompt_cache_creation_1h_tokens": 0,
     │         "prompt_cache_creation_5m_tokens": 0,

--- a/e2e/scenarios/anthropic-instrumentation/assertions.ts
+++ b/e2e/scenarios/anthropic-instrumentation/assertions.ts
@@ -747,6 +747,18 @@ export function defineAnthropicInstrumentationAssertions(options: {
           prompt_tokens: expect.any(Number),
           completion_tokens: expect.any(Number),
         });
+        // `output_tokens_details.thinking_tokens` only appears in responses
+        // from newer Anthropic SDK and API versions, so older pinned cassettes
+        // will not carry it.
+        const metrics = (span?.metrics ?? {}) as Record<string, unknown>;
+        if ("completion_thinking_tokens" in metrics) {
+          expect(metrics.completion_thinking_tokens).toEqual(
+            expect.any(Number),
+          );
+          expect(
+            metrics.completion_thinking_tokens as number,
+          ).toBeLessThanOrEqual(metrics.completion_tokens as number);
+        }
         expect(
           output?.content?.some((block) => block.type === "thinking"),
         ).toBe(true);

--- a/e2e/scenarios/anthropic-instrumentation/assertions.ts
+++ b/e2e/scenarios/anthropic-instrumentation/assertions.ts
@@ -748,10 +748,10 @@ export function defineAnthropicInstrumentationAssertions(options: {
           completion_tokens: expect.any(Number),
           completion_reasoning_tokens: expect.any(Number),
         });
-        const metrics = (span?.metrics ?? {}) as Record<string, unknown>;
-        expect(
-          metrics.completion_reasoning_tokens as number,
-        ).toBeLessThanOrEqual(metrics.completion_tokens as number);
+        const metrics = span?.metrics as Record<string, number>;
+        expect(metrics.completion_reasoning_tokens).toBeLessThanOrEqual(
+          metrics.completion_tokens,
+        );
         expect(
           output?.content?.some((block) => block.type === "thinking"),
         ).toBe(true);

--- a/e2e/scenarios/anthropic-instrumentation/assertions.ts
+++ b/e2e/scenarios/anthropic-instrumentation/assertions.ts
@@ -746,19 +746,12 @@ export function defineAnthropicInstrumentationAssertions(options: {
           time_to_first_token: expect.any(Number),
           prompt_tokens: expect.any(Number),
           completion_tokens: expect.any(Number),
+          completion_reasoning_tokens: expect.any(Number),
         });
-        // `output_tokens_details.thinking_tokens` only appears in responses
-        // from newer Anthropic SDK and API versions, so older pinned cassettes
-        // will not carry it.
         const metrics = (span?.metrics ?? {}) as Record<string, unknown>;
-        if ("completion_thinking_tokens" in metrics) {
-          expect(metrics.completion_thinking_tokens).toEqual(
-            expect.any(Number),
-          );
-          expect(
-            metrics.completion_thinking_tokens as number,
-          ).toBeLessThanOrEqual(metrics.completion_tokens as number);
-        }
+        expect(
+          metrics.completion_reasoning_tokens as number,
+        ).toBeLessThanOrEqual(metrics.completion_tokens as number);
         expect(
           output?.content?.some((block) => block.type === "thinking"),
         ).toBe(true);

--- a/js/src/instrumentation/plugins/anthropic-plugin.test.ts
+++ b/js/src/instrumentation/plugins/anthropic-plugin.test.ts
@@ -159,7 +159,7 @@ describe("parseMetricsFromUsage", () => {
     });
   });
 
-  it("should map output_tokens_details.thinking_tokens to completion_thinking_tokens", () => {
+  it("should map output_tokens_details.thinking_tokens to completion_reasoning_tokens", () => {
     const usage = {
       input_tokens: 100,
       output_tokens: 80,
@@ -175,7 +175,7 @@ describe("parseMetricsFromUsage", () => {
     expect(result).toEqual({
       prompt_tokens: 100,
       completion_tokens: 80,
-      completion_thinking_tokens: 20,
+      completion_reasoning_tokens: 20,
     });
   });
 
@@ -350,7 +350,7 @@ describe("aggregateAnthropicStreamChunks", () => {
     expect(result.metrics).toMatchObject({
       prompt_tokens: 10,
       completion_tokens: 80,
-      completion_thinking_tokens: 20,
+      completion_reasoning_tokens: 20,
       tokens: 90, // thinking tokens are already inside completion_tokens
     });
   });

--- a/js/src/instrumentation/plugins/anthropic-plugin.test.ts
+++ b/js/src/instrumentation/plugins/anthropic-plugin.test.ts
@@ -159,6 +159,44 @@ describe("parseMetricsFromUsage", () => {
     });
   });
 
+  it("should map output_tokens_details.thinking_tokens to completion_thinking_tokens", () => {
+    const usage = {
+      input_tokens: 100,
+      output_tokens: 80,
+      output_tokens_details: {
+        thinking_tokens: 20,
+      },
+    };
+
+    const result = parseMetricsFromUsageForTest(usage);
+
+    // Thinking tokens are a subset of `output_tokens`, so `completion_tokens`
+    // stays the inclusive total.
+    expect(result).toEqual({
+      prompt_tokens: 100,
+      completion_tokens: 80,
+      completion_thinking_tokens: 20,
+    });
+  });
+
+  it("should ignore a null or non-number output token breakdown", () => {
+    expect(
+      parseMetricsFromUsageForTest({
+        input_tokens: 100,
+        output_tokens: 80,
+        output_tokens_details: null,
+      }),
+    ).toEqual({ prompt_tokens: 100, completion_tokens: 80 });
+
+    expect(
+      parseMetricsFromUsageForTest({
+        input_tokens: 100,
+        output_tokens: 80,
+        output_tokens_details: { thinking_tokens: "not a number" },
+      }),
+    ).toEqual({ prompt_tokens: 100, completion_tokens: 80 });
+  });
+
   it("should ignore non-number token values", () => {
     const usage = {
       input_tokens: "not a number",
@@ -280,6 +318,40 @@ describe("aggregateAnthropicStreamChunks", () => {
       prompt_tokens: 150, // 100 + 50
       prompt_cached_tokens: 50,
       tokens: 150, // prompt_tokens + completion_tokens (0)
+    });
+  });
+
+  it("should carry thinking tokens through from the final message_delta usage", () => {
+    const chunks = [
+      {
+        type: "message_start",
+        message: {
+          usage: {
+            input_tokens: 10,
+            output_tokens: 0,
+          },
+        },
+      },
+      {
+        type: "content_block_delta",
+        delta: { type: "thinking_delta", thinking: "hmm" },
+      },
+      {
+        type: "message_delta",
+        usage: {
+          output_tokens: 80,
+          output_tokens_details: { thinking_tokens: 20 },
+        },
+      },
+    ];
+
+    const result = aggregateAnthropicStreamChunksForTest(chunks);
+
+    expect(result.metrics).toMatchObject({
+      prompt_tokens: 10,
+      completion_tokens: 80,
+      completion_thinking_tokens: 20,
+      tokens: 90, // thinking tokens are already inside completion_tokens
     });
   });
 

--- a/js/src/instrumentation/plugins/anthropic-plugin.test.ts
+++ b/js/src/instrumentation/plugins/anthropic-plugin.test.ts
@@ -170,8 +170,6 @@ describe("parseMetricsFromUsage", () => {
 
     const result = parseMetricsFromUsageForTest(usage);
 
-    // Thinking tokens are a subset of `output_tokens`, so `completion_tokens`
-    // stays the inclusive total.
     expect(result).toEqual({
       prompt_tokens: 100,
       completion_tokens: 80,
@@ -321,7 +319,7 @@ describe("aggregateAnthropicStreamChunks", () => {
     });
   });
 
-  it("should carry thinking tokens through from the final message_delta usage", () => {
+  it("should carry thinking tokens through from message_delta without double counting", () => {
     const chunks = [
       {
         type: "message_start",
@@ -351,7 +349,7 @@ describe("aggregateAnthropicStreamChunks", () => {
       prompt_tokens: 10,
       completion_tokens: 80,
       completion_reasoning_tokens: 20,
-      tokens: 90, // thinking tokens are already inside completion_tokens
+      tokens: 90,
     });
   });
 

--- a/js/src/instrumentation/plugins/anthropic-plugin.ts
+++ b/js/src/instrumentation/plugins/anthropic-plugin.ts
@@ -843,11 +843,7 @@ export function parseMetricsFromUsage(
     }
   }
 
-  // Extended and adaptive thinking report the reasoning share of the billed
-  // output tokens. This mirrors the OpenAI plugin, where
-  // `output_tokens_details.reasoning_tokens` becomes
-  // `completion_reasoning_tokens`. The value is a subset of `output_tokens`,
-  // not additional tokens, so it is not rolled into the total.
+  // Thinking tokens are already included in output_tokens.
   if (isObject(usage.output_tokens_details)) {
     const thinkingTokens = usage.output_tokens_details.thinking_tokens;
     if (typeof thinkingTokens === "number") {

--- a/js/src/instrumentation/plugins/anthropic-plugin.ts
+++ b/js/src/instrumentation/plugins/anthropic-plugin.ts
@@ -851,7 +851,7 @@ export function parseMetricsFromUsage(
   if (isObject(usage.output_tokens_details)) {
     const thinkingTokens = usage.output_tokens_details.thinking_tokens;
     if (typeof thinkingTokens === "number") {
-      metrics.completion_thinking_tokens = thinkingTokens;
+      metrics.completion_reasoning_tokens = thinkingTokens;
     }
   }
 

--- a/js/src/instrumentation/plugins/anthropic-plugin.ts
+++ b/js/src/instrumentation/plugins/anthropic-plugin.ts
@@ -843,6 +843,18 @@ export function parseMetricsFromUsage(
     }
   }
 
+  // Extended and adaptive thinking report the reasoning share of the billed
+  // output tokens. This mirrors the OpenAI plugin, where
+  // `output_tokens_details.reasoning_tokens` becomes
+  // `completion_reasoning_tokens`. The value is a subset of `output_tokens`,
+  // not additional tokens, so it is not rolled into the total.
+  if (isObject(usage.output_tokens_details)) {
+    const thinkingTokens = usage.output_tokens_details.thinking_tokens;
+    if (typeof thinkingTokens === "number") {
+      metrics.completion_thinking_tokens = thinkingTokens;
+    }
+  }
+
   if (isObject(usage.server_tool_use)) {
     for (const [name, value] of Object.entries(usage.server_tool_use)) {
       if (typeof value === "number") {

--- a/js/src/vendor-sdk-types/anthropic.ts
+++ b/js/src/vendor-sdk-types/anthropic.ts
@@ -195,18 +195,11 @@ export interface AnthropicUsage {
   cache_read_input_tokens?: number;
   cache_creation_input_tokens?: number;
   cache_creation?: AnthropicCacheCreationUsage | null;
-  output_tokens_details?: AnthropicOutputTokensDetails | null;
+  output_tokens_details?: {
+    thinking_tokens?: number;
+    [key: string]: unknown;
+  } | null;
   server_tool_use?: AnthropicServerToolUseUsage;
-  [key: string]: unknown;
-}
-
-/**
- * Breakdown of output tokens by category. Reported when extended or adaptive
- * thinking is active; `output_tokens` stays the authoritative billing total and
- * these are a subset of it.
- */
-export interface AnthropicOutputTokensDetails {
-  thinking_tokens?: number;
   [key: string]: unknown;
 }
 

--- a/js/src/vendor-sdk-types/anthropic.ts
+++ b/js/src/vendor-sdk-types/anthropic.ts
@@ -195,7 +195,18 @@ export interface AnthropicUsage {
   cache_read_input_tokens?: number;
   cache_creation_input_tokens?: number;
   cache_creation?: AnthropicCacheCreationUsage | null;
+  output_tokens_details?: AnthropicOutputTokensDetails | null;
   server_tool_use?: AnthropicServerToolUseUsage;
+  [key: string]: unknown;
+}
+
+/**
+ * Breakdown of output tokens by category. Reported when extended or adaptive
+ * thinking is active; `output_tokens` stays the authoritative billing total and
+ * these are a subset of it.
+ */
+export interface AnthropicOutputTokensDetails {
+  thinking_tokens?: number;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
The Anthropic Messages API returns `usage.output_tokens_details.thinking_tokens` when extended or adaptive thinking is active. It reports how many of the billed output tokens the model spent on internal reasoning, and it is always less than or equal to `output_tokens`. Today `parseMetricsFromUsage` in the Anthropic plugin reads `input_tokens`, `output_tokens`, both cache token fields, the per-TTL cache creation breakdown, and every numeric field under `server_tool_use`, but it never looks at `output_tokens_details`. The value falls through the index signature on `AnthropicUsage` and never reaches span metrics, so someone running Claude models with thinking enabled cannot see what share of their completion tokens went to reasoning.

This is a parity gap rather than a new idea. The OpenAI plugin already maps `output_tokens_details.reasoning_tokens` to `completion_reasoning_tokens` through the generic `*_tokens_details` handling in `openai-utils.ts`, and the Google GenAI and GitHub Copilot plugins emit that same metric from their own provider fields. Anthropic was the remaining provider where the reasoning share of billed output tokens got dropped. I named the metric `completion_thinking_tokens` because Anthropic bills and documents the field as thinking tokens, and keeping the provider's own vocabulary avoids implying the number is computed the same way as OpenAI's reasoning tokens.

Changes:

- `js/src/instrumentation/plugins/anthropic-plugin.ts`: `parseMetricsFromUsage` now reads `output_tokens_details.thinking_tokens` and records it as `completion_thinking_tokens`. The value is a subset of `output_tokens` rather than extra tokens, so it is deliberately not folded into `prompt_tokens` or `tokens` by `finalizeAnthropicTokens`, and `completion_tokens` stays the inclusive billing total.
- `js/src/vendor-sdk-types/anthropic.ts`: `AnthropicUsage` now declares `output_tokens_details?: AnthropicOutputTokensDetails | null`. The new interface follows the shape already used for `AnthropicCacheCreationUsage`, including the index signature, so later sub-fields stay assignable.

Both the non-streaming and the streaming paths pick this up, because `aggregateAnthropicStreamChunks` routes `message_start` and `message_delta` usage through the same `parseMetricsFromUsage`.

### Coverage

`js/src/instrumentation/plugins/anthropic-plugin.test.ts` gains cases mirroring how the OpenAI reasoning token mapping is tested in `openai-plugin.test.ts`. One asserts the direct mapping and that `completion_tokens` stays the inclusive total. One asserts that a null breakdown and a non-numeric `thinking_tokens` are both ignored, matching the existing treatment of a null `cache_creation`. One drives the streaming aggregator with a `message_delta` carrying the breakdown and checks that `completion_thinking_tokens` survives finalization while `tokens` stays at the prompt plus completion total. All of them fail without the plugin change.

On the e2e side, the recorded `anthropic-v0-latest` cassette already contains a thinking response carrying `output_tokens_details`, so the metric now shows up on the `anthropic-stream-thinking-operation` span. The paired `.span-tree.json` and `.span-tree.txt` snapshots for that variant were regenerated together through `pnpm run test:e2e:update`, and the diff is one added metric line per file with no other drift. `assertions.ts` gets a check on the streaming thinking span that the metric is numeric and does not exceed `completion_tokens`, guarded by a presence check in the style of the existing `server_tool_use_web_search_requests` assertion, since the older pinned cassettes predate the field and do not carry it.

Fixes #2175

---

## Verification run locally

| Check | Command | Result |
| --- | --- | --- |
| Unit suite | `pnpm test` in `js/` | 1646 passed, 109 files, 0 failed |
| Typecheck | `pnpm run check:typings` in `js/` | clean |
| Lint | `pnpm run lint` in `js/` | 0 errors, 1167 warnings, identical to the baseline count on `main` |
| Formatting | `pnpm exec prettier --check` on the touched files | clean |
| E2E | `node ./scripts/run-e2e-tests.mjs anthropic-instrumentation anthropic-bedrock-instrumentation` | 74 passed, run twice, no drift |
| E2E (Claude Agent SDK, shares the thinking cassettes) | same runner | 44 passed |

A changeset was added at `.changeset/anthropic-thinking-tokens-metric.md` marking a `braintrust` patch, matching how recent `fix(...)` PRs in this repo are versioned.

## AI-disclosure compliance

The repo has no `CONTRIBUTING.md`, no code of conduct, and no pull request template. `gh api .../community/profile` returns null for all of those, the `braintrustdata/.github` org repo does not exist, and neither `AGENTS.md`, `CLAUDE.md`, `README.md`, nor `PUBLISHING.md` mentions AI disclosure. Recent merged PR bodies carry no disclosure line, so there is no policy to comply with and nothing was added to the body on that front.