### PR TITLE
fix: preserve all OpenAI streaming chat choices

### DIFF
--- a/.changeset/openai-streaming-choices.md
+++ b/.changeset/openai-streaming-choices.md
@@ -1,0 +1,5 @@
+---
+"braintrust": patch
+---
+
+fix: Preserve all OpenAI streaming chat choices in instrumentation output

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-auto-hook.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-auto-hook.span-tree.json
@@ -278,6 +278,49 @@
           }
         },
         {
+          "name": "openai-stream-multiple-choices-operation",
+          "children": [
+            {
+              "name": "Chat Completion",
+              "type": "llm",
+              "children": [],
+              "input": [
+                {
+                  "content_kind": "string",
+                  "role": "user"
+                }
+              ],
+              "output": [
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                },
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                }
+              ],
+              "metadata": {
+                "model": "gpt-4o-mini-2024-07-18",
+                "provider": "openai"
+              },
+              "metrics": {
+                "has_time_to_first_token": true
+              }
+            }
+          ],
+          "input": {
+            "kind": "undefined"
+          },
+          "output": null,
+          "metadata": {
+            "operation": "stream-multiple-choices"
+          },
+          "metrics": {
+            "has_time_to_first_token": false
+          }
+        },
+        {
           "name": "openai-parse-operation",
           "children": [
             {

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-auto-hook.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-auto-hook.span-tree.json
@@ -28,7 +28,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -38,9 +47,6 @@
           "output": null,
           "metadata": {
             "operation": "chat"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -67,7 +73,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -77,9 +92,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -106,7 +118,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -116,9 +137,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -145,7 +163,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 1,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 13
               }
             }
           ],
@@ -155,9 +182,6 @@
           "output": null,
           "metadata": {
             "operation": "stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -184,7 +208,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 6,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 17,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -194,9 +227,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -223,7 +253,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -233,9 +272,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -262,7 +298,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -272,9 +308,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-fixture"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -305,7 +338,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -315,9 +348,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-multiple-choices"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -346,7 +376,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 5,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 45,
+                "time_to_first_token": 0,
+                "tokens": 50
               }
             }
           ],
@@ -356,9 +395,6 @@
           "output": null,
           "metadata": {
             "operation": "parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -385,7 +421,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 14,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -395,9 +440,6 @@
           "output": null,
           "metadata": {
             "operation": "sync-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -418,7 +460,8 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": false
+                "prompt_tokens": 1,
+                "tokens": 1
               }
             }
           ],
@@ -428,9 +471,6 @@
           "output": null,
           "metadata": {
             "operation": "embeddings"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -450,9 +490,6 @@
               "metadata": {
                 "model": "omni-moderation-2024-09-26",
                 "provider": "openai"
-              },
-              "metrics": {
-                "has_time_to_first_token": false
               }
             }
           ],
@@ -462,9 +499,6 @@
           "output": null,
           "metadata": {
             "operation": "moderations"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -493,7 +527,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 4,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 17
               }
             }
           ],
@@ -503,9 +543,6 @@
           "output": null,
           "metadata": {
             "operation": "responses"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -534,7 +571,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -544,9 +587,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -575,7 +615,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 4,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 17
               }
             }
           ],
@@ -585,9 +631,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-create-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -616,7 +659,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -626,9 +675,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -657,7 +703,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 4,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 17
               }
             }
           ],
@@ -667,9 +719,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream-partial"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -701,7 +750,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 16,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 46,
+                "time_to_first_token": 0,
+                "tokens": 62
               }
             }
           ],
@@ -711,9 +766,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         }
       ],
@@ -724,9 +776,6 @@
       "metadata": {
         "openaiSdkVersion": "<openai-sdk-version>",
         "scenario": "openai-instrumentation"
-      },
-      "metrics": {
-        "has_time_to_first_token": false
       }
     }
   ]

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-auto-hook.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-auto-hook.span-tree.txt
@@ -228,6 +228,41 @@ span_tree:
     │       metrics: {
     │         "has_time_to_first_token": true
     │       }
+    ├── openai-stream-multiple-choices-operation
+    │   input: {
+    │     "kind": "undefined"
+    │   }
+    │   output: null
+    │   metadata: {
+    │     "operation": "stream-multiple-choices"
+    │   }
+    │   metrics: {
+    │     "has_time_to_first_token": false
+    │   }
+    │   └── Chat Completion [llm]
+    │       input: [
+    │         {
+    │           "content_kind": "string",
+    │           "role": "user"
+    │         }
+    │       ]
+    │       output: [
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         },
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         }
+    │       ]
+    │       metadata: {
+    │         "model": "gpt-4o-mini-2024-07-18",
+    │         "provider": "openai"
+    │       }
+    │       metrics: {
+    │         "has_time_to_first_token": true
+    │       }
     ├── openai-parse-operation
     │   input: {
     │     "kind": "undefined"

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-auto-hook.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-auto-hook.span-tree.txt
@@ -8,9 +8,6 @@ span_tree:
       "openaiSdkVersion": "<openai-sdk-version>",
       "scenario": "openai-instrumentation"
     }
-    metrics: {
-      "has_time_to_first_token": false
-    }
     ├── openai-chat-operation
     │   input: {
     │     "kind": "undefined"
@@ -18,9 +15,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "chat"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -40,7 +34,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-with-response-operation
     │   input: {
@@ -50,9 +53,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -71,7 +71,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-tool-operation
     │   input: {
@@ -81,9 +90,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -102,7 +108,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-operation
     │   input: {
@@ -112,9 +127,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -133,7 +145,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 1,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 13
     │       }
     ├── openai-stream-with-response-operation
     │   input: {
@@ -143,9 +164,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -164,7 +182,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 6,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 17,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-stream-tool-operation
     │   input: {
@@ -174,9 +201,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -195,7 +219,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-fixture-operation
     │   input: {
@@ -205,9 +238,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-fixture"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -226,7 +256,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-stream-multiple-choices-operation
     │   input: {
@@ -235,9 +265,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "stream-multiple-choices"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -261,7 +288,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-parse-operation
     │   input: {
@@ -270,9 +297,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "parse"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -294,7 +318,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 5,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 45,
+    │         "time_to_first_token": 0,
+    │         "tokens": 50
     │       }
     ├── openai-sync-stream-operation
     │   input: {
@@ -303,9 +336,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "sync-stream"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -325,7 +355,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 14,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     ├── openai-embeddings-operation
     │   input: {
@@ -334,9 +373,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "embeddings"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Embedding [llm]
     │       input: {
@@ -350,7 +386,8 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": false
+    │         "prompt_tokens": 1,
+    │         "tokens": 1
     │       }
     ├── openai-moderations-operation
     │   input: {
@@ -359,9 +396,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "moderations"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Moderation [llm]
     │       input: {
@@ -375,9 +409,6 @@ span_tree:
     │         "model": "omni-moderation-2024-09-26",
     │         "provider": "openai"
     │       }
-    │       metrics: {
-    │         "has_time_to_first_token": false
-    │       }
     ├── openai-responses-operation
     │   input: {
     │     "kind": "undefined"
@@ -385,9 +416,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "responses"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── openai.responses.create [llm]
     │       input: {
@@ -409,7 +437,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 4,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 17
     │       }
     ├── openai-responses-with-response-operation
     │   input: {
@@ -419,9 +453,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -442,7 +473,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-create-stream-operation
     │   input: {
@@ -452,9 +489,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-create-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -475,7 +509,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 4,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 17
     │       }
     ├── openai-responses-stream-operation
     │   input: {
@@ -485,9 +525,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -508,7 +545,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-stream-partial-operation
     │   input: {
@@ -518,9 +561,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream-partial"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -541,7 +581,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 4,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 17
     │       }
     └── openai-responses-parse-operation
         input: {
@@ -550,9 +596,6 @@ span_tree:
         output: null
         metadata: {
           "operation": "responses-parse"
-        }
-        metrics: {
-          "has_time_to_first_token": false
         }
         └── openai.responses.parse [llm]
             input: {
@@ -577,5 +620,11 @@ span_tree:
               "provider": "openai"
             }
             metrics: {
-              "has_time_to_first_token": true
+              "completion_reasoning_tokens": 0,
+              "completion_tokens": 16,
+              "prompt_cache_write_tokens": 0,
+              "prompt_cached_tokens": 0,
+              "prompt_tokens": 46,
+              "time_to_first_token": 0,
+              "tokens": 62
             }

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-latest-auto-hook.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-latest-auto-hook.span-tree.json
@@ -278,6 +278,49 @@
           }
         },
         {
+          "name": "openai-stream-multiple-choices-operation",
+          "children": [
+            {
+              "name": "Chat Completion",
+              "type": "llm",
+              "children": [],
+              "input": [
+                {
+                  "content_kind": "string",
+                  "role": "user"
+                }
+              ],
+              "output": [
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                },
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                }
+              ],
+              "metadata": {
+                "model": "gpt-4o-mini-2024-07-18",
+                "provider": "openai"
+              },
+              "metrics": {
+                "has_time_to_first_token": true
+              }
+            }
+          ],
+          "input": {
+            "kind": "undefined"
+          },
+          "output": null,
+          "metadata": {
+            "operation": "stream-multiple-choices"
+          },
+          "metrics": {
+            "has_time_to_first_token": false
+          }
+        },
+        {
           "name": "openai-parse-operation",
           "children": [
             {

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-latest-auto-hook.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-latest-auto-hook.span-tree.json
@@ -28,7 +28,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -38,9 +47,6 @@
           "output": null,
           "metadata": {
             "operation": "chat"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -67,7 +73,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -77,9 +92,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -106,7 +118,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -116,9 +137,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -145,7 +163,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 1,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 13
               }
             }
           ],
@@ -155,9 +182,6 @@
           "output": null,
           "metadata": {
             "operation": "stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -184,7 +208,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 6,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 17,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -194,9 +227,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -223,7 +253,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -233,9 +272,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -262,7 +298,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -272,9 +308,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-fixture"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -305,7 +338,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -315,9 +348,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-multiple-choices"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -346,7 +376,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 5,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 45,
+                "time_to_first_token": 0,
+                "tokens": 50
               }
             }
           ],
@@ -356,9 +395,6 @@
           "output": null,
           "metadata": {
             "operation": "parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -385,7 +421,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 14,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -395,9 +440,6 @@
           "output": null,
           "metadata": {
             "operation": "sync-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -418,7 +460,8 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": false
+                "prompt_tokens": 1,
+                "tokens": 1
               }
             }
           ],
@@ -428,9 +471,6 @@
           "output": null,
           "metadata": {
             "operation": "embeddings"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -450,9 +490,6 @@
               "metadata": {
                 "model": "omni-moderation-2024-09-26",
                 "provider": "openai"
-              },
-              "metrics": {
-                "has_time_to_first_token": false
               }
             }
           ],
@@ -462,9 +499,6 @@
           "output": null,
           "metadata": {
             "operation": "moderations"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -493,7 +527,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 3,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -503,9 +543,6 @@
           "output": null,
           "metadata": {
             "operation": "responses"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -534,7 +571,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -544,9 +587,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -575,7 +615,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 5,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 18
               }
             }
           ],
@@ -585,9 +631,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-create-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -616,7 +659,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -626,9 +675,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -657,7 +703,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 3,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -667,9 +719,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream-partial"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -701,7 +750,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 22,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 46,
+                "time_to_first_token": 0,
+                "tokens": 68
               }
             }
           ],
@@ -711,9 +766,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         }
       ],
@@ -724,9 +776,6 @@
       "metadata": {
         "openaiSdkVersion": "<openai-sdk-version>",
         "scenario": "openai-instrumentation"
-      },
-      "metrics": {
-        "has_time_to_first_token": false
       }
     }
   ]

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-latest-auto-hook.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-latest-auto-hook.span-tree.txt
@@ -8,9 +8,6 @@ span_tree:
       "openaiSdkVersion": "<openai-sdk-version>",
       "scenario": "openai-instrumentation"
     }
-    metrics: {
-      "has_time_to_first_token": false
-    }
     ├── openai-chat-operation
     │   input: {
     │     "kind": "undefined"
@@ -18,9 +15,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "chat"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -40,7 +34,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-with-response-operation
     │   input: {
@@ -50,9 +53,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -71,7 +71,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-tool-operation
     │   input: {
@@ -81,9 +90,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -102,7 +108,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-operation
     │   input: {
@@ -112,9 +127,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -133,7 +145,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 1,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 13
     │       }
     ├── openai-stream-with-response-operation
     │   input: {
@@ -143,9 +164,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -164,7 +182,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 6,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 17,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-stream-tool-operation
     │   input: {
@@ -174,9 +201,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -195,7 +219,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-fixture-operation
     │   input: {
@@ -205,9 +238,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-fixture"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -226,7 +256,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-stream-multiple-choices-operation
     │   input: {
@@ -235,9 +265,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "stream-multiple-choices"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -261,7 +288,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-parse-operation
     │   input: {
@@ -270,9 +297,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "parse"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -294,7 +318,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 5,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 45,
+    │         "time_to_first_token": 0,
+    │         "tokens": 50
     │       }
     ├── openai-sync-stream-operation
     │   input: {
@@ -303,9 +336,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "sync-stream"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -325,7 +355,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 14,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     ├── openai-embeddings-operation
     │   input: {
@@ -334,9 +373,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "embeddings"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Embedding [llm]
     │       input: {
@@ -350,7 +386,8 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": false
+    │         "prompt_tokens": 1,
+    │         "tokens": 1
     │       }
     ├── openai-moderations-operation
     │   input: {
@@ -359,9 +396,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "moderations"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Moderation [llm]
     │       input: {
@@ -375,9 +409,6 @@ span_tree:
     │         "model": "omni-moderation-2024-09-26",
     │         "provider": "openai"
     │       }
-    │       metrics: {
-    │         "has_time_to_first_token": false
-    │       }
     ├── openai-responses-operation
     │   input: {
     │     "kind": "undefined"
@@ -385,9 +416,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "responses"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── openai.responses.create [llm]
     │       input: {
@@ -409,7 +437,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 3,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     ├── openai-responses-with-response-operation
     │   input: {
@@ -419,9 +453,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -442,7 +473,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-create-stream-operation
     │   input: {
@@ -452,9 +489,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-create-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -475,7 +509,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 5,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 18
     │       }
     ├── openai-responses-stream-operation
     │   input: {
@@ -485,9 +525,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -508,7 +545,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-stream-partial-operation
     │   input: {
@@ -518,9 +561,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream-partial"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -541,7 +581,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 3,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     └── openai-responses-parse-operation
         input: {
@@ -550,9 +596,6 @@ span_tree:
         output: null
         metadata: {
           "operation": "responses-parse"
-        }
-        metrics: {
-          "has_time_to_first_token": false
         }
         └── openai.responses.parse [llm]
             input: {
@@ -577,5 +620,11 @@ span_tree:
               "provider": "openai"
             }
             metrics: {
-              "has_time_to_first_token": true
+              "completion_reasoning_tokens": 0,
+              "completion_tokens": 22,
+              "prompt_cache_write_tokens": 0,
+              "prompt_cached_tokens": 0,
+              "prompt_tokens": 46,
+              "time_to_first_token": 0,
+              "tokens": 68
             }

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-latest-auto-hook.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-latest-auto-hook.span-tree.txt
@@ -228,6 +228,41 @@ span_tree:
     │       metrics: {
     │         "has_time_to_first_token": true
     │       }
+    ├── openai-stream-multiple-choices-operation
+    │   input: {
+    │     "kind": "undefined"
+    │   }
+    │   output: null
+    │   metadata: {
+    │     "operation": "stream-multiple-choices"
+    │   }
+    │   metrics: {
+    │     "has_time_to_first_token": false
+    │   }
+    │   └── Chat Completion [llm]
+    │       input: [
+    │         {
+    │           "content_kind": "string",
+    │           "role": "user"
+    │         }
+    │       ]
+    │       output: [
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         },
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         }
+    │       ]
+    │       metadata: {
+    │         "model": "gpt-4o-mini-2024-07-18",
+    │         "provider": "openai"
+    │       }
+    │       metrics: {
+    │         "has_time_to_first_token": true
+    │       }
     ├── openai-parse-operation
     │   input: {
     │     "kind": "undefined"

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-latest-wrapped.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-latest-wrapped.span-tree.json
@@ -278,6 +278,49 @@
           }
         },
         {
+          "name": "openai-stream-multiple-choices-operation",
+          "children": [
+            {
+              "name": "Chat Completion",
+              "type": "llm",
+              "children": [],
+              "input": [
+                {
+                  "content_kind": "string",
+                  "role": "user"
+                }
+              ],
+              "output": [
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                },
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                }
+              ],
+              "metadata": {
+                "model": "gpt-4o-mini-2024-07-18",
+                "provider": "openai"
+              },
+              "metrics": {
+                "has_time_to_first_token": true
+              }
+            }
+          ],
+          "input": {
+            "kind": "undefined"
+          },
+          "output": null,
+          "metadata": {
+            "operation": "stream-multiple-choices"
+          },
+          "metrics": {
+            "has_time_to_first_token": false
+          }
+        },
+        {
           "name": "openai-parse-operation",
           "children": [
             {

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-latest-wrapped.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-latest-wrapped.span-tree.json
@@ -28,7 +28,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -38,9 +47,6 @@
           "output": null,
           "metadata": {
             "operation": "chat"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -67,7 +73,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -77,9 +92,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -106,7 +118,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -116,9 +137,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -145,7 +163,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 1,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 13
               }
             }
           ],
@@ -155,9 +182,6 @@
           "output": null,
           "metadata": {
             "operation": "stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -184,7 +208,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 6,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 17,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -194,9 +227,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -223,7 +253,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -233,9 +272,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -262,7 +298,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -272,9 +308,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-fixture"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -305,7 +338,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -315,9 +348,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-multiple-choices"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -346,7 +376,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 5,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 45,
+                "time_to_first_token": 0,
+                "tokens": 50
               }
             }
           ],
@@ -356,9 +395,6 @@
           "output": null,
           "metadata": {
             "operation": "parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -385,7 +421,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -395,9 +431,6 @@
           "output": null,
           "metadata": {
             "operation": "sync-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -418,7 +451,8 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": false
+                "prompt_tokens": 1,
+                "tokens": 1
               }
             }
           ],
@@ -428,9 +462,6 @@
           "output": null,
           "metadata": {
             "operation": "embeddings"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -450,9 +481,6 @@
               "metadata": {
                 "model": "omni-moderation-2024-09-26",
                 "provider": "openai"
-              },
-              "metrics": {
-                "has_time_to_first_token": false
               }
             }
           ],
@@ -462,9 +490,6 @@
           "output": null,
           "metadata": {
             "operation": "moderations"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -493,7 +518,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 3,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -503,9 +534,6 @@
           "output": null,
           "metadata": {
             "operation": "responses"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -534,7 +562,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -544,9 +578,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -575,7 +606,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 5,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 18
               }
             }
           ],
@@ -585,9 +622,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-create-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -616,7 +650,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -626,9 +666,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -657,7 +694,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 3,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -667,9 +710,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream-partial"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -701,7 +741,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 22,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 46,
+                "time_to_first_token": 0,
+                "tokens": 68
               }
             }
           ],
@@ -711,9 +757,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         }
       ],
@@ -724,9 +767,6 @@
       "metadata": {
         "openaiSdkVersion": "<openai-sdk-version>",
         "scenario": "openai-instrumentation"
-      },
-      "metrics": {
-        "has_time_to_first_token": false
       }
     }
   ]

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-latest-wrapped.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-latest-wrapped.span-tree.txt
@@ -8,9 +8,6 @@ span_tree:
       "openaiSdkVersion": "<openai-sdk-version>",
       "scenario": "openai-instrumentation"
     }
-    metrics: {
-      "has_time_to_first_token": false
-    }
     ├── openai-chat-operation
     │   input: {
     │     "kind": "undefined"
@@ -18,9 +15,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "chat"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -40,7 +34,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-with-response-operation
     │   input: {
@@ -50,9 +53,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -71,7 +71,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-tool-operation
     │   input: {
@@ -81,9 +90,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -102,7 +108,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-operation
     │   input: {
@@ -112,9 +127,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -133,7 +145,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 1,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 13
     │       }
     ├── openai-stream-with-response-operation
     │   input: {
@@ -143,9 +164,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -164,7 +182,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 6,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 17,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-stream-tool-operation
     │   input: {
@@ -174,9 +201,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -195,7 +219,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-fixture-operation
     │   input: {
@@ -205,9 +238,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-fixture"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -226,7 +256,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-stream-multiple-choices-operation
     │   input: {
@@ -235,9 +265,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "stream-multiple-choices"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -261,7 +288,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-parse-operation
     │   input: {
@@ -270,9 +297,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "parse"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -294,7 +318,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 5,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 45,
+    │         "time_to_first_token": 0,
+    │         "tokens": 50
     │       }
     ├── openai-sync-stream-operation
     │   input: {
@@ -303,9 +336,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "sync-stream"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -325,7 +355,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-embeddings-operation
     │   input: {
@@ -334,9 +364,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "embeddings"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Embedding [llm]
     │       input: {
@@ -350,7 +377,8 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": false
+    │         "prompt_tokens": 1,
+    │         "tokens": 1
     │       }
     ├── openai-moderations-operation
     │   input: {
@@ -359,9 +387,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "moderations"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Moderation [llm]
     │       input: {
@@ -375,9 +400,6 @@ span_tree:
     │         "model": "omni-moderation-2024-09-26",
     │         "provider": "openai"
     │       }
-    │       metrics: {
-    │         "has_time_to_first_token": false
-    │       }
     ├── openai-responses-operation
     │   input: {
     │     "kind": "undefined"
@@ -385,9 +407,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "responses"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── openai.responses.create [llm]
     │       input: {
@@ -409,7 +428,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 3,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     ├── openai-responses-with-response-operation
     │   input: {
@@ -419,9 +444,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -442,7 +464,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-create-stream-operation
     │   input: {
@@ -452,9 +480,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-create-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -475,7 +500,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 5,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 18
     │       }
     ├── openai-responses-stream-operation
     │   input: {
@@ -485,9 +516,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -508,7 +536,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-stream-partial-operation
     │   input: {
@@ -518,9 +552,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream-partial"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -541,7 +572,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 3,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     └── openai-responses-parse-operation
         input: {
@@ -550,9 +587,6 @@ span_tree:
         output: null
         metadata: {
           "operation": "responses-parse"
-        }
-        metrics: {
-          "has_time_to_first_token": false
         }
         └── openai.responses.parse [llm]
             input: {
@@ -577,5 +611,11 @@ span_tree:
               "provider": "openai"
             }
             metrics: {
-              "has_time_to_first_token": true
+              "completion_reasoning_tokens": 0,
+              "completion_tokens": 22,
+              "prompt_cache_write_tokens": 0,
+              "prompt_cached_tokens": 0,
+              "prompt_tokens": 46,
+              "time_to_first_token": 0,
+              "tokens": 68
             }

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-latest-wrapped.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-latest-wrapped.span-tree.txt
@@ -228,6 +228,41 @@ span_tree:
     │       metrics: {
     │         "has_time_to_first_token": true
     │       }
+    ├── openai-stream-multiple-choices-operation
+    │   input: {
+    │     "kind": "undefined"
+    │   }
+    │   output: null
+    │   metadata: {
+    │     "operation": "stream-multiple-choices"
+    │   }
+    │   metrics: {
+    │     "has_time_to_first_token": false
+    │   }
+    │   └── Chat Completion [llm]
+    │       input: [
+    │         {
+    │           "content_kind": "string",
+    │           "role": "user"
+    │         }
+    │       ]
+    │       output: [
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         },
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         }
+    │       ]
+    │       metadata: {
+    │         "model": "gpt-4o-mini-2024-07-18",
+    │         "provider": "openai"
+    │       }
+    │       metrics: {
+    │         "has_time_to_first_token": true
+    │       }
     ├── openai-parse-operation
     │   input: {
     │     "kind": "undefined"

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-wrapped.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-wrapped.span-tree.json
@@ -278,6 +278,49 @@
           }
         },
         {
+          "name": "openai-stream-multiple-choices-operation",
+          "children": [
+            {
+              "name": "Chat Completion",
+              "type": "llm",
+              "children": [],
+              "input": [
+                {
+                  "content_kind": "string",
+                  "role": "user"
+                }
+              ],
+              "output": [
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                },
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                }
+              ],
+              "metadata": {
+                "model": "gpt-4o-mini-2024-07-18",
+                "provider": "openai"
+              },
+              "metrics": {
+                "has_time_to_first_token": true
+              }
+            }
+          ],
+          "input": {
+            "kind": "undefined"
+          },
+          "output": null,
+          "metadata": {
+            "operation": "stream-multiple-choices"
+          },
+          "metrics": {
+            "has_time_to_first_token": false
+          }
+        },
+        {
           "name": "openai-parse-operation",
           "children": [
             {

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-wrapped.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-wrapped.span-tree.json
@@ -28,7 +28,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -38,9 +47,6 @@
           "output": null,
           "metadata": {
             "operation": "chat"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -67,7 +73,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -77,9 +92,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -106,7 +118,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -116,9 +137,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -145,7 +163,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 1,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 13
               }
             }
           ],
@@ -155,9 +182,6 @@
           "output": null,
           "metadata": {
             "operation": "stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -184,7 +208,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 6,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 17,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -194,9 +227,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -223,7 +253,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -233,9 +272,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -262,7 +298,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -272,9 +308,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-fixture"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -305,7 +338,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -315,9 +348,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-multiple-choices"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -346,7 +376,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 5,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 45,
+                "time_to_first_token": 0,
+                "tokens": 50
               }
             }
           ],
@@ -356,9 +395,6 @@
           "output": null,
           "metadata": {
             "operation": "parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -385,7 +421,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -395,9 +431,6 @@
           "output": null,
           "metadata": {
             "operation": "sync-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -418,7 +451,8 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": false
+                "prompt_tokens": 1,
+                "tokens": 1
               }
             }
           ],
@@ -428,9 +462,6 @@
           "output": null,
           "metadata": {
             "operation": "embeddings"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -450,9 +481,6 @@
               "metadata": {
                 "model": "omni-moderation-2024-09-26",
                 "provider": "openai"
-              },
-              "metrics": {
-                "has_time_to_first_token": false
               }
             }
           ],
@@ -462,9 +490,6 @@
           "output": null,
           "metadata": {
             "operation": "moderations"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -493,7 +518,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 4,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 17
               }
             }
           ],
@@ -503,9 +534,6 @@
           "output": null,
           "metadata": {
             "operation": "responses"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -534,7 +562,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -544,9 +578,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -575,7 +606,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 4,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 17
               }
             }
           ],
@@ -585,9 +622,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-create-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -616,7 +650,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -626,9 +666,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -657,7 +694,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 4,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 17
               }
             }
           ],
@@ -667,9 +710,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream-partial"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -701,7 +741,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 16,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 46,
+                "time_to_first_token": 0,
+                "tokens": 62
               }
             }
           ],
@@ -711,9 +757,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         }
       ],
@@ -724,9 +767,6 @@
       "metadata": {
         "openaiSdkVersion": "<openai-sdk-version>",
         "scenario": "openai-instrumentation"
-      },
-      "metrics": {
-        "has_time_to_first_token": false
       }
     }
   ]

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-wrapped.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-wrapped.span-tree.txt
@@ -8,9 +8,6 @@ span_tree:
       "openaiSdkVersion": "<openai-sdk-version>",
       "scenario": "openai-instrumentation"
     }
-    metrics: {
-      "has_time_to_first_token": false
-    }
     ├── openai-chat-operation
     │   input: {
     │     "kind": "undefined"
@@ -18,9 +15,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "chat"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -40,7 +34,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-with-response-operation
     │   input: {
@@ -50,9 +53,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -71,7 +71,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-tool-operation
     │   input: {
@@ -81,9 +90,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -102,7 +108,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-operation
     │   input: {
@@ -112,9 +127,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -133,7 +145,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 1,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 13
     │       }
     ├── openai-stream-with-response-operation
     │   input: {
@@ -143,9 +164,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -164,7 +182,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 6,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 17,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-stream-tool-operation
     │   input: {
@@ -174,9 +201,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -195,7 +219,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-fixture-operation
     │   input: {
@@ -205,9 +238,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-fixture"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -226,7 +256,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-stream-multiple-choices-operation
     │   input: {
@@ -235,9 +265,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "stream-multiple-choices"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -261,7 +288,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-parse-operation
     │   input: {
@@ -270,9 +297,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "parse"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -294,7 +318,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 5,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 45,
+    │         "time_to_first_token": 0,
+    │         "tokens": 50
     │       }
     ├── openai-sync-stream-operation
     │   input: {
@@ -303,9 +336,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "sync-stream"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -325,7 +355,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-embeddings-operation
     │   input: {
@@ -334,9 +364,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "embeddings"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Embedding [llm]
     │       input: {
@@ -350,7 +377,8 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": false
+    │         "prompt_tokens": 1,
+    │         "tokens": 1
     │       }
     ├── openai-moderations-operation
     │   input: {
@@ -359,9 +387,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "moderations"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Moderation [llm]
     │       input: {
@@ -375,9 +400,6 @@ span_tree:
     │         "model": "omni-moderation-2024-09-26",
     │         "provider": "openai"
     │       }
-    │       metrics: {
-    │         "has_time_to_first_token": false
-    │       }
     ├── openai-responses-operation
     │   input: {
     │     "kind": "undefined"
@@ -385,9 +407,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "responses"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── openai.responses.create [llm]
     │       input: {
@@ -409,7 +428,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 4,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 17
     │       }
     ├── openai-responses-with-response-operation
     │   input: {
@@ -419,9 +444,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -442,7 +464,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-create-stream-operation
     │   input: {
@@ -452,9 +480,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-create-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -475,7 +500,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 4,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 17
     │       }
     ├── openai-responses-stream-operation
     │   input: {
@@ -485,9 +516,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -508,7 +536,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-stream-partial-operation
     │   input: {
@@ -518,9 +552,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream-partial"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -541,7 +572,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 4,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 17
     │       }
     └── openai-responses-parse-operation
         input: {
@@ -550,9 +587,6 @@ span_tree:
         output: null
         metadata: {
           "operation": "responses-parse"
-        }
-        metrics: {
-          "has_time_to_first_token": false
         }
         └── openai.responses.parse [llm]
             input: {
@@ -577,5 +611,11 @@ span_tree:
               "provider": "openai"
             }
             metrics: {
-              "has_time_to_first_token": true
+              "completion_reasoning_tokens": 0,
+              "completion_tokens": 16,
+              "prompt_cache_write_tokens": 0,
+              "prompt_cached_tokens": 0,
+              "prompt_tokens": 46,
+              "time_to_first_token": 0,
+              "tokens": 62
             }

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-wrapped.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v4-wrapped.span-tree.txt
@@ -228,6 +228,41 @@ span_tree:
     │       metrics: {
     │         "has_time_to_first_token": true
     │       }
+    ├── openai-stream-multiple-choices-operation
+    │   input: {
+    │     "kind": "undefined"
+    │   }
+    │   output: null
+    │   metadata: {
+    │     "operation": "stream-multiple-choices"
+    │   }
+    │   metrics: {
+    │     "has_time_to_first_token": false
+    │   }
+    │   └── Chat Completion [llm]
+    │       input: [
+    │         {
+    │           "content_kind": "string",
+    │           "role": "user"
+    │         }
+    │       ]
+    │       output: [
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         },
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         }
+    │       ]
+    │       metadata: {
+    │         "model": "gpt-4o-mini-2024-07-18",
+    │         "provider": "openai"
+    │       }
+    │       metrics: {
+    │         "has_time_to_first_token": true
+    │       }
     ├── openai-parse-operation
     │   input: {
     │     "kind": "undefined"

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-auto-hook.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-auto-hook.span-tree.json
@@ -278,6 +278,49 @@
           }
         },
         {
+          "name": "openai-stream-multiple-choices-operation",
+          "children": [
+            {
+              "name": "Chat Completion",
+              "type": "llm",
+              "children": [],
+              "input": [
+                {
+                  "content_kind": "string",
+                  "role": "user"
+                }
+              ],
+              "output": [
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                },
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                }
+              ],
+              "metadata": {
+                "model": "gpt-4o-mini-2024-07-18",
+                "provider": "openai"
+              },
+              "metrics": {
+                "has_time_to_first_token": true
+              }
+            }
+          ],
+          "input": {
+            "kind": "undefined"
+          },
+          "output": null,
+          "metadata": {
+            "operation": "stream-multiple-choices"
+          },
+          "metrics": {
+            "has_time_to_first_token": false
+          }
+        },
+        {
           "name": "openai-parse-operation",
           "children": [
             {

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-auto-hook.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-auto-hook.span-tree.json
@@ -28,7 +28,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -38,9 +47,6 @@
           "output": null,
           "metadata": {
             "operation": "chat"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -67,7 +73,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -77,9 +92,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -106,7 +118,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -116,9 +137,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -145,7 +163,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 1,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 13
               }
             }
           ],
@@ -155,9 +182,6 @@
           "output": null,
           "metadata": {
             "operation": "stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -184,7 +208,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 6,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 17,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -194,9 +227,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -223,7 +253,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -233,9 +272,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -262,7 +298,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -272,9 +308,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-fixture"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -305,7 +338,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -315,9 +348,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-multiple-choices"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -346,7 +376,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 5,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 45,
+                "time_to_first_token": 0,
+                "tokens": 50
               }
             }
           ],
@@ -356,9 +395,6 @@
           "output": null,
           "metadata": {
             "operation": "parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -385,7 +421,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 14,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -395,9 +440,6 @@
           "output": null,
           "metadata": {
             "operation": "sync-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -418,7 +460,8 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": false
+                "prompt_tokens": 1,
+                "tokens": 1
               }
             }
           ],
@@ -428,9 +471,6 @@
           "output": null,
           "metadata": {
             "operation": "embeddings"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -450,9 +490,6 @@
               "metadata": {
                 "model": "omni-moderation-2024-09-26",
                 "provider": "openai"
-              },
-              "metrics": {
-                "has_time_to_first_token": false
               }
             }
           ],
@@ -462,9 +499,6 @@
           "output": null,
           "metadata": {
             "operation": "moderations"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -493,7 +527,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 3,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -503,9 +543,6 @@
           "output": null,
           "metadata": {
             "operation": "responses"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -534,7 +571,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -544,9 +587,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -575,7 +615,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 5,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 18
               }
             }
           ],
@@ -585,9 +631,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-create-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -616,7 +659,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -626,9 +675,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -657,7 +703,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 3,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -667,9 +719,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream-partial"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -701,7 +750,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 26,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 46,
+                "time_to_first_token": 0,
+                "tokens": 72
               }
             }
           ],
@@ -711,9 +766,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         }
       ],
@@ -724,9 +776,6 @@
       "metadata": {
         "openaiSdkVersion": "<openai-sdk-version>",
         "scenario": "openai-instrumentation"
-      },
-      "metrics": {
-        "has_time_to_first_token": false
       }
     }
   ]

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-auto-hook.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-auto-hook.span-tree.txt
@@ -8,9 +8,6 @@ span_tree:
       "openaiSdkVersion": "<openai-sdk-version>",
       "scenario": "openai-instrumentation"
     }
-    metrics: {
-      "has_time_to_first_token": false
-    }
     ├── openai-chat-operation
     │   input: {
     │     "kind": "undefined"
@@ -18,9 +15,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "chat"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -40,7 +34,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-with-response-operation
     │   input: {
@@ -50,9 +53,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -71,7 +71,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-tool-operation
     │   input: {
@@ -81,9 +90,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -102,7 +108,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-operation
     │   input: {
@@ -112,9 +127,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -133,7 +145,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 1,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 13
     │       }
     ├── openai-stream-with-response-operation
     │   input: {
@@ -143,9 +164,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -164,7 +182,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 6,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 17,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-stream-tool-operation
     │   input: {
@@ -174,9 +201,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -195,7 +219,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-fixture-operation
     │   input: {
@@ -205,9 +238,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-fixture"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -226,7 +256,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-stream-multiple-choices-operation
     │   input: {
@@ -235,9 +265,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "stream-multiple-choices"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -261,7 +288,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-parse-operation
     │   input: {
@@ -270,9 +297,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "parse"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -294,7 +318,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 5,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 45,
+    │         "time_to_first_token": 0,
+    │         "tokens": 50
     │       }
     ├── openai-sync-stream-operation
     │   input: {
@@ -303,9 +336,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "sync-stream"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -325,7 +355,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 14,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     ├── openai-embeddings-operation
     │   input: {
@@ -334,9 +373,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "embeddings"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Embedding [llm]
     │       input: {
@@ -350,7 +386,8 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": false
+    │         "prompt_tokens": 1,
+    │         "tokens": 1
     │       }
     ├── openai-moderations-operation
     │   input: {
@@ -359,9 +396,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "moderations"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Moderation [llm]
     │       input: {
@@ -375,9 +409,6 @@ span_tree:
     │         "model": "omni-moderation-2024-09-26",
     │         "provider": "openai"
     │       }
-    │       metrics: {
-    │         "has_time_to_first_token": false
-    │       }
     ├── openai-responses-operation
     │   input: {
     │     "kind": "undefined"
@@ -385,9 +416,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "responses"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── openai.responses.create [llm]
     │       input: {
@@ -409,7 +437,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 3,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     ├── openai-responses-with-response-operation
     │   input: {
@@ -419,9 +453,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -442,7 +473,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-create-stream-operation
     │   input: {
@@ -452,9 +489,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-create-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -475,7 +509,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 5,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 18
     │       }
     ├── openai-responses-stream-operation
     │   input: {
@@ -485,9 +525,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -508,7 +545,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-stream-partial-operation
     │   input: {
@@ -518,9 +561,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream-partial"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -541,7 +581,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 3,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     └── openai-responses-parse-operation
         input: {
@@ -550,9 +596,6 @@ span_tree:
         output: null
         metadata: {
           "operation": "responses-parse"
-        }
-        metrics: {
-          "has_time_to_first_token": false
         }
         └── openai.responses.parse [llm]
             input: {
@@ -577,5 +620,11 @@ span_tree:
               "provider": "openai"
             }
             metrics: {
-              "has_time_to_first_token": true
+              "completion_reasoning_tokens": 0,
+              "completion_tokens": 26,
+              "prompt_cache_write_tokens": 0,
+              "prompt_cached_tokens": 0,
+              "prompt_tokens": 46,
+              "time_to_first_token": 0,
+              "tokens": 72
             }

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-auto-hook.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-auto-hook.span-tree.txt
@@ -228,6 +228,41 @@ span_tree:
     │       metrics: {
     │         "has_time_to_first_token": true
     │       }
+    ├── openai-stream-multiple-choices-operation
+    │   input: {
+    │     "kind": "undefined"
+    │   }
+    │   output: null
+    │   metadata: {
+    │     "operation": "stream-multiple-choices"
+    │   }
+    │   metrics: {
+    │     "has_time_to_first_token": false
+    │   }
+    │   └── Chat Completion [llm]
+    │       input: [
+    │         {
+    │           "content_kind": "string",
+    │           "role": "user"
+    │         }
+    │       ]
+    │       output: [
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         },
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         }
+    │       ]
+    │       metadata: {
+    │         "model": "gpt-4o-mini-2024-07-18",
+    │         "provider": "openai"
+    │       }
+    │       metrics: {
+    │         "has_time_to_first_token": true
+    │       }
     ├── openai-parse-operation
     │   input: {
     │     "kind": "undefined"

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-latest-auto-hook.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-latest-auto-hook.span-tree.json
@@ -28,7 +28,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -38,9 +47,6 @@
           "output": null,
           "metadata": {
             "operation": "chat"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -67,7 +73,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -77,9 +92,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -106,7 +118,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -116,9 +137,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -145,7 +163,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 1,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 13
               }
             }
           ],
@@ -155,9 +182,6 @@
           "output": null,
           "metadata": {
             "operation": "stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -184,7 +208,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 6,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 17,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -194,9 +227,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -223,7 +253,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -233,9 +272,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -262,7 +298,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -272,9 +308,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-fixture"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -305,7 +338,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -315,9 +348,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-multiple-choices"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -346,7 +376,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 5,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 45,
+                "time_to_first_token": 0,
+                "tokens": 50
               }
             }
           ],
@@ -356,9 +395,6 @@
           "output": null,
           "metadata": {
             "operation": "parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -385,7 +421,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 14,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -395,9 +440,6 @@
           "output": null,
           "metadata": {
             "operation": "sync-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -418,7 +460,8 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": false
+                "prompt_tokens": 1,
+                "tokens": 1
               }
             }
           ],
@@ -428,9 +471,6 @@
           "output": null,
           "metadata": {
             "operation": "embeddings"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -450,9 +490,6 @@
               "metadata": {
                 "model": "omni-moderation-2024-09-26",
                 "provider": "openai"
-              },
-              "metrics": {
-                "has_time_to_first_token": false
               }
             }
           ],
@@ -462,9 +499,6 @@
           "output": null,
           "metadata": {
             "operation": "moderations"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -493,7 +527,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 3,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -503,9 +543,6 @@
           "output": null,
           "metadata": {
             "operation": "responses"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -534,7 +571,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -544,9 +587,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -575,7 +615,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 4,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 17
               }
             }
           ],
@@ -585,9 +631,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-create-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -616,7 +659,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -626,9 +675,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -657,7 +703,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 3,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -667,9 +719,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream-partial"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -701,7 +750,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 35,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 46,
+                "time_to_first_token": 0,
+                "tokens": 81
               }
             }
           ],
@@ -711,9 +766,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         }
       ],
@@ -724,9 +776,6 @@
       "metadata": {
         "openaiSdkVersion": "<openai-sdk-version>",
         "scenario": "openai-instrumentation"
-      },
-      "metrics": {
-        "has_time_to_first_token": false
       }
     }
   ]

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-latest-auto-hook.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-latest-auto-hook.span-tree.json
@@ -278,6 +278,49 @@
           }
         },
         {
+          "name": "openai-stream-multiple-choices-operation",
+          "children": [
+            {
+              "name": "Chat Completion",
+              "type": "llm",
+              "children": [],
+              "input": [
+                {
+                  "content_kind": "string",
+                  "role": "user"
+                }
+              ],
+              "output": [
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                },
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                }
+              ],
+              "metadata": {
+                "model": "gpt-4o-mini-2024-07-18",
+                "provider": "openai"
+              },
+              "metrics": {
+                "has_time_to_first_token": true
+              }
+            }
+          ],
+          "input": {
+            "kind": "undefined"
+          },
+          "output": null,
+          "metadata": {
+            "operation": "stream-multiple-choices"
+          },
+          "metrics": {
+            "has_time_to_first_token": false
+          }
+        },
+        {
           "name": "openai-parse-operation",
           "children": [
             {

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-latest-auto-hook.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-latest-auto-hook.span-tree.txt
@@ -8,9 +8,6 @@ span_tree:
       "openaiSdkVersion": "<openai-sdk-version>",
       "scenario": "openai-instrumentation"
     }
-    metrics: {
-      "has_time_to_first_token": false
-    }
     ├── openai-chat-operation
     │   input: {
     │     "kind": "undefined"
@@ -18,9 +15,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "chat"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -40,7 +34,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-with-response-operation
     │   input: {
@@ -50,9 +53,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -71,7 +71,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-tool-operation
     │   input: {
@@ -81,9 +90,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -102,7 +108,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-operation
     │   input: {
@@ -112,9 +127,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -133,7 +145,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 1,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 13
     │       }
     ├── openai-stream-with-response-operation
     │   input: {
@@ -143,9 +164,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -164,7 +182,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 6,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 17,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-stream-tool-operation
     │   input: {
@@ -174,9 +201,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -195,7 +219,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-fixture-operation
     │   input: {
@@ -205,9 +238,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-fixture"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -226,7 +256,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-stream-multiple-choices-operation
     │   input: {
@@ -235,9 +265,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "stream-multiple-choices"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -261,7 +288,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-parse-operation
     │   input: {
@@ -270,9 +297,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "parse"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -294,7 +318,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 5,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 45,
+    │         "time_to_first_token": 0,
+    │         "tokens": 50
     │       }
     ├── openai-sync-stream-operation
     │   input: {
@@ -303,9 +336,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "sync-stream"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -325,7 +355,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 14,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     ├── openai-embeddings-operation
     │   input: {
@@ -334,9 +373,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "embeddings"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Embedding [llm]
     │       input: {
@@ -350,7 +386,8 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": false
+    │         "prompt_tokens": 1,
+    │         "tokens": 1
     │       }
     ├── openai-moderations-operation
     │   input: {
@@ -359,9 +396,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "moderations"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Moderation [llm]
     │       input: {
@@ -375,9 +409,6 @@ span_tree:
     │         "model": "omni-moderation-2024-09-26",
     │         "provider": "openai"
     │       }
-    │       metrics: {
-    │         "has_time_to_first_token": false
-    │       }
     ├── openai-responses-operation
     │   input: {
     │     "kind": "undefined"
@@ -385,9 +416,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "responses"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── openai.responses.create [llm]
     │       input: {
@@ -409,7 +437,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 3,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     ├── openai-responses-with-response-operation
     │   input: {
@@ -419,9 +453,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -442,7 +473,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-create-stream-operation
     │   input: {
@@ -452,9 +489,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-create-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -475,7 +509,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 4,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 17
     │       }
     ├── openai-responses-stream-operation
     │   input: {
@@ -485,9 +525,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -508,7 +545,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-stream-partial-operation
     │   input: {
@@ -518,9 +561,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream-partial"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -541,7 +581,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 3,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     └── openai-responses-parse-operation
         input: {
@@ -550,9 +596,6 @@ span_tree:
         output: null
         metadata: {
           "operation": "responses-parse"
-        }
-        metrics: {
-          "has_time_to_first_token": false
         }
         └── openai.responses.parse [llm]
             input: {
@@ -577,5 +620,11 @@ span_tree:
               "provider": "openai"
             }
             metrics: {
-              "has_time_to_first_token": true
+              "completion_reasoning_tokens": 0,
+              "completion_tokens": 35,
+              "prompt_cache_write_tokens": 0,
+              "prompt_cached_tokens": 0,
+              "prompt_tokens": 46,
+              "time_to_first_token": 0,
+              "tokens": 81
             }

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-latest-auto-hook.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-latest-auto-hook.span-tree.txt
@@ -228,6 +228,41 @@ span_tree:
     │       metrics: {
     │         "has_time_to_first_token": true
     │       }
+    ├── openai-stream-multiple-choices-operation
+    │   input: {
+    │     "kind": "undefined"
+    │   }
+    │   output: null
+    │   metadata: {
+    │     "operation": "stream-multiple-choices"
+    │   }
+    │   metrics: {
+    │     "has_time_to_first_token": false
+    │   }
+    │   └── Chat Completion [llm]
+    │       input: [
+    │         {
+    │           "content_kind": "string",
+    │           "role": "user"
+    │         }
+    │       ]
+    │       output: [
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         },
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         }
+    │       ]
+    │       metadata: {
+    │         "model": "gpt-4o-mini-2024-07-18",
+    │         "provider": "openai"
+    │       }
+    │       metrics: {
+    │         "has_time_to_first_token": true
+    │       }
     ├── openai-parse-operation
     │   input: {
     │     "kind": "undefined"

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-latest-wrapped.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-latest-wrapped.span-tree.json
@@ -278,6 +278,49 @@
           }
         },
         {
+          "name": "openai-stream-multiple-choices-operation",
+          "children": [
+            {
+              "name": "Chat Completion",
+              "type": "llm",
+              "children": [],
+              "input": [
+                {
+                  "content_kind": "string",
+                  "role": "user"
+                }
+              ],
+              "output": [
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                },
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                }
+              ],
+              "metadata": {
+                "model": "gpt-4o-mini-2024-07-18",
+                "provider": "openai"
+              },
+              "metrics": {
+                "has_time_to_first_token": true
+              }
+            }
+          ],
+          "input": {
+            "kind": "undefined"
+          },
+          "output": null,
+          "metadata": {
+            "operation": "stream-multiple-choices"
+          },
+          "metrics": {
+            "has_time_to_first_token": false
+          }
+        },
+        {
           "name": "openai-parse-operation",
           "children": [
             {

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-latest-wrapped.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-latest-wrapped.span-tree.json
@@ -28,7 +28,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -38,9 +47,6 @@
           "output": null,
           "metadata": {
             "operation": "chat"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -67,7 +73,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -77,9 +92,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -106,7 +118,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -116,9 +137,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -145,7 +163,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 1,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 13
               }
             }
           ],
@@ -155,9 +182,6 @@
           "output": null,
           "metadata": {
             "operation": "stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -184,7 +208,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 6,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 17,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -194,9 +227,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -223,7 +253,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -233,9 +272,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -262,7 +298,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -272,9 +308,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-fixture"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -305,7 +338,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -315,9 +348,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-multiple-choices"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -346,7 +376,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 5,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 45,
+                "time_to_first_token": 0,
+                "tokens": 50
               }
             }
           ],
@@ -356,9 +395,6 @@
           "output": null,
           "metadata": {
             "operation": "parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -385,7 +421,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -395,9 +431,6 @@
           "output": null,
           "metadata": {
             "operation": "sync-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -418,7 +451,8 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": false
+                "prompt_tokens": 1,
+                "tokens": 1
               }
             }
           ],
@@ -428,9 +462,6 @@
           "output": null,
           "metadata": {
             "operation": "embeddings"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -450,9 +481,6 @@
               "metadata": {
                 "model": "omni-moderation-2024-09-26",
                 "provider": "openai"
-              },
-              "metrics": {
-                "has_time_to_first_token": false
               }
             }
           ],
@@ -462,9 +490,6 @@
           "output": null,
           "metadata": {
             "operation": "moderations"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -493,7 +518,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 3,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -503,9 +534,6 @@
           "output": null,
           "metadata": {
             "operation": "responses"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -534,7 +562,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -544,9 +578,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -575,7 +606,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 4,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 17
               }
             }
           ],
@@ -585,9 +622,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-create-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -616,7 +650,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -626,9 +666,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -657,7 +694,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 3,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -667,9 +710,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream-partial"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -701,7 +741,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 35,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 46,
+                "time_to_first_token": 0,
+                "tokens": 81
               }
             }
           ],
@@ -711,9 +757,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         }
       ],
@@ -724,9 +767,6 @@
       "metadata": {
         "openaiSdkVersion": "<openai-sdk-version>",
         "scenario": "openai-instrumentation"
-      },
-      "metrics": {
-        "has_time_to_first_token": false
       }
     }
   ]

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-latest-wrapped.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-latest-wrapped.span-tree.txt
@@ -228,6 +228,41 @@ span_tree:
     │       metrics: {
     │         "has_time_to_first_token": true
     │       }
+    ├── openai-stream-multiple-choices-operation
+    │   input: {
+    │     "kind": "undefined"
+    │   }
+    │   output: null
+    │   metadata: {
+    │     "operation": "stream-multiple-choices"
+    │   }
+    │   metrics: {
+    │     "has_time_to_first_token": false
+    │   }
+    │   └── Chat Completion [llm]
+    │       input: [
+    │         {
+    │           "content_kind": "string",
+    │           "role": "user"
+    │         }
+    │       ]
+    │       output: [
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         },
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         }
+    │       ]
+    │       metadata: {
+    │         "model": "gpt-4o-mini-2024-07-18",
+    │         "provider": "openai"
+    │       }
+    │       metrics: {
+    │         "has_time_to_first_token": true
+    │       }
     ├── openai-parse-operation
     │   input: {
     │     "kind": "undefined"

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-latest-wrapped.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-latest-wrapped.span-tree.txt
@@ -8,9 +8,6 @@ span_tree:
       "openaiSdkVersion": "<openai-sdk-version>",
       "scenario": "openai-instrumentation"
     }
-    metrics: {
-      "has_time_to_first_token": false
-    }
     ├── openai-chat-operation
     │   input: {
     │     "kind": "undefined"
@@ -18,9 +15,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "chat"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -40,7 +34,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-with-response-operation
     │   input: {
@@ -50,9 +53,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -71,7 +71,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-tool-operation
     │   input: {
@@ -81,9 +90,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -102,7 +108,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-operation
     │   input: {
@@ -112,9 +127,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -133,7 +145,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 1,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 13
     │       }
     ├── openai-stream-with-response-operation
     │   input: {
@@ -143,9 +164,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -164,7 +182,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 6,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 17,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-stream-tool-operation
     │   input: {
@@ -174,9 +201,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -195,7 +219,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-fixture-operation
     │   input: {
@@ -205,9 +238,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-fixture"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -226,7 +256,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-stream-multiple-choices-operation
     │   input: {
@@ -235,9 +265,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "stream-multiple-choices"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -261,7 +288,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-parse-operation
     │   input: {
@@ -270,9 +297,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "parse"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -294,7 +318,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 5,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 45,
+    │         "time_to_first_token": 0,
+    │         "tokens": 50
     │       }
     ├── openai-sync-stream-operation
     │   input: {
@@ -303,9 +336,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "sync-stream"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -325,7 +355,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-embeddings-operation
     │   input: {
@@ -334,9 +364,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "embeddings"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Embedding [llm]
     │       input: {
@@ -350,7 +377,8 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": false
+    │         "prompt_tokens": 1,
+    │         "tokens": 1
     │       }
     ├── openai-moderations-operation
     │   input: {
@@ -359,9 +387,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "moderations"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Moderation [llm]
     │       input: {
@@ -375,9 +400,6 @@ span_tree:
     │         "model": "omni-moderation-2024-09-26",
     │         "provider": "openai"
     │       }
-    │       metrics: {
-    │         "has_time_to_first_token": false
-    │       }
     ├── openai-responses-operation
     │   input: {
     │     "kind": "undefined"
@@ -385,9 +407,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "responses"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── openai.responses.create [llm]
     │       input: {
@@ -409,7 +428,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 3,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     ├── openai-responses-with-response-operation
     │   input: {
@@ -419,9 +444,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -442,7 +464,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-create-stream-operation
     │   input: {
@@ -452,9 +480,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-create-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -475,7 +500,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 4,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 17
     │       }
     ├── openai-responses-stream-operation
     │   input: {
@@ -485,9 +516,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -508,7 +536,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-stream-partial-operation
     │   input: {
@@ -518,9 +552,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream-partial"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -541,7 +572,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 3,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     └── openai-responses-parse-operation
         input: {
@@ -550,9 +587,6 @@ span_tree:
         output: null
         metadata: {
           "operation": "responses-parse"
-        }
-        metrics: {
-          "has_time_to_first_token": false
         }
         └── openai.responses.parse [llm]
             input: {
@@ -577,5 +611,11 @@ span_tree:
               "provider": "openai"
             }
             metrics: {
-              "has_time_to_first_token": true
+              "completion_reasoning_tokens": 0,
+              "completion_tokens": 35,
+              "prompt_cache_write_tokens": 0,
+              "prompt_cached_tokens": 0,
+              "prompt_tokens": 46,
+              "time_to_first_token": 0,
+              "tokens": 81
             }

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-wrapped.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-wrapped.span-tree.json
@@ -28,7 +28,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -38,9 +47,6 @@
           "output": null,
           "metadata": {
             "operation": "chat"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -67,7 +73,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -77,9 +92,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -106,7 +118,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -116,9 +137,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -145,7 +163,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 1,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 13
               }
             }
           ],
@@ -155,9 +182,6 @@
           "output": null,
           "metadata": {
             "operation": "stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -184,7 +208,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 6,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 17,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -194,9 +227,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -223,7 +253,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -233,9 +272,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -262,7 +298,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -272,9 +308,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-fixture"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -305,7 +338,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -315,9 +348,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-multiple-choices"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -346,7 +376,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 5,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 45,
+                "time_to_first_token": 0,
+                "tokens": 50
               }
             }
           ],
@@ -356,9 +395,6 @@
           "output": null,
           "metadata": {
             "operation": "parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -385,7 +421,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -395,9 +431,6 @@
           "output": null,
           "metadata": {
             "operation": "sync-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -418,7 +451,8 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": false
+                "prompt_tokens": 1,
+                "tokens": 1
               }
             }
           ],
@@ -428,9 +462,6 @@
           "output": null,
           "metadata": {
             "operation": "embeddings"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -450,9 +481,6 @@
               "metadata": {
                 "model": "omni-moderation-2024-09-26",
                 "provider": "openai"
-              },
-              "metrics": {
-                "has_time_to_first_token": false
               }
             }
           ],
@@ -462,9 +490,6 @@
           "output": null,
           "metadata": {
             "operation": "moderations"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -493,7 +518,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 3,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -503,9 +534,6 @@
           "output": null,
           "metadata": {
             "operation": "responses"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -534,7 +562,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -544,9 +578,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -575,7 +606,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 5,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 18
               }
             }
           ],
@@ -585,9 +622,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-create-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -616,7 +650,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -626,9 +666,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -657,7 +694,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 3,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -667,9 +710,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream-partial"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -701,7 +741,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 26,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 46,
+                "time_to_first_token": 0,
+                "tokens": 72
               }
             }
           ],
@@ -711,9 +757,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         }
       ],
@@ -724,9 +767,6 @@
       "metadata": {
         "openaiSdkVersion": "<openai-sdk-version>",
         "scenario": "openai-instrumentation"
-      },
-      "metrics": {
-        "has_time_to_first_token": false
       }
     }
   ]

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-wrapped.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-wrapped.span-tree.json
@@ -278,6 +278,49 @@
           }
         },
         {
+          "name": "openai-stream-multiple-choices-operation",
+          "children": [
+            {
+              "name": "Chat Completion",
+              "type": "llm",
+              "children": [],
+              "input": [
+                {
+                  "content_kind": "string",
+                  "role": "user"
+                }
+              ],
+              "output": [
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                },
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                }
+              ],
+              "metadata": {
+                "model": "gpt-4o-mini-2024-07-18",
+                "provider": "openai"
+              },
+              "metrics": {
+                "has_time_to_first_token": true
+              }
+            }
+          ],
+          "input": {
+            "kind": "undefined"
+          },
+          "output": null,
+          "metadata": {
+            "operation": "stream-multiple-choices"
+          },
+          "metrics": {
+            "has_time_to_first_token": false
+          }
+        },
+        {
           "name": "openai-parse-operation",
           "children": [
             {

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-wrapped.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-wrapped.span-tree.txt
@@ -228,6 +228,41 @@ span_tree:
     │       metrics: {
     │         "has_time_to_first_token": true
     │       }
+    ├── openai-stream-multiple-choices-operation
+    │   input: {
+    │     "kind": "undefined"
+    │   }
+    │   output: null
+    │   metadata: {
+    │     "operation": "stream-multiple-choices"
+    │   }
+    │   metrics: {
+    │     "has_time_to_first_token": false
+    │   }
+    │   └── Chat Completion [llm]
+    │       input: [
+    │         {
+    │           "content_kind": "string",
+    │           "role": "user"
+    │         }
+    │       ]
+    │       output: [
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         },
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         }
+    │       ]
+    │       metadata: {
+    │         "model": "gpt-4o-mini-2024-07-18",
+    │         "provider": "openai"
+    │       }
+    │       metrics: {
+    │         "has_time_to_first_token": true
+    │       }
     ├── openai-parse-operation
     │   input: {
     │     "kind": "undefined"

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-wrapped.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v5-wrapped.span-tree.txt
@@ -8,9 +8,6 @@ span_tree:
       "openaiSdkVersion": "<openai-sdk-version>",
       "scenario": "openai-instrumentation"
     }
-    metrics: {
-      "has_time_to_first_token": false
-    }
     ├── openai-chat-operation
     │   input: {
     │     "kind": "undefined"
@@ -18,9 +15,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "chat"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -40,7 +34,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-with-response-operation
     │   input: {
@@ -50,9 +53,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -71,7 +71,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-tool-operation
     │   input: {
@@ -81,9 +90,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -102,7 +108,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-operation
     │   input: {
@@ -112,9 +127,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -133,7 +145,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 1,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 13
     │       }
     ├── openai-stream-with-response-operation
     │   input: {
@@ -143,9 +164,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -164,7 +182,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 6,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 17,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-stream-tool-operation
     │   input: {
@@ -174,9 +201,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -195,7 +219,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-fixture-operation
     │   input: {
@@ -205,9 +238,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-fixture"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -226,7 +256,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-stream-multiple-choices-operation
     │   input: {
@@ -235,9 +265,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "stream-multiple-choices"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -261,7 +288,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-parse-operation
     │   input: {
@@ -270,9 +297,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "parse"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -294,7 +318,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 5,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 45,
+    │         "time_to_first_token": 0,
+    │         "tokens": 50
     │       }
     ├── openai-sync-stream-operation
     │   input: {
@@ -303,9 +336,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "sync-stream"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -325,7 +355,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-embeddings-operation
     │   input: {
@@ -334,9 +364,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "embeddings"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Embedding [llm]
     │       input: {
@@ -350,7 +377,8 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": false
+    │         "prompt_tokens": 1,
+    │         "tokens": 1
     │       }
     ├── openai-moderations-operation
     │   input: {
@@ -359,9 +387,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "moderations"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Moderation [llm]
     │       input: {
@@ -375,9 +400,6 @@ span_tree:
     │         "model": "omni-moderation-2024-09-26",
     │         "provider": "openai"
     │       }
-    │       metrics: {
-    │         "has_time_to_first_token": false
-    │       }
     ├── openai-responses-operation
     │   input: {
     │     "kind": "undefined"
@@ -385,9 +407,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "responses"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── openai.responses.create [llm]
     │       input: {
@@ -409,7 +428,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 3,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     ├── openai-responses-with-response-operation
     │   input: {
@@ -419,9 +444,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -442,7 +464,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-create-stream-operation
     │   input: {
@@ -452,9 +480,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-create-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -475,7 +500,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 5,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 18
     │       }
     ├── openai-responses-stream-operation
     │   input: {
@@ -485,9 +516,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -508,7 +536,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-stream-partial-operation
     │   input: {
@@ -518,9 +552,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream-partial"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -541,7 +572,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 3,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     └── openai-responses-parse-operation
         input: {
@@ -550,9 +587,6 @@ span_tree:
         output: null
         metadata: {
           "operation": "responses-parse"
-        }
-        metrics: {
-          "has_time_to_first_token": false
         }
         └── openai.responses.parse [llm]
             input: {
@@ -577,5 +611,11 @@ span_tree:
               "provider": "openai"
             }
             metrics: {
-              "has_time_to_first_token": true
+              "completion_reasoning_tokens": 0,
+              "completion_tokens": 26,
+              "prompt_cache_write_tokens": 0,
+              "prompt_cached_tokens": 0,
+              "prompt_tokens": 46,
+              "time_to_first_token": 0,
+              "tokens": 72
             }

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-auto-hook.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-auto-hook.span-tree.json
@@ -356,6 +356,49 @@
           }
         },
         {
+          "name": "openai-stream-multiple-choices-operation",
+          "children": [
+            {
+              "name": "Chat Completion",
+              "type": "llm",
+              "children": [],
+              "input": [
+                {
+                  "content_kind": "string",
+                  "role": "user"
+                }
+              ],
+              "output": [
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                },
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                }
+              ],
+              "metadata": {
+                "model": "gpt-4o-mini-2024-07-18",
+                "provider": "openai"
+              },
+              "metrics": {
+                "has_time_to_first_token": true
+              }
+            }
+          ],
+          "input": {
+            "kind": "undefined"
+          },
+          "output": null,
+          "metadata": {
+            "operation": "stream-multiple-choices"
+          },
+          "metrics": {
+            "has_time_to_first_token": false
+          }
+        },
+        {
           "name": "openai-parse-operation",
           "children": [
             {

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-auto-hook.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-auto-hook.span-tree.json
@@ -28,7 +28,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -38,9 +47,6 @@
           "output": null,
           "metadata": {
             "operation": "chat"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -67,7 +73,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -77,9 +92,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -106,7 +118,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 3,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 8516,
+                "time_to_first_token": 0,
+                "tokens": 8519
               }
             }
           ],
@@ -116,9 +137,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-image-attachment"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -145,7 +163,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 24,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 236,
+                "time_to_first_token": 0,
+                "tokens": 260
               }
             }
           ],
@@ -155,9 +182,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-pdf-attachment"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -184,7 +208,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -194,9 +227,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -223,7 +253,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 1,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 13
               }
             }
           ],
@@ -233,9 +272,6 @@
           "output": null,
           "metadata": {
             "operation": "stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -262,7 +298,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 6,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 17,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -272,9 +317,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -301,7 +343,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -311,9 +362,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -340,7 +388,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -350,9 +398,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-fixture"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -383,7 +428,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -393,9 +438,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-multiple-choices"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -424,7 +466,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 5,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 45,
+                "time_to_first_token": 0,
+                "tokens": 50
               }
             }
           ],
@@ -434,9 +485,6 @@
           "output": null,
           "metadata": {
             "operation": "parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -463,7 +511,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 14,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -473,9 +530,6 @@
           "output": null,
           "metadata": {
             "operation": "sync-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -496,7 +550,8 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": false
+                "prompt_tokens": 1,
+                "tokens": 1
               }
             }
           ],
@@ -506,9 +561,6 @@
           "output": null,
           "metadata": {
             "operation": "embeddings"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -528,9 +580,6 @@
               "metadata": {
                 "model": "omni-moderation-2024-09-26",
                 "provider": "openai"
-              },
-              "metrics": {
-                "has_time_to_first_token": false
               }
             }
           ],
@@ -540,9 +589,6 @@
           "output": null,
           "metadata": {
             "operation": "moderations"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -571,7 +617,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 3,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -581,9 +633,6 @@
           "output": null,
           "metadata": {
             "operation": "responses"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -612,7 +661,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -622,9 +677,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -653,7 +705,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 4,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 17
               }
             }
           ],
@@ -663,9 +721,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-create-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -694,7 +749,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -704,9 +765,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -735,7 +793,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 3,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -745,9 +809,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream-partial"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -779,7 +840,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 17,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 46,
+                "time_to_first_token": 0,
+                "tokens": 63
               }
             }
           ],
@@ -789,9 +856,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -834,7 +898,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 204,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 133,
+                "time_to_first_token": 0,
+                "tokens": 337
               }
             }
           ],
@@ -844,9 +914,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-compact"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         }
       ],
@@ -857,9 +924,6 @@
       "metadata": {
         "openaiSdkVersion": "<openai-sdk-version>",
         "scenario": "openai-instrumentation"
-      },
-      "metrics": {
-        "has_time_to_first_token": false
       }
     }
   ]

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-auto-hook.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-auto-hook.span-tree.txt
@@ -290,6 +290,41 @@ span_tree:
     │       metrics: {
     │         "has_time_to_first_token": true
     │       }
+    ├── openai-stream-multiple-choices-operation
+    │   input: {
+    │     "kind": "undefined"
+    │   }
+    │   output: null
+    │   metadata: {
+    │     "operation": "stream-multiple-choices"
+    │   }
+    │   metrics: {
+    │     "has_time_to_first_token": false
+    │   }
+    │   └── Chat Completion [llm]
+    │       input: [
+    │         {
+    │           "content_kind": "string",
+    │           "role": "user"
+    │         }
+    │       ]
+    │       output: [
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         },
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         }
+    │       ]
+    │       metadata: {
+    │         "model": "gpt-4o-mini-2024-07-18",
+    │         "provider": "openai"
+    │       }
+    │       metrics: {
+    │         "has_time_to_first_token": true
+    │       }
     ├── openai-parse-operation
     │   input: {
     │     "kind": "undefined"

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-auto-hook.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-auto-hook.span-tree.txt
@@ -8,9 +8,6 @@ span_tree:
       "openaiSdkVersion": "<openai-sdk-version>",
       "scenario": "openai-instrumentation"
     }
-    metrics: {
-      "has_time_to_first_token": false
-    }
     ├── openai-chat-operation
     │   input: {
     │     "kind": "undefined"
@@ -18,9 +15,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "chat"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -40,7 +34,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-with-response-operation
     │   input: {
@@ -50,9 +53,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -71,7 +71,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-image-attachment-operation
     │   input: {
@@ -81,9 +90,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-image-attachment"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -102,7 +108,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 3,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 8516,
+    │         "time_to_first_token": 0,
+    │         "tokens": 8519
     │       }
     ├── openai-chat-pdf-attachment-operation
     │   input: {
@@ -112,9 +127,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-pdf-attachment"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -133,7 +145,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 24,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 236,
+    │         "time_to_first_token": 0,
+    │         "tokens": 260
     │       }
     ├── openai-chat-tool-operation
     │   input: {
@@ -143,9 +164,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -164,7 +182,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-operation
     │   input: {
@@ -174,9 +201,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -195,7 +219,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 1,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 13
     │       }
     ├── openai-stream-with-response-operation
     │   input: {
@@ -205,9 +238,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -226,7 +256,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 6,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 17,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-stream-tool-operation
     │   input: {
@@ -236,9 +275,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -257,7 +293,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-fixture-operation
     │   input: {
@@ -267,9 +312,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-fixture"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -288,7 +330,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-stream-multiple-choices-operation
     │   input: {
@@ -297,9 +339,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "stream-multiple-choices"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -323,7 +362,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-parse-operation
     │   input: {
@@ -332,9 +371,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "parse"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -356,7 +392,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 5,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 45,
+    │         "time_to_first_token": 0,
+    │         "tokens": 50
     │       }
     ├── openai-sync-stream-operation
     │   input: {
@@ -365,9 +410,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "sync-stream"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -387,7 +429,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 14,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     ├── openai-embeddings-operation
     │   input: {
@@ -396,9 +447,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "embeddings"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Embedding [llm]
     │       input: {
@@ -412,7 +460,8 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": false
+    │         "prompt_tokens": 1,
+    │         "tokens": 1
     │       }
     ├── openai-moderations-operation
     │   input: {
@@ -421,9 +470,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "moderations"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Moderation [llm]
     │       input: {
@@ -437,9 +483,6 @@ span_tree:
     │         "model": "omni-moderation-2024-09-26",
     │         "provider": "openai"
     │       }
-    │       metrics: {
-    │         "has_time_to_first_token": false
-    │       }
     ├── openai-responses-operation
     │   input: {
     │     "kind": "undefined"
@@ -447,9 +490,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "responses"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── openai.responses.create [llm]
     │       input: {
@@ -471,7 +511,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 3,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     ├── openai-responses-with-response-operation
     │   input: {
@@ -481,9 +527,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -504,7 +547,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-create-stream-operation
     │   input: {
@@ -514,9 +563,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-create-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -537,7 +583,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 4,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 17
     │       }
     ├── openai-responses-stream-operation
     │   input: {
@@ -547,9 +599,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -570,7 +619,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-stream-partial-operation
     │   input: {
@@ -580,9 +635,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream-partial"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -603,7 +655,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 3,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     ├── openai-responses-parse-operation
     │   input: {
@@ -612,9 +670,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "responses-parse"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── openai.responses.parse [llm]
     │       input: {
@@ -639,7 +694,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 17,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 46,
+    │         "time_to_first_token": 0,
+    │         "tokens": 63
     │       }
     └── openai-responses-compact-operation
         input: {
@@ -648,9 +709,6 @@ span_tree:
         output: null
         metadata: {
           "operation": "responses-compact"
-        }
-        metrics: {
-          "has_time_to_first_token": false
         }
         └── openai.responses.compact [llm]
             input: [
@@ -686,5 +744,11 @@ span_tree:
               "provider": "openai"
             }
             metrics: {
-              "has_time_to_first_token": true
+              "completion_reasoning_tokens": 0,
+              "completion_tokens": 204,
+              "prompt_cache_write_tokens": 0,
+              "prompt_cached_tokens": 0,
+              "prompt_tokens": 133,
+              "time_to_first_token": 0,
+              "tokens": 337
             }

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-latest-auto-hook.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-latest-auto-hook.span-tree.json
@@ -28,7 +28,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -38,9 +47,6 @@
           "output": null,
           "metadata": {
             "operation": "chat"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -67,7 +73,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -77,9 +92,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -106,7 +118,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 3,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 8516,
+                "time_to_first_token": 0,
+                "tokens": 8519
               }
             }
           ],
@@ -116,9 +137,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-image-attachment"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -145,7 +163,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 24,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 236,
+                "time_to_first_token": 0,
+                "tokens": 260
               }
             }
           ],
@@ -155,9 +182,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-pdf-attachment"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -184,7 +208,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -194,9 +227,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -223,7 +253,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 1,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 13
               }
             }
           ],
@@ -233,9 +272,6 @@
           "output": null,
           "metadata": {
             "operation": "stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -262,7 +298,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 6,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 17,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -272,9 +317,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -301,7 +343,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -311,9 +362,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -340,7 +388,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -350,9 +398,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-fixture"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -383,7 +428,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -393,9 +438,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-multiple-choices"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -424,7 +466,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 5,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 45,
+                "time_to_first_token": 0,
+                "tokens": 50
               }
             }
           ],
@@ -434,9 +485,6 @@
           "output": null,
           "metadata": {
             "operation": "parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -463,7 +511,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 14,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -473,9 +530,6 @@
           "output": null,
           "metadata": {
             "operation": "sync-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -496,7 +550,8 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": false
+                "prompt_tokens": 1,
+                "tokens": 1
               }
             }
           ],
@@ -506,9 +561,6 @@
           "output": null,
           "metadata": {
             "operation": "embeddings"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -528,9 +580,6 @@
               "metadata": {
                 "model": "omni-moderation-2024-09-26",
                 "provider": "openai"
-              },
-              "metrics": {
-                "has_time_to_first_token": false
               }
             }
           ],
@@ -540,9 +589,6 @@
           "output": null,
           "metadata": {
             "operation": "moderations"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -571,7 +617,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 4,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 17
               }
             }
           ],
@@ -581,9 +633,6 @@
           "output": null,
           "metadata": {
             "operation": "responses"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -612,7 +661,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -622,9 +677,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -653,7 +705,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 4,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 17
               }
             }
           ],
@@ -663,9 +721,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-create-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -694,7 +749,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -704,9 +765,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -735,7 +793,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 3,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -745,9 +809,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream-partial"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -779,7 +840,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 24,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 46,
+                "time_to_first_token": 0,
+                "tokens": 70
               }
             }
           ],
@@ -789,9 +856,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -834,7 +898,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 235,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 133,
+                "time_to_first_token": 0,
+                "tokens": 368
               }
             }
           ],
@@ -844,9 +914,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-compact"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         }
       ],
@@ -857,9 +924,6 @@
       "metadata": {
         "openaiSdkVersion": "<openai-sdk-version>",
         "scenario": "openai-instrumentation"
-      },
-      "metrics": {
-        "has_time_to_first_token": false
       }
     }
   ]

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-latest-auto-hook.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-latest-auto-hook.span-tree.json
@@ -356,6 +356,49 @@
           }
         },
         {
+          "name": "openai-stream-multiple-choices-operation",
+          "children": [
+            {
+              "name": "Chat Completion",
+              "type": "llm",
+              "children": [],
+              "input": [
+                {
+                  "content_kind": "string",
+                  "role": "user"
+                }
+              ],
+              "output": [
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                },
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                }
+              ],
+              "metadata": {
+                "model": "gpt-4o-mini-2024-07-18",
+                "provider": "openai"
+              },
+              "metrics": {
+                "has_time_to_first_token": true
+              }
+            }
+          ],
+          "input": {
+            "kind": "undefined"
+          },
+          "output": null,
+          "metadata": {
+            "operation": "stream-multiple-choices"
+          },
+          "metrics": {
+            "has_time_to_first_token": false
+          }
+        },
+        {
           "name": "openai-parse-operation",
           "children": [
             {

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-latest-auto-hook.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-latest-auto-hook.span-tree.txt
@@ -290,6 +290,41 @@ span_tree:
     │       metrics: {
     │         "has_time_to_first_token": true
     │       }
+    ├── openai-stream-multiple-choices-operation
+    │   input: {
+    │     "kind": "undefined"
+    │   }
+    │   output: null
+    │   metadata: {
+    │     "operation": "stream-multiple-choices"
+    │   }
+    │   metrics: {
+    │     "has_time_to_first_token": false
+    │   }
+    │   └── Chat Completion [llm]
+    │       input: [
+    │         {
+    │           "content_kind": "string",
+    │           "role": "user"
+    │         }
+    │       ]
+    │       output: [
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         },
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         }
+    │       ]
+    │       metadata: {
+    │         "model": "gpt-4o-mini-2024-07-18",
+    │         "provider": "openai"
+    │       }
+    │       metrics: {
+    │         "has_time_to_first_token": true
+    │       }
     ├── openai-parse-operation
     │   input: {
     │     "kind": "undefined"

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-latest-auto-hook.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-latest-auto-hook.span-tree.txt
@@ -8,9 +8,6 @@ span_tree:
       "openaiSdkVersion": "<openai-sdk-version>",
       "scenario": "openai-instrumentation"
     }
-    metrics: {
-      "has_time_to_first_token": false
-    }
     ├── openai-chat-operation
     │   input: {
     │     "kind": "undefined"
@@ -18,9 +15,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "chat"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -40,7 +34,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-with-response-operation
     │   input: {
@@ -50,9 +53,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -71,7 +71,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-image-attachment-operation
     │   input: {
@@ -81,9 +90,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-image-attachment"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -102,7 +108,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 3,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 8516,
+    │         "time_to_first_token": 0,
+    │         "tokens": 8519
     │       }
     ├── openai-chat-pdf-attachment-operation
     │   input: {
@@ -112,9 +127,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-pdf-attachment"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -133,7 +145,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 24,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 236,
+    │         "time_to_first_token": 0,
+    │         "tokens": 260
     │       }
     ├── openai-chat-tool-operation
     │   input: {
@@ -143,9 +164,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -164,7 +182,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-operation
     │   input: {
@@ -174,9 +201,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -195,7 +219,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 1,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 13
     │       }
     ├── openai-stream-with-response-operation
     │   input: {
@@ -205,9 +238,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -226,7 +256,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 6,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 17,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-stream-tool-operation
     │   input: {
@@ -236,9 +275,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -257,7 +293,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-fixture-operation
     │   input: {
@@ -267,9 +312,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-fixture"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -288,7 +330,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-stream-multiple-choices-operation
     │   input: {
@@ -297,9 +339,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "stream-multiple-choices"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -323,7 +362,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-parse-operation
     │   input: {
@@ -332,9 +371,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "parse"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -356,7 +392,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 5,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 45,
+    │         "time_to_first_token": 0,
+    │         "tokens": 50
     │       }
     ├── openai-sync-stream-operation
     │   input: {
@@ -365,9 +410,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "sync-stream"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -387,7 +429,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 14,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     ├── openai-embeddings-operation
     │   input: {
@@ -396,9 +447,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "embeddings"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Embedding [llm]
     │       input: {
@@ -412,7 +460,8 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": false
+    │         "prompt_tokens": 1,
+    │         "tokens": 1
     │       }
     ├── openai-moderations-operation
     │   input: {
@@ -421,9 +470,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "moderations"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Moderation [llm]
     │       input: {
@@ -437,9 +483,6 @@ span_tree:
     │         "model": "omni-moderation-2024-09-26",
     │         "provider": "openai"
     │       }
-    │       metrics: {
-    │         "has_time_to_first_token": false
-    │       }
     ├── openai-responses-operation
     │   input: {
     │     "kind": "undefined"
@@ -447,9 +490,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "responses"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── openai.responses.create [llm]
     │       input: {
@@ -471,7 +511,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 4,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 17
     │       }
     ├── openai-responses-with-response-operation
     │   input: {
@@ -481,9 +527,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -504,7 +547,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-create-stream-operation
     │   input: {
@@ -514,9 +563,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-create-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -537,7 +583,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 4,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 17
     │       }
     ├── openai-responses-stream-operation
     │   input: {
@@ -547,9 +599,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -570,7 +619,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-stream-partial-operation
     │   input: {
@@ -580,9 +635,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream-partial"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -603,7 +655,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 3,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     ├── openai-responses-parse-operation
     │   input: {
@@ -612,9 +670,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "responses-parse"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── openai.responses.parse [llm]
     │       input: {
@@ -639,7 +694,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 24,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 46,
+    │         "time_to_first_token": 0,
+    │         "tokens": 70
     │       }
     └── openai-responses-compact-operation
         input: {
@@ -648,9 +709,6 @@ span_tree:
         output: null
         metadata: {
           "operation": "responses-compact"
-        }
-        metrics: {
-          "has_time_to_first_token": false
         }
         └── openai.responses.compact [llm]
             input: [
@@ -686,5 +744,11 @@ span_tree:
               "provider": "openai"
             }
             metrics: {
-              "has_time_to_first_token": true
+              "completion_reasoning_tokens": 0,
+              "completion_tokens": 235,
+              "prompt_cache_write_tokens": 0,
+              "prompt_cached_tokens": 0,
+              "prompt_tokens": 133,
+              "time_to_first_token": 0,
+              "tokens": 368
             }

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-latest-wrapped.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-latest-wrapped.span-tree.json
@@ -356,6 +356,49 @@
           }
         },
         {
+          "name": "openai-stream-multiple-choices-operation",
+          "children": [
+            {
+              "name": "Chat Completion",
+              "type": "llm",
+              "children": [],
+              "input": [
+                {
+                  "content_kind": "string",
+                  "role": "user"
+                }
+              ],
+              "output": [
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                },
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                }
+              ],
+              "metadata": {
+                "model": "gpt-4o-mini-2024-07-18",
+                "provider": "openai"
+              },
+              "metrics": {
+                "has_time_to_first_token": true
+              }
+            }
+          ],
+          "input": {
+            "kind": "undefined"
+          },
+          "output": null,
+          "metadata": {
+            "operation": "stream-multiple-choices"
+          },
+          "metrics": {
+            "has_time_to_first_token": false
+          }
+        },
+        {
           "name": "openai-parse-operation",
           "children": [
             {

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-latest-wrapped.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-latest-wrapped.span-tree.json
@@ -28,7 +28,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -38,9 +47,6 @@
           "output": null,
           "metadata": {
             "operation": "chat"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -67,7 +73,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -77,9 +92,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -106,7 +118,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 3,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 8516,
+                "time_to_first_token": 0,
+                "tokens": 8519
               }
             }
           ],
@@ -116,9 +137,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-image-attachment"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -145,7 +163,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 24,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 236,
+                "time_to_first_token": 0,
+                "tokens": 260
               }
             }
           ],
@@ -155,9 +182,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-pdf-attachment"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -184,7 +208,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -194,9 +227,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -223,7 +253,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 1,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 13
               }
             }
           ],
@@ -233,9 +272,6 @@
           "output": null,
           "metadata": {
             "operation": "stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -262,7 +298,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 6,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 17,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -272,9 +317,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -301,7 +343,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -311,9 +362,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -340,7 +388,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -350,9 +398,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-fixture"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -383,7 +428,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -393,9 +438,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-multiple-choices"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -424,7 +466,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 5,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 45,
+                "time_to_first_token": 0,
+                "tokens": 50
               }
             }
           ],
@@ -434,9 +485,6 @@
           "output": null,
           "metadata": {
             "operation": "parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -463,7 +511,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -473,9 +521,6 @@
           "output": null,
           "metadata": {
             "operation": "sync-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -496,7 +541,8 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": false
+                "prompt_tokens": 1,
+                "tokens": 1
               }
             }
           ],
@@ -506,9 +552,6 @@
           "output": null,
           "metadata": {
             "operation": "embeddings"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -528,9 +571,6 @@
               "metadata": {
                 "model": "omni-moderation-2024-09-26",
                 "provider": "openai"
-              },
-              "metrics": {
-                "has_time_to_first_token": false
               }
             }
           ],
@@ -540,9 +580,6 @@
           "output": null,
           "metadata": {
             "operation": "moderations"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -571,7 +608,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 4,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 17
               }
             }
           ],
@@ -581,9 +624,6 @@
           "output": null,
           "metadata": {
             "operation": "responses"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -612,7 +652,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -622,9 +668,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -653,7 +696,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 4,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 17
               }
             }
           ],
@@ -663,9 +712,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-create-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -694,7 +740,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -704,9 +756,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -735,7 +784,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 3,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -745,9 +800,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream-partial"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -779,7 +831,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 24,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 46,
+                "time_to_first_token": 0,
+                "tokens": 70
               }
             }
           ],
@@ -789,9 +847,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -834,7 +889,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 235,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 133,
+                "time_to_first_token": 0,
+                "tokens": 368
               }
             }
           ],
@@ -844,9 +905,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-compact"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         }
       ],
@@ -857,9 +915,6 @@
       "metadata": {
         "openaiSdkVersion": "<openai-sdk-version>",
         "scenario": "openai-instrumentation"
-      },
-      "metrics": {
-        "has_time_to_first_token": false
       }
     }
   ]

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-latest-wrapped.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-latest-wrapped.span-tree.txt
@@ -290,6 +290,41 @@ span_tree:
     │       metrics: {
     │         "has_time_to_first_token": true
     │       }
+    ├── openai-stream-multiple-choices-operation
+    │   input: {
+    │     "kind": "undefined"
+    │   }
+    │   output: null
+    │   metadata: {
+    │     "operation": "stream-multiple-choices"
+    │   }
+    │   metrics: {
+    │     "has_time_to_first_token": false
+    │   }
+    │   └── Chat Completion [llm]
+    │       input: [
+    │         {
+    │           "content_kind": "string",
+    │           "role": "user"
+    │         }
+    │       ]
+    │       output: [
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         },
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         }
+    │       ]
+    │       metadata: {
+    │         "model": "gpt-4o-mini-2024-07-18",
+    │         "provider": "openai"
+    │       }
+    │       metrics: {
+    │         "has_time_to_first_token": true
+    │       }
     ├── openai-parse-operation
     │   input: {
     │     "kind": "undefined"

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-latest-wrapped.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-latest-wrapped.span-tree.txt
@@ -8,9 +8,6 @@ span_tree:
       "openaiSdkVersion": "<openai-sdk-version>",
       "scenario": "openai-instrumentation"
     }
-    metrics: {
-      "has_time_to_first_token": false
-    }
     ├── openai-chat-operation
     │   input: {
     │     "kind": "undefined"
@@ -18,9 +15,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "chat"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -40,7 +34,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-with-response-operation
     │   input: {
@@ -50,9 +53,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -71,7 +71,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-image-attachment-operation
     │   input: {
@@ -81,9 +90,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-image-attachment"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -102,7 +108,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 3,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 8516,
+    │         "time_to_first_token": 0,
+    │         "tokens": 8519
     │       }
     ├── openai-chat-pdf-attachment-operation
     │   input: {
@@ -112,9 +127,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-pdf-attachment"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -133,7 +145,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 24,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 236,
+    │         "time_to_first_token": 0,
+    │         "tokens": 260
     │       }
     ├── openai-chat-tool-operation
     │   input: {
@@ -143,9 +164,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -164,7 +182,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-operation
     │   input: {
@@ -174,9 +201,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -195,7 +219,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 1,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 13
     │       }
     ├── openai-stream-with-response-operation
     │   input: {
@@ -205,9 +238,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -226,7 +256,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 6,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 17,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-stream-tool-operation
     │   input: {
@@ -236,9 +275,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -257,7 +293,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-fixture-operation
     │   input: {
@@ -267,9 +312,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-fixture"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -288,7 +330,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-stream-multiple-choices-operation
     │   input: {
@@ -297,9 +339,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "stream-multiple-choices"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -323,7 +362,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-parse-operation
     │   input: {
@@ -332,9 +371,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "parse"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -356,7 +392,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 5,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 45,
+    │         "time_to_first_token": 0,
+    │         "tokens": 50
     │       }
     ├── openai-sync-stream-operation
     │   input: {
@@ -365,9 +410,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "sync-stream"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -387,7 +429,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-embeddings-operation
     │   input: {
@@ -396,9 +438,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "embeddings"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Embedding [llm]
     │       input: {
@@ -412,7 +451,8 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": false
+    │         "prompt_tokens": 1,
+    │         "tokens": 1
     │       }
     ├── openai-moderations-operation
     │   input: {
@@ -421,9 +461,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "moderations"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Moderation [llm]
     │       input: {
@@ -437,9 +474,6 @@ span_tree:
     │         "model": "omni-moderation-2024-09-26",
     │         "provider": "openai"
     │       }
-    │       metrics: {
-    │         "has_time_to_first_token": false
-    │       }
     ├── openai-responses-operation
     │   input: {
     │     "kind": "undefined"
@@ -447,9 +481,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "responses"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── openai.responses.create [llm]
     │       input: {
@@ -471,7 +502,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 4,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 17
     │       }
     ├── openai-responses-with-response-operation
     │   input: {
@@ -481,9 +518,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -504,7 +538,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-create-stream-operation
     │   input: {
@@ -514,9 +554,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-create-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -537,7 +574,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 4,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 17
     │       }
     ├── openai-responses-stream-operation
     │   input: {
@@ -547,9 +590,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -570,7 +610,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-stream-partial-operation
     │   input: {
@@ -580,9 +626,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream-partial"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -603,7 +646,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 3,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     ├── openai-responses-parse-operation
     │   input: {
@@ -612,9 +661,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "responses-parse"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── openai.responses.parse [llm]
     │       input: {
@@ -639,7 +685,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 24,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 46,
+    │         "time_to_first_token": 0,
+    │         "tokens": 70
     │       }
     └── openai-responses-compact-operation
         input: {
@@ -648,9 +700,6 @@ span_tree:
         output: null
         metadata: {
           "operation": "responses-compact"
-        }
-        metrics: {
-          "has_time_to_first_token": false
         }
         └── openai.responses.compact [llm]
             input: [
@@ -686,5 +735,11 @@ span_tree:
               "provider": "openai"
             }
             metrics: {
-              "has_time_to_first_token": true
+              "completion_reasoning_tokens": 0,
+              "completion_tokens": 235,
+              "prompt_cache_write_tokens": 0,
+              "prompt_cached_tokens": 0,
+              "prompt_tokens": 133,
+              "time_to_first_token": 0,
+              "tokens": 368
             }

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-wrapped.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-wrapped.span-tree.json
@@ -356,6 +356,49 @@
           }
         },
         {
+          "name": "openai-stream-multiple-choices-operation",
+          "children": [
+            {
+              "name": "Chat Completion",
+              "type": "llm",
+              "children": [],
+              "input": [
+                {
+                  "content_kind": "string",
+                  "role": "user"
+                }
+              ],
+              "output": [
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                },
+                {
+                  "json_keys": [],
+                  "role": "assistant"
+                }
+              ],
+              "metadata": {
+                "model": "gpt-4o-mini-2024-07-18",
+                "provider": "openai"
+              },
+              "metrics": {
+                "has_time_to_first_token": true
+              }
+            }
+          ],
+          "input": {
+            "kind": "undefined"
+          },
+          "output": null,
+          "metadata": {
+            "operation": "stream-multiple-choices"
+          },
+          "metrics": {
+            "has_time_to_first_token": false
+          }
+        },
+        {
           "name": "openai-parse-operation",
           "children": [
             {

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-wrapped.span-tree.json
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-wrapped.span-tree.json
@@ -28,7 +28,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -38,9 +47,6 @@
           "output": null,
           "metadata": {
             "operation": "chat"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -67,7 +73,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 14
               }
             }
           ],
@@ -77,9 +92,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -106,7 +118,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 3,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 8516,
+                "time_to_first_token": 0,
+                "tokens": 8519
               }
             }
           ],
@@ -116,9 +137,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-image-attachment"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -145,7 +163,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 24,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 236,
+                "time_to_first_token": 0,
+                "tokens": 260
               }
             }
           ],
@@ -155,9 +182,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-pdf-attachment"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -184,7 +208,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -194,9 +227,6 @@
           "output": null,
           "metadata": {
             "operation": "chat-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -223,7 +253,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 1,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 12,
+                "time_to_first_token": 0,
+                "tokens": 13
               }
             }
           ],
@@ -233,9 +272,6 @@
           "output": null,
           "metadata": {
             "operation": "stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -262,7 +298,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 6,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 17,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -272,9 +317,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -301,7 +343,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 7,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 77,
+                "time_to_first_token": 0,
+                "tokens": 84
               }
             }
           ],
@@ -311,9 +362,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-tool"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -340,7 +388,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -350,9 +398,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-fixture"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -383,7 +428,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -393,9 +438,6 @@
           "output": null,
           "metadata": {
             "operation": "stream-multiple-choices"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -424,7 +466,16 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_accepted_prediction_tokens": 0,
+                "completion_audio_tokens": 0,
+                "completion_reasoning_tokens": 0,
+                "completion_rejected_prediction_tokens": 0,
+                "completion_tokens": 5,
+                "prompt_audio_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 45,
+                "time_to_first_token": 0,
+                "tokens": 50
               }
             }
           ],
@@ -434,9 +485,6 @@
           "output": null,
           "metadata": {
             "operation": "parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -463,7 +511,7 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "time_to_first_token": 0
               }
             }
           ],
@@ -473,9 +521,6 @@
           "output": null,
           "metadata": {
             "operation": "sync-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -496,7 +541,8 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": false
+                "prompt_tokens": 1,
+                "tokens": 1
               }
             }
           ],
@@ -506,9 +552,6 @@
           "output": null,
           "metadata": {
             "operation": "embeddings"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -528,9 +571,6 @@
               "metadata": {
                 "model": "omni-moderation-2024-09-26",
                 "provider": "openai"
-              },
-              "metrics": {
-                "has_time_to_first_token": false
               }
             }
           ],
@@ -540,9 +580,6 @@
           "output": null,
           "metadata": {
             "operation": "moderations"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -571,7 +608,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 3,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -581,9 +624,6 @@
           "output": null,
           "metadata": {
             "operation": "responses"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -612,7 +652,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -622,9 +668,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-with-response"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -653,7 +696,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 4,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 17
               }
             }
           ],
@@ -663,9 +712,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-create-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -694,7 +740,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 2,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 21,
+                "time_to_first_token": 0,
+                "tokens": 23
               }
             }
           ],
@@ -704,9 +756,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -735,7 +784,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 3,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 13,
+                "time_to_first_token": 0,
+                "tokens": 16
               }
             }
           ],
@@ -745,9 +800,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-stream-partial"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -779,7 +831,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 17,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 46,
+                "time_to_first_token": 0,
+                "tokens": 63
               }
             }
           ],
@@ -789,9 +847,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-parse"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         },
         {
@@ -834,7 +889,13 @@
                 "provider": "openai"
               },
               "metrics": {
-                "has_time_to_first_token": true
+                "completion_reasoning_tokens": 0,
+                "completion_tokens": 204,
+                "prompt_cache_write_tokens": 0,
+                "prompt_cached_tokens": 0,
+                "prompt_tokens": 133,
+                "time_to_first_token": 0,
+                "tokens": 337
               }
             }
           ],
@@ -844,9 +905,6 @@
           "output": null,
           "metadata": {
             "operation": "responses-compact"
-          },
-          "metrics": {
-            "has_time_to_first_token": false
           }
         }
       ],
@@ -857,9 +915,6 @@
       "metadata": {
         "openaiSdkVersion": "<openai-sdk-version>",
         "scenario": "openai-instrumentation"
-      },
-      "metrics": {
-        "has_time_to_first_token": false
       }
     }
   ]

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-wrapped.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-wrapped.span-tree.txt
@@ -8,9 +8,6 @@ span_tree:
       "openaiSdkVersion": "<openai-sdk-version>",
       "scenario": "openai-instrumentation"
     }
-    metrics: {
-      "has_time_to_first_token": false
-    }
     ├── openai-chat-operation
     │   input: {
     │     "kind": "undefined"
@@ -18,9 +15,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "chat"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -40,7 +34,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-with-response-operation
     │   input: {
@@ -50,9 +53,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -71,7 +71,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 14
     │       }
     ├── openai-chat-image-attachment-operation
     │   input: {
@@ -81,9 +90,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-image-attachment"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -102,7 +108,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 3,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 8516,
+    │         "time_to_first_token": 0,
+    │         "tokens": 8519
     │       }
     ├── openai-chat-pdf-attachment-operation
     │   input: {
@@ -112,9 +127,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-pdf-attachment"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -133,7 +145,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 24,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 236,
+    │         "time_to_first_token": 0,
+    │         "tokens": 260
     │       }
     ├── openai-chat-tool-operation
     │   input: {
@@ -143,9 +164,6 @@ span_tree:
     │   metadata: {
     │     "operation": "chat-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -164,7 +182,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-operation
     │   input: {
@@ -174,9 +201,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -195,7 +219,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 1,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 12,
+    │         "time_to_first_token": 0,
+    │         "tokens": 13
     │       }
     ├── openai-stream-with-response-operation
     │   input: {
@@ -205,9 +238,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -226,7 +256,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 6,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 17,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-stream-tool-operation
     │   input: {
@@ -236,9 +275,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-tool"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -257,7 +293,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 7,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 77,
+    │         "time_to_first_token": 0,
+    │         "tokens": 84
     │       }
     ├── openai-stream-fixture-operation
     │   input: {
@@ -267,9 +312,6 @@ span_tree:
     │   metadata: {
     │     "operation": "stream-fixture"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── Chat Completion [llm]
     │       input: [
     │         {
@@ -288,7 +330,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-stream-multiple-choices-operation
     │   input: {
@@ -297,9 +339,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "stream-multiple-choices"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -323,7 +362,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-parse-operation
     │   input: {
@@ -332,9 +371,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "parse"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -356,7 +392,16 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_accepted_prediction_tokens": 0,
+    │         "completion_audio_tokens": 0,
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_rejected_prediction_tokens": 0,
+    │         "completion_tokens": 5,
+    │         "prompt_audio_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 45,
+    │         "time_to_first_token": 0,
+    │         "tokens": 50
     │       }
     ├── openai-sync-stream-operation
     │   input: {
@@ -365,9 +410,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "sync-stream"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Chat Completion [llm]
     │       input: [
@@ -387,7 +429,7 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "time_to_first_token": 0
     │       }
     ├── openai-embeddings-operation
     │   input: {
@@ -396,9 +438,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "embeddings"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Embedding [llm]
     │       input: {
@@ -412,7 +451,8 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": false
+    │         "prompt_tokens": 1,
+    │         "tokens": 1
     │       }
     ├── openai-moderations-operation
     │   input: {
@@ -421,9 +461,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "moderations"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── Moderation [llm]
     │       input: {
@@ -437,9 +474,6 @@ span_tree:
     │         "model": "omni-moderation-2024-09-26",
     │         "provider": "openai"
     │       }
-    │       metrics: {
-    │         "has_time_to_first_token": false
-    │       }
     ├── openai-responses-operation
     │   input: {
     │     "kind": "undefined"
@@ -447,9 +481,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "responses"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── openai.responses.create [llm]
     │       input: {
@@ -471,7 +502,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 3,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     ├── openai-responses-with-response-operation
     │   input: {
@@ -481,9 +518,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-with-response"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -504,7 +538,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-create-stream-operation
     │   input: {
@@ -514,9 +554,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-create-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -537,7 +574,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 4,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 17
     │       }
     ├── openai-responses-stream-operation
     │   input: {
@@ -547,9 +590,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -570,7 +610,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 2,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 21,
+    │         "time_to_first_token": 0,
+    │         "tokens": 23
     │       }
     ├── openai-responses-stream-partial-operation
     │   input: {
@@ -580,9 +626,6 @@ span_tree:
     │   metadata: {
     │     "operation": "responses-stream-partial"
     │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
-    │   }
     │   └── openai.responses.create [llm]
     │       input: {
     │         "kind": "text"
@@ -603,7 +646,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 3,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 13,
+    │         "time_to_first_token": 0,
+    │         "tokens": 16
     │       }
     ├── openai-responses-parse-operation
     │   input: {
@@ -612,9 +661,6 @@ span_tree:
     │   output: null
     │   metadata: {
     │     "operation": "responses-parse"
-    │   }
-    │   metrics: {
-    │     "has_time_to_first_token": false
     │   }
     │   └── openai.responses.parse [llm]
     │       input: {
@@ -639,7 +685,13 @@ span_tree:
     │         "provider": "openai"
     │       }
     │       metrics: {
-    │         "has_time_to_first_token": true
+    │         "completion_reasoning_tokens": 0,
+    │         "completion_tokens": 17,
+    │         "prompt_cache_write_tokens": 0,
+    │         "prompt_cached_tokens": 0,
+    │         "prompt_tokens": 46,
+    │         "time_to_first_token": 0,
+    │         "tokens": 63
     │       }
     └── openai-responses-compact-operation
         input: {
@@ -648,9 +700,6 @@ span_tree:
         output: null
         metadata: {
           "operation": "responses-compact"
-        }
-        metrics: {
-          "has_time_to_first_token": false
         }
         └── openai.responses.compact [llm]
             input: [
@@ -686,5 +735,11 @@ span_tree:
               "provider": "openai"
             }
             metrics: {
-              "has_time_to_first_token": true
+              "completion_reasoning_tokens": 0,
+              "completion_tokens": 204,
+              "prompt_cache_write_tokens": 0,
+              "prompt_cached_tokens": 0,
+              "prompt_tokens": 133,
+              "time_to_first_token": 0,
+              "tokens": 337
             }

--- a/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-wrapped.span-tree.txt
+++ b/e2e/scenarios/openai-instrumentation/__snapshots__/openai-v6-wrapped.span-tree.txt
@@ -290,6 +290,41 @@ span_tree:
     │       metrics: {
     │         "has_time_to_first_token": true
     │       }
+    ├── openai-stream-multiple-choices-operation
+    │   input: {
+    │     "kind": "undefined"
+    │   }
+    │   output: null
+    │   metadata: {
+    │     "operation": "stream-multiple-choices"
+    │   }
+    │   metrics: {
+    │     "has_time_to_first_token": false
+    │   }
+    │   └── Chat Completion [llm]
+    │       input: [
+    │         {
+    │           "content_kind": "string",
+    │           "role": "user"
+    │         }
+    │       ]
+    │       output: [
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         },
+    │         {
+    │           "json_keys": [],
+    │           "role": "assistant"
+    │         }
+    │       ]
+    │       metadata: {
+    │         "model": "gpt-4o-mini-2024-07-18",
+    │         "provider": "openai"
+    │       }
+    │       metrics: {
+    │         "has_time_to_first_token": true
+    │       }
     ├── openai-parse-operation
     │   input: {
     │     "kind": "undefined"

--- a/e2e/scenarios/openai-instrumentation/assertions.ts
+++ b/e2e/scenarios/openai-instrumentation/assertions.ts
@@ -419,16 +419,6 @@ function isRecord(value: Json | undefined): value is Record<string, Json> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function summarizeMetricPresence(metrics: Json): Json {
-  if (!isRecord(metrics)) {
-    return null;
-  }
-
-  return {
-    has_time_to_first_token: typeof metrics.time_to_first_token === "number",
-  } satisfies Json;
-}
-
 function jsonKeysFromText(value: unknown): string[] {
   if (typeof value !== "string") {
     return [];
@@ -610,6 +600,7 @@ function summarizeOpenAIPayload(
   summaryName: string | undefined,
 ): Json {
   const name = summaryName ?? event.span.name ?? "";
+  const fields = spanTreeFields(event);
 
   return {
     input: summarizeInput(event.input as Json),
@@ -617,7 +608,7 @@ function summarizeOpenAIPayload(
       event.row.metadata as Record<string, unknown> | undefined,
       ["model", "openaiSdkVersion", "operation", "provider", "scenario"],
     ),
-    metrics: summarizeMetricPresence(event.metrics as Json),
+    metrics: fields.metrics as Json,
     name: name || null,
     output: summarizeOutput(name, event.output as Json),
     type: event.span.type ?? null,

--- a/e2e/scenarios/openai-instrumentation/assertions.ts
+++ b/e2e/scenarios/openai-instrumentation/assertions.ts
@@ -77,6 +77,63 @@ function validateStreamFixtureOutput(span: CapturedLogEvent | undefined): void {
   expect(message?.refusal).toBe("NOPE");
 }
 
+function validateMultipleChoicesStreamOutput(
+  span: CapturedLogEvent | undefined,
+): void {
+  expect(span?.output).toEqual([
+    expect.objectContaining({
+      index: 0,
+      finish_reason: "tool_calls",
+      message: expect.objectContaining({
+        role: "assistant",
+        tool_calls: [
+          {
+            id: "choice_0_call_0",
+            type: "function",
+            function: {
+              name: "get_weather",
+              arguments: '{"location":"Boston"}',
+            },
+          },
+          {
+            id: "choice_0_call_1",
+            type: "function",
+            function: {
+              name: "get_weather",
+              arguments: '{"location":"Paris"}',
+            },
+          },
+        ],
+      }),
+    }),
+    expect.objectContaining({
+      index: 1,
+      finish_reason: "tool_calls",
+      message: expect.objectContaining({
+        role: "assistant",
+        tool_calls: [
+          {
+            id: "choice_1_call_0",
+            type: "function",
+            function: {
+              name: "get_weather",
+              arguments: '{"location":"Tokyo"}',
+            },
+          },
+          {
+            id: "choice_1_call_1",
+            type: "function",
+            function: {
+              name: "get_weather",
+              arguments: '{"location":"Rome"}',
+            },
+          },
+        ],
+      }),
+    }),
+  ]);
+}
+
 function validateAttachmentInput(
   span: CapturedLogEvent | undefined,
   contentType: string,
@@ -188,6 +245,15 @@ const OPERATION_SPECS: readonly OperationSpec[] = [
     testName:
       "captures trace for streamed chat completion with logprobs and refusal",
     validate: validateStreamFixtureOutput,
+  },
+  {
+    childNames: ["Chat Completion"],
+    expectsOutput: true,
+    expectsTimeToFirstToken: true,
+    name: "openai-stream-multiple-choices-operation",
+    operation: "stream-multiple-choices",
+    testName: "captures all streamed chat completion choices by index",
+    validate: validateMultipleChoicesStreamOutput,
   },
   {
     childNames: ["Chat Completion"],

--- a/e2e/scenarios/openai-instrumentation/scenario.impl.mjs
+++ b/e2e/scenarios/openai-instrumentation/scenario.impl.mjs
@@ -42,6 +42,14 @@ const MOCK_CHAT_STREAM_SSE = [
   "data: [DONE]",
   "",
 ].join("\n");
+const MOCK_CHAT_MULTIPLE_CHOICES_STREAM_SSE = [
+  'data: {"id":"chatcmpl-multiple-choices-fixture","object":"chat.completion.chunk","created":1740000000,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"choice_0_call_0","type":"function","function":{"name":"get_weather","arguments":"{\\"location\\":\\"Bos"}},{"index":1,"id":"choice_0_call_1","type":"function","function":{"name":"get_weather","arguments":"{\\"location\\":\\"Par"}}]},"logprobs":null,"finish_reason":null},{"index":1,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"choice_1_call_0","type":"function","function":{"name":"get_weather","arguments":"{\\"location\\":\\"Tok"}},{"index":1,"id":"choice_1_call_1","type":"function","function":{"name":"get_weather","arguments":"{\\"location\\":\\"Ro"}}]},"logprobs":null,"finish_reason":null}]}',
+  "",
+  'data: {"id":"chatcmpl-multiple-choices-fixture","object":"chat.completion.chunk","created":1740000000,"model":"gpt-4o-mini","choices":[{"index":1,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"me\\"}"}},{"index":0,"function":{"arguments":"yo\\"}"}}]},"logprobs":null,"finish_reason":"tool_calls"},{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"is\\"}"}},{"index":0,"function":{"arguments":"ton\\"}"}}]},"logprobs":null,"finish_reason":"tool_calls"}]}',
+  "",
+  "data: [DONE]",
+  "",
+].join("\n");
 
 const CHAT_PARSE_SCHEMA = {
   type: "object",
@@ -86,12 +94,12 @@ function parseMajorVersion(version) {
   return Number.isNaN(major) ? null : major;
 }
 
-function createMockStreamingClient(options) {
+function createMockStreamingClient(options, responseBody) {
   const baseClient = new options.OpenAI({
     apiKey: process.env.OPENAI_API_KEY ?? "test-openai-key",
     baseURL: "https://example.test/v1",
     fetch: async () =>
-      new Response(MOCK_CHAT_STREAM_SSE, {
+      new Response(responseBody, {
         headers: {
           "content-type": "text/event-stream",
         },
@@ -112,7 +120,14 @@ export async function runOpenAIInstrumentationScenario(options) {
   const client = options.decorateClient
     ? options.decorateClient(baseClient)
     : baseClient;
-  const streamFixtureClient = createMockStreamingClient(options);
+  const streamFixtureClient = createMockStreamingClient(
+    options,
+    MOCK_CHAT_STREAM_SSE,
+  );
+  const multipleChoicesStreamFixtureClient = createMockStreamingClient(
+    options,
+    MOCK_CHAT_MULTIPLE_CHOICES_STREAM_SSE,
+  );
   const openAIMajorVersion = parseMajorVersion(options.openaiSdkVersion);
   const shouldCheckPrivateFieldMethods =
     typeof options.decorateClient === "function" &&
@@ -377,6 +392,31 @@ export async function runOpenAIInstrumentationScenario(options) {
             max_tokens: 12,
             temperature: 0,
           });
+          await collectAsync(chatStream);
+        },
+      );
+
+      await runOperation(
+        "openai-stream-multiple-choices-operation",
+        "stream-multiple-choices",
+        async () => {
+          const chatStream =
+            await multipleChoicesStreamFixtureClient.chat.completions.create({
+              model: OPENAI_MODEL,
+              messages: [
+                {
+                  role: "user",
+                  content:
+                    "Return two streamed choices with two weather tool calls each.",
+                },
+              ],
+              stream: true,
+              n: 2,
+              parallel_tool_calls: true,
+              max_tokens: 12,
+              temperature: 0,
+              tools: CHAT_TOOLS,
+            });
           await collectAsync(chatStream);
         },
       );

--- a/js/src/instrumentation/braintrust-plugin.test.ts
+++ b/js/src/instrumentation/braintrust-plugin.test.ts
@@ -1460,13 +1460,13 @@ describe("aggregateChatCompletionChunks", () => {
   it("should aggregate simple text chunks", () => {
     const chunks = [
       {
-        choices: [{ delta: { role: "assistant", content: "Hello" } }],
+        choices: [{ index: 0, delta: { role: "assistant", content: "Hello" } }],
       },
       {
-        choices: [{ delta: { content: " world" } }],
+        choices: [{ index: 0, delta: { content: " world" } }],
       },
       {
-        choices: [{ delta: { content: "!" } }],
+        choices: [{ index: 0, delta: { content: "!" } }],
       },
     ];
 
@@ -1490,10 +1490,10 @@ describe("aggregateChatCompletionChunks", () => {
   it("should extract role from first chunk", () => {
     const chunks = [
       {
-        choices: [{ delta: { role: "assistant" } }],
+        choices: [{ index: 0, delta: { role: "assistant" } }],
       },
       {
-        choices: [{ delta: { content: "Hi" } }],
+        choices: [{ index: 0, delta: { content: "Hi" } }],
       },
     ];
 
@@ -1505,10 +1505,10 @@ describe("aggregateChatCompletionChunks", () => {
   it("should extract finish_reason from last chunk with it", () => {
     const chunks = [
       {
-        choices: [{ delta: { role: "assistant", content: "Done" } }],
+        choices: [{ index: 0, delta: { role: "assistant", content: "Done" } }],
       },
       {
-        choices: [{ delta: { finish_reason: "stop" } }],
+        choices: [{ index: 0, delta: { finish_reason: "stop" } }],
       },
     ];
 
@@ -1522,10 +1522,12 @@ describe("aggregateChatCompletionChunks", () => {
       {
         choices: [
           {
+            index: 0,
             delta: {
               role: "assistant",
               tool_calls: [
                 {
+                  index: 0,
                   id: "call_1",
                   type: "function",
                   function: { name: "get_weather", arguments: '{"loc' },
@@ -1538,9 +1540,11 @@ describe("aggregateChatCompletionChunks", () => {
       {
         choices: [
           {
+            index: 0,
             delta: {
               tool_calls: [
                 {
+                  index: 0,
                   function: { arguments: 'ation":"' },
                 },
               ],
@@ -1551,9 +1555,11 @@ describe("aggregateChatCompletionChunks", () => {
       {
         choices: [
           {
+            index: 0,
             delta: {
               tool_calls: [
                 {
+                  index: 0,
                   function: { arguments: 'NYC"}' },
                 },
               ],
@@ -1579,10 +1585,12 @@ describe("aggregateChatCompletionChunks", () => {
       {
         choices: [
           {
+            index: 0,
             delta: {
               role: "assistant",
               tool_calls: [
                 {
+                  index: 0,
                   id: "call_1",
                   type: "function",
                   function: { name: "tool1", arguments: '{"a":' },
@@ -1595,9 +1603,11 @@ describe("aggregateChatCompletionChunks", () => {
       {
         choices: [
           {
+            index: 0,
             delta: {
               tool_calls: [
                 {
+                  index: 0,
                   function: { arguments: "1}" },
                 },
               ],
@@ -1608,9 +1618,11 @@ describe("aggregateChatCompletionChunks", () => {
       {
         choices: [
           {
+            index: 0,
             delta: {
               tool_calls: [
                 {
+                  index: 1,
                   id: "call_2",
                   type: "function",
                   function: { name: "tool2", arguments: '{"b":' },
@@ -1623,9 +1635,11 @@ describe("aggregateChatCompletionChunks", () => {
       {
         choices: [
           {
+            index: 0,
             delta: {
               tool_calls: [
                 {
+                  index: 1,
                   function: { arguments: "2}" },
                 },
               ],
@@ -1654,10 +1668,10 @@ describe("aggregateChatCompletionChunks", () => {
   it("should parse usage metrics from chunks", () => {
     const chunks = [
       {
-        choices: [{ delta: { role: "assistant", content: "Hi" } }],
+        choices: [{ index: 0, delta: { role: "assistant", content: "Hi" } }],
       },
       {
-        choices: [{ delta: { content: "!" } }],
+        choices: [{ index: 0, delta: { content: "!" } }],
         usage: {
           prompt_tokens: 10,
           completion_tokens: 2,
@@ -1678,13 +1692,13 @@ describe("aggregateChatCompletionChunks", () => {
   it("should merge usage from multiple chunks", () => {
     const chunks = [
       {
-        choices: [{ delta: { role: "assistant" } }],
+        choices: [{ index: 0, delta: { role: "assistant" } }],
         usage: {
           prompt_tokens: 10,
         },
       },
       {
-        choices: [{ delta: { content: "Hi" } }],
+        choices: [{ index: 0, delta: { content: "Hi" } }],
         usage: {
           completion_tokens: 5,
           total_tokens: 15,
@@ -1724,7 +1738,7 @@ describe("aggregateChatCompletionChunks", () => {
       {},
       { choices: null },
       { choices: [] },
-      { choices: [{ delta: { content: "Hi" } }] },
+      { choices: [{ index: 0, delta: { content: "Hi" } }] },
     ];
 
     const result = aggregateChatCompletionChunks(chunks as any);
@@ -1755,6 +1769,7 @@ describe("aggregateChatCompletionChunks", () => {
       {
         choices: [
           {
+            index: 0,
             delta: {
               role: "assistant",
               content: "Let me check",
@@ -1765,9 +1780,11 @@ describe("aggregateChatCompletionChunks", () => {
       {
         choices: [
           {
+            index: 0,
             delta: {
               tool_calls: [
                 {
+                  index: 0,
                   id: "call_1",
                   type: "function",
                   function: { name: "check", arguments: "{}" },
@@ -1778,7 +1795,7 @@ describe("aggregateChatCompletionChunks", () => {
         ],
       },
       {
-        choices: [{ delta: { finish_reason: "tool_calls" } }],
+        choices: [{ index: 0, delta: { finish_reason: "tool_calls" } }],
       },
     ];
 

--- a/js/src/instrumentation/plugins/groq-plugin.test.ts
+++ b/js/src/instrumentation/plugins/groq-plugin.test.ts
@@ -43,6 +43,7 @@ describe("aggregateGroqChatCompletionChunks", () => {
         {
           choices: [
             {
+              index: 0,
               delta: {
                 role: "assistant",
                 reasoning: "First, count the marbles. ",
@@ -54,6 +55,7 @@ describe("aggregateGroqChatCompletionChunks", () => {
         {
           choices: [
             {
+              index: 0,
               delta: {
                 reasoning: "Then double the remainder.",
               },
@@ -64,6 +66,7 @@ describe("aggregateGroqChatCompletionChunks", () => {
         {
           choices: [
             {
+              index: 0,
               delta: {
                 content: "14",
               },

--- a/js/src/instrumentation/plugins/openai-plugin.test.ts
+++ b/js/src/instrumentation/plugins/openai-plugin.test.ts
@@ -301,13 +301,15 @@ describe("aggregateChatCompletionChunks", () => {
     it("should aggregate simple text chunks", () => {
       const chunks = [
         {
-          choices: [{ delta: { role: "assistant", content: "Hello" } }],
+          choices: [
+            { index: 0, delta: { role: "assistant", content: "Hello" } },
+          ],
         },
         {
-          choices: [{ delta: { content: " world" } }],
+          choices: [{ index: 0, delta: { content: " world" } }],
         },
         {
-          choices: [{ delta: { content: "!" } }],
+          choices: [{ index: 0, delta: { content: "!" } }],
         },
       ];
 
@@ -407,10 +409,10 @@ describe("aggregateChatCompletionChunks", () => {
     it("should extract role from first chunk", () => {
       const chunks = [
         {
-          choices: [{ delta: { role: "assistant" } }],
+          choices: [{ index: 0, delta: { role: "assistant" } }],
         },
         {
-          choices: [{ delta: { content: "Hi" } }],
+          choices: [{ index: 0, delta: { content: "Hi" } }],
         },
       ];
 
@@ -422,13 +424,13 @@ describe("aggregateChatCompletionChunks", () => {
     it("should only use role from first chunk with role", () => {
       const chunks = [
         {
-          choices: [{ delta: { content: "Hi" } }],
+          choices: [{ index: 0, delta: { content: "Hi" } }],
         },
         {
-          choices: [{ delta: { role: "assistant" } }],
+          choices: [{ index: 0, delta: { role: "assistant" } }],
         },
         {
-          choices: [{ delta: { role: "user" } }], // Should be ignored
+          choices: [{ index: 0, delta: { role: "user" } }], // Should be ignored
         },
       ];
 
@@ -442,16 +444,16 @@ describe("aggregateChatCompletionChunks", () => {
     it("should concatenate content across chunks", () => {
       const chunks = [
         {
-          choices: [{ delta: { content: "Hello" } }],
+          choices: [{ index: 0, delta: { content: "Hello" } }],
         },
         {
-          choices: [{ delta: { content: " " } }],
+          choices: [{ index: 0, delta: { content: " " } }],
         },
         {
-          choices: [{ delta: { content: "world" } }],
+          choices: [{ index: 0, delta: { content: "world" } }],
         },
         {
-          choices: [{ delta: { content: "!" } }],
+          choices: [{ index: 0, delta: { content: "!" } }],
         },
       ];
 
@@ -463,13 +465,13 @@ describe("aggregateChatCompletionChunks", () => {
     it("should handle chunks with empty content", () => {
       const chunks = [
         {
-          choices: [{ delta: { content: "Hello" } }],
+          choices: [{ index: 0, delta: { content: "Hello" } }],
         },
         {
-          choices: [{ delta: { content: "" } }],
+          choices: [{ index: 0, delta: { content: "" } }],
         },
         {
-          choices: [{ delta: { content: "!" } }],
+          choices: [{ index: 0, delta: { content: "!" } }],
         },
       ];
 
@@ -481,13 +483,13 @@ describe("aggregateChatCompletionChunks", () => {
     it("should handle undefined content in chunks", () => {
       const chunks = [
         {
-          choices: [{ delta: { content: "Hello" } }],
+          choices: [{ index: 0, delta: { content: "Hello" } }],
         },
         {
-          choices: [{ delta: {} }],
+          choices: [{ index: 0, delta: {} }],
         },
         {
-          choices: [{ delta: { content: "!" } }],
+          choices: [{ index: 0, delta: { content: "!" } }],
         },
       ];
 
@@ -498,15 +500,173 @@ describe("aggregateChatCompletionChunks", () => {
   });
 
   describe("tool calls aggregation", () => {
+    it("should aggregate parallel tool calls across multiple choices", () => {
+      const chunks = [
+        {
+          choices: [
+            {
+              index: 0,
+              delta: {
+                role: "assistant",
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "choice_0_call_0",
+                    type: "function",
+                    function: {
+                      name: "get_weather",
+                      arguments: '{"location":"Bos',
+                    },
+                  },
+                  {
+                    index: 1,
+                    id: "choice_0_call_1",
+                    type: "function",
+                    function: {
+                      name: "get_weather",
+                      arguments: '{"location":"Par',
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              index: 1,
+              delta: {
+                role: "assistant",
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "choice_1_call_0",
+                    type: "function",
+                    function: {
+                      name: "get_weather",
+                      arguments: '{"location":"Tok',
+                    },
+                  },
+                  {
+                    index: 1,
+                    id: "choice_1_call_1",
+                    type: "function",
+                    function: {
+                      name: "get_weather",
+                      arguments: '{"location":"Ro',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          choices: [
+            {
+              index: 1,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 1,
+                    function: { arguments: 'me"}' },
+                  },
+                  {
+                    index: 0,
+                    function: { arguments: 'yo"}' },
+                  },
+                ],
+              },
+              finish_reason: "tool_calls",
+            },
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 1,
+                    function: { arguments: 'is"}' },
+                  },
+                  {
+                    index: 0,
+                    function: { arguments: 'ton"}' },
+                  },
+                ],
+              },
+              finish_reason: "tool_calls",
+            },
+          ],
+        },
+      ];
+
+      const result = aggregateChatCompletionChunks(chunks);
+
+      expect(result.output).toEqual([
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: undefined,
+            tool_calls: [
+              {
+                id: "choice_0_call_0",
+                type: "function",
+                function: {
+                  name: "get_weather",
+                  arguments: '{"location":"Boston"}',
+                },
+              },
+              {
+                id: "choice_0_call_1",
+                type: "function",
+                function: {
+                  name: "get_weather",
+                  arguments: '{"location":"Paris"}',
+                },
+              },
+            ],
+          },
+          logprobs: null,
+          finish_reason: "tool_calls",
+        },
+        {
+          index: 1,
+          message: {
+            role: "assistant",
+            content: undefined,
+            tool_calls: [
+              {
+                id: "choice_1_call_0",
+                type: "function",
+                function: {
+                  name: "get_weather",
+                  arguments: '{"location":"Tokyo"}',
+                },
+              },
+              {
+                id: "choice_1_call_1",
+                type: "function",
+                function: {
+                  name: "get_weather",
+                  arguments: '{"location":"Rome"}',
+                },
+              },
+            ],
+          },
+          logprobs: null,
+          finish_reason: "tool_calls",
+        },
+      ]);
+    });
+
     it("should aggregate tool calls by id", () => {
       const chunks = [
         {
           choices: [
             {
+              index: 0,
               delta: {
                 role: "assistant",
                 tool_calls: [
                   {
+                    index: 0,
                     id: "call_1",
                     type: "function",
                     function: { name: "get_weather", arguments: '{"loc' },
@@ -519,9 +679,11 @@ describe("aggregateChatCompletionChunks", () => {
         {
           choices: [
             {
+              index: 0,
               delta: {
                 tool_calls: [
                   {
+                    index: 0,
                     function: { arguments: 'ation":"' },
                   },
                 ],
@@ -532,9 +694,11 @@ describe("aggregateChatCompletionChunks", () => {
         {
           choices: [
             {
+              index: 0,
               delta: {
                 tool_calls: [
                   {
+                    index: 0,
                     function: { arguments: 'NYC"}' },
                   },
                 ],
@@ -560,10 +724,12 @@ describe("aggregateChatCompletionChunks", () => {
         {
           choices: [
             {
+              index: 0,
               delta: {
                 role: "assistant",
                 tool_calls: [
                   {
+                    index: 0,
                     id: "call_1",
                     type: "function",
                     function: { name: "tool1", arguments: '{"a":' },
@@ -576,9 +742,11 @@ describe("aggregateChatCompletionChunks", () => {
         {
           choices: [
             {
+              index: 0,
               delta: {
                 tool_calls: [
                   {
+                    index: 0,
                     function: { arguments: "1}" },
                   },
                 ],
@@ -589,9 +757,11 @@ describe("aggregateChatCompletionChunks", () => {
         {
           choices: [
             {
+              index: 0,
               delta: {
                 tool_calls: [
                   {
+                    index: 1,
                     id: "call_2",
                     type: "function",
                     function: { name: "tool2", arguments: '{"b":' },
@@ -604,9 +774,11 @@ describe("aggregateChatCompletionChunks", () => {
         {
           choices: [
             {
+              index: 0,
               delta: {
                 tool_calls: [
                   {
+                    index: 1,
                     function: { arguments: "2}" },
                   },
                 ],
@@ -637,10 +809,12 @@ describe("aggregateChatCompletionChunks", () => {
         {
           choices: [
             {
+              index: 0,
               delta: {
                 role: "assistant",
                 tool_calls: [
                   {
+                    index: 0,
                     type: "function",
                     function: { name: "tool", arguments: '{"a":' },
                   },
@@ -652,9 +826,11 @@ describe("aggregateChatCompletionChunks", () => {
         {
           choices: [
             {
+              index: 0,
               delta: {
                 tool_calls: [
                   {
+                    index: 0,
                     function: { arguments: "1}" },
                   },
                 ],
@@ -678,10 +854,12 @@ describe("aggregateChatCompletionChunks", () => {
     it("should extract finish_reason from last chunk with it", () => {
       const chunks = [
         {
-          choices: [{ delta: { role: "assistant", content: "Done" } }],
+          choices: [
+            { index: 0, delta: { role: "assistant", content: "Done" } },
+          ],
         },
         {
-          choices: [{ delta: { finish_reason: "stop" } }],
+          choices: [{ index: 0, delta: { finish_reason: "stop" } }],
         },
       ];
 
@@ -693,10 +871,10 @@ describe("aggregateChatCompletionChunks", () => {
     it("should use latest finish_reason when multiple chunks have it", () => {
       const chunks = [
         {
-          choices: [{ delta: { finish_reason: "length" } }],
+          choices: [{ index: 0, delta: { finish_reason: "length" } }],
         },
         {
-          choices: [{ delta: { finish_reason: "stop" } }],
+          choices: [{ index: 0, delta: { finish_reason: "stop" } }],
         },
       ];
 
@@ -710,6 +888,7 @@ describe("aggregateChatCompletionChunks", () => {
         {
           choices: [
             {
+              index: 0,
               delta: {
                 role: "assistant",
                 content: "Let me check",
@@ -720,9 +899,11 @@ describe("aggregateChatCompletionChunks", () => {
         {
           choices: [
             {
+              index: 0,
               delta: {
                 tool_calls: [
                   {
+                    index: 0,
                     id: "call_1",
                     type: "function",
                     function: { name: "check", arguments: "{}" },
@@ -733,7 +914,7 @@ describe("aggregateChatCompletionChunks", () => {
           ],
         },
         {
-          choices: [{ delta: { finish_reason: "tool_calls" } }],
+          choices: [{ index: 0, delta: { finish_reason: "tool_calls" } }],
         },
       ];
 
@@ -747,10 +928,10 @@ describe("aggregateChatCompletionChunks", () => {
     it("should parse usage metrics from chunk with usage field", () => {
       const chunks = [
         {
-          choices: [{ delta: { role: "assistant", content: "Hi" } }],
+          choices: [{ index: 0, delta: { role: "assistant", content: "Hi" } }],
         },
         {
-          choices: [{ delta: { content: "!" } }],
+          choices: [{ index: 0, delta: { content: "!" } }],
           usage: {
             prompt_tokens: 10,
             completion_tokens: 2,
@@ -771,13 +952,13 @@ describe("aggregateChatCompletionChunks", () => {
     it("should merge usage from multiple chunks", () => {
       const chunks = [
         {
-          choices: [{ delta: { role: "assistant" } }],
+          choices: [{ index: 0, delta: { role: "assistant" } }],
           usage: {
             prompt_tokens: 10,
           },
         },
         {
-          choices: [{ delta: { content: "Hi" } }],
+          choices: [{ index: 0, delta: { content: "Hi" } }],
           usage: {
             completion_tokens: 5,
             total_tokens: 15,
@@ -815,7 +996,7 @@ describe("aggregateChatCompletionChunks", () => {
     it("should handle new API token format in usage", () => {
       const chunks = [
         {
-          choices: [{ delta: { content: "Hi" } }],
+          choices: [{ index: 0, delta: { content: "Hi" } }],
           usage: {
             input_tokens: 100,
             output_tokens: 50,
@@ -842,7 +1023,7 @@ describe("aggregateChatCompletionChunks", () => {
         {},
         { choices: null },
         { choices: [] },
-        { choices: [{ delta: { content: "Hi" } }] },
+        { choices: [{ index: 0, delta: { content: "Hi" } }] },
       ];
 
       const result = aggregateChatCompletionChunks(chunks as any);
@@ -852,8 +1033,8 @@ describe("aggregateChatCompletionChunks", () => {
 
     it("should handle chunks with null delta", () => {
       const chunks = [
-        { choices: [{ delta: null }] },
-        { choices: [{ delta: { content: "Hi" } }] },
+        { choices: [{ index: 0, delta: null }] },
+        { choices: [{ index: 0, delta: { content: "Hi" } }] },
       ];
 
       const result = aggregateChatCompletionChunks(chunks as any);
@@ -866,6 +1047,7 @@ describe("aggregateChatCompletionChunks", () => {
         {
           choices: [
             {
+              index: 0,
               delta: {
                 role: "assistant",
                 content: "Let me check",
@@ -876,9 +1058,11 @@ describe("aggregateChatCompletionChunks", () => {
         {
           choices: [
             {
+              index: 0,
               delta: {
                 tool_calls: [
                   {
+                    index: 0,
                     id: "call_1",
                     type: "function",
                     function: { name: "check", arguments: "{}" },
@@ -889,7 +1073,7 @@ describe("aggregateChatCompletionChunks", () => {
           ],
         },
         {
-          choices: [{ delta: { finish_reason: "tool_calls" } }],
+          choices: [{ index: 0, delta: { finish_reason: "tool_calls" } }],
         },
       ];
 
@@ -905,6 +1089,7 @@ describe("aggregateChatCompletionChunks", () => {
         {
           choices: [
             {
+              index: 0,
               delta: {
                 role: "assistant",
                 content: "Done",

--- a/js/src/instrumentation/plugins/openai-plugin.test.ts
+++ b/js/src/instrumentation/plugins/openai-plugin.test.ts
@@ -328,6 +328,62 @@ describe("aggregateChatCompletionChunks", () => {
       expect(result.metrics).toEqual({});
     });
 
+    it("should aggregate multiple streamed choices by index", () => {
+      const chunks = [
+        {
+          choices: [
+            {
+              index: 0,
+              delta: { role: "assistant", content: "Hel" },
+            },
+            {
+              index: 1,
+              delta: { role: "assistant", content: "Bon" },
+            },
+          ],
+        },
+        {
+          choices: [
+            {
+              index: 1,
+              delta: { content: "jour" },
+              finish_reason: "stop",
+            },
+            {
+              index: 0,
+              delta: { content: "lo" },
+              finish_reason: "length",
+            },
+          ],
+        },
+      ];
+
+      const result = aggregateChatCompletionChunks(chunks);
+
+      expect(result.output).toEqual([
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: "Hello",
+            tool_calls: undefined,
+          },
+          logprobs: null,
+          finish_reason: "length",
+        },
+        {
+          index: 1,
+          message: {
+            role: "assistant",
+            content: "Bonjour",
+            tool_calls: undefined,
+          },
+          logprobs: null,
+          finish_reason: "stop",
+        },
+      ]);
+    });
+
     it("should handle empty chunks array", () => {
       const result = aggregateChatCompletionChunks([]);
 

--- a/js/src/instrumentation/plugins/openai-plugin.ts
+++ b/js/src/instrumentation/plugins/openai-plugin.ts
@@ -472,17 +472,13 @@ type AggregatedChatChoice = {
   role: string | undefined;
   content: string | undefined;
   refusal: string | undefined;
-  tool_calls: OpenAIChatChoice["message"]["tool_calls"] | undefined;
+  toolCallsByIndex: Map<
+    number,
+    NonNullable<OpenAIChatChoice["message"]["tool_calls"]>[number]
+  >;
   logprobs: OpenAIChatLogprobs | null | undefined;
   finish_reason: string | null | undefined;
 };
-
-function getStreamingChoiceIndex(
-  choice: NonNullable<OpenAIChatCompletionChunk["choices"]>[number],
-  position: number,
-): number {
-  return typeof choice.index === "number" ? choice.index : position;
-}
 
 function createAggregatedChatChoice(index: number): AggregatedChatChoice {
   return {
@@ -490,20 +486,24 @@ function createAggregatedChatChoice(index: number): AggregatedChatChoice {
     role: undefined,
     content: undefined,
     refusal: undefined,
-    tool_calls: undefined,
+    toolCallsByIndex: new Map(),
     logprobs: undefined,
     finish_reason: undefined,
   };
 }
 
 function toChatChoice(choice: AggregatedChatChoice): OpenAIChatChoice {
+  const toolCalls = Array.from(choice.toolCallsByIndex.entries())
+    .sort(([left], [right]) => left - right)
+    .map(([, toolCall]) => toolCall);
+
   return {
     index: choice.index,
     message: {
       role: choice.role,
       content: choice.content,
       ...(choice.refusal !== undefined ? { refusal: choice.refusal } : {}),
-      tool_calls: choice.tool_calls,
+      tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
     },
     logprobs: choice.logprobs ?? null,
     finish_reason: choice.finish_reason,
@@ -512,7 +512,7 @@ function toChatChoice(choice: AggregatedChatChoice): OpenAIChatChoice {
 
 /**
  * Aggregate chat completion chunks into a single response.
- * Combines role (first), content (concatenated), tool_calls (by id),
+ * Combines role (first), content (concatenated), tool_calls (by index),
  * finish_reason (last), and usage (last chunk).
  */
 export function aggregateChatCompletionChunks(
@@ -539,8 +539,8 @@ export function aggregateChatCompletionChunks(
       continue;
     }
 
-    for (const [position, choice] of choices.entries()) {
-      const choiceIndex = getStreamingChoiceIndex(choice, position);
+    for (const choice of choices) {
+      const choiceIndex = choice.index;
       let aggregatedChoice = choicesByIndex.get(choiceIndex);
       if (!aggregatedChoice) {
         aggregatedChoice = createAggregatedChatChoice(choiceIndex);
@@ -580,25 +580,33 @@ export function aggregateChatCompletionChunks(
       }
 
       if (delta.tool_calls) {
-        const toolDelta = delta.tool_calls[0];
-        if (
-          !aggregatedChoice.tool_calls ||
-          (toolDelta.id &&
-            aggregatedChoice.tool_calls[aggregatedChoice.tool_calls.length - 1]
-              .id !== toolDelta.id)
-        ) {
-          aggregatedChoice.tool_calls = [
-            ...(aggregatedChoice.tool_calls || []),
-            {
-              id: toolDelta.id,
-              type: toolDelta.type,
-              function: toolDelta.function,
-            },
-          ];
-        } else {
-          aggregatedChoice.tool_calls[
-            aggregatedChoice.tool_calls.length - 1
-          ].function.arguments += toolDelta.function.arguments;
+        for (const toolDelta of delta.tool_calls) {
+          let aggregatedToolCall = aggregatedChoice.toolCallsByIndex.get(
+            toolDelta.index,
+          );
+          if (!aggregatedToolCall) {
+            aggregatedToolCall = {
+              function: { arguments: "" },
+            };
+            aggregatedChoice.toolCallsByIndex.set(
+              toolDelta.index,
+              aggregatedToolCall,
+            );
+          }
+
+          if (toolDelta.id !== undefined) {
+            aggregatedToolCall.id = toolDelta.id;
+          }
+          if (toolDelta.type !== undefined) {
+            aggregatedToolCall.type = toolDelta.type;
+          }
+          if (toolDelta.function?.name !== undefined) {
+            aggregatedToolCall.function.name = toolDelta.function.name;
+          }
+          if (toolDelta.function?.arguments !== undefined) {
+            aggregatedToolCall.function.arguments +=
+              toolDelta.function.arguments;
+          }
         }
       }
     }

--- a/js/src/instrumentation/plugins/openai-plugin.ts
+++ b/js/src/instrumentation/plugins/openai-plugin.ts
@@ -467,6 +467,49 @@ function aggregateChatLogprobs(
   return aggregated;
 }
 
+type AggregatedChatChoice = {
+  index: number;
+  role: string | undefined;
+  content: string | undefined;
+  refusal: string | undefined;
+  tool_calls: OpenAIChatChoice["message"]["tool_calls"] | undefined;
+  logprobs: OpenAIChatLogprobs | null | undefined;
+  finish_reason: string | null | undefined;
+};
+
+function getStreamingChoiceIndex(
+  choice: NonNullable<OpenAIChatCompletionChunk["choices"]>[number],
+  position: number,
+): number {
+  return typeof choice.index === "number" ? choice.index : position;
+}
+
+function createAggregatedChatChoice(index: number): AggregatedChatChoice {
+  return {
+    index,
+    role: undefined,
+    content: undefined,
+    refusal: undefined,
+    tool_calls: undefined,
+    logprobs: undefined,
+    finish_reason: undefined,
+  };
+}
+
+function toChatChoice(choice: AggregatedChatChoice): OpenAIChatChoice {
+  return {
+    index: choice.index,
+    message: {
+      role: choice.role,
+      content: choice.content,
+      ...(choice.refusal !== undefined ? { refusal: choice.refusal } : {}),
+      tool_calls: choice.tool_calls,
+    },
+    logprobs: choice.logprobs ?? null,
+    finish_reason: choice.finish_reason,
+  };
+}
+
 /**
  * Aggregate chat completion chunks into a single response.
  * Combines role (first), content (concatenated), tool_calls (by id),
@@ -480,12 +523,7 @@ export function aggregateChatCompletionChunks(
   output: OpenAIChatChoice[];
   metrics: Record<string, number>;
 } {
-  let role = undefined;
-  let content = undefined;
-  let refusal = undefined;
-  let tool_calls = undefined;
-  let logprobs: OpenAIChatLogprobs | null | undefined = undefined;
-  let finish_reason = undefined;
+  const choicesByIndex = new Map<number, AggregatedChatChoice>();
   let metrics: Record<string, number> = {};
 
   for (const chunk of chunks) {
@@ -496,76 +534,87 @@ export function aggregateChatCompletionChunks(
       };
     }
 
-    const choice = chunk.choices?.[0];
-    if (!choice) {
+    const choices = chunk.choices;
+    if (!choices?.length) {
       continue;
     }
 
-    if (choice.finish_reason) {
-      finish_reason = choice.finish_reason;
-    }
+    for (const [position, choice] of choices.entries()) {
+      const choiceIndex = getStreamingChoiceIndex(choice, position);
+      let aggregatedChoice = choicesByIndex.get(choiceIndex);
+      if (!aggregatedChoice) {
+        aggregatedChoice = createAggregatedChatChoice(choiceIndex);
+        choicesByIndex.set(choiceIndex, aggregatedChoice);
+      }
 
-    logprobs = aggregateChatLogprobs(logprobs, choice.logprobs);
+      if (choice.finish_reason) {
+        aggregatedChoice.finish_reason = choice.finish_reason;
+      }
 
-    const delta = choice.delta;
-    if (!delta) {
-      continue;
-    }
+      aggregatedChoice.logprobs = aggregateChatLogprobs(
+        aggregatedChoice.logprobs,
+        choice.logprobs,
+      );
 
-    if (delta.finish_reason) {
-      finish_reason = delta.finish_reason;
-    }
+      const delta = choice.delta;
+      if (!delta) {
+        continue;
+      }
 
-    if (!role && delta.role) {
-      role = delta.role;
-    }
+      if (delta.finish_reason) {
+        aggregatedChoice.finish_reason = delta.finish_reason;
+      }
 
-    if (delta.content) {
-      content = (content || "") + delta.content;
-    }
+      if (!aggregatedChoice.role && delta.role) {
+        aggregatedChoice.role = delta.role;
+      }
 
-    if (delta.refusal) {
-      refusal = (refusal || "") + delta.refusal;
-    }
+      if (delta.content) {
+        aggregatedChoice.content =
+          (aggregatedChoice.content || "") + delta.content;
+      }
 
-    if (delta.tool_calls) {
-      const toolDelta = delta.tool_calls[0];
-      if (
-        !tool_calls ||
-        (toolDelta.id && tool_calls[tool_calls.length - 1].id !== toolDelta.id)
-      ) {
-        tool_calls = [
-          ...(tool_calls || []),
-          {
-            id: toolDelta.id,
-            type: toolDelta.type,
-            function: toolDelta.function,
-          },
-        ];
-      } else {
-        tool_calls[tool_calls.length - 1].function.arguments +=
-          toolDelta.function.arguments;
+      if (delta.refusal) {
+        aggregatedChoice.refusal =
+          (aggregatedChoice.refusal || "") + delta.refusal;
+      }
+
+      if (delta.tool_calls) {
+        const toolDelta = delta.tool_calls[0];
+        if (
+          !aggregatedChoice.tool_calls ||
+          (toolDelta.id &&
+            aggregatedChoice.tool_calls[aggregatedChoice.tool_calls.length - 1]
+              .id !== toolDelta.id)
+        ) {
+          aggregatedChoice.tool_calls = [
+            ...(aggregatedChoice.tool_calls || []),
+            {
+              id: toolDelta.id,
+              type: toolDelta.type,
+              function: toolDelta.function,
+            },
+          ];
+        } else {
+          aggregatedChoice.tool_calls[
+            aggregatedChoice.tool_calls.length - 1
+          ].function.arguments += toolDelta.function.arguments;
+        }
       }
     }
   }
 
   metrics = withCachedMetric(metrics, streamResult, endEvent);
+  const output = Array.from(choicesByIndex.values())
+    .sort((left, right) => left.index - right.index)
+    .map(toChatChoice);
 
   return {
     metrics,
-    output: [
-      {
-        index: 0,
-        message: {
-          role,
-          content,
-          ...(refusal !== undefined ? { refusal } : {}),
-          tool_calls,
-        },
-        logprobs: logprobs ?? null,
-        finish_reason,
-      },
-    ],
+    output:
+      output.length > 0
+        ? output
+        : [toChatChoice(createAggregatedChatChoice(0))],
   };
 }
 

--- a/js/src/vendor-sdk-types/openai-common.ts
+++ b/js/src/vendor-sdk-types/openai-common.ts
@@ -64,10 +64,24 @@ interface OpenAIChatToolFunction {
   [key: string]: unknown;
 }
 
+interface OpenAIChatToolFunctionDelta {
+  arguments?: string;
+  name?: string;
+  [key: string]: unknown;
+}
+
 interface OpenAIChatToolCall {
   id?: string;
   type?: string;
   function: OpenAIChatToolFunction;
+  [key: string]: unknown;
+}
+
+interface OpenAIChatToolCallDelta {
+  index: number;
+  id?: string;
+  type?: string;
+  function?: OpenAIChatToolFunctionDelta;
   [key: string]: unknown;
 }
 
@@ -111,12 +125,13 @@ interface OpenAIChatDelta {
   role?: string;
   content?: string;
   refusal?: string;
-  tool_calls?: OpenAIChatToolCall[];
+  tool_calls?: OpenAIChatToolCallDelta[];
   finish_reason?: string | null;
   [key: string]: unknown;
 }
 
 export interface OpenAIChatChunkChoice {
+  index: number;
   delta?: OpenAIChatDelta;
   finish_reason?: string | null;
   logprobs?: OpenAIChatLogprobs | null;


### PR DESCRIPTION
## Summary

OpenAI streaming chat completions may contain multiple choices, and chunks can interleave them. The instrumentation previously aggregated only `choices[0]`, so additional choices were dropped from recorded output. Aggregate choices by their protocol index, preserve their fields and ordering, and add a regression test plus a patch changeset.

## Verification

- `pnpm --dir js exec vitest run src/instrumentation/plugins/openai-plugin.test.ts` (70 passed)
- `pnpm --dir js exec prettier --check src/instrumentation/plugins/openai-plugin.ts src/instrumentation/plugins/openai-plugin.test.ts ../.changeset/openai-streaming-choices.md`
- `pnpm --dir js exec eslint src/instrumentation/plugins/openai-plugin.ts src/instrumentation/plugins/openai-plugin.test.ts` (0 errors)